### PR TITLE
fix(tui): question dialog fills 85% of wide terminals

### DIFF
--- a/packages/dsh-pi-tui/src/tui-app.ts
+++ b/packages/dsh-pi-tui/src/tui-app.ts
@@ -102,14 +102,17 @@ const CONTEXT_BAR_WIDTH = 12
 
 /**
  * Rounded-frame wrapper for overlay content: `╭─╮` border in the border
- * token, one cell of padding, width sized to the content. Keyboard input
- * forwards to the wrapped component.
+ * token, one cell of padding, width sized to the content. With `fillWidth`
+ * the frame keeps the overlay's full width instead of hugging the widest
+ * content row. Keyboard input forwards to the wrapped component.
  */
 export class Frame implements Component {
   private readonly child: Component
+  private readonly fillWidth: boolean
 
-  constructor(child: Component) {
+  constructor(child: Component, fillWidth = false) {
     this.child = child
+    this.fillWidth = fillWidth
   }
 
   invalidate(): void {
@@ -127,7 +130,9 @@ export class Frame implements Component {
   render(width: number): string[] {
     const inner = Math.max(1, Math.floor(width) - 4)
     const lines = this.child.render(inner).map(line => truncateToWidth(line, inner, '…'))
-    const contentWidth = Math.min(inner, Math.max(1, ...lines.map(line => visibleWidth(line))))
+    const contentWidth = this.fillWidth
+      ? inner
+      : Math.min(inner, Math.max(1, ...lines.map(line => visibleWidth(line))))
     const frameWidth = contentWidth + 4
     const b = color.border
     const out = [b(`╭${'─'.repeat(frameWidth - 2)}╮`)]
@@ -2869,7 +2874,7 @@ export class TuiApp {
   /** Mount one flow's overlay and make it the active one. */
   private presentQuestion(state: QuestionState): void {
     this.activeQuestions = state
-    state.handle = this.showOverlayOnHost(new Frame(state.flow), { width: 76, maxHeight: 26 })
+    state.handle = this.showOverlayOnHost(new Frame(state.flow, true), { width: '85%', minWidth: 64, maxHeight: 26 })
   }
 
   /** Abort one flow (its signal fired). The ACTIVE flow settles rejected

--- a/packages/dsh-pi-tui/test/rendering.test.ts
+++ b/packages/dsh-pi-tui/test/rendering.test.ts
@@ -24,8 +24,8 @@ process.env.NO_COLOR = ''
 process.env.FORCE_COLOR = ''
 process.env.CI = ''
 
-function startApp(width = 100): { vt: VirtualTerminal; app: TuiApp } {
-  const vt = new VirtualTerminal(width, 24)
+function startApp(width = 100, height = 24): { vt: VirtualTerminal; app: TuiApp } {
+  const vt = new VirtualTerminal(width, height)
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
   app.start()
   return { vt, app }
@@ -103,6 +103,21 @@ test('askQuestions collects a single selection', async () => {
   await viewport(vt)
   vt.sendInput('\r')
   assert.deepEqual(await promise, [{ id: 'q1', selected: ['No'] }])
+})
+
+test('question dialog fills 85% of a wide terminal instead of hugging the longest row', async () => {
+  const { vt, app } = startApp(160, 32)
+  const promise = app.askQuestions([{ id: 'q1', question: 'Continue?', options: [{ label: 'Yes' }] }])
+  const view = await viewport(vt)
+  const lines = view.split('\n').map(line => line.replace(/\x1b\[[0-9;?]*m/g, ''))
+  const top = lines.findIndex(line => line.includes('╭'))
+  const bottom = lines.findIndex(line => line.includes('╰'))
+  assert.ok(top >= 0 && bottom >= top, `frame missing:\n${view}`)
+  // 85% of 160 columns = 136, borders included.
+  assert.equal(lines[top]!.trim().length, 136, `frame should fill 85% of the terminal:\n${view}`)
+  assert.equal(lines[bottom]!.trim().length, 136, `bottom border must match the top:\n${view}`)
+  vt.sendInput('\x1b')
+  await promise.catch(() => {})
 })
 
 test('question dialog wraps long text, keeps descriptions on their own lines, and never ellipsizes', async () => {


### PR DESCRIPTION
Closes #3

> 注:issue #3 记录了完整背景。**本 PR 只保留 question 弹层宽度这一块**——approval 弹层超框部分,你的 `feat/tui-render-fixes-busy-enter`(wrapped-height approval budget、全宽对话框、自适应 maxHeight)已经用自己的方案解决了,这部分我已从 PR 中移除,以免撞车。

## 改动

- `Frame` 增加 `fillWidth` 选项:默认仍按内容收缩;`fillWidth=true` 时保持 overlay 的满宽。
- question 弹层使用 `new Frame(state.flow, true)` + `{ width: '85%', minWidth: 64, maxHeight: 26 }`:宽屏占满 85%,不再缩成中间 ~60 列的小窄条;窄屏 minWidth 兜底。
- 回归测试:160 列终端下短问题弹框应为 136 列(85%),上下边框一致。

## 验证

- typecheck ✅
- 全量测试:pi-tui 964、dsh-pi-tui 513、tarball 8,全绿(基于你最新 main 2cea286,无冲突)

> 本 PR **仅供参考,不一定要 merge**:欢迎只采纳思路、自行改写或直接关闭。
