### PR TITLE
fix(tui): 会话日志被外部删除后不再让 dsh 进程 fatal 退出

### DIFF
--- a/packages/dsh-pi-tui/src/commands.ts
+++ b/packages/dsh-pi-tui/src/commands.ts
@@ -171,7 +171,9 @@ export function registerTuiCommands(runner: TuiCommandRunner): { refreshSkills()
         // No session was ever created: nothing to flush, exit immediately.
         void runner.exit(0)
       } else {
-        void runner.sessions.flush(liveAgent.session).then(() => runner.exit(0))
+        // Exit even when the durable flush fails: a broken session log must
+        // not trap the user inside the TUI.
+        void runner.sessions.flush(liveAgent.session).then(() => runner.exit(0), () => runner.exit(0))
       }
       return { kind: 'success' }
     },

--- a/packages/dsh-pi-tui/src/guard.ts
+++ b/packages/dsh-pi-tui/src/guard.ts
@@ -65,6 +65,8 @@ export type GuardOutcome =
   | { kind: 'ok'; revision: string; fileEvents?: number }
   /** The file has more committed events than this process's memory. */
   | { kind: 'diverged'; revision: string; fileEvents: number; memoryEvents: number }
+  /** The file was observed earlier in this process but has since disappeared. */
+  | { kind: 'removed'; revision: string }
   /** The committed prefix cannot be read (corrupt or mid-write). */
   | { kind: 'unreadable'; revision: string; error: string }
   /** The guard cannot run for this deployment/session; do not block. */
@@ -97,11 +99,19 @@ export async function checkDivergence(
   try {
     current = stat(artifact.path)
   } catch (error) {
-    // A missing artifact is a fresh session (lazy materialization): nothing
-    // external can have written it. Anything else is unreadable.
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // A missing artifact is a fresh session (lazy materialization): nothing
+      // external can have written it. But when this process already observed
+      // a committed file earlier, disappearance means the log was removed
+      // externally — the next append would ENOENT and could take down the
+      // process, so block before the write instead.
+      if (state.revision !== '') {
+        state.diverged = true
+        return { kind: 'removed', revision: state.revision }
+      }
       return { kind: 'ok', revision: state.revision }
     }
+    // Anything else is unreadable.
     state.diverged = true
     return { kind: 'unreadable', revision: state.revision, error: error instanceof Error ? error.message : String(error) }
   }

--- a/packages/dsh-pi-tui/src/index.ts
+++ b/packages/dsh-pi-tui/src/index.ts
@@ -211,6 +211,7 @@ const DANGER_PATTERNS: readonly RegExp[] = [
 /** Divergence-guard notices (user-facing, English like the rest of the TUI). */
 const GUARD_BLOCKED_NOTIFY = 'This session may be open in another dsh process (TUI/web); send blocked. Press Enter again to force (may corrupt the session log)'
 const GUARD_FORCED_NOTIFY = 'Forced send — the session may be written by another process; the log may be damaged'
+const GUARD_REMOVED_NOTIFY = 'This session\'s log was removed externally — it can no longer be persisted. Press Enter again to continue without persistence (restart to recover)'
 
 /**
  * Whether a shell command matches a destructive pattern. `rm` is treated
@@ -569,7 +570,7 @@ export function apply(ctx: Context, config: Config): void {
      * 'forced' when the user overrode a still-bad state, and 'unavailable'
      * when the deployment cannot guard (proceed).
      */
-    const guardSend = async (): Promise<'ok' | 'blocked' | 'forced' | 'unavailable'> => {
+    const guardSend = async (): Promise<'ok' | 'blocked' | 'blocked-removed' | 'forced' | 'unavailable'> => {
       if (liveAgent === undefined) return 'ok'
       const session: GuardSessionLike = {
         id: liveAgent.session.id,
@@ -601,6 +602,13 @@ export function apply(ctx: Context, config: Config): void {
             return 'forced'
           }
           return 'blocked'
+        case 'removed':
+          diag.warn('guard removed', { session: session.id, revision: outcome.revision })
+          if (guardForced) {
+            guardForced = false
+            return 'forced'
+          }
+          return 'blocked-removed'
         case 'unavailable':
           guardForced = false
           return 'ok'
@@ -934,6 +942,11 @@ export function apply(ctx: Context, config: Config): void {
           app.notify(GUARD_BLOCKED_NOTIFY, 'error')
           return
         }
+        if (verdict === 'blocked-removed') {
+          app.setEditorText(text)
+          app.notify(GUARD_REMOVED_NOTIFY, 'error')
+          return
+        }
         if (verdict === 'forced') {
           app.notify(GUARD_FORCED_NOTIFY, 'error')
         }
@@ -1080,6 +1093,11 @@ export function apply(ctx: Context, config: Config): void {
           if (verdict === 'blocked') {
             app.setEditorText(text)
             app.notify(GUARD_BLOCKED_NOTIFY, 'error')
+            return
+          }
+          if (verdict === 'blocked-removed') {
+            app.setEditorText(text)
+            app.notify(GUARD_REMOVED_NOTIFY, 'error')
             return
           }
           const forced = verdict === 'forced'
@@ -1503,7 +1521,19 @@ export function apply(ctx: Context, config: Config): void {
         app.setWorking(false)
         paintNow()
         refreshStatus()
-        void sessions.flush(liveAgent!.session)
+        const finished = liveAgent!.session
+        void sessions.flush(finished).catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error)
+          const removed = (error as NodeJS.ErrnoException).code === 'ENOENT'
+          diag.error('flush failed', { session: finished.id, error: message, removed })
+          // A failed durable write must never kill the process: the live
+          // session keeps working in memory and the next turn-end retries.
+          // When the log was removed externally the retry cannot succeed
+          // until restart, so the notice says so instead of a bare error.
+          app.notify(removed
+            ? 'session persistence failed: the session log was removed externally — this session can no longer be persisted (restart to recover)'
+            : `session persistence failed: ${message}`, 'error')
+        })
       } else if (event.type === 'step/start') {
         refreshStatus()
       }

--- a/packages/dsh-pi-tui/test/guard.test.ts
+++ b/packages/dsh-pi-tui/test/guard.test.ts
@@ -142,3 +142,44 @@ test('stat ENOENT (artifact not yet materialized) is ok', async () => {
   const outcome = await checkDivergence(persistence, session(1), stat, freshGuardState())
   assert.equal(outcome.kind, 'ok')
 })
+
+test('stat ENOENT after a previous observation reports removed and latches', async () => {
+  const persistence = fakePersistence({ locate: ARTIFACT, events: 0 })
+  const stat = fakeStat()
+  const state = freshGuardState()
+  // First check observes a real committed file (one full read).
+  const first = await checkDivergence(persistence, session(1), stat.stat, state)
+  assert.equal(first.kind, 'ok')
+  assert.equal(persistence.reads, 1)
+  // The log disappears externally: stat now throws ENOENT.
+  const missing = (() => {
+    const error = new Error('no such file') as NodeJS.ErrnoException
+    error.code = 'ENOENT'
+    throw error
+  }) as unknown as GuardStatLike
+  const second = await checkDivergence(persistence, session(1), missing, state)
+  assert.equal(second.kind, 'removed')
+  if (second.kind === 'removed') assert.notEqual(second.revision, '')
+  // Latches without another full read: still removed on the next check.
+  const third = await checkDivergence(persistence, session(1), missing, state)
+  assert.equal(third.kind, 'removed')
+  assert.equal(persistence.reads, 1)
+})
+
+test('removed recovers when the file reappears and reads clean', async () => {
+  const persistence = fakePersistence({ locate: ARTIFACT, events: 0 })
+  const stat = fakeStat()
+  const state = freshGuardState()
+  await checkDivergence(persistence, session(1), stat.stat, state)
+  const missing = (() => {
+    const error = new Error('no such file') as NodeJS.ErrnoException
+    error.code = 'ENOENT'
+    throw error
+  }) as unknown as GuardStatLike
+  const removed = await checkDivergence(persistence, session(1), missing, state)
+  assert.equal(removed.kind, 'removed')
+  // A new file with a different revision re-enters the normal read path.
+  stat.set(200, 2)
+  const recovered = await checkDivergence(persistence, session(1), stat.stat, state)
+  assert.equal(recovered.kind, 'ok')
+})


### PR DESCRIPTION
Closes #1

## 背景

上游 deepseek-harness 确认:会话日志被外部删除后,下一次写入 ENOENT,
turn-end flush 的裸 rejection 会让整个 dsh 进程 fatal 退出
(https://github.com/deepseek-ai/deepseek-harness/discussions/1891)。

本 PR 做 dsh-pi-tui 消费者侧防护:

## 改动

- `src/guard.ts`:新增 `removed` outcome。本进程先前已观察到文件 revision、
  之后 stat ENOENT → 判为日志被外部删除,提交前拦截(原来是当作懒
  materialize 直接放行,守卫完全失守)。
- `src/index.ts`:
  - `removed` 拦截显示专门文案(`GUARD_REMOVED_NOTIFY`),二次 Enter 仍可强制。
  - turn-end flush 捕获失败(diag + notify),不再产生 unhandled rejection;
    ENOENT 显示"会话无法继续持久化,重启恢复"的可行动提示。
- `src/commands.ts`:`/exit` 即使最终 flush 失败也照常退出。
- `test/guard.test.ts`:新增两个用例(删除后 `removed` 且 latch;文件重新出现后恢复正常)。

## 验证

- `pnpm --filter @xmoon76/dsh-pi-tui typecheck` ✅
- `pnpm --filter @xmoon76/dsh-pi-tui test` ✅ 215/215
- `pnpm build` ✅
