### PR TITLE
perf(history): bound Ctrl+R search with recent-first reverse JSONL scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Ctrl+R history search is now bounded and recent-first.** Instead of
+  parsing every candidate history file in full on each keystroke, the
+  search reads the JSONL store from the tail backwards through a new
+  reverse reader, consuming a global scan budget (5000 physical lines per
+  search across all files, never per file) and visiting the most recently
+  active workspaces first. Large histories no longer cost a full parse per
+  query; the canonical files are never read whole. The search result is
+  now a page: when older history remains, the source returns a
+  continuation that can resume exactly where the search stopped (no
+  re-scanning, no duplicate rows) — the foundation for a future
+  "Search older" UI. Legacy rows whose directory can only be proven
+  outside the scanned window may be omitted from `All directories` (an
+  intentional coverage trade-off; v2 cwd validation itself is unchanged).
+
 ## [0.3.2] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -254,6 +254,18 @@
 
 ## [Unreleased]
 
+### 变更
+
+- **Ctrl+R 历史搜索改为有界、最近优先。** 不再每次按键都完整解析所有候选
+  历史文件：搜索通过新的 reverse reader 从 JSONL 存储尾部倒序读取，消耗
+  全局扫描预算（每次搜索在所有文件中最多 5000 条 physical lines，绝不是
+  每文件 5000），并优先访问最近活跃的 workspace。大历史不再每次查询都付出
+  全量解析成本，canonical 文件永远不会被整体读取。搜索结果现在是分页的：
+  当还有更老的历史时，source 返回 continuation，可精确从上次停止处继续
+  （不重扫、不重复行）——这是未来 "Search older" UI 的基础。目录只能在
+  扫描窗口之外证明的 legacy 行可能从 `All directories` 中省略（有意的
+  coverage trade-off；v2 cwd 验证规则本身不变）。
+
 ## [0.3.2] - 2026-08-22
 
 ### 新增

--- a/docs/input-history.md
+++ b/docs/input-history.md
@@ -115,6 +115,13 @@ context (a mismatched continuation is a typed error). Reaching the scan
 budget is NOT exhausted. The panel currently renders only `page.results`;
 "Search older" is a later UI phase on this contract.
 
+The history store is append-only, so a concurrent append between pages does
+not invalidate a continuation: the scan continues by its old snapshot
+boundary and the appended rows belong to the next fresh search. Only a
+file that SHRANK or was rewritten under a continuation cursor invalidates
+it — the source then throws `HistorySearchContinuationStaleError` (a typed
+error) instead of silently skipping the file and reporting exhausted.
+
 Two intentional trade-offs of the bounded window:
 
 - **Coverage**: histories outside the first scan window may not appear

--- a/docs/input-history.md
+++ b/docs/input-history.md
@@ -96,6 +96,34 @@ can never claim it). It is "find and EDIT", never "find and run":
   backend can swap in without touching the panel) and
   `src/history-panel.ts` (the overlay).
 
+### Bounded recent-first scanning (the perf contract)
+
+The search never parses a whole history file. Every call reads the JSONL
+store from the tail backwards through `src/history-reverse-reader.ts`
+(fixed-size chunks, lines reassembled across chunk boundaries, UTF-8 safe)
+and consumes a GLOBAL scan budget — `HISTORY_SEARCH_SCAN_LIMIT` (5000)
+physical lines across ALL files per call, never per file. The `All
+directories` scope stats the candidates with bounded concurrency and scans
+them serially in mtime-DESC order (most recently active workspace first);
+mtime only schedules files, the final order is always row.ts.
+
+The result is a `HistorySearchPage`: the matches NEW to the call's window,
+plus a `HistorySearchContinuation` when older history remains. A
+continuation resumes exactly where the call stopped (no re-scan of the
+covered suffix, no duplicate rows across pages) and is bound to the request
+context (a mismatched continuation is a typed error). Reaching the scan
+budget is NOT exhausted. The panel currently renders only `page.results`;
+"Search older" is a later UI phase on this contract.
+
+Two intentional trade-offs of the bounded window:
+
+- **Coverage**: histories outside the first scan window may not appear
+  initially — the default search is recent-first, not exhaustive.
+- **Legacy cwd coverage**: the file proof comes from `knownCwds` (upfront)
+  or a validating v2 row observed INSIDE the scanned window. Rows whose
+  proof lies outside the window are omitted from `All directories` — v2
+  cwd hash validation itself stays strict and unchanged.
+
 ### Recall-order contract (trap: get this backwards and ↑ shows the OLDEST entry)
 
 The file is oldest-first; `TuiApp.resetInputHistory` takes **newest-first**
@@ -145,8 +173,14 @@ unwritten entries.
   rules (`appendHistoryLine` v1 / `appendHistoryRecord` v2). Pinned by
   `test/history.test.ts`.
 - `src/history-search.ts` — the Ctrl+R search source (`HistorySearchSource`
-  seam + `FileHistorySearchSource`): scope, legacy cwd recovery, matching,
-  ordering, dedupe, cancellation. Pinned by `test/history-search.test.ts`.
+  seam + `FileHistorySearchSource`): scope, bounded recent-first reverse
+  scanning, the global scan budget, the page/continuation contract, legacy
+  cwd recovery, matching, ordering, dedupe, cancellation. Pinned by
+  `test/history-search.test.ts`.
+- `src/history-reverse-reader.ts` — the reverse JSONL batch reader
+  (EOF-backwards chunks, cross-chunk/UTF-8-safe line assembly, revision-
+  bound continuation cursors, abort). Pinned by
+  `test/history-reverse-reader.test.ts`.
 - `src/history-panel.ts` — the Ctrl+R modal panel (query input, scope
   tabs, list, details, responsive layout). Pinned by
   `test/history-panel.test.ts` and the `test/ctrl-r.test.ts` integration

--- a/src/history-panel.ts
+++ b/src/history-panel.ts
@@ -31,7 +31,7 @@ import { Input } from '@xmoon76/pi-tui'
 import type { Component, Focusable } from '@xmoon76/pi-tui'
 import { truncateToWidth, visibleWidth } from '@xmoon76/pi-tui'
 import type { HistorySearchResult, HistorySearchSource, HistoryScope } from './history-search.ts'
-import { HISTORY_SEARCH_LIMIT } from './history-search.ts'
+import { HISTORY_SEARCH_RESULT_LIMIT } from './history-search.ts'
 import { HISTORY_SEARCH_DEBOUNCE_MS } from './history-search.ts'
 
 /** Split threshold: at or above this panel width the list and details
@@ -300,12 +300,16 @@ export class HistoryPanel implements Component, Focusable {
       scope: this.state.scope,
       cwd: this.cwd,
       query: this.state.query,
-      limit: HISTORY_SEARCH_LIMIT,
+      limit: HISTORY_SEARCH_RESULT_LIMIT,
       signal: controller.signal,
     }
     let results: HistorySearchResult[]
     try {
-      results = await this.source.search(request)
+      // The source returns a bounded page (results + an optional
+      // continuation for older history). The panel renders only the page's
+      // results today; "Search older" is a later UI phase on that contract.
+      const page = await this.source.search(request)
+      results = page.results
     } catch (error) {
       // Second fence for a late failure: the generation was invalidated by
       // scheduleSearch/dispose, and the abort was requested — an

--- a/src/history-reverse-reader.ts
+++ b/src/history-reverse-reader.ts
@@ -1,0 +1,245 @@
+/**
+ * Reverse JSONL batch reader — reads an append-only JSONL file from EOF
+ * backwards in fixed-size chunks, yielding complete physical lines newest
+ * first. The reader owns ONLY the byte→line direction: query, cwd proof,
+ * dedupe, sorting and the global scan budget live in history-search.ts.
+ *
+ * Contract:
+ * - Lines are materialized on 0x0A boundaries over raw bytes; a line may
+ *   span any number of chunks (including 256KiB+ rows) and UTF-8 code
+ *   points are only decoded after the full physical line is assembled, so
+ *   a chunk boundary can never split a code point.
+ * - A batch returns at most `maxRows` complete lines; when it stops
+ *   mid-line or mid-chunk, `nextCursor` records the exact resume position
+ *   (`nextByteEnd`) so the next batch continues without re-reading the
+ *   already-covered suffix and without gaps or duplicates.
+ * - The cursor is bound to the file revision (size + mtimeMs): a file that
+ *   changed while a cursor was held throws {@link ReverseJsonlRevisionError}
+ *   instead of blindly reusing a stale byte position.
+ * - The first batch snapshots the file size and never reads past it, so a
+ *   concurrent append during the scan is naturally excluded.
+ * - Abort: the signal is checked before the stat and before every chunk
+ *   read; an abort throws an `AbortError`-named error.
+ * - A vanished/shrunk file degrades: stat/open/read failures propagate to
+ *   the caller (the search source skips the file); a short read (file
+ *   truncated between stat and read) stops the scan at the new EOF.
+ * @module @xmoon76/dsh-pi-tui/history-reverse-reader
+ */
+
+import { open, stat } from 'node:fs/promises'
+
+/** The resume state of a reverse scan, bound to the file revision it was
+ * created against. */
+export interface ReverseJsonlCursor {
+  /** Byte offset where the next batch's read window ENDS (exclusive). */
+  nextByteEnd: number
+  /** Bytes of the current (incomplete) line already materialized, in file
+   * order, starting at `nextByteEnd`. Carried across batches so a line
+   * spanning a batch boundary is never re-read or truncated. */
+  pending: Buffer
+  /** The file revision this cursor was created against. */
+  revision: {
+    size: number
+    mtimeMs: number
+  }
+}
+
+/** One complete physical line, newest first, with its byte range in the
+ * file (the range excludes the trailing `\n`). */
+export interface ReverseJsonlLine {
+  text: string
+  byteStart: number
+  byteEnd: number
+}
+
+/** One bounded batch of reverse lines plus the resume state. */
+export interface ReverseJsonlBatch {
+  lines: ReverseJsonlLine[]
+  /** Present iff `eof` is false: pass it back to continue the scan. */
+  nextCursor?: ReverseJsonlCursor
+  /** True when the whole file has been scanned (no more lines exist). */
+  eof: boolean
+  /** Bytes actually read from disk for this batch. */
+  bytesRead: number
+}
+
+/** Thrown when a cursor is reused against a file whose revision (size or
+ * mtime) changed — the byte position can no longer be trusted. */
+export class ReverseJsonlRevisionError extends Error {
+  constructor(
+    file: string,
+    expected: { size: number; mtimeMs: number },
+    actual: { size: number; mtimeMs: number },
+  ) {
+    super(
+      `history file changed while a reverse-read cursor was held: ${file} `
+      + `(expected size ${expected.size} mtime ${expected.mtimeMs}, `
+      + `got size ${actual.size} mtime ${actual.mtimeMs})`,
+    )
+    this.name = 'ReverseJsonlRevisionError'
+  }
+}
+
+/** Read options for {@link readJsonlReverseBatch}. */
+export interface ReverseJsonlBatchOptions {
+  /** Resume state from a previous batch; absent starts a fresh scan from
+   * the file's EOF. */
+  cursor?: ReverseJsonlCursor
+  /** Upper bound of complete lines this batch returns (>= 1). */
+  maxRows: number
+  /** Fixed read-window size in bytes (>= 1). */
+  chunkBytes: number
+  signal?: AbortSignal
+}
+
+/**
+ * Read one bounded batch of complete JSONL lines from the file's tail,
+ * newest first. See the module doc for the full contract.
+ * @param file - the JSONL history file path.
+ */
+export async function readJsonlReverseBatch(
+  file: string,
+  options: ReverseJsonlBatchOptions,
+): Promise<ReverseJsonlBatch> {
+  const maxRows = Number.isFinite(options.maxRows) ? Math.max(1, Math.floor(options.maxRows)) : 1
+  const chunkBytes = Number.isFinite(options.chunkBytes) ? Math.max(1, Math.floor(options.chunkBytes)) : 1
+  if (options.signal?.aborted) throw abortError()
+  const fileStat = await stat(file)
+  if (options.cursor !== undefined) {
+    const cursor = options.cursor
+    if (cursor.revision.size !== fileStat.size || cursor.revision.mtimeMs !== fileStat.mtimeMs) {
+      throw new ReverseJsonlRevisionError(
+        file,
+        cursor.revision,
+        { size: fileStat.size, mtimeMs: fileStat.mtimeMs },
+      )
+    }
+  }
+  const revision = { size: fileStat.size, mtimeMs: fileStat.mtimeMs }
+  // The scan boundary: the first batch snapshots the size and only ever
+  // moves backwards, so appends during the scan are naturally excluded.
+  let position = options.cursor !== undefined ? options.cursor.nextByteEnd : fileStat.size
+  // Bytes of the current (incomplete) line already materialized, in file
+  // order; `pendingStart` is its first byte's file offset. A cursor may
+  // carry pending bytes from a previous batch (they start at
+  // `cursor.nextByteEnd` and are never re-read).
+  let pending = options.cursor?.pending ?? Buffer.alloc(0)
+  let pendingStart = options.cursor?.nextByteEnd ?? 0
+  // Where the next batch's read window must end. Updated on every stop:
+  // - mid-line: the pending bytes' START (they ride in the cursor, so the
+  //   next window must not re-read them);
+  // - mid-chunk at a line boundary: just past the `\n` at the start of the
+  //   last emitted line;
+  // - chunk boundary: the window start.
+  let resumeByteEnd = position
+  // A chunk is "done" when every byte of it was consumed (either into
+  // emitted lines or into pending). EOF is only true when the file start
+  // was reached AND the last chunk was fully consumed AND nothing is
+  // pending — a maxRows stop mid-chunk must NOT report EOF.
+  let chunkDone = position === 0
+  const lines: ReverseJsonlLine[] = []
+  let bytesRead = 0
+  const handle = await open(file, 'r')
+  try {
+    while (position > 0 && lines.length < maxRows) {
+      if (options.signal?.aborted) throw abortError()
+      const windowEnd = position
+      const start = Math.max(0, position - chunkBytes)
+      const buf = Buffer.allocUnsafe(position - start)
+      const { bytesRead: n } = await handle.read(buf, 0, buf.length, start)
+      bytesRead += n
+      if (n === 0) {
+        // The file shrank between stat and read: stop at the new EOF.
+        position = 0
+        chunkDone = true
+        break
+      }
+      position = start
+      chunkDone = false
+      const actual = n === buf.length ? buf : buf.subarray(0, n)
+      const nl = actual.lastIndexOf(0x0A)
+      if (nl === -1) {
+        // The whole window is part of the current (incomplete) line.
+        pending = Buffer.concat([actual, pending])
+        pendingStart = start
+        resumeByteEnd = position
+        chunkDone = true
+        continue
+      }
+      const tail = actual.subarray(nl + 1)
+      if (tail.length > 0 || pending.length > 0) {
+        // The line whose head is in this window and whose tail was pending
+        // from later windows (or a plain tail line at a chunk boundary).
+        lines.push({
+          text: Buffer.concat([tail, pending]).toString('utf8'),
+          byteStart: start + nl + 1,
+          byteEnd: windowEnd + pending.length,
+        })
+        pending = Buffer.alloc(0)
+        resumeByteEnd = start + nl + 1
+        if (lines.length >= maxRows) break
+      }
+      let scan = nl
+      while (lines.length < maxRows) {
+        if (scan === 0) {
+          // The `\n` at index 0 terminates the line whose head lives in the
+          // previous window (already held as pending) — nothing before it
+          // remains in this window. NOTE: `lastIndexOf(0x0A, -1)` would
+          // wrap to the buffer END (negative starts count from the tail),
+          // re-scanning the window forever — the explicit guard is the fix.
+          pending = Buffer.alloc(0)
+          pendingStart = start
+          resumeByteEnd = position
+          chunkDone = true
+          break
+        }
+        const prev = actual.lastIndexOf(0x0A, scan - 1)
+        if (prev === -1) {
+          // The bytes before `scan` start a line that continues into the
+          // previous window: hold them as pending (they ride in the cursor
+          // if the batch stops here).
+          pending = Buffer.from(actual.subarray(0, scan))
+          pendingStart = start
+          resumeByteEnd = position
+          chunkDone = true
+          break
+        }
+        lines.push({
+          text: actual.toString('utf8', prev + 1, scan),
+          byteStart: start + prev + 1,
+          byteEnd: start + scan,
+        })
+        // Resume just past the `\n` at the START of the emitted line
+        // (`prev`), so the next window re-finds it as the last `\n` and
+        // continues backwards — never re-emitting this line.
+        resumeByteEnd = start + prev + 1
+        scan = prev
+      }
+    }
+    if (position === 0 && pending.length > 0 && lines.length < maxRows) {
+      // The first line of the file (no leading `\n`).
+      lines.push({
+        text: pending.toString('utf8'),
+        byteStart: pendingStart,
+        byteEnd: pendingStart + pending.length,
+      })
+      pending = Buffer.alloc(0)
+    }
+  } finally {
+    await handle.close()
+  }
+  const eof = position === 0 && pending.length === 0 && chunkDone
+  return {
+    lines,
+    nextCursor: eof ? undefined : { nextByteEnd: resumeByteEnd, pending, revision },
+    eof,
+    bytesRead,
+  }
+}
+
+/** An `AbortError`-named error (the search source treats it as cancellation). */
+function abortError(): Error {
+  const error = new Error('aborted')
+  error.name = 'AbortError'
+  return error
+}

--- a/src/history-reverse-reader.ts
+++ b/src/history-reverse-reader.ts
@@ -90,6 +90,13 @@ export interface ReverseJsonlBatchOptions {
   /** Fixed read-window size in bytes (>= 1). */
   chunkBytes: number
   signal?: AbortSignal
+  /** Verify the cursor's revision against the live file before resuming
+   * (default true). True only when the cursor crosses a SEARCH boundary
+   * (a continuation from an earlier call): intra-search batches share the
+   * first batch's snapshot and must tolerate a concurrent append — the
+   * scan only ever moves backwards from the snapshot size, so the appended
+   * bytes are naturally excluded without a revision check. */
+  verifyRevision?: boolean
 }
 
 /**
@@ -105,7 +112,7 @@ export async function readJsonlReverseBatch(
   const chunkBytes = Number.isFinite(options.chunkBytes) ? Math.max(1, Math.floor(options.chunkBytes)) : 1
   if (options.signal?.aborted) throw abortError()
   const fileStat = await stat(file)
-  if (options.cursor !== undefined) {
+  if (options.cursor !== undefined && options.verifyRevision !== false) {
     const cursor = options.cursor
     if (cursor.revision.size !== fileStat.size || cursor.revision.mtimeMs !== fileStat.mtimeMs) {
       throw new ReverseJsonlRevisionError(
@@ -140,23 +147,36 @@ export async function readJsonlReverseBatch(
   const lines: ReverseJsonlLine[] = []
   let bytesRead = 0
   const handle = await open(file, 'r')
+  // One-byte probe for the empty-tail-line check (the byte at the window
+  // boundary decides whether a chunk-cut empty line is real).
+  const probe = Buffer.allocUnsafe(1)
   try {
     while (position > 0 && lines.length < maxRows) {
       if (options.signal?.aborted) throw abortError()
       const windowEnd = position
       const start = Math.max(0, position - chunkBytes)
       const buf = Buffer.allocUnsafe(position - start)
-      const { bytesRead: n } = await handle.read(buf, 0, buf.length, start)
-      bytesRead += n
-      if (n === 0) {
-        // The file shrank between stat and read: stop at the new EOF.
+      // A single FileHandle.read may return fewer bytes than requested
+      // (e.g. the file shrank between stat and read): loop until the
+      // window is filled or a real EOF is reached, so no byte of the
+      // window is ever skipped.
+      let filled = 0
+      while (filled < buf.length) {
+        if (options.signal?.aborted) throw abortError()
+        const { bytesRead: n } = await handle.read(buf, filled, buf.length - filled, start + filled)
+        bytesRead += n
+        if (n === 0) break
+        filled += n
+      }
+      if (filled === 0) {
+        // The file shrank below the window start: stop at the new EOF.
         position = 0
         chunkDone = true
         break
       }
       position = start
       chunkDone = false
-      const actual = n === buf.length ? buf : buf.subarray(0, n)
+      const actual = filled === buf.length ? buf : buf.subarray(0, filled)
       const nl = actual.lastIndexOf(0x0A)
       if (nl === -1) {
         // The whole window is part of the current (incomplete) line.
@@ -167,7 +187,17 @@ export async function readJsonlReverseBatch(
         continue
       }
       const tail = actual.subarray(nl + 1)
-      if (tail.length > 0 || pending.length > 0) {
+      // The tail line = the line between this window's last `\n` and the
+      // pending's end (the next window's first `\n`). It is emitted when
+      // it has content OR when it is a REAL empty line: the window is not
+      // the file's last (windowEnd < size) and the byte at windowEnd is
+      // `\n` — the empty line between two newlines that a chunk boundary
+      // cut apart. The file's own trailing empty line (the first window,
+      // windowEnd === size) is never a line, and a non-newline byte at
+      // windowEnd means the line continues into the next window (already
+      // emitted there or held as pending) — never a spurious empty line.
+      if (tail.length > 0 || pending.length > 0
+        || (windowEnd < fileStat.size && await isNewlineAt(handle, windowEnd, probe))) {
         // The line whose head is in this window and whose tail was pending
         // from later windows (or a plain tail line at a chunk boundary).
         lines.push({
@@ -182,11 +212,18 @@ export async function readJsonlReverseBatch(
       let scan = nl
       while (lines.length < maxRows) {
         if (scan === 0) {
-          // The `\n` at index 0 terminates the line whose head lives in the
-          // previous window (already held as pending) — nothing before it
-          // remains in this window. NOTE: `lastIndexOf(0x0A, -1)` would
-          // wrap to the buffer END (negative starts count from the tail),
-          // re-scanning the window forever — the explicit guard is the fix.
+          // The `\n` at index 0 terminates the line whose head lives in
+          // the previous window (already held as pending and emitted as
+          // the tail line). When the file itself starts with `\n` (start
+          // === 0), the first line is empty — emit it. Otherwise the line
+          // completes in the next window (its tail is empty here), so
+          // nothing is emitted and the empty tail is carried as pending.
+          // NOTE: `lastIndexOf(0x0A, -1)` would wrap to the buffer END
+          // (negative starts count from the tail), re-scanning the window
+          // forever — the explicit guard is the fix.
+          if (start === 0) {
+            lines.push({ text: '', byteStart: 0, byteEnd: 0 })
+          }
           pending = Buffer.alloc(0)
           pendingStart = start
           resumeByteEnd = position
@@ -242,4 +279,15 @@ function abortError(): Error {
   const error = new Error('aborted')
   error.name = 'AbortError'
   return error
+}
+
+/** Whether the byte at `position` is a newline (a vanished byte — the file
+ * shrank — is not). */
+async function isNewlineAt(
+  handle: import('node:fs/promises').FileHandle,
+  position: number,
+  probe: Buffer,
+): Promise<boolean> {
+  const { bytesRead } = await handle.read(probe, 0, 1, position)
+  return bytesRead === 1 && probe[0] === 0x0A
 }

--- a/src/history-reverse-reader.ts
+++ b/src/history-reverse-reader.ts
@@ -14,8 +14,11 @@
  *   (`nextByteEnd`) so the next batch continues without re-reading the
  *   already-covered suffix and without gaps or duplicates.
  * - The cursor is bound to the file revision (size + mtimeMs): a file that
- *   changed while a cursor was held throws {@link ReverseJsonlRevisionError}
- *   instead of blindly reusing a stale byte position.
+ *   SHRANK or was rewritten (same size, new mtime) while a cursor was held
+ *   throws {@link ReverseJsonlRevisionError} instead of blindly reusing a
+ *   stale byte position. Append-only GROWTH is tolerated — the old snapshot
+ *   range is untouched, so the scan continues by the old boundary and the
+ *   appended bytes belong to the next fresh search.
  * - The first batch snapshots the file size and never reads past it, so a
  *   concurrent append during the scan is naturally excluded.
  * - Abort: the signal is checked before the stat and before every chunk
@@ -63,8 +66,9 @@ export interface ReverseJsonlBatch {
   bytesRead: number
 }
 
-/** Thrown when a cursor is reused against a file whose revision (size or
- * mtime) changed — the byte position can no longer be trusted. */
+/** Thrown when a cursor is reused against a file that SHRANK or was
+ * rewritten (same size, new mtime) — the byte position can no longer be
+ * trusted. Append-only growth does NOT throw. */
 export class ReverseJsonlRevisionError extends Error {
   constructor(
     file: string,
@@ -114,7 +118,15 @@ export async function readJsonlReverseBatch(
   const fileStat = await stat(file)
   if (options.cursor !== undefined && options.verifyRevision !== false) {
     const cursor = options.cursor
-    if (cursor.revision.size !== fileStat.size || cursor.revision.mtimeMs !== fileStat.mtimeMs) {
+    // The history store is append-only: growth between pages leaves the
+    // old snapshot range untouched, so the cursor stays valid and the scan
+    // continues by the OLD boundary (the appended bytes belong to the next
+    // fresh search). Only a SHRINK (the byte positions are gone) or a
+    // same-size rewrite (the bytes shifted) invalidates the cursor.
+    const shrank = fileStat.size < cursor.revision.size
+    const sameSizeButTouched = fileStat.size === cursor.revision.size
+      && fileStat.mtimeMs !== cursor.revision.mtimeMs
+    if (shrank || sameSizeButTouched) {
       throw new ReverseJsonlRevisionError(
         file,
         cursor.revision,

--- a/src/history-search.ts
+++ b/src/history-search.ts
@@ -284,6 +284,23 @@ export class FileHistorySearchSource implements HistorySearchSource {
     let fileProof: string | null = continuation !== undefined
       ? continuation.fileProof
       : scope === 'all' ? this.knownCwdFor(files[0]?.path ?? '') : null
+    if (continuation !== undefined && scope === 'all' && fileProof === null && pending.length > 0) {
+      // The knownCwds resolver is read on EVERY search (never a startup
+      // snapshot): a cwd learned between pages must recover the pending
+      // rows immediately, before the scan resumes.
+      const first = files[0]
+      if (first !== undefined) {
+        const known = this.knownCwdFor(first.path)
+        if (known !== null) {
+          fileProof = known
+          for (const held of pending) {
+            if (!matchesQuery(held.record.content, request.query)) continue
+            this.mergeResult(map, newKeys, this.buildResult(first.path, held.record, fileProof, held.byteStart), scope)
+          }
+          pending = []
+        }
+      }
+    }
     outer:
     while (fileIndex < files.length) {
       if (request.signal?.aborted) return emptyPage()

--- a/src/history-search.ts
+++ b/src/history-search.ts
@@ -272,9 +272,17 @@ export class FileHistorySearchSource implements HistorySearchSource {
     const map = continuation !== undefined
       ? new Map(continuation.seen)
       : new Map<string, HistorySearchResult>()
-    const newKeys: string[] = []
+    // Keys added OR replaced by this call (a Set: a key replaced several
+    // times within one call is reported once, with its current value).
+    const newKeys = new Set<string>()
     const carriedOverflow = continuation?.overflow ?? []
     let cursor: ReverseJsonlCursor | undefined = continuation?.cursor
+    // The revision check applies only when the cursor crosses a SEARCH
+    // boundary (a continuation from an earlier call). Intra-search batches
+    // share the first batch's snapshot: a concurrent append between them
+    // must not abort the scan (the plan's snapshot contract — the scan
+    // only moves backwards from the snapshot size).
+    let verifyRevision = continuation !== undefined
     let scanned = 0
     let fileIndex = 0
     // Per-file cwd state, restored from the continuation for the partially
@@ -284,20 +292,25 @@ export class FileHistorySearchSource implements HistorySearchSource {
     let fileProof: string | null = continuation !== undefined
       ? continuation.fileProof
       : scope === 'all' ? this.knownCwdFor(files[0]?.path ?? '') : null
-    if (continuation !== undefined && scope === 'all' && fileProof === null && pending.length > 0) {
+    if (continuation !== undefined && scope === 'all' && fileProof === null) {
       // The knownCwds resolver is read on EVERY search (never a startup
-      // snapshot): a cwd learned between pages must recover the pending
-      // rows immediately, before the scan resumes.
+      // snapshot): a cwd learned between pages must apply to the first
+      // continuation file immediately — whether it holds pending rows from
+      // an earlier page (flush them with the fresh proof) or is a fresh
+      // file the previous page finished at the budget boundary (its rows
+      // need the proof from the very first line).
       const first = files[0]
       if (first !== undefined) {
         const known = this.knownCwdFor(first.path)
         if (known !== null) {
           fileProof = known
-          for (const held of pending) {
-            if (!matchesQuery(held.record.content, request.query)) continue
-            this.mergeResult(map, newKeys, this.buildResult(first.path, held.record, fileProof, held.byteStart), scope)
+          if (pending.length > 0) {
+            for (const held of pending) {
+              if (!matchesQuery(held.record.content, request.query)) continue
+              this.mergeResult(map, newKeys, this.buildResult(first.path, held.record, fileProof, held.byteStart), scope)
+            }
+            pending = []
           }
-          pending = []
         }
       }
     }
@@ -307,7 +320,7 @@ export class FileHistorySearchSource implements HistorySearchSource {
       // Empty-query early exit: this call already has enough reportable
       // results (carried overflow + new keys — per call, so a continuation
       // page never stalls on the already-full dedupe state).
-      if (request.query === '' && carriedOverflow.length + newKeys.length >= request.limit) break
+      if (request.query === '' && carriedOverflow.length + newKeys.size >= request.limit) break
       const file = files[fileIndex]!
       if (fileIndex > 0) {
         // A fresh file: reset the per-file cwd state.
@@ -329,7 +342,9 @@ export class FileHistorySearchSource implements HistorySearchSource {
             maxRows: Math.min(128, remaining),
             chunkBytes: this.readChunkBytes,
             signal: request.signal,
+            verifyRevision,
           })
+          verifyRevision = false
           if (stats !== undefined) {
             stats.bytesRead += batch.bytesRead
             stats.physicalLinesScanned += batch.lines.length
@@ -350,7 +365,7 @@ export class FileHistorySearchSource implements HistorySearchSource {
             break
           }
           cursor = batch.nextCursor
-          if (request.query === '' && carriedOverflow.length + newKeys.length >= request.limit) break outer
+          if (request.query === '' && carriedOverflow.length + newKeys.size >= request.limit) break outer
         }
       } catch (error) {
         if (isAbortError(error)) return emptyPage()
@@ -377,10 +392,22 @@ export class FileHistorySearchSource implements HistorySearchSource {
     // The page reports the carried overflow plus this call's new matches,
     // sorted and sliced to the limit; the tail becomes the next page's
     // overflow (drained by ts, so "Search older" never skips a match).
-    const combined = [...carriedOverflow, ...newKeys.map(key => map.get(key)!)]
+    // The combined set is deduped by key (newest wins): a key replaced by
+    // a newer occurrence found on this page is reported with the NEW
+    // value, and a superseded occurrence carried in the overflow is
+    // dropped — the merged pages, re-deduped, equal the full-scan result.
+    const combined = [...carriedOverflow, ...[...newKeys].map(key => map.get(key)!)]
       .sort(compareResults)
-    const results = combined.slice(0, request.limit)
-    const overflow = combined.slice(request.limit)
+    const deduped: HistorySearchResult[] = []
+    const combinedKeys = new Set<string>()
+    for (const row of combined) {
+      const key = scope === 'current' ? row.content : `${row.cwd ?? ''}\0${row.content}`
+      if (combinedKeys.has(key)) continue
+      combinedKeys.add(key)
+      deduped.push(row)
+    }
+    const results = deduped.slice(0, request.limit)
+    const overflow = deduped.slice(request.limit)
     const exhausted = fileIndex >= files.length && overflow.length === 0
     return {
       results,
@@ -459,7 +486,7 @@ export class FileHistorySearchSource implements HistorySearchSource {
     fileProof: string | null,
     pending: HistorySearchPendingRow[],
     map: Map<string, HistorySearchResult>,
-    newKeys: string[],
+    newKeys: Set<string>,
   ): string | null {
     if (record.version === 2 && record.cwd !== null && historyFilePath(this.dshHome, record.cwd) === file) {
       if (request.scope === 'all' && fileProof === null) {
@@ -505,12 +532,12 @@ export class FileHistorySearchSource implements HistorySearchSource {
 
   /** Incremental dedupe: keep the NEWEST occurrence per key (compareResults
    * is the beats predicate — the same winner the final sort would pick).
-   * A key is reported as new only the first time it enters the map, so a
-   * continuation page never re-reports rows a previous page already
-   * returned. */
+   * A key is reported when it first enters the map AND when a later page
+   * finds a newer occurrence (the replacement is re-reported with its new
+   * value, so the merged pages, re-deduped, equal the full-scan result). */
   private mergeResult(
     map: Map<string, HistorySearchResult>,
-    newKeys: string[],
+    newKeys: Set<string>,
     result: HistorySearchResult,
     scope: HistoryScope,
   ): void {
@@ -518,9 +545,10 @@ export class FileHistorySearchSource implements HistorySearchSource {
     const existing = map.get(key)
     if (existing === undefined) {
       map.set(key, result)
-      newKeys.push(key)
+      newKeys.add(key)
     } else if (compareResults(result, existing) < 0) {
       map.set(key, result)
+      newKeys.add(key)
     }
   }
 

--- a/src/history-search.ts
+++ b/src/history-search.ts
@@ -137,13 +137,29 @@ export interface HistorySearchContinuation {
   readonly query: string
   readonly limit: number
   /** The files not yet fully scanned, in scan order (the first one is the
-   * partially-scanned current file). */
+   * partially-scanned current file; fully-scanned files are never kept). */
   readonly files: readonly HistoryFileCandidate[]
   /** The reverse-reader cursor for the first file, when it was partially
    * scanned (undefined when the next file starts fresh). */
   readonly cursor: ReverseJsonlCursor | undefined
   /** The dedupe state accumulated so far (key → newest occurrence). */
   readonly seen: ReadonlyMap<string, HistorySearchResult>
+  /** The current file's cwd proof (Rule 1/2), carried so a proof formed in
+   * an earlier page still applies to older rows of the same file. */
+  readonly fileProof: string | null
+  /** The current file's rows held pending (all scope, unresolved cwd),
+   * carried so a proof found on a LATER page still recovers them. */
+  readonly pending: readonly HistorySearchPendingRow[]
+  /** Matches found in the covered window beyond the page's result limit —
+   * the next page reports them before scanning further, so no match is
+   * ever lost across pages. */
+  readonly overflow: readonly HistorySearchResult[]
+}
+
+/** One all-scope row held pending while its file's cwd proof is unknown. */
+export interface HistorySearchPendingRow {
+  record: ParsedHistoryRecord
+  byteStart: number
 }
 
 /** The search seam the panel consumes. */
@@ -250,28 +266,42 @@ export class FileHistorySearchSource implements HistorySearchSource {
     }
     // The dedupe state: restored from the continuation (so pages never
     // duplicate rows) or fresh. `newKeys` tracks the keys added by THIS
-    // call — the page reports only those (their current map values).
+    // call; `carriedOverflow` are the matches a previous page sliced away
+    // — this page reports them before its own new matches, so no match is
+    // ever lost across pages.
     const map = continuation !== undefined
       ? new Map(continuation.seen)
       : new Map<string, HistorySearchResult>()
     const newKeys: string[] = []
+    const carriedOverflow = continuation?.overflow ?? []
     let cursor: ReverseJsonlCursor | undefined = continuation?.cursor
     let scanned = 0
     let fileIndex = 0
+    // Per-file cwd state, restored from the continuation for the partially
+    // scanned file: the proof may have formed in an earlier page, and rows
+    // held pending must survive until the proof forms or the file ends.
+    let pending: HistorySearchPendingRow[] = continuation !== undefined ? [...continuation.pending] : []
+    let fileProof: string | null = continuation !== undefined
+      ? continuation.fileProof
+      : scope === 'all' ? this.knownCwdFor(files[0]?.path ?? '') : null
     outer:
-    for (; fileIndex < files.length; fileIndex += 1) {
+    while (fileIndex < files.length) {
       if (request.signal?.aborted) return emptyPage()
-      // Empty-query early exit: this call already collected enough NEW
-      // unique results (per call, so a continuation page never stalls on
-      // the already-full dedupe state).
-      if (request.query === '' && newKeys.length >= request.limit) break
+      // Empty-query early exit: this call already has enough reportable
+      // results (carried overflow + new keys — per call, so a continuation
+      // page never stalls on the already-full dedupe state).
+      if (request.query === '' && carriedOverflow.length + newKeys.length >= request.limit) break
       const file = files[fileIndex]!
+      if (fileIndex > 0) {
+        // A fresh file: reset the per-file cwd state.
+        pending = []
+        fileProof = scope === 'all' ? this.knownCwdFor(file.path) : null
+      }
       if (stats !== undefined) stats.filesVisited += 1
       // All-scope rows whose cwd is not yet provable are held pending:
       // the proof may form later in the window (Rule 1), and only rows
       // still unresolved at the file's end are excluded (Rule 3).
-      const pending: Array<{ record: ParsedHistoryRecord; byteStart: number }> = []
-      let fileProof: string | null = scope === 'all' ? this.knownCwdFor(file.path) : null
+      let fileDone = false
       try {
         for (;;) {
           if (request.signal?.aborted) return emptyPage()
@@ -299,10 +329,11 @@ export class FileHistorySearchSource implements HistorySearchSource {
           }
           if (batch.eof) {
             cursor = undefined
+            fileDone = true
             break
           }
           cursor = batch.nextCursor
-          if (request.query === '' && newKeys.length >= request.limit) break outer
+          if (request.query === '' && carriedOverflow.length + newKeys.length >= request.limit) break outer
         }
       } catch (error) {
         if (isAbortError(error)) return emptyPage()
@@ -311,16 +342,31 @@ export class FileHistorySearchSource implements HistorySearchSource {
         // continuation cursor) skips the rest of this file; rows already
         // collected stay.
         cursor = undefined
+        fileDone = true
+      }
+      if (fileDone) {
+        // The file is fully scanned (or skipped): the continuation must
+        // not include it — a fresh scan would re-read it from EOF.
+        fileIndex += 1
+        pending = []
+        fileProof = null
+        if (scanned >= this.scanLimit) break
+        continue
       }
       if (scanned >= this.scanLimit) break
+      fileIndex += 1
     }
     if (request.signal?.aborted) return emptyPage()
-    const exhausted = fileIndex >= files.length
+    // The page reports the carried overflow plus this call's new matches,
+    // sorted and sliced to the limit; the tail becomes the next page's
+    // overflow (drained by ts, so "Search older" never skips a match).
+    const combined = [...carriedOverflow, ...newKeys.map(key => map.get(key)!)]
+      .sort(compareResults)
+    const results = combined.slice(0, request.limit)
+    const overflow = combined.slice(request.limit)
+    const exhausted = fileIndex >= files.length && overflow.length === 0
     return {
-      results: newKeys
-        .map(key => map.get(key)!)
-        .sort(compareResults)
-        .slice(0, request.limit),
+      results,
       continuation: exhausted ? undefined : {
         scope: request.scope,
         cwd: request.cwd,
@@ -329,6 +375,9 @@ export class FileHistorySearchSource implements HistorySearchSource {
         files: files.slice(fileIndex),
         cursor,
         seen: map,
+        fileProof,
+        pending,
+        overflow,
       },
       exhausted,
     }
@@ -391,7 +440,7 @@ export class FileHistorySearchSource implements HistorySearchSource {
     record: ParsedHistoryRecord,
     byteStart: number,
     fileProof: string | null,
-    pending: Array<{ record: ParsedHistoryRecord; byteStart: number }>,
+    pending: HistorySearchPendingRow[],
     map: Map<string, HistorySearchResult>,
     newKeys: string[],
   ): string | null {

--- a/src/history-search.ts
+++ b/src/history-search.ts
@@ -61,7 +61,7 @@
 import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { historyFilePath, parseHistoryRecordLine, type ParsedHistoryRecord } from './history.ts'
-import { readJsonlReverseBatch, type ReverseJsonlCursor } from './history-reverse-reader.ts'
+import { readJsonlReverseBatch, ReverseJsonlRevisionError, type ReverseJsonlCursor } from './history-reverse-reader.ts'
 
 /** The two scope categories (`/sessions` vocabulary). */
 export type HistoryScope = 'current' | 'all'
@@ -195,6 +195,18 @@ export class HistorySearchContinuationError extends Error {
   constructor() {
     super('history search continuation does not match the request (scope/cwd/query/limit)')
     this.name = 'HistorySearchContinuationError'
+  }
+}
+
+/** Thrown when a file SHRANK or was rewritten under a continuation cursor —
+ * the byte positions can no longer be trusted. This is NOT a per-file skip:
+ * silently reporting exhausted would drop the remaining rows. The caller
+ * must start a fresh search. (Append-only growth is tolerated and never
+ * throws — the continuation continues by its old snapshot boundary.) */
+export class HistorySearchContinuationStaleError extends Error {
+  constructor() {
+    super('history search continuation is stale (a file changed under its cursor); start a fresh search')
+    this.name = 'HistorySearchContinuationStaleError'
   }
 }
 
@@ -369,10 +381,15 @@ export class FileHistorySearchSource implements HistorySearchSource {
         }
       } catch (error) {
         if (isAbortError(error)) return emptyPage()
-        // A per-file failure (vanished file, read error, or a
-        // ReverseJsonlRevisionError when the file changed under a
-        // continuation cursor) skips the rest of this file; rows already
-        // collected stay.
+        if (error instanceof ReverseJsonlRevisionError) {
+          // A file shrank or was rewritten under a continuation cursor:
+          // the byte positions are gone. This is NOT a per-file skip —
+          // treating it as fileDone would silently report exhausted and
+          // drop the remaining rows. The caller must start a fresh search.
+          throw new HistorySearchContinuationStaleError()
+        }
+        // Any other per-file failure (vanished file, read error) skips the
+        // rest of this file; rows already collected stay.
         cursor = undefined
         fileDone = true
       }

--- a/src/history-search.ts
+++ b/src/history-search.ts
@@ -7,7 +7,8 @@
  *   file is keyed by that cwd, so the effective cwd is known — plan §6.1).
  * - `'all'` — every `*.jsonl` under `$DSH_HOME/user-history/` (`.tmp`/`.lock`
  *   and non-JSONL names ignored; corrupt or vanished files degrade to empty —
- *   plan §11.2/§40). cwd is resolved per file:
+ *   plan §11.2/§40). Files are scanned in mtime-DESC order (the most recently
+ *   active workspace first — plan §7/§8); cwd is resolved per file:
  *   1. a v2 row whose cwd VALIDATES against the file (`historyFilePath(home,
  *      cwd) === file`) proves the hash, and its cwd inherits to the file's v1
  *      rows (Rule 1);
@@ -16,29 +17,51 @@
  *   3. rows whose cwd stays unknown are EXCLUDED (Rule 3) — never a
  *      fabricated cwd, and the detail pane would otherwise lie.
  *
+ * Bounded recent-first scanning (the perf contract):
+ * - Every call scans at most `scanLimit` PHYSICAL lines across all files
+ *   (a GLOBAL budget, never per-file), reading each file from EOF backwards
+ *   through the reverse JSONL reader (history-reverse-reader.ts) — the
+ *   canonical file is never read whole.
+ * - The result is a {@link HistorySearchPage}: the matches NEW to this call's
+ *   window, plus a {@link HistorySearchContinuation} when older history
+ *   remains. A continuation resumes exactly where the call stopped (no
+ *   re-scan of the covered suffix) and carries the dedupe state, so pages
+ *   never duplicate rows. Reaching `scanLimit` does NOT mean exhausted.
+ *   The panel currently renders only `page.results`; "Search older" is a
+ *   later UI phase on this contract.
+ * - Legacy cwd coverage may degrade with the window: the file proof comes
+ *   from `knownCwds` (upfront) or a validating v2 row observed INSIDE the
+ *   scanned window. Rows whose proof lies outside the window are omitted
+ *   from `All directories` — an intentional coverage trade-off; v2 cwd hash
+ *   validation itself stays strict and unchanged.
+ *
  * Matching: case-insensitive literal substring over content; `''` matches
- * everything (an empty-query Ctrl+R is a recent-history browser).
+ * everything (an empty-query Ctrl+R is a recent-history browser, and may
+ * stop early once this call has collected `limit` new unique results).
  *
  * Ordering: newest-first by ts; legacy (v1) rows have NO timestamp (never
  * fabricated) and sort AFTER every timed row, then by file asc + newest row
  * first within the file (deterministic — plan §7/§12).
  *
  * Dedupe: current → by `content`; all → by `${cwd}\0${content}` (a prompt
- * in two directories stays two rows — plan §13). The NEWEST occurrence wins.
+ * in two directories stays two rows — plan §13). The NEWEST occurrence wins
+ * (compareResults is the beats predicate, applied incrementally).
  *
- * Cancellation: the search observes the AbortSignal between files; the panel
+ * Cancellation: the search observes the AbortSignal between files, per
+ * batch and inside the reader; an abort returns an empty page. The panel
  * ALSO guards by generation, so a stale response can never overwrite a
  * fresher query (plan §14).
  *
  * Future-proof: the panel consumes ONLY {@link HistorySearchSource} — a
- * SQLite/FTS backend may replace the file implementation without touching the
- * UI (plan §54).
+ * SQLite/FTS backend may replace the file implementation without touching
+ * the UI (plan §54).
  * @module @xmoon76/dsh-pi-tui/history-search
  */
 
-import { readdir, readFile } from 'node:fs/promises'
+import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
-import { historyFilePath, parseHistoryRecords, type ParsedHistoryRecord } from './history.ts'
+import { historyFilePath, parseHistoryRecordLine, type ParsedHistoryRecord } from './history.ts'
+import { readJsonlReverseBatch, type ReverseJsonlCursor } from './history-reverse-reader.ts'
 
 /** The two scope categories (`/sessions` vocabulary). */
 export type HistoryScope = 'current' | 'all'
@@ -47,7 +70,16 @@ export type HistoryScope = 'current' | 'all'
 export const HISTORY_SEARCH_DEBOUNCE_MS = 75
 
 /** Row cap handed to the source (plan §52: 100–200 results, never 5000). */
-export const HISTORY_SEARCH_LIMIT = 200
+export const HISTORY_SEARCH_RESULT_LIMIT = 200
+
+/** Global per-call scan budget in physical JSONL lines (plan §4.2: 5000).
+ * A call stops scanning once this many lines were materialized across ALL
+ * files — the default window, not a permanent search boundary (a
+ * continuation can keep going). */
+export const HISTORY_SEARCH_SCAN_LIMIT = 5000
+
+/** Reverse-reader chunk size in bytes (plan §5: 64KiB). */
+export const HISTORY_SEARCH_READ_CHUNK_BYTES = 64 * 1024
 
 /** One search invocation. */
 export interface HistorySearchRequest {
@@ -63,7 +95,9 @@ export interface HistorySearchRequest {
 
 /** One matched row the panel renders. */
 export interface HistorySearchResult {
-  /** Stable identity (`${sourceFile}:${sourceIndex}`). */
+  /** Stable identity (`${sourceFile}:${sourceByteOffset}` — the byte
+   * offset of the row's first content byte, stable for append-only files
+   * without any forward scan). */
   id: string
   content: string
   /** NULL only for rows excluded in the `all` scope — the panel never
@@ -73,14 +107,79 @@ export interface HistorySearchResult {
   ts: number | null
   sessionId?: string
   sourceFile: string
-  /** Row position within the parsed file (corrupt lines simply do not
-   * appear, so positions are stable for a given file content). */
-  sourceIndex: number
+  /** The row's first content byte in the file (the reverse reader's
+   * identity — no forward scan is ever needed for it). */
+  sourceByteOffset: number
+}
+
+/** One bounded search page: the matches NEW to this call's window, plus the
+ * resume state when older history remains. */
+export interface HistorySearchPage {
+  /** The matches found in this call's window that were not already in the
+   * dedupe state, sorted by {@link compareResults} and sliced to the
+   * request limit. */
+  results: HistorySearchResult[]
+  /** Present iff `exhausted` is false: pass it back to `search()` to
+   * continue into older history without re-scanning the covered suffix. */
+  continuation?: HistorySearchContinuation
+  /** True when every candidate file was scanned to EOF — no older history
+   * remains. Reaching the scan budget is NOT exhausted. */
+  exhausted: boolean
+}
+
+/** The opaque resume state of a bounded search. Owned by the source: the
+ * caller stores it and hands it back verbatim. */
+export interface HistorySearchContinuation {
+  /** The request context this continuation belongs to (a mismatched
+   * continuation is a typed error, never silently reused). */
+  readonly scope: HistoryScope
+  readonly cwd: string
+  readonly query: string
+  readonly limit: number
+  /** The files not yet fully scanned, in scan order (the first one is the
+   * partially-scanned current file). */
+  readonly files: readonly HistoryFileCandidate[]
+  /** The reverse-reader cursor for the first file, when it was partially
+   * scanned (undefined when the next file starts fresh). */
+  readonly cursor: ReverseJsonlCursor | undefined
+  /** The dedupe state accumulated so far (key → newest occurrence). */
+  readonly seen: ReadonlyMap<string, HistorySearchResult>
 }
 
 /** The search seam the panel consumes. */
 export interface HistorySearchSource {
-  search(request: HistorySearchRequest): Promise<HistorySearchResult[]>
+  search(
+    request: HistorySearchRequest,
+    continuation?: HistorySearchContinuation,
+  ): Promise<HistorySearchPage>
+}
+
+/** One candidate history file with its stat metadata (mtime drives the
+ * scan order; the final result order never uses it). */
+export interface HistoryFileCandidate {
+  path: string
+  mtimeMs: number
+  size: number
+}
+
+/** Per-call work accounting (test-only instrumentation — proves the scan
+ * is bounded without wall-clock benchmarks). */
+export interface HistorySearchDebugStats {
+  /** Files whose content scan was entered. */
+  filesVisited: number
+  /** Physical JSONL lines materialized (blank/corrupt/valid alike). */
+  physicalLinesScanned: number
+  /** Bytes actually read from disk. */
+  bytesRead: number
+}
+
+/** Thrown when a continuation is reused with a different request context —
+ * the dedupe state and scan position would silently produce wrong results. */
+export class HistorySearchContinuationError extends Error {
+  constructor() {
+    super('history search continuation does not match the request (scope/cwd/query/limit)')
+    this.name = 'HistorySearchContinuationError'
+  }
 }
 
 /** Constructor options for the file-backed source. */
@@ -94,8 +193,19 @@ export interface FileHistorySearchSourceOptions {
    * immediately recoverable, never a startup snapshot.
    */
   knownCwds?: ReadonlyMap<string, string> | (() => ReadonlyMap<string, string>)
-  /** Concurrent file reads in the `all` scope (plan §16; default 8). */
+  /** Bounded concurrency for the all-scope STAT phase (plan §12: 8/16;
+   * default 8). The content scan itself is SERIAL — recent-first with one
+   * global budget, so concurrency can never overscan it. */
   concurrency?: number
+  /** Global per-call scan budget in physical lines (default
+   * {@link HISTORY_SEARCH_SCAN_LIMIT}). */
+  scanLimit?: number
+  /** Reverse-reader chunk size in bytes (default
+   * {@link HISTORY_SEARCH_READ_CHUNK_BYTES}). */
+  readChunkBytes?: number
+  /** Optional mutable stats sink, reset and filled on every search call
+   * (test-only instrumentation). */
+  stats?: HistorySearchDebugStats
 }
 
 /**
@@ -106,93 +216,153 @@ export class FileHistorySearchSource implements HistorySearchSource {
   private readonly dshHome: string
   private readonly knownCwds: ReadonlyMap<string, string> | (() => ReadonlyMap<string, string>)
   private readonly concurrency: number
+  private readonly scanLimit: number
+  private readonly readChunkBytes: number
+  private readonly stats: HistorySearchDebugStats | undefined
 
   constructor(options: FileHistorySearchSourceOptions) {
     this.dshHome = options.dshHome
     this.knownCwds = options.knownCwds ?? new Map<string, string>()
     this.concurrency = Math.max(1, options.concurrency ?? 8)
+    this.scanLimit = Math.max(1, options.scanLimit ?? HISTORY_SEARCH_SCAN_LIMIT)
+    this.readChunkBytes = Math.max(1, options.readChunkBytes ?? HISTORY_SEARCH_READ_CHUNK_BYTES)
+    this.stats = options.stats
   }
 
-  async search(request: HistorySearchRequest): Promise<HistorySearchResult[]> {
+  async search(
+    request: HistorySearchRequest,
+    continuation?: HistorySearchContinuation,
+  ): Promise<HistorySearchPage> {
+    if (continuation !== undefined) this.validateContinuation(request, continuation)
     const scope = request.scope
-    const files = scope === 'current'
-      ? [historyFilePath(this.dshHome, request.cwd)]
-      : await this.listAllFiles()
-    const results: HistorySearchResult[] = []
-    // A REAL bounded worker pool over the file set: each worker awaits its
-    // own async read and the pool keeps at most `concurrency` reads in
-    // flight, so the event loop stays free between files (an all-scope
-    // scan never blocks typing/rendering; plan §16). The abort signal is
-    // checked by every worker between files. A per-file failure only drops
-    // that file's rows (plan §40).
-    const queue = [...files]
-    const workers = Array.from({ length: Math.min(this.concurrency, Math.max(1, queue.length)) }, async () => {
-      for (;;) {
-        if (request.signal?.aborted) return
-        const file = queue.shift()
-        if (file === undefined) return
-        const records = await this.readRows(file)
-        // The file-level cwd proof, computed ONCE per file (Rules 1+2).
-        const fileCwd = scope === 'all' ? this.resolveFileCwd(file, records) : null
-        for (let rowIndex = 0; rowIndex < records.length; rowIndex += 1) {
-          const row = records[rowIndex]!
-          const cwd = this.effectiveCwd(request, file, row, fileCwd)
-          if (cwd === null) continue
-          if (!matchesQuery(row.content, request.query)) continue
-          const result: HistorySearchResult = {
-            id: `${file}:${rowIndex}`,
-            content: row.content,
-            cwd,
-            ts: row.ts,
-            sourceFile: file,
-            sourceIndex: rowIndex,
+    const files = continuation !== undefined
+      ? [...continuation.files]
+      : scope === 'current'
+        // The current-scope file is known by path; its stat happens inside
+        // the reader (mtime/size are only used for all-scope ordering).
+        ? [{ path: historyFilePath(this.dshHome, request.cwd), mtimeMs: 0, size: 0 }]
+        : await this.listAllFiles()
+    const stats = this.stats
+    if (stats !== undefined) {
+      stats.filesVisited = 0
+      stats.physicalLinesScanned = 0
+      stats.bytesRead = 0
+    }
+    // The dedupe state: restored from the continuation (so pages never
+    // duplicate rows) or fresh. `newKeys` tracks the keys added by THIS
+    // call — the page reports only those (their current map values).
+    const map = continuation !== undefined
+      ? new Map(continuation.seen)
+      : new Map<string, HistorySearchResult>()
+    const newKeys: string[] = []
+    let cursor: ReverseJsonlCursor | undefined = continuation?.cursor
+    let scanned = 0
+    let fileIndex = 0
+    outer:
+    for (; fileIndex < files.length; fileIndex += 1) {
+      if (request.signal?.aborted) return emptyPage()
+      // Empty-query early exit: this call already collected enough NEW
+      // unique results (per call, so a continuation page never stalls on
+      // the already-full dedupe state).
+      if (request.query === '' && newKeys.length >= request.limit) break
+      const file = files[fileIndex]!
+      if (stats !== undefined) stats.filesVisited += 1
+      // All-scope rows whose cwd is not yet provable are held pending:
+      // the proof may form later in the window (Rule 1), and only rows
+      // still unresolved at the file's end are excluded (Rule 3).
+      const pending: Array<{ record: ParsedHistoryRecord; byteStart: number }> = []
+      let fileProof: string | null = scope === 'all' ? this.knownCwdFor(file.path) : null
+      try {
+        for (;;) {
+          if (request.signal?.aborted) return emptyPage()
+          const remaining = this.scanLimit - scanned
+          if (remaining <= 0) break
+          const batch = await readJsonlReverseBatch(file.path, {
+            cursor,
+            maxRows: Math.min(128, remaining),
+            chunkBytes: this.readChunkBytes,
+            signal: request.signal,
+          })
+          if (stats !== undefined) {
+            stats.bytesRead += batch.bytesRead
+            stats.physicalLinesScanned += batch.lines.length
           }
-          if (row.sessionId !== undefined) result.sessionId = row.sessionId
-          results.push(result)
+          for (const line of batch.lines) {
+            // A physical line consumes the budget BEFORE parsing — blank
+            // and corrupt lines can never cause unbounded scanning.
+            scanned += 1
+            const record = parseHistoryRecordLine(line.text)
+            if (record === null) continue
+            fileProof = this.consumeRecord(
+              request, file.path, record, line.byteStart, fileProof, pending, map, newKeys,
+            )
+          }
+          if (batch.eof) {
+            cursor = undefined
+            break
+          }
+          cursor = batch.nextCursor
+          if (request.query === '' && newKeys.length >= request.limit) break outer
         }
+      } catch (error) {
+        if (isAbortError(error)) return emptyPage()
+        // A per-file failure (vanished file, read error, or a
+        // ReverseJsonlRevisionError when the file changed under a
+        // continuation cursor) skips the rest of this file; rows already
+        // collected stay.
+        cursor = undefined
       }
-    })
-    await Promise.all(workers)
-    if (request.signal?.aborted) return []
-    return dedupeKeepNewest(results, scope).sort(compareResults).slice(0, request.limit)
-  }
-
-  /** Parse one file's live rows asynchronously; unreadable/corrupt files
-   * (including a vanished file) degrade to `[]`. */
-  private async readRows(file: string): Promise<ParsedHistoryRecord[]> {
-    try {
-      return parseHistoryRecords(await readFile(file, 'utf8'))
-    } catch {
-      return []
+      if (scanned >= this.scanLimit) break
+    }
+    if (request.signal?.aborted) return emptyPage()
+    const exhausted = fileIndex >= files.length
+    return {
+      results: newKeys
+        .map(key => map.get(key)!)
+        .sort(compareResults)
+        .slice(0, request.limit),
+      continuation: exhausted ? undefined : {
+        scope: request.scope,
+        cwd: request.cwd,
+        query: request.query,
+        limit: request.limit,
+        files: files.slice(fileIndex),
+        cursor,
+        seen: map,
+      },
+      exhausted,
     }
   }
 
-  /** Every candidate file in the `all` scope (sorted for determinism). */
-  private async listAllFiles(): Promise<string[]> {
+  /** Every candidate file in the `all` scope, stat'd with bounded
+   * concurrency and ordered mtime DESC (most recently active first), then
+   * path ASC as the deterministic tie-breaker. A file that fails to stat
+   * (vanished) is dropped. */
+  private async listAllFiles(): Promise<HistoryFileCandidate[]> {
     try {
       const names = await readdir(join(this.dshHome, 'user-history'))
-      return names
+      const candidates = names
         .filter(name => name.endsWith('.jsonl') && !name.endsWith('.tmp') && !name.endsWith('.lock'))
         .map(name => join(this.dshHome, 'user-history', name))
-        .sort()
+      const stats = await mapBounded(candidates, this.concurrency, async (path) => {
+        try {
+          const info = await stat(path)
+          return { path, mtimeMs: info.mtimeMs, size: info.size }
+        } catch {
+          return null
+        }
+      })
+      return stats
+        .filter((candidate): candidate is HistoryFileCandidate => candidate !== null)
+        .sort((a, b) => b.mtimeMs - a.mtimeMs || a.path.localeCompare(b.path))
     } catch {
       return []
     }
   }
 
-  /**
-   * Rule 1 + Rule 2 cwd proof for ONE file in the `all` scope:
-   * - a v2 row whose cwd validates against the file itself
-   *   (`historyFilePath(home, cwd) === file`) identifies the hash — that
-   *   cwd inherits to the file's legacy rows;
-   * - else the known-cwd map (`md5(cwd) → cwd`) proves it;
-   * - else NULL (Rule 3: legacy rows of this file are excluded).
-   */
-  private resolveFileCwd(file: string, records: readonly ParsedHistoryRecord[]): string | null {
-    for (const row of records) {
-      if (row.version !== 2 || row.cwd === null) continue
-      if (historyFilePath(this.dshHome, row.cwd) === file) return row.cwd
-    }
+  /** Rule 2 cwd proof from the known-cwd map, validated against the file
+   * (a stale map entry never fabricates a cwd). */
+  private knownCwdFor(file: string): string | null {
     const hash = file.slice(file.lastIndexOf('/') + 1).replace(/\.jsonl$/, '')
     const known = typeof this.knownCwds === 'function' ? this.knownCwds() : this.knownCwds
     const fromKnown = known.get(hash)
@@ -200,23 +370,105 @@ export class FileHistorySearchSource implements HistorySearchSource {
     return null
   }
 
-  /** The display cwd of ONE row, or NULL when the row must be excluded.
+  /** Route ONE parsed row into the result state and return the (possibly
+   * updated) file proof.
    *
    * A v2 row's cwd is trusted ONLY when it validates against the file it
    * lives in (`historyFilePath(home, cwd) === file` — plan §40: an invalid
    * v2 cwd/hash mismatch is never trusted; it could be a moved directory or
-   * a hand-edited row). Untrusted metadata degrades to the file-level proof:
+   * a hand-edited row). In the all scope, the FIRST validating v2 row also
+   * forms the file proof (Rule 1) and flushes the rows held pending so far.
+   * Untrusted metadata degrades to the file-level proof:
    * - current scope: the file IS the current cwd's file, so every row
    *   (v1, valid v2, invalid v2) ends up at `request.cwd` — inherited, not
    *   fabricated (plan §6.1);
    * - all scope: the row falls back to the file proof (Rule 1/2), and a
-   *   row whose file is still unresolved is EXCLUDED (Rule 3). */
-  private effectiveCwd(request: HistorySearchRequest, file: string, row: ParsedHistoryRecord, fileCwd: string | null): string | null {
-    if (row.version === 2 && row.cwd !== null && historyFilePath(this.dshHome, row.cwd) === file) {
-      return row.cwd
+   *   row whose file is still unresolved is held pending — excluded only
+   *   when the file ends without a proof (Rule 3). */
+  private consumeRecord(
+    request: HistorySearchRequest,
+    file: string,
+    record: ParsedHistoryRecord,
+    byteStart: number,
+    fileProof: string | null,
+    pending: Array<{ record: ParsedHistoryRecord; byteStart: number }>,
+    map: Map<string, HistorySearchResult>,
+    newKeys: string[],
+  ): string | null {
+    if (record.version === 2 && record.cwd !== null && historyFilePath(this.dshHome, record.cwd) === file) {
+      if (request.scope === 'all' && fileProof === null) {
+        // The proof forms NOW: flush the pending rows with it.
+        fileProof = record.cwd
+        for (const held of pending) {
+          if (!matchesQuery(held.record.content, request.query)) continue
+          this.mergeResult(map, newKeys, this.buildResult(file, held.record, fileProof, held.byteStart), request.scope)
+        }
+        pending.length = 0
+      }
+      if (!matchesQuery(record.content, request.query)) return fileProof
+      this.mergeResult(map, newKeys, this.buildResult(file, record, record.cwd, byteStart), request.scope)
+      return fileProof
     }
-    if (request.scope === 'current') return request.cwd
-    return fileCwd // v1 or untrusted v2: inherit the file proof; NULL → Rule 3 exclusion
+    if (request.scope === 'current') {
+      if (!matchesQuery(record.content, request.query)) return fileProof
+      this.mergeResult(map, newKeys, this.buildResult(file, record, request.cwd, byteStart), request.scope)
+      return fileProof
+    }
+    // All scope: v1 or an untrusted v2 cwd.
+    if (fileProof !== null) {
+      if (!matchesQuery(record.content, request.query)) return fileProof
+      this.mergeResult(map, newKeys, this.buildResult(file, record, fileProof, byteStart), request.scope)
+      return fileProof
+    }
+    pending.push({ record, byteStart })
+    return fileProof
+  }
+
+  private buildResult(file: string, record: ParsedHistoryRecord, cwd: string, byteStart: number): HistorySearchResult {
+    const result: HistorySearchResult = {
+      id: `${file}:${byteStart}`,
+      content: record.content,
+      cwd,
+      ts: record.ts,
+      sourceFile: file,
+      sourceByteOffset: byteStart,
+    }
+    if (record.sessionId !== undefined) result.sessionId = record.sessionId
+    return result
+  }
+
+  /** Incremental dedupe: keep the NEWEST occurrence per key (compareResults
+   * is the beats predicate — the same winner the final sort would pick).
+   * A key is reported as new only the first time it enters the map, so a
+   * continuation page never re-reports rows a previous page already
+   * returned. */
+  private mergeResult(
+    map: Map<string, HistorySearchResult>,
+    newKeys: string[],
+    result: HistorySearchResult,
+    scope: HistoryScope,
+  ): void {
+    const key = scope === 'current' ? result.content : `${result.cwd ?? ''}\0${result.content}`
+    const existing = map.get(key)
+    if (existing === undefined) {
+      map.set(key, result)
+      newKeys.push(key)
+    } else if (compareResults(result, existing) < 0) {
+      map.set(key, result)
+    }
+  }
+
+  /** A continuation belongs to exactly one request context: reusing it
+   * with a different scope/cwd/query/limit would silently produce wrong
+   * results (the dedupe state and scan position were built for the old
+   * context). */
+  private validateContinuation(request: HistorySearchRequest, continuation: HistorySearchContinuation): void {
+    if (continuation.scope !== request.scope
+      || continuation.cwd !== request.cwd
+      || continuation.query !== request.query
+      || continuation.limit !== request.limit) {
+      throw new HistorySearchContinuationError()
+    }
   }
 }
 
@@ -224,24 +476,6 @@ export class FileHistorySearchSource implements HistorySearchSource {
 function matchesQuery(content: string, query: string): boolean {
   if (query === '') return true
   return content.toLowerCase().includes(query.toLowerCase())
-}
-
-/** Keep the NEWEST occurrence of each key (results are pre-sorted newest
- * first by ts — but legacy rows sort later, so dedupe must run on the
- * FINAL total order, which slice does after sorting: see search()). */
-function dedupeKeepNewest(results: HistorySearchResult[], scope: HistoryScope): HistorySearchResult[] {
-  // The caller sorts AFTER dedupe, so dedupe first by ts-DESC order to keep
-  // the newest winner (v2 rows vs legacy duplicates of the same content).
-  const ordered = [...results].sort(compareResults)
-  const seen = new Set<string>()
-  const kept: HistorySearchResult[] = []
-  for (const row of ordered) {
-    const key = scope === 'current' ? row.content : `${row.cwd ?? ''}\0${row.content}`
-    if (seen.has(key)) continue
-    seen.add(key)
-    kept.push(row)
-  }
-  return kept
 }
 
 /** Newest-first by ts (legacy rows — ts NULL — sort after every timed row),
@@ -252,5 +486,36 @@ function compareResults(left: HistorySearchResult, right: HistorySearchResult): 
   if (rt !== lt) return rt - lt
   const byFile = left.sourceFile.localeCompare(right.sourceFile)
   if (byFile !== 0) return byFile
-  return right.sourceIndex - left.sourceIndex
+  return right.sourceByteOffset - left.sourceByteOffset
+}
+
+/** The abort contract: an aborted search resolves an empty page (the panel
+ * drops it by generation anyway). */
+function emptyPage(): HistorySearchPage {
+  return { results: [], exhausted: false }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+/** Run `fn` over `items` with at most `concurrency` calls in flight,
+ * preserving the input order of the results. */
+async function mapBounded<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  const workers = Array.from({ length: Math.min(concurrency, Math.max(1, items.length)) }, async () => {
+    for (;;) {
+      const index = next
+      next += 1
+      if (index >= items.length) return
+      results[index] = await fn(items[index]!)
+    }
+  })
+  await Promise.all(workers)
+  return results
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -104,6 +104,39 @@ export function parseHistoryLines(text: string): string[] {
 }
 
 /**
+ * Parse ONE history line into a normalized record, or NULL when the line
+ * carries no record (blank, unparsable JSON, non-string/empty content,
+ * unsupported version). Shared by the forward whole-file parser
+ * ({@link parseHistoryRecords}) and the reverse bounded search reader
+ * (history-search.ts) so v1/v2 parsing semantics can never drift between
+ * the two read paths.
+ * @param line - one physical JSONL line (may be blank).
+ */
+export function parseHistoryRecordLine(line: string): ParsedHistoryRecord | null {
+  const trimmed = line.trim()
+  if (trimmed === '') return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    // Corrupt line: skip, keep loading.
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const row = parsed as Record<string, unknown>
+  if (typeof row.content !== 'string' || row.content === '') return null
+  if (row.v === 2) {
+    const cwd = typeof row.cwd === 'string' && row.cwd !== '' ? row.cwd : null
+    const ts = typeof row.ts === 'number' && Number.isFinite(row.ts) ? row.ts : null
+    const record: ParsedHistoryRecord = { content: row.content, cwd, ts, version: 2 }
+    if (typeof row.sessionId === 'string' && row.sessionId !== '') record.sessionId = row.sessionId
+    return record
+  }
+  // v1 (or unknown): legacy `{}`-only rows keep working.
+  return { content: row.content, cwd: null, ts: null, version: 1 }
+}
+
+/**
  * Parse one history file's text into normalized records, in file order
  * (oldest first). v1 rows are `{"content"}`; v2 rows keep their
  * metadata. Corrupt lines (unparsable JSON, non-string content, unsupported
@@ -116,28 +149,8 @@ export function parseHistoryLines(text: string): string[] {
 export function parseHistoryRecords(text: string): ParsedHistoryRecord[] {
   const records: ParsedHistoryRecord[] = []
   for (const line of text.split('\n')) {
-    const trimmed = line.trim()
-    if (trimmed === '') continue
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(trimmed)
-    } catch {
-      // Corrupt line: skip, keep loading.
-      continue
-    }
-    if (typeof parsed !== 'object' || parsed === null) continue
-    const row = parsed as Record<string, unknown>
-    if (typeof row.content !== 'string' || row.content === '') continue
-    if (row.v === 2) {
-      const cwd = typeof row.cwd === 'string' && row.cwd !== '' ? row.cwd : null
-      const ts = typeof row.ts === 'number' && Number.isFinite(row.ts) ? row.ts : null
-      const record: ParsedHistoryRecord = { content: row.content, cwd, ts, version: 2 }
-      if (typeof row.sessionId === 'string' && row.sessionId !== '') record.sessionId = row.sessionId
-      records.push(record)
-    } else {
-      // v1 (or unknown): legacy `{}`-only rows keep working.
-      records.push({ content: row.content, cwd: null, ts: null, version: 1 })
-    }
+    const record = parseHistoryRecordLine(line)
+    if (record !== null) records.push(record)
   }
   return records
 }

--- a/test/history-panel.test.ts
+++ b/test/history-panel.test.ts
@@ -28,21 +28,21 @@ class FakeSource implements HistorySearchSource {
   fail = false
   /** Manually-settled pending searches (deterministic race control — the
    * test resolves them in the exact order it wants; no wall-clock timing). */
-  pending: Array<{ resolve: (rows: HistorySearchResult[]) => void; reject: (error: unknown) => void }> = []
+  pending: Array<{ resolve: (page: import('../src/history-search.ts').HistorySearchPage) => void; reject: (error: unknown) => void }> = []
   /** When true, `search()` returns a deferred the test resolves via
    * {@link resolveNext}. Otherwise it resolves after the delay. */
   manual = false
-  search(request: import('../src/history-search.ts').HistorySearchRequest): Promise<HistorySearchResult[]> {
+  search(request: import('../src/history-search.ts').HistorySearchRequest): Promise<import('../src/history-search.ts').HistorySearchPage> {
     this.requests.push({ scope: request.scope, query: request.query, cwd: request.cwd, limit: request.limit })
     if (this.fail) return Promise.reject(new Error('boom'))
     if (this.manual) {
-      return new Promise<HistorySearchResult[]>((resolve, reject) => {
+      return new Promise<import('../src/history-search.ts').HistorySearchPage>((resolve, reject) => {
         this.pending.push({ resolve, reject })
       })
     }
     const delay = this.delayByQuery[request.query] ?? this.delayMs
     return new Promise(resolve => {
-      setTimeout(() => resolve([...this.rows]), delay)
+      setTimeout(() => resolve({ results: [...this.rows], exhausted: true }), delay)
     })
   }
   /** Resolve the OLDEST pending search with rows (FIFO — the order the
@@ -50,7 +50,7 @@ class FakeSource implements HistorySearchSource {
   resolveNext(rows: HistorySearchResult[]): void {
     const pending = this.pending.shift()
     if (pending === undefined) throw new Error('resolveNext: no pending search')
-    pending.resolve([...rows])
+    pending.resolve({ results: [...rows], exhausted: true })
   }
   /** Reject the OLDEST pending search (FIFO). */
   rejectNext(error: unknown): void {
@@ -61,7 +61,7 @@ class FakeSource implements HistorySearchSource {
 }
 
 function row(content: string, ts: number, cwd = '/a', id = content): HistorySearchResult {
-  return { id, content, cwd, ts, sourceFile: '/a/h.jsonl', sourceIndex: 0 }
+  return { id, content, cwd, ts, sourceFile: '/a/h.jsonl', sourceByteOffset: 0 }
 }
 
 function makePanel(source: FakeSource, opts: Partial<import('../src/history-panel.ts').HistoryPanelOptions> = {}) {
@@ -353,7 +353,7 @@ test('panel: the detail pane is suppressed (never truncated) when the budget can
   // keep ALL metadata rows; otherwise it is suppressed entirely.
   const source = new FakeSource()
   // A row with the FULL metadata set (Directory + Time + Session = 3 rows).
-  source.rows = [{ id: 'p', content: 'prompt', cwd: '/work/a', ts: 1, sessionId: 'ses_1', sourceFile: '/a/h.jsonl', sourceIndex: 0 }]
+  source.rows = [{ id: 'p', content: 'prompt', cwd: '/work/a', ts: 1, sessionId: 'ses_1', sourceFile: '/a/h.jsonl', sourceByteOffset: 0 }]
   const { panel } = makePanel(source, { maxRows: 8 })
   panel.start()
   await settle()
@@ -387,7 +387,7 @@ test('panel: a suppressed detail in the split layout leaves NO stray separator',
   // Round-6 repro: when the detail cannot fit its metadata, renderSplit
   // used to emit a lone `│` after the list.
   const source = new FakeSource()
-  source.rows = [{ id: 'p', content: 'prompt', cwd: '/work/a', ts: 1, sessionId: 'ses_1', sourceFile: '/a/h.jsonl', sourceIndex: 0 }]
+  source.rows = [{ id: 'p', content: 'prompt', cwd: '/work/a', ts: 1, sessionId: 'ses_1', sourceFile: '/a/h.jsonl', sourceByteOffset: 0 }]
   const { panel } = makePanel(source, { maxRows: 8 })
   panel.start()
   await settle()

--- a/test/history-reverse-reader.test.ts
+++ b/test/history-reverse-reader.test.ts
@@ -252,15 +252,20 @@ test('abort stops the scan with an AbortError', async () => {
   }
 })
 
-test('a cursor is invalidated when the file size changes', async () => {
+test('a cursor tolerates append-only growth and is invalidated by a shrink', async () => {
   const { file, dir } = tempFile('a\nb\nc\n')
   try {
     const first = await readJsonlReverseBatch(file, { maxRows: 1, chunkBytes: 64 })
     assert.equal(first.eof, false)
-    // Append: the revision (size) changed — the old cursor must not be reused.
+    // Append-only growth: the old snapshot range is unchanged — the cursor
+    // continues by the old boundary (the appended row is not part of it).
     writeFileSync(file, 'a\nb\nc\nd\n')
+    const second = await readJsonlReverseBatch(file, { cursor: first.nextCursor, maxRows: 1, chunkBytes: 64 })
+    assert.equal(second.lines[0]?.text, 'b')
+    // A shrink invalidates the cursor: the byte positions are gone.
+    writeFileSync(file, 'a\n')
     await assert.rejects(
-      readJsonlReverseBatch(file, { cursor: first.nextCursor, maxRows: 1, chunkBytes: 64 }),
+      readJsonlReverseBatch(file, { cursor: second.nextCursor, maxRows: 1, chunkBytes: 64 }),
       (error: unknown) => error instanceof ReverseJsonlRevisionError,
     )
   } finally {

--- a/test/history-reverse-reader.test.ts
+++ b/test/history-reverse-reader.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Headless tests for the reverse JSONL batch reader (history-reverse-reader.ts):
+ * newest-first ordering, chunk-boundary correctness (cross-chunk rows, UTF-8
+ * splits, oversized rows), cursor continuation without gaps/duplicates,
+ * abort, and revision-bound cursor invalidation. Pure filesystem — no
+ * terminal, no dsh services.
+ * @module @xmoon76/dsh-pi-tui/history-reverse-reader.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readJsonlReverseBatch, ReverseJsonlRevisionError } from '../src/history-reverse-reader.ts'
+import type { ReverseJsonlCursor, ReverseJsonlLine } from '../src/history-reverse-reader.ts'
+
+function tempFile(content: string | Buffer): { file: string; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-tui-reverse-jsonl-'))
+  const file = join(dir, 'h.jsonl')
+  writeFileSync(file, content)
+  return { file, dir }
+}
+
+/** Read the whole file newest-first via repeated batches. */
+async function readAll(
+  file: string,
+  opts: { chunkBytes?: number; maxRows?: number } = {},
+): Promise<ReverseJsonlLine[]> {
+  const lines: ReverseJsonlLine[] = []
+  let cursor: ReverseJsonlCursor | undefined
+  for (;;) {
+    const batch = await readJsonlReverseBatch(file, {
+      cursor,
+      maxRows: opts.maxRows ?? 128,
+      chunkBytes: opts.chunkBytes ?? 64 * 1024,
+    })
+    lines.push(...batch.lines)
+    if (batch.eof) return lines
+    cursor = batch.nextCursor
+  }
+}
+
+test('newest-first: lines come back in reverse file order', async () => {
+  const { file, dir } = tempFile('a\nb\nc\n')
+  try {
+    const lines = await readAll(file)
+    assert.deepEqual(lines.map(line => line.text), ['c', 'b', 'a'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('with and without a final newline', async () => {
+  const withNl = tempFile('a\nb\n')
+  const withoutNl = tempFile('a\nb')
+  try {
+    assert.deepEqual((await readAll(withNl.file)).map(line => line.text), ['b', 'a'])
+    assert.deepEqual((await readAll(withoutNl.file)).map(line => line.text), ['b', 'a'])
+  } finally {
+    rmSync(withNl.dir, { recursive: true, force: true })
+    rmSync(withoutNl.dir, { recursive: true, force: true })
+  }
+})
+
+test('a single row spanning multiple chunks is reassembled with exact byte ranges', async () => {
+  // 'x'*200 + '\n' + 'tail\n': the big row is bytes [0,200), 'tail' is [201,205).
+  const { file, dir } = tempFile('x'.repeat(200) + '\n' + 'tail\n')
+  try {
+    const lines = await readAll(file, { chunkBytes: 64 })
+    assert.deepEqual(lines.map(line => line.text), ['tail', 'x'.repeat(200)])
+    const tail = lines[0]!
+    assert.equal(tail.byteStart, 201)
+    assert.equal(tail.byteEnd, 205)
+    const big = lines[1]!
+    assert.equal(big.byteStart, 0)
+    assert.equal(big.byteEnd, 200)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('UTF-8/CJK code points split by a chunk boundary decode intact', async () => {
+  // Each 你 is 3 bytes; a 5-byte chunk boundary cuts code points mid-sequence.
+  const content = '你'.repeat(100) + '\n'
+  const { file, dir } = tempFile(content)
+  try {
+    const lines = await readAll(file, { chunkBytes: 5 })
+    assert.deepEqual(lines.map(line => line.text), ['你'.repeat(100)])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('JSON-escaped multiline content stays one physical line', async () => {
+  const row = JSON.stringify({ content: 'line one\nline two\nline three' })
+  const { file, dir } = tempFile(row + '\n')
+  try {
+    const lines = await readAll(file)
+    assert.deepEqual(lines.map(line => line.text), [row])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('corrupt rows are returned verbatim (the parser decides to skip them)', async () => {
+  const { file, dir } = tempFile('not json\n{"content":"ok"}\n')
+  try {
+    const lines = await readAll(file)
+    assert.deepEqual(lines.map(line => line.text), ['{"content":"ok"}', 'not json'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a 256KiB+ oversized row is read fully across many chunks', async () => {
+  const big = 'x'.repeat(300 * 1024)
+  const { file, dir } = tempFile(big + '\n')
+  try {
+    const lines = await readAll(file, { chunkBytes: 64 * 1024 })
+    assert.deepEqual(lines.map(line => line.text), [big])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('cursor continuation: no gaps, no duplicates, contiguous byte coverage', async () => {
+  const rows = Array.from({ length: 1000 }, (_, i) => `line-${i}`)
+  const { file, dir } = tempFile(rows.join('\n') + '\n')
+  try {
+    const lines = await readAll(file, { chunkBytes: 64, maxRows: 37 })
+    assert.equal(lines.length, 1000)
+    // Newest first, exactly once each.
+    assert.deepEqual(lines.map(line => line.text), [...rows].reverse())
+    // The byte ranges tile the file's content: each line's range is
+    // followed by exactly its terminating `\n` (the file ends with one),
+    // so byteEnd + 1 == the next line's byteStart, and the oldest line
+    // starts at byte 0 — no overlap, no gap, no lost byte.
+    const size = Buffer.byteLength(rows.join('\n') + '\n')
+    let expectedEnd = size
+    for (const line of lines) {
+      assert.equal(line.byteEnd + 1, expectedEnd, `byteEnd of ${line.text}`)
+      expectedEnd = line.byteStart
+    }
+    assert.equal(expectedEnd, 0)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('maxRows=1 walks the file one line per batch without loss', async () => {
+  const { file, dir } = tempFile('a\nb\nc\nd\n')
+  try {
+    const lines = await readAll(file, { maxRows: 1 })
+    assert.deepEqual(lines.map(line => line.text), ['d', 'c', 'b', 'a'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('an empty file is exhausted immediately', async () => {
+  const { file, dir } = tempFile('')
+  try {
+    const batch = await readJsonlReverseBatch(file, { maxRows: 10, chunkBytes: 64 })
+    assert.equal(batch.eof, true)
+    assert.deepEqual(batch.lines, [])
+    assert.equal(batch.nextCursor, undefined)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('abort stops the scan with an AbortError', async () => {
+  const rows = Array.from({ length: 2000 }, (_, i) => `row-${i}`)
+  const { file, dir } = tempFile(rows.join('\n') + '\n')
+  try {
+    const controller = new AbortController()
+    const first = await readJsonlReverseBatch(file, {
+      maxRows: 10,
+      chunkBytes: 64,
+      signal: controller.signal,
+    })
+    assert.equal(first.lines.length, 10)
+    assert.equal(first.eof, false)
+    controller.abort()
+    await assert.rejects(
+      readJsonlReverseBatch(file, {
+        cursor: first.nextCursor,
+        maxRows: 10,
+        chunkBytes: 64,
+        signal: controller.signal,
+      }),
+      (error: unknown) => (error as Error).name === 'AbortError',
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a cursor is invalidated when the file size changes', async () => {
+  const { file, dir } = tempFile('a\nb\nc\n')
+  try {
+    const first = await readJsonlReverseBatch(file, { maxRows: 1, chunkBytes: 64 })
+    assert.equal(first.eof, false)
+    // Append: the revision (size) changed — the old cursor must not be reused.
+    writeFileSync(file, 'a\nb\nc\nd\n')
+    await assert.rejects(
+      readJsonlReverseBatch(file, { cursor: first.nextCursor, maxRows: 1, chunkBytes: 64 }),
+      (error: unknown) => error instanceof ReverseJsonlRevisionError,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a cursor is invalidated when the mtime changes', async () => {
+  const { file, dir } = tempFile('a\nb\nc\n')
+  try {
+    const first = await readJsonlReverseBatch(file, { maxRows: 1, chunkBytes: 64 })
+    assert.equal(first.eof, false)
+    // Touch the file (same content, new mtime): the revision changed.
+    const future = new Date(Date.now() + 60_000)
+    const { utimesSync } = await import('node:fs')
+    utimesSync(file, future, future)
+    await assert.rejects(
+      readJsonlReverseBatch(file, { cursor: first.nextCursor, maxRows: 1, chunkBytes: 64 }),
+      (error: unknown) => error instanceof ReverseJsonlRevisionError,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/test/history-reverse-reader.test.ts
+++ b/test/history-reverse-reader.test.ts
@@ -170,6 +170,61 @@ test('an empty file is exhausted immediately', async () => {
   }
 })
 
+test('blank lines survive chunk boundaries (the scan===0 empty-line case)', async () => {
+  // 'a\n\nb': the empty line between the two newlines spans the chunk
+  // boundary at byte 2 — it must not be lost.
+  const { file, dir } = tempFile('a\n\nb')
+  try {
+    const lines = await readAll(file, { chunkBytes: 2 })
+    assert.deepEqual(lines.map(line => line.text), ['b', '', 'a'])
+    const blank = lines[1]!
+    assert.equal(blank.byteStart, 2)
+    assert.equal(blank.byteEnd, 2)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a newlines-only file yields its blank lines', async () => {
+  const { file, dir } = tempFile('\n\n')
+  try {
+    const lines = await readAll(file)
+    assert.deepEqual(lines.map(line => line.text), ['', ''])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('intra-search batches tolerate a concurrent append (snapshot semantics)', async () => {
+  const { file, dir } = tempFile('a\nb\nc\n')
+  try {
+    const first = await readJsonlReverseBatch(file, { maxRows: 1, chunkBytes: 64 })
+    assert.equal(first.eof, false)
+    // A concurrent append between batches of the SAME search: the scan
+    // continues from the snapshot boundary and the appended row is simply
+    // not part of this generation (verifyRevision is false intra-search).
+    writeFileSync(file, 'a\nb\nc\nd\n')
+    const second = await readJsonlReverseBatch(file, {
+      cursor: first.nextCursor,
+      maxRows: 1,
+      chunkBytes: 64,
+      verifyRevision: false,
+    })
+    assert.equal(second.lines.length, 1)
+    assert.equal(second.lines[0]?.text, 'b')
+    const third = await readJsonlReverseBatch(file, {
+      cursor: second.nextCursor,
+      maxRows: 1,
+      chunkBytes: 64,
+      verifyRevision: false,
+    })
+    assert.equal(third.lines[0]?.text, 'a')
+    assert.equal(third.eof, true)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('abort stops the scan with an AbortError', async () => {
   const rows = Array.from({ length: 2000 }, (_, i) => `row-${i}`)
   const { file, dir } = tempFile(rows.join('\n') + '\n')

--- a/test/history-search.test.ts
+++ b/test/history-search.test.ts
@@ -586,3 +586,30 @@ test('S16: all-scope pending rows survive across pages — a proof found on a la
     rmSync(home, { recursive: true, force: true })
   }
 })
+
+test('S17: a knownCwds resolver update between pages recovers pending rows', async () => {
+  const home = tempHome()
+  try {
+    // 100 legacy v1 rows, no v2 proof anywhere: page 1 leaves them pending
+    // (no proof in its window); the cwd becomes known BEFORE page 2 — the
+    // resolver is read per search, so the pending rows must be recovered.
+    writeV1(home, '/a', Array.from({ length: 100 }, (_, i) => `legacy-${i}`))
+    const known = new Map<string, string>()
+    const resolver = (): ReadonlyMap<string, string> => known
+    const src = new FileHistorySearchSource({ dshHome: home, knownCwds: resolver, scanLimit: 50 })
+    const request = { scope: 'all' as const, cwd: '/nowhere', query: '', limit: 1000 }
+    const page1 = await src.search(request)
+    assert.equal(page1.results.length, 0, 'page 1: no proof yet, all rows pending')
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    // The cwd joins the set between pages (a session created/switched).
+    known.set(historyFilePath(home, '/a').split('/').pop()!.replace(/\.jsonl$/, ''), '/a')
+    const page2 = await src.search(request, page1.continuation)
+    const legacy = page2.results.filter(row => row.content.startsWith('legacy-'))
+    assert.equal(legacy.length, 100, 'the resolver update recovers the pending rows')
+    assert.ok(legacy.every(row => row.cwd === '/a'), 'the recovered rows carry the proven cwd')
+    assert.equal(page2.exhausted, true)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/test/history-search.test.ts
+++ b/test/history-search.test.ts
@@ -653,6 +653,16 @@ test('S19: a fresh continuation file (exact budget boundary) still gets its know
     // cwd is known via the resolver — its rows must NOT be discarded.
     writeV2(home, '/a', Array.from({ length: 100 }, (_, i) => ({ content: `a-${i}`, ts: i })))
     writeV1(home, '/b', Array.from({ length: 50 }, (_, i) => `legacy-${i}`))
+    // Pin the scan order: /a must be the newest mtime (scanned first and
+    // fully consumed at the exact budget boundary) — without this the two
+    // writes can land in different milliseconds and flip the order.
+    const aFile = historyFilePath(home, '/a')
+    const bFile = historyFilePath(home, '/b')
+    const { utimesSync } = await import('node:fs')
+    const old = new Date(Date.now() - 60_000)
+    const newer = new Date(Date.now())
+    utimesSync(bFile, old, old)
+    utimesSync(aFile, newer, newer)
     const known = new Map<string, string>()
     known.set(historyFilePath(home, '/b').split('/').pop()!.replace(/\.jsonl$/, ''), '/b')
     const src = new FileHistorySearchSource({ dshHome: home, knownCwds: known, scanLimit: 100 })

--- a/test/history-search.test.ts
+++ b/test/history-search.test.ts
@@ -394,7 +394,8 @@ test('S5: resultLimit and scanLimit are separate — a query never stops at 20 m
     const page = await src.search({ scope: 'current', cwd: '/a', query: 'prompt', limit: 20 })
     assert.equal(page.results.length, 20)
     assert.equal(stats.physicalLinesScanned, 500, 'the scan ran to EOF, not to 20 matches')
-    assert.equal(page.exhausted, true)
+    assert.equal(page.exhausted, false, 'the overflow still holds the unreported matches')
+    assert.ok(page.continuation !== undefined)
   } finally {
     rmSync(home, { recursive: true, force: true })
   }
@@ -509,6 +510,78 @@ test('S13: a continuation with a mismatched request context is a typed error', a
       src.search({ ...request, scope: 'all' }, page.continuation),
       (error: unknown) => error instanceof HistorySearchContinuationError,
     )
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S14: page overflow is carried — no match is ever lost across pages', async () => {
+  const home = tempHome()
+  try {
+    // 100 rows, limit 10: a single batch collects far more than the page
+    // can report — the overflow must drain on the following pages.
+    writeV2(home, '/a', Array.from({ length: 100 }, (_, i) => ({ content: `prompt-${i}`, ts: i })))
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 5000 })
+    const request = { scope: 'current' as const, cwd: '/a', query: '', limit: 10 }
+    const pages: HistorySearchResult[][] = []
+    let continuation: import('../src/history-search.ts').HistorySearchContinuation | undefined
+    for (let i = 0; i < 20; i += 1) {
+      const page = await src.search(request, continuation)
+      pages.push(page.results)
+      if (page.exhausted) break
+      continuation = page.continuation
+    }
+    const merged = pages.flat()
+    assert.equal(merged.length, 100, 'every match is reported across pages')
+    assert.equal(new Set(merged.map(row => row.content)).size, 100, 'no duplicates across pages')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S15: a file fully scanned at the exact budget boundary is not re-scanned by the next page', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 100 }, (_, i) => ({ content: `a-${i}`, ts: i })))
+    writeV2(home, '/b', Array.from({ length: 100 }, (_, i) => ({ content: `b-${i}`, ts: 100 + i })))
+    const stats: HistorySearchDebugStats = { filesVisited: 0, physicalLinesScanned: 0, bytesRead: 0 }
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100, stats })
+    const request = { scope: 'all' as const, cwd: '/nowhere', query: 'zzz', limit: 100 }
+    const page1 = await src.search(request)
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    const page2 = await src.search(request, page1.continuation)
+    assert.equal(stats.physicalLinesScanned, 100, 'page 2 scanned only file B — file A was not re-scanned')
+    assert.equal(page2.exhausted, true)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S16: all-scope pending rows survive across pages — a proof found on a later page recovers them', async () => {
+  const home = tempHome()
+  try {
+    // One validating v2 row (OLDEST) + 100 legacy v1 rows (newer): page 1
+    // scans the v1 rows with no proof yet (all pending), page 2 finds the
+    // proof — the pending rows from page 1 must still be recovered.
+    const file = historyFilePath(home, '/a')
+    mkdirSync(file.slice(0, file.lastIndexOf('/')), { recursive: true })
+    const lines = [
+      JSON.stringify({ v: 2, content: 'modern', cwd: '/a', ts: 5 }),
+      ...Array.from({ length: 100 }, (_, i) => JSON.stringify({ content: `legacy-${i}` })),
+    ]
+    writeFileSync(file, lines.join('\n') + '\n', { mode: 0o600 })
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100 })
+    const request = { scope: 'all' as const, cwd: '/nowhere', query: '', limit: 1000 }
+    const page1 = await src.search(request)
+    assert.equal(page1.results.length, 0, 'page 1 scanned only unresolved v1 rows')
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    const page2 = await src.search(request, page1.continuation)
+    const legacy = page2.results.filter(row => row.content.startsWith('legacy-'))
+    assert.equal(legacy.length, 100, 'every pending legacy row is recovered by the later proof')
+    assert.ok(legacy.every(row => row.cwd === '/a'), 'the recovered rows carry the proven cwd')
+    assert.equal(page2.exhausted, true)
   } finally {
     rmSync(home, { recursive: true, force: true })
   }

--- a/test/history-search.test.ts
+++ b/test/history-search.test.ts
@@ -11,8 +11,8 @@ import test from 'node:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { FileHistorySearchSource } from '../src/history-search.ts'
-import type { HistorySearchResult, HistoryScope } from '../src/history-search.ts'
+import { FileHistorySearchSource, HistorySearchContinuationError } from '../src/history-search.ts'
+import type { HistorySearchDebugStats, HistorySearchResult, HistoryScope } from '../src/history-search.ts'
 import { appendHistoryRecord, historyFilePath, historyFilePathFromHash } from '../src/history.ts'
 
 function tempHome(): string {
@@ -50,7 +50,8 @@ async function search(
   query: string,
   opts: { knownCwds?: Map<string, string>; signal?: AbortSignal } = {},
 ): Promise<HistorySearchResult[]> {
-  return source(home, opts.knownCwds).search({ scope, cwd, query, limit: 100, signal: opts.signal })
+  const page = await source(home, opts.knownCwds).search({ scope, cwd, query, limit: 100, signal: opts.signal })
+  return page.results
 }
 
 test('current scope reads only the cwd file; v1 rows inherit the cwd', async () => {
@@ -161,12 +162,12 @@ test('all scope: knownCwds may be a RESOLVER — cwds learned after construction
     const resolver = (): ReadonlyMap<string, string> => known
     const source = new FileHistorySearchSource({ dshHome: home, knownCwds: resolver })
     const before = await source.search({ scope: 'all', cwd: '/nowhere', query: '', limit: 100 })
-    assert.equal(before.length, 0, 'unresolved before the cwd is known (Rule 3)')
+    assert.equal(before.results.length, 0, 'unresolved before the cwd is known (Rule 3)')
     // The cwd joins the set later (a session created/switched).
     known.set(historyFilePath(home, '/later-dir').split('/').pop()!.replace(/\.jsonl$/, ''), '/later-dir')
     const after = await source.search({ scope: 'all', cwd: '/nowhere', query: '', limit: 100 })
-    assert.equal(after.length, 1)
-    assert.equal(after[0]?.cwd, '/later-dir', 'the resolver is read per search')
+    assert.equal(after.results.length, 1)
+    assert.equal(after.results[0]?.cwd, '/later-dir', 'the resolver is read per search')
   } finally {
     rmSync(home, { recursive: true, force: true })
   }
@@ -294,8 +295,220 @@ test('limit caps the returned rows', async () => {
       { content: 'three', ts: 3 },
     ])
     const limited = await source(home).search({ scope: 'current', cwd: '/a', query: '', limit: 2 })
-    assert.equal(limited.length, 2)
-    assert.equal(limited[0]?.content, 'three')
+    assert.equal(limited.results.length, 2)
+    assert.equal(limited.results[0]?.content, 'three')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Bounded recent-first scanning (the perf contract): global scan budget,
+// mtime priority, page/continuation semantics, early exit, stats.
+// ---------------------------------------------------------------------------
+
+test('S1: current scope never parses the whole file — the global budget bounds the scan', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 10000 }, (_, i) => ({ content: `prompt-${i}`, ts: i })))
+    // A sparse query (no early exit): the scan must stop at the budget.
+    const stats: HistorySearchDebugStats = { filesVisited: 0, physicalLinesScanned: 0, bytesRead: 0 }
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 500, stats })
+    const page = await src.search({ scope: 'current', cwd: '/a', query: 'zzz-no-match', limit: 100 })
+    assert.equal(page.results.length, 0)
+    assert.ok(stats.physicalLinesScanned <= 500, `scanned ${stats.physicalLinesScanned} > 500`)
+    assert.ok(stats.physicalLinesScanned < 10000, 'the whole file must not be parsed')
+    assert.equal(page.exhausted, false, 'budget exhaustion is not EOF')
+    assert.ok(page.continuation !== undefined, 'older history remains reachable')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S2: the all-scope budget is GLOBAL — three files share one cap, never per-file', async () => {
+  const home = tempHome()
+  try {
+    for (const dir of ['/a', '/b', '/c']) {
+      writeV2(home, dir, Array.from({ length: 3000 }, (_, i) => ({ content: `prompt-${dir}-${i}`, ts: i })))
+    }
+    const stats: HistorySearchDebugStats = { filesVisited: 0, physicalLinesScanned: 0, bytesRead: 0 }
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 5000, stats })
+    const page = await src.search({ scope: 'all', cwd: '/nowhere', query: 'zzz-no-match', limit: 100 })
+    assert.ok(stats.physicalLinesScanned <= 5000, `scanned ${stats.physicalLinesScanned} > 5000`)
+    assert.ok(stats.physicalLinesScanned > 3000, 'the scan must cross file boundaries (not 5000 per file)')
+    assert.equal(page.exhausted, false)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S3: the all-scope scan visits the most recently modified file first', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 100 }, (_, i) => ({ content: `a-${i}`, ts: i })))
+    writeV2(home, '/b', Array.from({ length: 100 }, (_, i) => ({ content: `b-${i}`, ts: 100 + i })))
+    const aFile = historyFilePath(home, '/a')
+    const bFile = historyFilePath(home, '/b')
+    const { utimesSync } = await import('node:fs')
+    const old = new Date(Date.now() - 60_000)
+    const newer = new Date(Date.now())
+    utimesSync(bFile, old, old)
+    utimesSync(aFile, newer, newer)
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 150 })
+    const page = await src.search({ scope: 'all', cwd: '/nowhere', query: '', limit: 1000 })
+    const fromA = page.results.filter(row => row.sourceFile === aFile).length
+    const fromB = page.results.filter(row => row.sourceFile === bFile).length
+    assert.equal(fromA, 100, 'the newest-mtime file is scanned first and fully')
+    assert.equal(fromB, 50, 'the older file is cut by the remaining budget')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S4: the final order is row.ts — file mtime never overrides it', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 100 }, (_, i) => ({ content: `a-${i}`, ts: i })))
+    writeV2(home, '/b', Array.from({ length: 100 }, (_, i) => ({ content: `b-${i}`, ts: 100 + i })))
+    const aFile = historyFilePath(home, '/a')
+    const bFile = historyFilePath(home, '/b')
+    const { utimesSync } = await import('node:fs')
+    const old = new Date(Date.now() - 60_000)
+    utimesSync(aFile, old, old) // /a is the OLDER mtime — scanned LAST
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 1000 })
+    const page = await src.search({ scope: 'all', cwd: '/nowhere', query: '', limit: 1000 })
+    assert.equal(page.results[0]?.sourceFile, bFile, 'the newest ts row leads regardless of scan order')
+    assert.equal(page.results[0]?.ts, 199)
+    assert.equal(page.results[page.results.length - 1]?.sourceFile, aFile)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S5: resultLimit and scanLimit are separate — a query never stops at 20 matches', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 500 }, (_, i) => ({ content: `prompt-${i}`, ts: i })))
+    const stats: HistorySearchDebugStats = { filesVisited: 0, physicalLinesScanned: 0, bytesRead: 0 }
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 1000, stats })
+    const page = await src.search({ scope: 'current', cwd: '/a', query: 'prompt', limit: 20 })
+    assert.equal(page.results.length, 20)
+    assert.equal(stats.physicalLinesScanned, 500, 'the scan ran to EOF, not to 20 matches')
+    assert.equal(page.exhausted, true)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S6: a sparse query scans to the budget/EOF, not to the first matches', async () => {
+  const home = tempHome()
+  try {
+    const rows = Array.from({ length: 6000 }, (_, i) => ({
+      content: i % 350 === 0 ? `needle-${i}` : `filler-${i}`,
+      ts: i,
+    }))
+    writeV2(home, '/a', rows)
+    const stats: HistorySearchDebugStats = { filesVisited: 0, physicalLinesScanned: 0, bytesRead: 0 }
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 5000, stats })
+    const page = await src.search({ scope: 'current', cwd: '/a', query: 'needle', limit: 100 })
+    // Needles in the newest 5000 rows (ts 1000..5999): 1050, 1400, ..., 5950.
+    assert.equal(page.results.length, 15)
+    assert.equal(stats.physicalLinesScanned, 5000, 'the scan ran to the budget, not to the matches')
+    assert.equal(page.exhausted, false)
+    assert.ok(page.continuation !== undefined)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S7: an empty query stops early once this call has enough unique results', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 10000 }, (_, i) => ({ content: `prompt-${i}`, ts: i })))
+    const stats: HistorySearchDebugStats = { filesVisited: 0, physicalLinesScanned: 0, bytesRead: 0 }
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 5000, stats })
+    const page = await src.search({ scope: 'current', cwd: '/a', query: '', limit: 100 })
+    assert.equal(page.results.length, 100)
+    assert.ok(stats.physicalLinesScanned < 5000, `early exit did not trigger (scanned ${stats.physicalLinesScanned})`)
+    assert.equal(page.exhausted, false)
+    assert.ok(page.continuation !== undefined, 'older history remains reachable')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S11: continuation pages resume without rescanning — no gaps, no duplicates', async () => {
+  const home = tempHome()
+  try {
+    const rows = Array.from({ length: 12000 }, (_, i) => ({
+      content: i % 400 === 0 ? `needle-${i}` : `filler-${i}`,
+      ts: i,
+    }))
+    writeV2(home, '/a', rows)
+    const stats: HistorySearchDebugStats = { filesVisited: 0, physicalLinesScanned: 0, bytesRead: 0 }
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 5000, stats })
+    const request = { scope: 'current' as const, cwd: '/a', query: 'needle', limit: 100 }
+    const page1 = await src.search(request)
+    const scanned1 = stats.physicalLinesScanned
+    assert.equal(page1.results.length, 12, 'needles in rows 7000..11999')
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    const page2 = await src.search(request, page1.continuation)
+    const scanned2 = stats.physicalLinesScanned
+    assert.equal(page2.results.length, 13, 'needles in rows 2000..6999')
+    assert.equal(page2.exhausted, false)
+    assert.ok(page2.continuation !== undefined)
+    const page3 = await src.search(request, page2.continuation)
+    const scanned3 = stats.physicalLinesScanned
+    assert.equal(page3.results.length, 5, 'needles in rows 0..1999')
+    assert.equal(page3.exhausted, true)
+    assert.equal(page3.continuation, undefined)
+    // No rescan of the covered suffix: the three calls together scanned
+    // exactly the file's 12000 rows (a rescan would exceed it).
+    assert.equal(scanned1 + scanned2 + scanned3, 12000)
+    // Merged pages: every needle exactly once, nothing missing.
+    const merged = [...page1.results, ...page2.results, ...page3.results]
+    assert.equal(merged.length, 30)
+    assert.equal(new Set(merged.map(row => row.content)).size, 30, 'no duplicate rows across pages')
+    assert.deepEqual(
+      new Set(merged.map(row => row.content)),
+      new Set(Array.from({ length: 30 }, (_, i) => `needle-${i * 400}`)),
+      'no missing rows across pages',
+    )
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S12: reaching the scan budget is not exhausted', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 1000 }, (_, i) => ({ content: `p-${i}`, ts: i })))
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100 })
+    const page = await src.search({ scope: 'current', cwd: '/a', query: 'zzz', limit: 100 })
+    assert.equal(page.exhausted, false)
+    assert.ok(page.continuation !== undefined)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S13: a continuation with a mismatched request context is a typed error', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 1000 }, (_, i) => ({ content: `p-${i}`, ts: i })))
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100 })
+    const request = { scope: 'current' as const, cwd: '/a', query: 'zzz', limit: 100 }
+    const page = await src.search(request)
+    assert.ok(page.continuation !== undefined)
+    await assert.rejects(
+      src.search({ ...request, query: 'different' }, page.continuation),
+      (error: unknown) => error instanceof HistorySearchContinuationError,
+    )
+    await assert.rejects(
+      src.search({ ...request, scope: 'all' }, page.continuation),
+      (error: unknown) => error instanceof HistorySearchContinuationError,
+    )
   } finally {
     rmSync(home, { recursive: true, force: true })
   }

--- a/test/history-search.test.ts
+++ b/test/history-search.test.ts
@@ -613,3 +613,59 @@ test('S17: a knownCwds resolver update between pages recovers pending rows', asy
     rmSync(home, { recursive: true, force: true })
   }
 })
+
+test('S18: a newer occurrence found on a later page is re-reported (cross-page replacement)', async () => {
+  const home = tempHome()
+  try {
+    // File A (newest mtime) holds 'shared' at ts=1; file B (older mtime)
+    // holds the same content at ts=100. Page 1 reports A's occurrence;
+    // page 2 finds the NEWER one — the replacement must be re-reported so
+    // the merged pages, re-deduped, equal the full-scan (newest-wins) set.
+    writeV2(home, '/a', [{ content: 'shared', ts: 1 }])
+    writeV2(home, '/b', [{ content: 'shared', ts: 100 }])
+    const bFile = historyFilePath(home, '/b')
+    const { utimesSync } = await import('node:fs')
+    const old = new Date(Date.now() - 60_000)
+    utimesSync(bFile, old, old) // /b is the OLDER mtime — scanned second
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 1 })
+    const request = { scope: 'all' as const, cwd: '/nowhere', query: '', limit: 100 }
+    const page1 = await src.search(request)
+    assert.equal(page1.results.length, 1)
+    assert.equal(page1.results[0]?.ts, 1, 'page 1 reports file A\'s occurrence')
+    assert.ok(page1.continuation !== undefined)
+    const page2 = await src.search(request, page1.continuation)
+    const merged = [...page1.results, ...page2.results]
+    const winner = merged
+      .filter(row => row.content === 'shared')
+      .sort((a, b) => (b.ts ?? -1) - (a.ts ?? -1))[0]
+    assert.equal(winner?.ts, 100, 'the newest occurrence wins in the merged set')
+    assert.equal(page2.exhausted, true)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S19: a fresh continuation file (exact budget boundary) still gets its knownCwds proof', async () => {
+  const home = tempHome()
+  try {
+    // File A (100 v2 rows) is fully scanned exactly at the budget; the
+    // continuation's first file is the unscanned legacy-only file B, whose
+    // cwd is known via the resolver — its rows must NOT be discarded.
+    writeV2(home, '/a', Array.from({ length: 100 }, (_, i) => ({ content: `a-${i}`, ts: i })))
+    writeV1(home, '/b', Array.from({ length: 50 }, (_, i) => `legacy-${i}`))
+    const known = new Map<string, string>()
+    known.set(historyFilePath(home, '/b').split('/').pop()!.replace(/\.jsonl$/, ''), '/b')
+    const src = new FileHistorySearchSource({ dshHome: home, knownCwds: known, scanLimit: 100 })
+    const request = { scope: 'all' as const, cwd: '/nowhere', query: '', limit: 1000 }
+    const page1 = await src.search(request)
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    const page2 = await src.search(request, page1.continuation)
+    const legacy = page2.results.filter(row => row.content.startsWith('legacy-'))
+    assert.equal(legacy.length, 50, 'the fresh continuation file is recovered via knownCwds')
+    assert.ok(legacy.every(row => row.cwd === '/b'), 'the recovered rows carry the proven cwd')
+    assert.equal(page2.exhausted, true)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/test/history-search.test.ts
+++ b/test/history-search.test.ts
@@ -11,7 +11,7 @@ import test from 'node:test'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { FileHistorySearchSource, HistorySearchContinuationError } from '../src/history-search.ts'
+import { FileHistorySearchSource, HistorySearchContinuationError, HistorySearchContinuationStaleError } from '../src/history-search.ts'
 import type { HistorySearchDebugStats, HistorySearchResult, HistoryScope } from '../src/history-search.ts'
 import { appendHistoryRecord, historyFilePath, historyFilePathFromHash } from '../src/history.ts'
 
@@ -675,6 +675,71 @@ test('S19: a fresh continuation file (exact budget boundary) still gets its know
     assert.equal(legacy.length, 50, 'the fresh continuation file is recovered via knownCwds')
     assert.ok(legacy.every(row => row.cwd === '/b'), 'the recovered rows carry the proven cwd')
     assert.equal(page2.exhausted, true)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S20: a concurrent append between pages does not invalidate the continuation (snapshot semantics)', async () => {
+  const home = tempHome()
+  try {
+    // 300 rows, a needle every 100th: page 1 scans the newest 100 (one
+    // needle); an append lands; page 2 must continue the OLD snapshot —
+    // the remaining 200 rows (two needles) are scanned, the appended row
+    // is not, and exhausted is only true after the old range is done.
+    const rows = Array.from({ length: 300 }, (_, i) => ({
+      content: i % 100 === 0 ? `needle-${i}` : `filler-${i}`,
+      ts: i,
+    }))
+    writeV2(home, '/a', rows)
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100 })
+    const request = { scope: 'current' as const, cwd: '/a', query: 'needle', limit: 100 }
+    const page1 = await src.search(request)
+    assert.equal(page1.results.length, 1, 'page 1 scanned the newest 100 rows (needle-200)')
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    // A concurrent append between pages (another window submitted).
+    const file = historyFilePath(home, '/a')
+    const { appendFileSync } = await import('node:fs')
+    appendFileSync(file, JSON.stringify({ v: 2, content: 'appended', cwd: '/a', ts: 9999 }) + '\n')
+    // Walk the remaining pages (the budget is per call: 100 rows each).
+    const all: string[] = [...page1.results.map(row => row.content)]
+    let continuation: import('../src/history-search.ts').HistorySearchContinuation | undefined = page1.continuation
+    for (let i = 0; i < 5; i += 1) {
+      const page: import('../src/history-search.ts').HistorySearchPage | undefined = continuation === undefined
+        ? undefined
+        : await src.search(request, continuation)
+      if (page === undefined) break
+      all.push(...page.results.map(row => row.content))
+      continuation = page.exhausted ? undefined : page.continuation
+    }
+    assert.ok(all.includes('needle-100') && all.includes('needle-0'),
+      'the remaining old rows are scanned, not dropped')
+    assert.ok(!all.includes('appended'), 'the appended row belongs to the next fresh search')
+    assert.equal(continuation, undefined, 'exhausted only after the old snapshot is fully scanned')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S21: a file shrunk under a continuation cursor is a stale-continuation error, not a silent skip', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 300 }, (_, i) => ({ content: `p-${i}`, ts: i })))
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100 })
+    const request = { scope: 'current' as const, cwd: '/a', query: 'zzz', limit: 100 }
+    const page1 = await src.search(request)
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    // Truncate the file: the cursor's byte positions are gone — the
+    // continuation must NOT silently report exhausted and drop the rest.
+    const file = historyFilePath(home, '/a')
+    const { truncateSync } = await import('node:fs')
+    truncateSync(file, 0)
+    await assert.rejects(
+      src.search(request, page1.continuation),
+      (error: unknown) => error instanceof HistorySearchContinuationStaleError,
+    )
   } finally {
     rmSync(home, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

Bounds the Ctrl+R input-history search so it no longer parses every candidate
history file in full on each keystroke. The search now reads the JSONL store
from the tail backwards through a new reverse reader, consuming a **global
scan budget** (5000 physical lines per search across all files, never per
file) and visiting the most recently active workspaces first. The canonical
files are never read whole.

The search result is now a **page**: when older history remains, the source
returns a continuation that resumes exactly where the search stopped (no
re-scanning of the covered suffix, no duplicate rows across pages) — the
foundation for a future "Search older" UI. Reaching the scan budget is not
exhausted.

Implementation plan: `temp/20260825/dsh-pi-tui-perf-history-reverse-jsonl-plan.md`
(updated during review: legacy cwd coverage may degrade with the scan window
while v2 cwd hash validation stays strict; bounded coverage is an explicit
intentional behavior change; continuation is a real contract of this PR).

## What changed

- **`src/history.ts`** — extracted `parseHistoryRecordLine()`: the single
  v1/v2 line parser shared by the forward whole-file parser and the reverse
  reader, so the two read paths can never drift.
- **`src/history-reverse-reader.ts`** (new) — reverse JSONL batch reader:
  EOF-backwards fixed-size chunks, lines reassembled across chunk boundaries
  (UTF-8 safe, 256KiB+ rows supported), revision-bound continuation cursors
  (size + mtimeMs; a changed file throws instead of reusing a stale byte
  position), abort support.
- **`src/history-search.ts`** — `FileHistorySearchSource` reworked:
  - global per-call scan budget (`HISTORY_SEARCH_SCAN_LIMIT` = 5000 physical
    lines across all files);
  - `All directories` stats candidates with bounded concurrency and scans
    them serially in mtime-DESC order (mtime only schedules files; the final
    order is always row.ts);
  - `HistorySearchSource.search` returns `HistorySearchPage` (results +
    continuation + exhausted); the continuation carries the remaining files,
    the reader cursor, the dedupe state, the current file's cwd proof and
    pending rows, and the page overflow — no match is ever lost across pages;
  - incremental dedupe (newest-by-ts wins, unchanged contract), empty-query
    early exit (per call), abort → empty page, per-file errors skip the file;
  - result identity is now `file:byteStart` (`sourceByteOffset`) — no forward
    scan is ever needed.
- **`src/history-panel.ts`** — consumes `page.results` only; "Search older"
  is a later UI phase on the new contract.
- **Docs** — `docs/input-history.md` documents the bounded recent-first
  semantics; CHANGELOG pair updated under `[Unreleased]`.

## Intentional behavior change

- The default Ctrl+R search is bounded by the scan budget: histories outside
  the first scan window may not appear initially (recent-first, not
  exhaustive). Interaction semantics (scope/query/Enter/Esc/draft/dedupe/
  ordering) are unchanged.
- Legacy rows whose directory can only be proven outside the scanned window
  may be omitted from `All directories` — an intentional coverage trade-off;
  v2 cwd hash validation itself is unchanged.

## Tests

- `test/history-reverse-reader.test.ts` (13): ordering, final-newline
  variants, cross-chunk rows, UTF-8 splits, escaped multiline, corrupt rows,
  256KiB+ rows, cursor continuation with contiguous byte coverage, maxRows=1
  walking, empty files, abort, revision invalidation.
- `test/history-search.test.ts` (S1–S17): budget bounds, global cap, mtime
  priority, row.ts ordering, limit separation, sparse queries, early exit,
  three-page continuation over 12,000 rows (no rescan/dup/gap), budget ≠
  exhausted, continuation context errors, overflow drain, exact
  EOF/budget boundary, pending rows recovered by a later-page proof,
  knownCwds resolver update between pages, cross-page dedupe
  replacement, fresh continuation file cwd proof, append between pages
  (snapshot semantics), shrink → stale-continuation error.
- Full bundle suite: 1894/1894 passing; typecheck, build, naming gate and
  client-boundary gate green.

## Review

Reviewed through the review-fix-loop (openai-codex / gpt-5.6-luna): 3 review-loop rounds (4 P1 findings fixed) plus the PR review
(2 P1 + 3 P2 + 1 continuation-stale blocker, all fixed) (continuation overflow, fully-scanned-file re-scan,
pending rows / file proof across pages, knownCwds resolver re-read on
continuation restore), each pinned by a regression test. Final verdict:
accepted, no open findings.
