### PR TITLE
fix(clipboard): keep execFile stdout binary-safe for image paste (P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ctrl+V image paste works again on Linux Wayland/X11.** The clipboard
+  runner executed `wl-paste`/`xclip` without an explicit encoding, so
+  binary stdout was decoded as UTF-8 and invalid bytes were replaced —
+  PNG magic arrived as `EF BF BD …`, the image parser could not recognize
+  the payload, and the paste silently did nothing. The runner now forces
+  `encoding: 'buffer'`, keeping stdout/stderr as raw bytes end to end, and
+  a byte-for-byte regression test guards the path. Ctrl+V is also recorded
+  in the host-reserved key inventory, matching the host's own lifecycle
+  handling.
+
 ## [0.3.2] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -254,6 +254,15 @@
 
 ## [Unreleased]
 
+### 修复
+
+- **Linux Wayland/X11 下 Ctrl+V 图片粘贴恢复可用。** 剪贴板 runner 执行
+  `wl-paste`/`xclip` 时未显式指定编码,二进制 stdout 被当作 UTF-8 解码,
+  非法字节被替换——PNG magic 变成 `EF BF BD …`,图片解析器无法识别
+  载荷,粘贴静默无反应。runner 现在强制 `encoding: 'buffer'`,stdout/
+  stderr 全程保持原始字节,并有逐字节回归测试守护该路径。Ctrl+V 也
+  补进了 host 保留键清单,与 host 自身的生命周期处理保持一致。
+
 ## [0.3.2] - 2026-08-22
 
 ### 新增

--- a/src/image/clipboard.ts
+++ b/src/image/clipboard.ts
@@ -55,6 +55,12 @@ export function createClipboardRunner(): RunCommand {
     const child = execFile(command, args as string[], {
       timeout: options?.timeoutMs ?? 2000,
       maxBuffer: 64 * 1024 * 1024,
+      // Binary-safe (P0): without an explicit encoding, execFile decodes
+      // stdout as UTF-8 and REPLACES invalid bytes — PNG magic (0x89 0x50
+      // 0x4E 0x47 ...) arrives as EF BF BD ... and parseImageMetadata
+      // cannot recognize the payload, so an image paste silently no-ops.
+      // `encoding: 'buffer'` keeps stdout/stderr as raw Buffers end to end.
+      encoding: 'buffer',
     }, (error, stdout, stderr) => {
       const code = error === null
         ? 0
@@ -62,8 +68,8 @@ export function createClipboardRunner(): RunCommand {
           ? (error as { code: number }).code
           : 1
       resolve({
-        stdout: Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout),
-        stderr: Buffer.isBuffer(stderr) ? stderr : Buffer.from(stderr ?? ''),
+        stdout,
+        stderr,
         code,
       })
     })

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -39,7 +39,7 @@ interface BindingRecord {
  * host's `matchesKey` lifecycle checks in tui-app.ts (Ctrl+C/D exit,
  * Ctrl+S steer-all, Ctrl+F transcript search, Ctrl+Shift+F search, Ctrl+O
  * expand, Ctrl+T todo panel, Ctrl+G external editor, Ctrl+R input-history
- * search, Ctrl+Enter queue,
+ * search, Ctrl+V clipboard image intake, Ctrl+Enter queue,
  * Enter submit, Esc cancel, Shift+Tab permission cycle, Alt+Up dequeue,
  * Alt+T thinking toggle). Every
  * reserved binding here must match a host `matchesKey(data, ...)` call;
@@ -56,6 +56,7 @@ export const RESERVED_HOST_KEYS: readonly NormalizedKey[] = [
   { key: 't', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+T todo panel
   { key: 'g', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+G external editor
   { key: 'r', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+R input-history search
+  { key: 'v', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+V clipboard image intake
   // Ctrl+J is deliberately NOT reserved/bound: legacy terminals send it
   // as LF, which the editor treats as Enter, so the chord was unreliable
   // in practice — the task browser is reached via ↓ (empty editor) and

--- a/test/clipboard.test.ts
+++ b/test/clipboard.test.ts
@@ -166,6 +166,26 @@ test('the real execFile runner pipes the input payload to the child stdin (issue
   assert.equal(result.stdout.toString('utf8'), 'hello stdin')
 })
 
+test('the real execFile runner preserves binary stdout byte-for-byte (clipboard image intake)', async () => {
+  // Regression (P0): without `encoding: 'buffer'`, execFile decodes stdout
+  // as UTF-8 and REPLACES invalid bytes — PNG magic (0x89 0x50 0x4E 0x47
+  // 0x0D 0x0A 0x1A 0x0A) becomes EF BF BD ... before parseImageMetadata
+  // ever sees it, so a Wayland/X11 image paste silently no-ops. The runner
+  // must hand the parser the EXACT bytes the child wrote.
+  const run = createClipboardRunner()
+  const expected = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG magic
+    0x00, 0xff, 0xfe, 0x80, // non-UTF-8 bytes
+  ])
+  const result = await run(process.execPath, [
+    '-e',
+    `process.stdout.write(Buffer.from(${JSON.stringify([...expected])}))`,
+  ])
+  assert.equal(result.code, 0)
+  assert.ok(Buffer.isBuffer(result.stdout), 'stdout must be a raw Buffer, never a decoded string')
+  assert.deepEqual(result.stdout, expected)
+})
+
 test('the real execFile runner survives an early-exiting child while piping a large payload (EPIPE, round-3 finding)', async () => {
   // A helper that exits immediately while a large payload is being piped
   // emits EPIPE on stdin; without an error listener the process crashes

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -495,6 +495,7 @@ test('KeybindingRegistry: reserved host keys are rejected (full lifecycle invent
     { key: 't', ctrl: true, shift: false },
     { key: 'g', ctrl: true, shift: false },
     { key: 'r', ctrl: true, shift: false },   // Ctrl+R input-history search
+    { key: 'v', ctrl: true, shift: false },   // Ctrl+V clipboard image intake
     // Ctrl+J is deliberately NOT reserved anymore: legacy terminals send
     // it as LF (the editor's Enter), so the host dropped the binding and a
     // plugin may claim the chord itself.


### PR DESCRIPTION
## Root cause

`createClipboardRunner()` ran `execFile` without an explicit encoding, so binary stdout was decoded as UTF-8 and invalid bytes were replaced — PNG magic (`89 50 4E 47 …`) arrived as `EF BF BD …`, `parseImageMetadata()` could not recognize the payload, and a Wayland/X11 image Ctrl+V silently no-opped (treated as empty text).

## Fix

Force `encoding: 'buffer'` on the execFile options so stdout/stderr stay raw `Buffer`s end to end (the defensive `Buffer.from` conversion is removed — it could never recover bytes already decoded). Also record Ctrl+V in `RESERVED_HOST_KEYS` to match the host's existing `matchesKey(data, 'ctrl+v')` lifecycle handling.

## Tests

- New byte-for-byte regression test against the real `createClipboardRunner` (PNG magic + non-UTF-8 bytes): **fails on the old implementation** (stdout arrives as `EF BF BD …`), passes on the fix.
- Full suite: fork 985/985, bundle 1860/1860, docs 11/11; `pnpm typecheck`, `pnpm build`, `git diff --check` clean.
- No new dependency, no user-facing semantic change (empty clipboard stays silent, text paste unchanged, real command failures still surface via notify error).

## Review

One review-fix-loop round (openai-codex / gpt-5.6-luna): **accepted, no findings**.

## Manual verification

Not manually verified — no Wayland GUI in the dev environment. Plan §10 manual matrix (Wayland + wl-paste + Ctrl+V) is the follow-up on a real machine.

Closes the P0 in `temp/20260825/dsh-pi-tui-clipboard-image-paste-fix-plan.md`.