### PR TITLE
feat(history): add the Current session scope to Ctrl+R search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Ctrl+R defaults to the current session and gains a third scope.**
+  `Tab` now cycles `Current session` → `Current directory` → `All
+  directories` (the query survives). `Current session` — the new default
+  when a session is live — shows only the current session's own inputs
+  (v2 rows carry the session id; legacy rows are never guessed into a
+  session), so the first thing Ctrl+R offers is what THIS conversation
+  typed, while `Current directory` and `All directories` keep the
+  cross-session reach. On a deferred start (no session yet) the panel
+  falls back to `Current directory` and hides the session tab. The
+  session id is captured at panel open time, so a session switch makes
+  the next Ctrl+R search the new session. The scope tabs are responsive
+  (full labels on wide terminals, short labels on narrow ones).
 - **Ctrl+R history search is now bounded and recent-first.** Instead of
   parsing every candidate history file in full on each keystroke, the
   search reads the JSONL store from the tail backwards through a new

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -256,6 +256,16 @@
 
 ### 变更
 
+- **Ctrl+R 默认改为当前会话，并新增第三档 scope。** `Tab` 现在循环
+  `Current session`(当前会话)→ `Current directory`(当前目录)→
+  `All directories`(全部目录)(查询词保留)。`Current session`——有
+  活跃会话时的新默认——只显示当前会话自己的输入(v2 行携带 session id,
+  legacy 行绝不猜测归属),所以 Ctrl+R 首先给出的是**本次对话**输入过
+  什么,而 `Current directory` 与 `All directories` 保留跨会话检索能力。
+  deferred start(尚无会话)时面板回退到 `Current directory` 并隐藏
+  会话 tab。session id 在面板打开时一次性捕获,因此切换会话后下一次
+  Ctrl+R 搜索的就是新会话。scope tab 是响应式的(宽终端完整标签,
+  窄终端短标签)。
 - **Ctrl+R 历史搜索改为有界、最近优先。** 不再每次按键都完整解析所有候选
   历史文件：搜索通过新的 reverse reader 从 JSONL 存储尾部倒序读取，消耗
   全局扫描预算（每次搜索在所有文件中最多 5000 条 physical lines，绝不是

--- a/docs/input-history.md
+++ b/docs/input-history.md
@@ -78,23 +78,45 @@ dedicated data file keyed by the working directory. We adopt that shape.
 `Ctrl+R` opens the input-history search panel (host-reserved key; plugins
 can never claim it). It is "find and EDIT", never "find and run":
 
-- **Scope**: `Tab` toggles `Current directory` (the default) ⇄
-  `All directories`; the query survives the switch.
+- **Scopes**: `Tab` cycles the scope; the query survives the switch.
+  - `Current session` (the default when a live session exists) — only the
+    CURRENT session's inputs: v2 rows whose `sessionId` matches the live
+    session id. v1 rows and v2 rows without a sessionId are excluded —
+    never guessed (legacy data has no reliable session proof).
+  - `Current directory` — the live cwd's file, every trusted row.
+  - `All directories` — every history file with the cwd-proof rules.
+  - Without a session identity (a deferred start before the first prompt)
+    the panel defaults to `Current directory` and the session tab is
+    hidden — a session tab with no identity would always be empty.
 - **Filtering**: case-insensitive substring over the content; an empty
   query browses the most recent history.
 - **Details**: the selected row's FULL multi-line content, plus its
   directory, timestamp and session — legacy rows honestly show
-  `Unknown (legacy history)` (never a fabricated time).
+  `Unknown (legacy history)` (never a fabricated time). The list shows
+  the prompt only; the directory prefix appears in `All directories` only.
 - **Enter** puts the selected text back into the editor (via
   `setEditorText`) and closes the panel — it never submits. **Esc** closes
   with the draft untouched (the panel never previews into the editor).
-- **Storage**: v2 rows carry `cwd` + `ts`; v1 rows inherit the cwd from a
-  v2 row that validates the file hash (Rule 1) or a known-cwd identity map
-  (Rule 2). Unresolved legacy files are excluded from `All directories`
-  (Rule 3 — never a guessed directory).
+- **Storage**: v2 rows carry `cwd` + `ts` + `sessionId`; v1 rows inherit
+  the cwd from a v2 row that validates the file hash (Rule 1) or a
+  known-cwd identity map (Rule 2). Unresolved legacy files are excluded
+  from `All directories` (Rule 3 — never a guessed directory).
 - **Search source**: `src/history-search.ts` (replaceable; a SQLite/FTS
   backend can swap in without touching the panel) and
   `src/history-panel.ts` (the overlay).
+
+### The session-scope persist gate (deferred start)
+
+The `session` scope is only as good as the `sessionId` on each row. The
+runner therefore writes an agent-facing submission's history row AFTER the
+session exists, with the FINAL session id — the first prompt of a deferred
+start (`dsh --profile …` without `--session`) creates the session, and a
+row written before creation would carry no sessionId and vanish from
+`Current session`. Sessionless submissions (`/help`, `/settings`,
+`/sessions`, `!!` shells) persist with `sessionId: undefined` and stay
+visible in `Current directory` / `All directories`. The ordering contract
+lives in `src/history-persist.ts` (`persistAfterSession`), pinned by
+`test/history-persist.test.ts` (the merge gate).
 
 ### Bounded recent-first scanning (the perf contract)
 
@@ -192,7 +214,12 @@ unwritten entries.
   tabs, list, details, responsive layout). Pinned by
   `test/history-panel.test.ts` and the `test/ctrl-r.test.ts` integration
   suite.
+- `src/history-persist.ts` — the session-scope persist gate: the pure
+  persist decision (`persistHistoryRecord`) and the deferred-start
+  ordering contract (`persistAfterSession`). Pinned by
+  `test/history-persist.test.ts`.
 - Runner wiring in `src/index.ts`: boot seed, per-session seed in
-  `initLiveSession`, append on submit in `dispatchUserInput` (v2 rows),
-  migration, and the injected `FileHistorySearchSource`.
+  `initLiveSession`, append on submit in `dispatchUserInput` (v2 rows,
+  after session creation for agent-facing submissions), migration, and the
+  injected `FileHistorySearchSource`.
 - `docs/README.md` — index.

--- a/src/history-panel.ts
+++ b/src/history-panel.ts
@@ -4,7 +4,8 @@
  *
  * Anatomy (one `render(width)` call decides the layout — plan §20):
  * - title line (` Input History `) + scope tabs
- *   (`[ Current directory ]` / ` All directories `);
+ *   (`[ Current session ]` / `[ Current directory ]` / ` All directories `;
+ *   the session tab exists only when a live session identity was injected);
  * - search row: the panel's OWN query `Input` (plan §19 — no SelectList
  *   internal search, so the query state is never duplicated);
  * - list + detail: wide (width >= 100) side-by-side (55/45 split);
@@ -17,7 +18,14 @@
  * is untouched — the panel never previews into it); Enter = accept (the
  * selected content goes to the editor through the app's `setEditorText`,
  * the panel closes, the editor regains focus — NEVER a submit, plan §33);
- * Tab = scope toggle with the query preserved; Ctrl+C = cancel (plan §35).
+ * Tab = scope cycle with the query preserved; Ctrl+C = cancel (plan §35).
+ *
+ * Scopes: `session` (default when a session identity was injected — only
+ * the live session's rows), `current` (the live cwd's file, every trusted
+ * row), `all` (every history file with the cwd-proof rules). Tab cycles
+ * session → current → all → session; without a session identity the panel
+ * starts at `current` and cycles current ⇄ all (a session tab with no
+ * identity would always be empty).
  *
  * Async safety (plan §14/§15): every refresh aborts the previous search,
  * bumps a generation counter, and only a result whose generation is STILL
@@ -52,6 +60,13 @@ export interface HistoryPanelOptions {
   source: HistorySearchSource
   /** The working directory for the `current` scope. */
   cwd: string
+  /**
+   * The live session identity, captured ONCE at open time. When defined,
+   * the panel defaults to the `session` scope and the Tab cycle includes
+   * it; when undefined (no session yet on a deferred start) the panel
+   * defaults to `current` and the session tab is hidden.
+   */
+  sessionId?: string
   /** Accept handler: receives the selected record's content. */
   onAccept: (content: string) => void
   /** Cancel handler (Esc/Ctrl+C). */
@@ -78,12 +93,6 @@ interface HistoryPanelState {
   loading: boolean
   error?: string
   generation: number
-}
-
-/** One list `SelectItem` for the history rows. */
-function historyToSelectItem(result: HistorySearchResult, scope: HistoryScope): { value: string; label: string } {
-  const prefix = scope === 'all' && result.cwd !== null ? `${shortCwd(result.cwd)}  ` : ''
-  return { value: result.id, label: `${prefix}${compactRow(result.content)}` }
 }
 
 /** The shortest distinctive cwd suffix (parent + name). */
@@ -127,17 +136,14 @@ export function formatRelativeAge(ts: number, now: number = Date.now()): string 
  * ↑/↓/PgUp/PgDn (list) and the query input.
  */
 export class HistoryPanel implements Component, Focusable {
-  private readonly state: HistoryPanelState = {
-    scope: 'current',
-    query: '',
-    results: [],
-    selectedIndex: 0,
-    loading: false,
-    generation: 0,
-  }
+  private readonly state: HistoryPanelState
   private readonly input: Input
   private readonly source: HistorySearchSource
   private readonly cwd: string
+  /** The live session identity captured at open time (undefined = no
+   * session yet — the session tab is hidden and the default scope is
+   * `current`). */
+  private readonly sessionId: string | undefined
   private readonly onAccept: (content: string) => void
   private readonly onClose: () => void
   private readonly onResultsChanged: (() => void) | undefined
@@ -150,6 +156,7 @@ export class HistoryPanel implements Component, Focusable {
   constructor(options: HistoryPanelOptions) {
     this.source = options.source
     this.cwd = options.cwd
+    this.sessionId = options.sessionId
     this.onAccept = options.onAccept
     this.onClose = options.onClose
     this.onResultsChanged = options.onResultsChanged
@@ -160,6 +167,18 @@ export class HistoryPanel implements Component, Focusable {
     // output past the overlay and clip the footer.
     this.maxRows = options.maxRows ?? 24
     this.input = new Input()
+    // The default scope: `session` when a live session identity exists
+    // (the agent-session model — the current session's inputs are the
+    // most relevant), `current` otherwise (a deferred start has no
+    // session yet; a session tab would always be empty).
+    this.state = {
+      scope: options.sessionId !== undefined ? 'session' : 'current',
+      query: '',
+      results: [],
+      selectedIndex: 0,
+      loading: false,
+      generation: 0,
+    }
     this.state.query = options.initialQuery ?? ''
     this.input.setValue(this.state.query)
   }
@@ -238,7 +257,14 @@ export class HistoryPanel implements Component, Focusable {
   }
 
   private toggleScope(): void {
-    this.state.scope = this.state.scope === 'current' ? 'all' : 'current'
+    // The Tab cycle: session → current → all → session (the session tab
+    // exists only when a live session identity was injected; without one
+    // the cycle is current ⇄ all). The query SURVIVES (plan §31).
+    this.state.scope = this.sessionId !== undefined
+      ? this.state.scope === 'session' ? 'current'
+        : this.state.scope === 'current' ? 'all'
+          : 'session'
+      : this.state.scope === 'current' ? 'all' : 'current'
     this.state.selectedIndex = 0
     this.scheduleSearch()
   }
@@ -299,6 +325,7 @@ export class HistoryPanel implements Component, Focusable {
     const request = {
       scope: this.state.scope,
       cwd: this.cwd,
+      sessionId: this.sessionId,
       query: this.state.query,
       limit: HISTORY_SEARCH_RESULT_LIMIT,
       signal: controller.signal,
@@ -355,14 +382,33 @@ export class HistoryPanel implements Component, Focusable {
   }
 
   private renderTitle(width: number): string {
-    const current = this.state.scope === 'current'
-    const currentTab = current ? '[ Current directory ]' : '  Current directory  '
-    const allTab = !current ? '[ All directories ]' : '  All directories  '
     const title = ` History Search `
     const titleWidth = visibleWidth(title)
-    const tabs = ` ${currentTab}   ${allTab} `
+    const tabs = this.renderTabs(width)
     const gap = ' '.repeat(Math.max(0, width - titleWidth - visibleWidth(tabs)))
     return `${title}${gap}${tabs}`.slice(0, width)
+  }
+
+  /**
+   * The scope tabs, responsive: wide terminals get the full labels
+   * (`[ Current session ]   Current directory   All directories`), narrow
+   * ones the short forms (`[ Session ]   Directory   All`) — three full
+   * labels must never be forced onto one line. The final `.slice(0,
+   * width)` in renderTitle truncates as the last resort. The session tab
+   * exists only when a live session identity was injected.
+   */
+  private renderTabs(width: number): string {
+    const wide = width >= 85
+    const sessionLabel = this.sessionId !== undefined ? (wide ? 'Current session' : 'Session') : null
+    const currentLabel = wide ? 'Current directory' : 'Directory'
+    const allLabel = wide ? 'All directories' : 'All'
+    const parts: string[] = []
+    if (sessionLabel !== null) {
+      parts.push(this.state.scope === 'session' ? `[ ${sessionLabel} ]` : `  ${sessionLabel}  `)
+    }
+    parts.push(this.state.scope === 'current' ? `[ ${currentLabel} ]` : `  ${currentLabel}  `)
+    parts.push(this.state.scope === 'all' ? `[ ${allLabel} ]` : `  ${allLabel}  `)
+    return ` ${parts.join('   ')} `
   }
 
   private renderSearchRow(width: number): string {

--- a/src/history-persist.ts
+++ b/src/history-persist.ts
@@ -77,3 +77,21 @@ export async function persistAfterSession(
   const sessionId = await resolveSession()
   persist(sessionId)
 }
+
+/**
+ * The session identity a submission kind's history row earns — the
+ * call-site decision table, pinned by tests so a future change cannot
+ * silently re-attribute rows:
+ * - `'agent-facing'` — the session id: the FINAL one after session
+ *   creation on a deferred start (the gate), the LIVE one otherwise
+ *   (steers into a running session);
+ * - `'sessionless'` — `undefined`: the submission never touches a session
+ *   (`!!` shells, bare `!`, local commands) and must stay out of the
+ *   `Current session` scope.
+ */
+export function historySessionIdFor(
+  kind: 'agent-facing' | 'sessionless',
+  sessionId: string | undefined,
+): string | undefined {
+  return kind === 'agent-facing' ? sessionId : undefined
+}

--- a/src/history-persist.ts
+++ b/src/history-persist.ts
@@ -1,0 +1,79 @@
+/**
+ * The Ctrl+R session-scope persist gate (plan M-gate): an agent-facing
+ * submission's history row must be written AFTER the session exists, with
+ * the FINAL session id — the first prompt of a deferred start creates the
+ * session, and a row written before creation would carry no sessionId and
+ * vanish from the `Current session` scope. Sessionless submissions (local
+ * commands, `!!` shells) persist with `sessionId: undefined` and stay
+ * visible in `Current directory` / `All directories`.
+ *
+ * Two pieces:
+ * - {@link persistHistoryRecord} — the pure persist decision + write (the
+ *   dedupe/image guards, the cwd/ts/sessionId snapshot, the append).
+ * - {@link persistAfterSession} — the ORDERING gate: resolve the session
+ *   FIRST, then persist with the resolved id. The runner uses it in the
+ *   submit path; the test pins the ordering so a future "optimization"
+ *   that writes before session creation cannot silently regress the first
+ *   prompt of a fresh session.
+ * @module @xmoon76/dsh-pi-tui/history-persist
+ */
+
+import { appendHistoryRecord } from './history.ts'
+
+/** The persist-time facts of one submission row. */
+export interface HistoryPersistContext {
+  /** The trimmed submission text. */
+  content: string
+  /** The cwd at persist time (the row's file key — resolved AFTER session
+   * creation so the row lands in the session's cwd file and its `cwd`
+   * field agrees with the file hash). */
+  cwd: string
+  /** The session identity at persist time (undefined = sessionless). */
+  sessionId: string | undefined
+  /** The USER's submission time (epoch-ms) — never the disk-write time. */
+  ts: number
+  /** The newest known content (consecutive-repeat dedupe). */
+  lastContent: string | undefined
+  /** Whether the submission carries staged images (never persisted — the
+   * placeholder dies with the draft on consume, so an ↑ recall would
+   * re-send it as ordinary text). */
+  hasImages: boolean
+  /** The history file path for the cwd. */
+  file: string
+}
+
+/** Persist one submission row; returns whether an entry was written. An
+ * empty content, a repeat of `lastContent` and an image-bearing submission
+ * are skipped without touching the file (shell-history behavior). */
+export function persistHistoryRecord(context: HistoryPersistContext): boolean {
+  if (context.content === '' || context.content === context.lastContent || context.hasImages) return false
+  return appendHistoryRecord(context.file, {
+    v: 2,
+    content: context.content,
+    cwd: context.cwd,
+    ts: context.ts,
+    sessionId: context.sessionId,
+  }, context.lastContent)
+}
+
+/**
+ * The deferred-start ordering gate: resolve/create the session FIRST, then
+ * persist the submission row with the FINAL session id. The first prompt
+ * of a deferred start creates the session inside `resolveSession`; a row
+ * written before that would carry no sessionId and vanish from the
+ * `Current session` scope. A resolution that resolves `undefined` (a
+ * sessionless submission) persists the row without a sessionId — it stays
+ * reachable in `Current directory` / `All directories`. A resolution that
+ * REJECTS (session creation failed) persists nothing: the submission never
+ * reached a session.
+ * @param resolveSession - resolves the FINAL session id (undefined when no
+ * session exists — sessionless submissions).
+ * @param persist - persists the row under the resolved id.
+ */
+export async function persistAfterSession(
+  resolveSession: () => Promise<string | undefined>,
+  persist: (sessionId: string | undefined) => void,
+): Promise<void> {
+  const sessionId = await resolveSession()
+  persist(sessionId)
+}

--- a/src/history-search.ts
+++ b/src/history-search.ts
@@ -2,6 +2,14 @@
  * Ctrl+R history search — the replaceable search-source seam (plan §10).
  *
  * Scope semantics:
+ * - `'session'` — ONE file: `$DSH_HOME/user-history/<md5(cwd)>.jsonl`, like
+ *   `'current'`, but ONLY v2 rows whose `sessionId` equals `request.sessionId`
+ *   are eligible. v1 rows and v2 rows without (or with a different)
+ *   sessionId are EXCLUDED — never guessed: legacy data has no reliable
+ *   session proof. A matching row inherits `request.cwd` (the file is keyed
+ *   by that cwd — plan §6.1). With `request.sessionId === undefined` nothing
+ *   matches (defensive: the panel only defaults to this scope when a live
+ *   session identity exists).
  * - `'current'` — ONE file: `$DSH_HOME/user-history/<md5(cwd)>.jsonl`. Every
  *   row (v1 AND v2) is displayable: legacy rows inherit `request.cwd` (the
  *   file is keyed by that cwd, so the effective cwd is known — plan §6.1).
@@ -43,9 +51,9 @@
  * fabricated) and sort AFTER every timed row, then by file asc + newest row
  * first within the file (deterministic — plan §7/§12).
  *
- * Dedupe: current → by `content`; all → by `${cwd}\0${content}` (a prompt
- * in two directories stays two rows — plan §13). The NEWEST occurrence wins
- * (compareResults is the beats predicate, applied incrementally).
+ * Dedupe: session/current → by `content`; all → by `${cwd}\0${content}` (a
+ * prompt in two directories stays two rows — plan §13). The NEWEST occurrence
+ * wins (compareResults is the beats predicate, applied incrementally).
  *
  * Cancellation: the search observes the AbortSignal between files, per
  * batch and inside the reader; an abort returns an empty page. The panel
@@ -63,8 +71,8 @@ import { join } from 'node:path'
 import { historyFilePath, parseHistoryRecordLine, type ParsedHistoryRecord } from './history.ts'
 import { readJsonlReverseBatch, ReverseJsonlRevisionError, type ReverseJsonlCursor } from './history-reverse-reader.ts'
 
-/** The two scope categories (`/sessions` vocabulary). */
-export type HistoryScope = 'current' | 'all'
+/** The three scope categories (`/sessions` vocabulary). */
+export type HistoryScope = 'session' | 'current' | 'all'
 
 /** Search debounce (local filesystem — plan §15: 50–100ms). */
 export const HISTORY_SEARCH_DEBOUNCE_MS = 75
@@ -84,8 +92,12 @@ export const HISTORY_SEARCH_READ_CHUNK_BYTES = 64 * 1024
 /** One search invocation. */
 export interface HistorySearchRequest {
   scope: HistoryScope
-  /** The live working directory (the current-scope file key). */
+  /** The live working directory (the current/session-scope file key). */
   cwd: string
+  /** The session identity the `session` scope filters by (v2 rows whose
+   * `sessionId` matches). Ignored by the other scopes; `undefined` with
+   * the session scope matches nothing (defensive). */
+  sessionId?: string
   /** The filter; `''` matches every row (recent-history browse). */
   query: string
   /** Row cap. */
@@ -134,6 +146,10 @@ export interface HistorySearchContinuation {
    * continuation is a typed error, never silently reused). */
   readonly scope: HistoryScope
   readonly cwd: string
+  /** The session identity the continuation's `session` scope filters by
+   * (a session-A continuation reused under session B is a typed error —
+   * the dedupe state and scan position were built for session A). */
+  readonly sessionId?: string
   readonly query: string
   readonly limit: number
   /** The files not yet fully scanned, in scan order (the first one is the
@@ -193,7 +209,7 @@ export interface HistorySearchDebugStats {
  * the dedupe state and scan position would silently produce wrong results. */
 export class HistorySearchContinuationError extends Error {
   constructor() {
-    super('history search continuation does not match the request (scope/cwd/query/limit)')
+    super('history search continuation does not match the request (scope/cwd/sessionId/query/limit)')
     this.name = 'HistorySearchContinuationError'
   }
 }
@@ -265,9 +281,11 @@ export class FileHistorySearchSource implements HistorySearchSource {
     const scope = request.scope
     const files = continuation !== undefined
       ? [...continuation.files]
-      : scope === 'current'
-        // The current-scope file is known by path; its stat happens inside
-        // the reader (mtime/size are only used for all-scope ordering).
+      : scope === 'current' || scope === 'session'
+        // The current/session-scope file is known by path; its stat happens
+        // inside the reader (mtime/size are only used for all-scope
+        // ordering). The session scope NEVER scans other cwds — the file
+        // keyed by the live cwd holds every row of the live session.
         ? [{ path: historyFilePath(this.dshHome, request.cwd), mtimeMs: 0, size: 0 }]
         : await this.listAllFiles()
     const stats = this.stats
@@ -418,7 +436,7 @@ export class FileHistorySearchSource implements HistorySearchSource {
     const deduped: HistorySearchResult[] = []
     const combinedKeys = new Set<string>()
     for (const row of combined) {
-      const key = scope === 'current' ? row.content : `${row.cwd ?? ''}\0${row.content}`
+      const key = dedupeKey(scope, row)
       if (combinedKeys.has(key)) continue
       combinedKeys.add(key)
       deduped.push(row)
@@ -431,6 +449,7 @@ export class FileHistorySearchSource implements HistorySearchSource {
       continuation: exhausted ? undefined : {
         scope: request.scope,
         cwd: request.cwd,
+        sessionId: request.sessionId,
         query: request.query,
         limit: request.limit,
         files: files.slice(fileIndex),
@@ -483,6 +502,12 @@ export class FileHistorySearchSource implements HistorySearchSource {
   /** Route ONE parsed row into the result state and return the (possibly
    * updated) file proof.
    *
+   * Session scope: ONLY v2 rows whose `sessionId` matches the request are
+   * eligible — v1 rows and v2 rows without (or with a different) sessionId
+   * are excluded, never guessed (legacy data has no reliable session
+   * proof). The file IS the current cwd's file, so a matching row inherits
+   * `request.cwd` exactly like the current scope.
+   *
    * A v2 row's cwd is trusted ONLY when it validates against the file it
    * lives in (`historyFilePath(home, cwd) === file` — plan §40: an invalid
    * v2 cwd/hash mismatch is never trusted; it could be a moved directory or
@@ -505,6 +530,13 @@ export class FileHistorySearchSource implements HistorySearchSource {
     map: Map<string, HistorySearchResult>,
     newKeys: Set<string>,
   ): string | null {
+    if (request.scope === 'session') {
+      if (request.sessionId === undefined) return fileProof
+      if (record.version !== 2 || record.sessionId !== request.sessionId) return fileProof
+      if (!matchesQuery(record.content, request.query)) return fileProof
+      this.mergeResult(map, newKeys, this.buildResult(file, record, request.cwd, byteStart), request.scope)
+      return fileProof
+    }
     if (record.version === 2 && record.cwd !== null && historyFilePath(this.dshHome, record.cwd) === file) {
       if (request.scope === 'all' && fileProof === null) {
         // The proof forms NOW: flush the pending rows with it.
@@ -558,7 +590,7 @@ export class FileHistorySearchSource implements HistorySearchSource {
     result: HistorySearchResult,
     scope: HistoryScope,
   ): void {
-    const key = scope === 'current' ? result.content : `${result.cwd ?? ''}\0${result.content}`
+    const key = dedupeKey(scope, result)
     const existing = map.get(key)
     if (existing === undefined) {
       map.set(key, result)
@@ -570,12 +602,13 @@ export class FileHistorySearchSource implements HistorySearchSource {
   }
 
   /** A continuation belongs to exactly one request context: reusing it
-   * with a different scope/cwd/query/limit would silently produce wrong
-   * results (the dedupe state and scan position were built for the old
-   * context). */
+   * with a different scope/cwd/sessionId/query/limit would silently produce
+   * wrong results (the dedupe state and scan position were built for the
+   * old context). */
   private validateContinuation(request: HistorySearchRequest, continuation: HistorySearchContinuation): void {
     if (continuation.scope !== request.scope
       || continuation.cwd !== request.cwd
+      || continuation.sessionId !== request.sessionId
       || continuation.query !== request.query
       || continuation.limit !== request.limit) {
       throw new HistorySearchContinuationError()
@@ -587,6 +620,13 @@ export class FileHistorySearchSource implements HistorySearchSource {
 function matchesQuery(content: string, query: string): boolean {
   if (query === '') return true
   return content.toLowerCase().includes(query.toLowerCase())
+}
+
+/** The dedupe key: the session/current scopes dedupe by content (one row
+ * per prompt — the newest wins); the all scope keys by (cwd, content) so a
+ * prompt in two directories stays two rows. */
+function dedupeKey(scope: HistoryScope, result: HistorySearchResult): string {
+  return scope === 'all' ? `${result.cwd ?? ''}\0${result.content}` : result.content
 }
 
 /** Newest-first by ts (legacy rows — ts NULL — sort after every timed row),

--- a/src/index.ts
+++ b/src/index.ts
@@ -3293,8 +3293,14 @@ export function apply(ctx: Context, config: Config): void {
      * already-steered input cannot be pulled back.
      * @param text - the submitted draft ('' allowed for Ctrl+S).
      * @param onlyDraft - busy-Enter mode: never read or remove the queue.
+     * @param persistHistory - the call site's persist closure (with its
+     * submission-time snapshot). Invoked AFTER the session exists with the
+     * FINAL session id — the deferred-start gate: Ctrl+S on a deferred
+     * start creates the session inside this flow, and a row written
+     * before creation would carry no sessionId and vanish from the Ctrl+R
+     * `Current session` scope. Absent, the steer persists nothing.
      */
-    const steerNow = (text: string, onlyDraft = false): void => {
+    const steerNow = (text: string, onlyDraft = false, persistHistory?: (sessionId: string | undefined) => void): void => {
       // The guard action is deliberately the Ctrl+S 'save' action (not
       // 'submit'): the busy-Enter steer writes the session like Ctrl+S,
       // and the one-time force token embeds the payload identity, so an
@@ -3335,7 +3341,20 @@ export function apply(ctx: Context, config: Config): void {
       runOwned('steer', () => runReservedSubmit({
         reserve: (t) => draftImages.pinReferenced(t),
         run: async () => {
-        await ensureSession()
+        // The deferred-start gate (history-persist.ts): the steered
+        // draft's history row is written AFTER the session exists, with
+        // the FINAL session id — Ctrl+S on a deferred start creates the
+        // session here, and a row written before creation would carry no
+        // sessionId and vanish from the Ctrl+R `Current session` scope.
+        // A rejected creation persists nothing (the steer never reached
+        // a session).
+        await persistAfterSession(
+          async () => {
+            await ensureSession()
+            return liveAgent?.session.id
+          },
+          (sessionId) => persistHistory?.(sessionId),
+        )
         if (liveAgent === undefined) return
         // The draft message is prepared BEFORE the guard: admission is
         // async I/O, and the guard's identity is the draft text (which
@@ -3404,38 +3423,43 @@ export function apply(ctx: Context, config: Config): void {
      */
     let lastHistoryContent: string | undefined
     /**
-     * Persist a STEERED submission (Ctrl+S, the steer-draft extension
-     * action, busy-Enter steer): the text goes to the RUNNING session, so
-     * the row carries the live session id. The ts and the image check are
-     * snapshotted at CALL time — the editor is cleared right after and the
-     * steer flow consumes the staged images on success, so a late check
-     * would wrongly persist the placeholder text. An empty draft (Ctrl+S
-     * with only a queue) persists nothing — the queued messages were
-     * already persisted when originally submitted.
+     * Build the steer-persist closure for a draft (Ctrl+S, the
+     * steer-draft extension action, busy-Enter steer): the submission-time
+     * facts — the ts (the row must record the USER's steer time, not the
+     * post-creation write time) and the image check (the editor is
+     * cleared right after and the steer flow consumes the staged images
+     * on success, so a late check would wrongly persist the placeholder
+     * text) — are snapshotted NOW. The returned closure writes the row
+     * under the session id the steer gate resolved (the FINAL id after
+     * session creation on a deferred start). An empty draft (Ctrl+S with
+     * only a queue) persists nothing — the queued messages were already
+     * persisted when originally submitted.
      */
-    const persistSteeredHistory = (text: string): void => {
+    const makeSteerPersist = (text: string): ((sessionId: string | undefined) => void) => {
       const trimmed = text.trim()
-      const hasImages = draftHasImages(text, draftImages)
-      if (trimmed === '' || trimmed === lastHistoryContent || hasImages) return
-      const historyCwd = sessionCwd()
       const historyTs = Date.now()
-      const file = historyFilePath(dshHome(process.env), historyCwd)
-      runDetached('input history write', () => {
-        const written = persistHistoryRecord({
-          content: trimmed,
-          cwd: historyCwd,
-          sessionId: historySessionIdFor('agent-facing', liveAgent?.session.id),
-          ts: historyTs,
-          lastContent: lastHistoryContent,
-          hasImages,
-          file,
+      const historyHasImages = draftHasImages(text, draftImages)
+      return (sessionId: string | undefined): void => {
+        if (trimmed === '' || trimmed === lastHistoryContent || historyHasImages) return
+        const historyCwd = sessionCwd()
+        const file = historyFilePath(dshHome(process.env), historyCwd)
+        runDetached('input history write', () => {
+          const written = persistHistoryRecord({
+            content: trimmed,
+            cwd: historyCwd,
+            sessionId: historySessionIdFor('agent-facing', sessionId),
+            ts: historyTs,
+            lastContent: lastHistoryContent,
+            hasImages: historyHasImages,
+            file,
+          })
+          if (written) lastHistoryContent = trimmed
+        }, {
+          diag,
+          notify: (message) => app.notify(message, 'error'),
+          recoverable: () => true,
         })
-        if (written) lastHistoryContent = trimmed
-      }, {
-        diag,
-        notify: (message) => app.notify(message, 'error'),
-        recoverable: () => true,
-      })
+      }
     }
     /**
      * Dispatch one user submission end to end: the viewer guard, the input-
@@ -3605,9 +3629,10 @@ export function apply(ctx: Context, config: Config): void {
         // `/<name> <args>` line — the harness gesture recognizes the
         // skill's own slash name and injects its body; the raw `/skill
         // <name>` form would never match (review finding 2). Image
-        // placeholders ride the normalized line untouched.
-        persistHistory(historySessionIdFor('agent-facing', liveAgent?.session.id))
-        steerNow(normalizeSkillInvocation(text) ?? text, true)
+        // placeholders ride the normalized line untouched. The history
+        // row is written inside steerNow AFTER the session exists (the
+        // deferred-start gate), with the FINAL session id.
+        steerNow(normalizeSkillInvocation(text) ?? text, true, persistHistory)
         return
       }
       dispatchViaSession(text, persistHistory)
@@ -3770,13 +3795,14 @@ export function apply(ctx: Context, config: Config): void {
           }
           case 'steer-draft': {
             const text = app.getDraft()
-            // The steered draft is an agent-facing submission: it must
-            // land in history with the live session id (the snapshot
-            // happens BEFORE the draft is cleared and the steer consumes
-            // the staged images).
-            persistSteeredHistory(text)
+            // The steered draft is an agent-facing submission: the
+            // snapshot (ts + image check) happens BEFORE the draft is
+            // cleared, and the row is written inside steerNow AFTER the
+            // session exists (the deferred-start gate) with the FINAL
+            // session id.
+            const persist = makeSteerPersist(text)
             app.setDraft('')
-            steerNow(text)
+            steerNow(text, false, persist)
             break
           }
           case 'cancel-activity': {
@@ -3814,11 +3840,11 @@ export function apply(ctx: Context, config: Config): void {
         }
       },
       onSteer: (text) => {
-        // Ctrl+S: the steered draft is an agent-facing submission — it
-        // must land in history with the live session id (the snapshot
-        // happens BEFORE the steer consumes the staged images).
-        persistSteeredHistory(text)
-        steerNow(text)
+        // Ctrl+S: the steered draft is an agent-facing submission — the
+        // snapshot happens now, and the row is written inside steerNow
+        // AFTER the session exists (the deferred-start gate) with the
+        // FINAL session id.
+        steerNow(text, false, makeSteerPersist(text))
       },
       onExtensionError: ({ slot, id, error }) => {
         try { extensionService?._recordRegistryError(slot, id, error) } catch {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ import { customThemeNames } from './theme.ts'
 import { diagFromEnv, dshHome, type Diag } from './diag.ts'
 import { runDetached, runOwned, isCancellation, type OwnedTaskOptions } from './detached.ts'
 import { appendHistoryLine, historyFilePath, loadHistoryFile } from './history.ts'
-import { persistAfterSession, persistHistoryRecord } from './history-persist.ts'
+import { historySessionIdFor, persistAfterSession, persistHistoryRecord } from './history-persist.ts'
 import { FileHistorySearchSource } from './history-search.ts'
 import { safeErrorMessage } from './error-boundary.ts'
 import { DraftImageStore } from './image/draft-store.ts'
@@ -3217,11 +3217,13 @@ export function apply(ctx: Context, config: Config): void {
       })
     }
     /**
-     * Run a sessionless slash command locally — no session, no log, no
-     * persistence. The handler comes from the commands service's global
-     * layer (in-process lookup with no agent is safe: it reads the global
-     * layer only). A sessionless command that failed to register falls back
-     * to the session dispatch, which reports unknown commands as messages.
+     * Run a sessionless slash command locally — no session, no session
+     * log. The input-history row still persists, sessionless (Current
+     * directory / All directories, never Current session). The handler
+     * comes from the commands service's global layer (in-process lookup
+     * with no agent is safe: it reads the global layer only). A
+     * sessionless command that failed to register falls back to the
+     * session dispatch, which reports unknown commands as messages.
      */
     const runLocalCommand = (parsed: { name: string; rawInput: string }, text: string, persistHistory: (sessionId: string | undefined) => void): void => {
       // M5: a plugin-declared local command with a bridge handler routes
@@ -3252,9 +3254,9 @@ export function apply(ctx: Context, config: Config): void {
         return
       }
       // A truly local command: no session is created — the row persists
-      // with `sessionId: undefined` (Current directory / All directories,
-      // never Current session).
-      persistHistory(undefined)
+      // sessionless (Current directory / All directories, never Current
+      // session).
+      persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id))
       // An owned workflow: the result decides the notify, the failure lands
       // in diagnostics — runOwned (AGENTS.md), never a bare void. The
       // handler may be a SYNC implementation, so the factory must run inside
@@ -3422,7 +3424,7 @@ export function apply(ctx: Context, config: Config): void {
         const written = persistHistoryRecord({
           content: trimmed,
           cwd: historyCwd,
-          sessionId: liveAgent?.session.id,
+          sessionId: historySessionIdFor('agent-facing', liveAgent?.session.id),
           ts: historyTs,
           lastContent: lastHistoryContent,
           hasImages,
@@ -3527,7 +3529,7 @@ export function apply(ctx: Context, config: Config): void {
           // `!!` runs purely locally with NO session write (pi's
           // excluded-from-context escape hatch) — the row is sessionless
           // (Current directory / All directories, never Current session).
-          persistHistory(undefined)
+          persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id))
           runLocalShell(text)
         } else if (shellCommandOf(text) !== '') {
           // An owned workflow: the session creation failure restores the
@@ -3536,7 +3538,7 @@ export function apply(ctx: Context, config: Config): void {
           // (the deferred-start gate), so a `!` line that creates the
           // session carries its id.
           runOwned('contextual shell', () => ensureSession().then(() => {
-            persistHistory(liveAgent?.session.id)
+            persistHistory(historySessionIdFor('agent-facing', liveAgent?.session.id))
             runLocalShell(text)
           }), {
             diag,
@@ -3545,7 +3547,7 @@ export function apply(ctx: Context, config: Config): void {
           })
         } else {
           // A bare `!` (no command) is a no-op — sessionless.
-          persistHistory(undefined)
+          persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id))
         }
         return
       }
@@ -3604,7 +3606,7 @@ export function apply(ctx: Context, config: Config): void {
         // skill's own slash name and injects its body; the raw `/skill
         // <name>` form would never match (review finding 2). Image
         // placeholders ride the normalized line untouched.
-        persistHistory(liveAgent?.session.id)
+        persistHistory(historySessionIdFor('agent-facing', liveAgent?.session.id))
         steerNow(normalizeSkillInvocation(text) ?? text, true)
         return
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2987,9 +2987,10 @@ export function apply(ctx: Context, config: Config): void {
           // id — the first prompt of a deferred start creates the session
           // inside resolveSession, and a row written before creation would
           // carry no sessionId and vanish from the Ctrl+R `Current
-          // session` scope. A failed creation persists sessionless (the
-          // input was still typed; it stays reachable in Current
-          // directory / All directories).
+          // session` scope. A resolution that REJECTS (session creation
+          // failed) persists nothing — the submission never reached a
+          // session; a resolution that resolves undefined (sessionless)
+          // persists a row without a sessionId.
           await persistAfterSession(
             async () => {
               await ensureSession()
@@ -3401,6 +3402,40 @@ export function apply(ctx: Context, config: Config): void {
      */
     let lastHistoryContent: string | undefined
     /**
+     * Persist a STEERED submission (Ctrl+S, the steer-draft extension
+     * action, busy-Enter steer): the text goes to the RUNNING session, so
+     * the row carries the live session id. The ts and the image check are
+     * snapshotted at CALL time — the editor is cleared right after and the
+     * steer flow consumes the staged images on success, so a late check
+     * would wrongly persist the placeholder text. An empty draft (Ctrl+S
+     * with only a queue) persists nothing — the queued messages were
+     * already persisted when originally submitted.
+     */
+    const persistSteeredHistory = (text: string): void => {
+      const trimmed = text.trim()
+      const hasImages = draftHasImages(text, draftImages)
+      if (trimmed === '' || trimmed === lastHistoryContent || hasImages) return
+      const historyCwd = sessionCwd()
+      const historyTs = Date.now()
+      const file = historyFilePath(dshHome(process.env), historyCwd)
+      runDetached('input history write', () => {
+        const written = persistHistoryRecord({
+          content: trimmed,
+          cwd: historyCwd,
+          sessionId: liveAgent?.session.id,
+          ts: historyTs,
+          lastContent: lastHistoryContent,
+          hasImages,
+          file,
+        })
+        if (written) lastHistoryContent = trimmed
+      }, {
+        diag,
+        notify: (message) => app.notify(message, 'error'),
+        recoverable: () => true,
+      })
+    }
+    /**
      * Dispatch one user submission end to end: the viewer guard, the input-
      * history persistence, `!` local shells, sessionless commands, the
      * busy-Enter preference, and the session dispatch. The Ctrl+Enter
@@ -3489,7 +3524,10 @@ export function apply(ctx: Context, config: Config): void {
       // (the FIRST user message is the deferred trigger).
       if (text.startsWith('!')) {
         if (text.startsWith('!!')) {
-          persistHistory(liveAgent?.session.id)
+          // `!!` runs purely locally with NO session write (pi's
+          // excluded-from-context escape hatch) — the row is sessionless
+          // (Current directory / All directories, never Current session).
+          persistHistory(undefined)
           runLocalShell(text)
         } else if (shellCommandOf(text) !== '') {
           // An owned workflow: the session creation failure restores the
@@ -3506,7 +3544,8 @@ export function apply(ctx: Context, config: Config): void {
             onError: failSubmission(text),
           })
         } else {
-          persistHistory(liveAgent?.session.id)
+          // A bare `!` (no command) is a no-op — sessionless.
+          persistHistory(undefined)
         }
         return
       }
@@ -3729,6 +3768,11 @@ export function apply(ctx: Context, config: Config): void {
           }
           case 'steer-draft': {
             const text = app.getDraft()
+            // The steered draft is an agent-facing submission: it must
+            // land in history with the live session id (the snapshot
+            // happens BEFORE the draft is cleared and the steer consumes
+            // the staged images).
+            persistSteeredHistory(text)
             app.setDraft('')
             steerNow(text)
             break
@@ -3767,7 +3811,13 @@ export function apply(ctx: Context, config: Config): void {
           }
         }
       },
-      onSteer: (text) => steerNow(text),
+      onSteer: (text) => {
+        // Ctrl+S: the steered draft is an agent-facing submission — it
+        // must land in history with the live session id (the snapshot
+        // happens BEFORE the steer consumes the staged images).
+        persistSteeredHistory(text)
+        steerNow(text)
+      },
       onExtensionError: ({ slot, id, error }) => {
         try { extensionService?._recordRegistryError(slot, id, error) } catch {}
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3602,13 +3602,20 @@ export function apply(ctx: Context, config: Config): void {
         SESSIONLESS_COMMANDS.has(parsed.name)
         || (extensionService?.commands.isSessionless(parsed.name, SESSIONLESS_COMMANDS) ?? false)
       )
-      if (parsed !== undefined && liveAgent === undefined && isSessionless) {
-        // A truly sessionless command: no session exists (and none is
-        // created) — the row persists with `sessionId: undefined` inside
-        // runLocalCommand (its fallback path goes through the
-        // deferred-start gate instead, so an unknown "sessionless" command
-        // that creates a session still carries the final session id).
-        runLocalCommand(parsed, text, persistHistory)
+      if (parsed !== undefined && isSessionless) {
+        // A recognized sessionless command: its history row is sessionless
+        // — it must NEVER appear in Current session, whether or not a
+        // session exists. Without a live agent it runs locally (and
+        // creates none; its fallback path goes through the deferred-start
+        // gate instead, so an unknown "sessionless" command that creates a
+        // session still carries the final session id). With a live agent
+        // it dispatches through the session's command service, but the
+        // persist closure still supplies undefined.
+        if (liveAgent === undefined) {
+          runLocalCommand(parsed, text, persistHistory)
+        } else {
+          dispatchViaSession(text, () => persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id)))
+        }
         return
       }
       // Busy-Enter preference (web busyEnter parity): while the agent is

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,8 @@ import { registerTuiCommands, type InitialCommandCatalog, type TuiCommandRunner 
 import { customThemeNames } from './theme.ts'
 import { diagFromEnv, dshHome, type Diag } from './diag.ts'
 import { runDetached, runOwned, isCancellation, type OwnedTaskOptions } from './detached.ts'
-import { appendHistoryLine, appendHistoryRecord, historyFilePath, loadHistoryFile } from './history.ts'
+import { appendHistoryLine, historyFilePath, loadHistoryFile } from './history.ts'
+import { persistAfterSession, persistHistoryRecord } from './history-persist.ts'
 import { FileHistorySearchSource } from './history-search.ts'
 import { safeErrorMessage } from './error-boundary.ts'
 import { DraftImageStore } from './image/draft-store.ts'
@@ -2955,7 +2956,7 @@ export function apply(ctx: Context, config: Config): void {
     /** The session-backed dispatch: create the session lazily (the first
      * user input is the deferred trigger), guard against cross-process
      * divergence, then execute a registered slash command or follow up. */
-    const dispatchViaSession = (text: string): void => {
+    const dispatchViaSession = (text: string, persistHistory: (sessionId: string | undefined) => void): void => {
       // Capture the advertised claim BEFORE any session creation: the
       // boolean must reflect the completion generation at submit time, never
       // a re-query after ensureSession (a refresh may have already revoked
@@ -2981,9 +2982,23 @@ export function apply(ctx: Context, config: Config): void {
       runOwned('submit', () => runReservedSubmit({
         reserve: (t) => draftImages.pinReferenced(t),
         run: async () => {
-        await ensureSession()
-        const agent = liveAgent
-        if (agent === undefined) return
+          // The deferred-start gate (history-persist.ts): the history row
+          // is written AFTER the session exists, with the FINAL session
+          // id — the first prompt of a deferred start creates the session
+          // inside resolveSession, and a row written before creation would
+          // carry no sessionId and vanish from the Ctrl+R `Current
+          // session` scope. A failed creation persists sessionless (the
+          // input was still typed; it stays reachable in Current
+          // directory / All directories).
+          await persistAfterSession(
+            async () => {
+              await ensureSession()
+              return liveAgent?.session.id
+            },
+            persistHistory,
+          )
+          const agent = liveAgent
+          if (agent === undefined) return
         // The guard checks THIS agent's session; capture the identity so
         // the write below can never target a session the guard did not see
         // (a session switch while the file read is in flight).
@@ -3207,7 +3222,7 @@ export function apply(ctx: Context, config: Config): void {
      * layer only). A sessionless command that failed to register falls back
      * to the session dispatch, which reports unknown commands as messages.
      */
-    const runLocalCommand = (parsed: { name: string; rawInput: string }, text: string): void => {
+    const runLocalCommand = (parsed: { name: string; rawInput: string }, text: string, persistHistory: (sessionId: string | undefined) => void): void => {
       // M5: a plugin-declared local command with a bridge handler routes
       // to the bridge FIRST (its rawInput is passed verbatim — never
       // re-parsed or rewritten, the skill rawInput regression gate); the
@@ -3217,7 +3232,11 @@ export function apply(ctx: Context, config: Config): void {
       const commands = ctx.get('commands')
       const definition = commands?.find(undefined as unknown as Agent, parsed.name)
       if (bridgeHandler === undefined && (commands === undefined || definition === undefined)) {
-        dispatchViaSession(text)
+        // The "sessionless" command is actually unknown: it falls back to
+        // a session dispatch — the history row goes through the
+        // deferred-start gate (persist AFTER the session exists, with the
+        // final session id), never a sessionless write here.
+        dispatchViaSession(text, persistHistory)
         return
       }
       const invocation = {
@@ -3228,9 +3247,13 @@ export function apply(ctx: Context, config: Config): void {
       } as CommandInvocation
       const handler = bridgeHandler ?? definition?.handler
       if (handler === undefined) {
-        dispatchViaSession(text)
+        dispatchViaSession(text, persistHistory)
         return
       }
+      // A truly local command: no session is created — the row persists
+      // with `sessionId: undefined` (Current directory / All directories,
+      // never Current session).
+      persistHistory(undefined)
       // An owned workflow: the result decides the notify, the failure lands
       // in diagnostics — runOwned (AGENTS.md), never a bare void. The
       // handler may be a SYNC implementation, so the factory must run inside
@@ -3414,31 +3437,44 @@ export function apply(ctx: Context, config: Config): void {
       // dropping it. `!` shell lines persist verbatim so ↑ recall re-runs
       // the shell branch.
       const trimmed = text.trim()
-      // A MULTIMODAL submission (draft text referencing staged images) is
-      // NOT persisted to the plain-text history: the placeholder dies with
-      // its draft on consumeDraftImages, so an ↑ recall would re-send the
+      // Submission-time facts snapshotted BEFORE any async work: the
+      // timestamp (the row must record the USER's submission time, not the
+      // disk-write time — an agent-facing write lands after session
+      // creation) and the image check (a MULTIMODAL submission is NOT
+      // persisted to the plain-text history: the placeholder dies with its
+      // draft on consumeDraftImages, so an ↑ recall would re-send the
       // placeholder as ORDINARY TEXT — the images would silently vanish
-      // from the model input (review finding 3). Structured attachment
-      // history (text + refs, recalled on recall) is a post-v1 extension.
-      if (trimmed !== '' && trimmed !== lastHistoryContent && !draftHasImages(text, draftImages)) {
-        // All submission-time facts are snapshotted BEFORE the detached
-        // write: the cwd (file path + row must agree), the timestamp (the
-        // row must record the USER's submission time, not the disk-write
-        // time) and the session id (a session switch must never label a
-        // session A row with session B — it would corrupt all-directory
-        // ordering/provenance). The callback only performs I/O.
+      // from the model input (review finding 3). A late check would miss
+      // the already-consumed images. Structured attachment history (text +
+      // refs, recalled on recall) is a post-v1 extension.)
+      const historyTs = Date.now()
+      const historyHasImages = draftHasImages(text, draftImages)
+      /**
+       * Persist the submitted line under the given session identity. The
+       * sessionId is a PARAMETER, resolved at the CALL SITE — the
+       * deferred-start gate (history-persist.ts): an agent-facing
+       * submission passes the FINAL session id AFTER the session exists
+       * (the first prompt of a deferred start creates the session; a row
+       * written before creation would carry no sessionId and vanish from
+       * the Ctrl+R `Current session` scope). Sessionless submissions pass
+       * undefined and stay visible in `Current directory` / `All
+       * directories`. The cwd is resolved at PERSIST time so the row
+       * lands in the session's cwd file with a `cwd` field that agrees
+       * with the file hash.
+       */
+      const persistHistory = (sessionId: string | undefined): void => {
         const historyCwd = sessionCwd()
-        const historyTs = Date.now()
-        const historySessionId = liveAgent?.session.id
         const file = historyFilePath(dshHome(process.env), historyCwd)
         runDetached('input history write', () => {
-          const written = appendHistoryRecord(file, {
-            v: 2,
+          const written = persistHistoryRecord({
             content: trimmed,
             cwd: historyCwd,
+            sessionId,
             ts: historyTs,
-            sessionId: historySessionId,
-          }, lastHistoryContent)
+            lastContent: lastHistoryContent,
+            hasImages: historyHasImages,
+            file,
+          })
           if (written) lastHistoryContent = trimmed
         }, {
           diag,
@@ -3453,16 +3489,24 @@ export function apply(ctx: Context, config: Config): void {
       // (the FIRST user message is the deferred trigger).
       if (text.startsWith('!')) {
         if (text.startsWith('!!')) {
+          persistHistory(liveAgent?.session.id)
           runLocalShell(text)
         } else if (shellCommandOf(text) !== '') {
           // An owned workflow: the session creation failure restores the
           // draft (failSubmission) — runOwned (AGENTS.md), never a bare
-          // void.
-          runOwned('contextual shell', () => ensureSession().then(() => runLocalShell(text)), {
+          // void. The history row is written AFTER the session exists
+          // (the deferred-start gate), so a `!` line that creates the
+          // session carries its id.
+          runOwned('contextual shell', () => ensureSession().then(() => {
+            persistHistory(liveAgent?.session.id)
+            runLocalShell(text)
+          }), {
             diag,
             sessionId: () => liveAgent?.session.id,
             onError: failSubmission(text),
           })
+        } else {
+          persistHistory(liveAgent?.session.id)
         }
         return
       }
@@ -3494,7 +3538,12 @@ export function apply(ctx: Context, config: Config): void {
         || (extensionService?.commands.isSessionless(parsed.name, SESSIONLESS_COMMANDS) ?? false)
       )
       if (parsed !== undefined && liveAgent === undefined && isSessionless) {
-        runLocalCommand(parsed, text)
+        // A truly sessionless command: no session exists (and none is
+        // created) — the row persists with `sessionId: undefined` inside
+        // runLocalCommand (its fallback path goes through the
+        // deferred-start gate instead, so an unknown "sessionless" command
+        // that creates a session still carries the final session id).
+        runLocalCommand(parsed, text, persistHistory)
         return
       }
       // Busy-Enter preference (web busyEnter parity): while the agent is
@@ -3516,10 +3565,11 @@ export function apply(ctx: Context, config: Config): void {
         // skill's own slash name and injects its body; the raw `/skill
         // <name>` form would never match (review finding 2). Image
         // placeholders ride the normalized line untouched.
+        persistHistory(liveAgent?.session.id)
         steerNow(normalizeSkillInvocation(text) ?? text, true)
         return
       }
-      dispatchViaSession(text)
+      dispatchViaSession(text, persistHistory)
     }
     // M3 runner wiring (F-1): when the extension host service is mounted,
     // the TUI surface attaches a SurfaceHost over its ledger — extensions
@@ -3979,6 +4029,10 @@ export function apply(ctx: Context, config: Config): void {
         knownCwds: () => knownHistoryCwds(),
       }),
       historySearchCwd: () => sessionCwd(),
+      // The session scope's identity — a GETTER like the cwd: a session
+      // switch must make the next Ctrl+R search the NEW session (the
+      // panel captures it once at open time).
+      historySearchSessionId: () => liveAgent?.session.id,
       // The transcript image surface (plan M8/M9): the durable loader plus
       // the dim fallback coloring.
       imageLoader,

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1214,6 +1214,15 @@ export interface TuiAppOptions {
    * cwd keeps the search scoped to the session root.
    */
   historySearchCwd?: () => string
+  /**
+   * The live session identity the `session` scope filters by (the runner
+   * forwards `liveAgent?.session.id`). A GETTER like `historySearchCwd` —
+   * resolved at panel OPEN time, never a snapshot: a session switch must
+   * make the next Ctrl+R search the NEW session. Absent (or resolving
+   * undefined — no session yet on a deferred start), the panel defaults
+   * to the `current` scope and hides the session tab.
+   */
+  historySearchSessionId?: () => string | undefined
 }
 
 /**
@@ -1437,6 +1446,10 @@ export class TuiApp {
    * the whole surface's cwd with the new session header, so the panel must
    * resolve the cwd at OPEN time, not at construction time. */
   private readonly historySearchCwd: (() => string) | undefined
+  /** The live session identity for the panel's `session` scope — a GETTER
+   * (the runner's `liveAgent?.session.id`), never a snapshot: a session
+   * switch must make the next Ctrl+R search the NEW session. */
+  private readonly historySearchSessionId: (() => string | undefined) | undefined
   /** The open CATEGORIZED picker (e.g. /sessions): Tab cycles its
    * categories while it is open. Cleared when the picker closes. */
   private activeCategorizedPicker: CategorizedPickerState | undefined
@@ -1804,6 +1817,9 @@ export class TuiApp {
     // Keep the GETTER: the cwd must be resolved at panel-open time (a
     // session switch changes `sessionCwd()` — see the field doc).
     this.historySearchCwd = options.historySearchCwd
+    // Same for the session identity: a session switch must make the next
+    // Ctrl+R search the NEW session (see the field doc).
+    this.historySearchSessionId = options.historySearchSessionId
     this.editorSeatHolder = new EditorSeatHolder({
       hostAdapter: () => this.hostEditorAdapter(),
       surfaceId: `tui-${Date.now().toString(36)}`,
@@ -3083,6 +3099,11 @@ export class TuiApp {
       // injected getter reflects the LIVE session, the status cwd is the
       // fallback when no getter is wired.
       cwd: this.historySearchCwd?.() ?? this.status.cwd,
+      // The session identity is captured ONCE at open time, like the cwd:
+      // the panel's default scope and every request use this snapshot for
+      // the panel's whole lifetime (a switch while the panel is up keeps
+      // the search stable; the next open re-resolves).
+      sessionId: this.historySearchSessionId?.(),
       maxRows: maxHeight - 2, // the Frame adds its two border rows
       onResultsChanged: () => this.requestRender(),
       onAccept: (content) => {

--- a/test/ctrl-r.test.ts
+++ b/test/ctrl-r.test.ts
@@ -19,10 +19,13 @@ function tempHome(): string {
   return mkdtempSync(join(tmpdir(), 'pi-tui-ctrl-r-'))
 }
 
-function seedHistory(home: string, cwd: string, rows: Array<{ content: string; ts: number }>): void {
+function seedHistory(home: string, cwd: string, rows: Array<{ content: string; ts: number; sessionId?: string }>): void {
   const file = historyFilePath(home, cwd)
   mkdirSync(file.slice(0, file.lastIndexOf('/')), { recursive: true })
-  writeFileSync(file, rows.map(row => JSON.stringify({ v: 2, content: row.content, cwd, ts: row.ts })).join('\n') + '\n', { mode: 0o600 })
+  writeFileSync(file, rows.map(row => JSON.stringify({
+    v: 2, content: row.content, cwd, ts: row.ts,
+    ...(row.sessionId !== undefined ? { sessionId: row.sessionId } : {}),
+  })).join('\n') + '\n', { mode: 0o600 })
 }
 
 async function makeApp(home: string, cwd = '/work/a') {
@@ -46,9 +49,11 @@ async function makeApp(home: string, cwd = '/work/a') {
   return { vt, app, submitted }
 }
 
-/** Whether the panel frame is currently painted (the "History" header). */
+/** Whether the panel frame is currently painted (the "History" header).
+ * The scope tabs are responsive (short labels on narrow terminals), so the
+ * probe matches the title line by its stable parts only. */
 function panelVisible(viewport: string[]): boolean {
-  return viewport.some(line => line.includes('History') && line.includes('Current directory'))
+  return viewport.some(line => line.includes('History') && (line.includes('Directory') || line.includes('Session')))
 }
 
 /** Poll until a predicate holds (bounded): deterministic settling for
@@ -170,6 +175,51 @@ test('Ctrl+R resolves the Current directory at OPEN time (a session switch moves
     await waitFor(() => vt.getViewport().some(line => line.includes('prompt from b')))
     assert.ok(!vt.getViewport().some(line => line.includes('prompt from a')),
       'the current-directory scope must follow the LIVE cwd, not the construction snapshot')
+    app.stop()
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('UI4: Ctrl+R captures the session identity at OPEN time (a session switch moves the scope)', async () => {
+  // The session scope's identity getter must be read at open time, never
+  // captured at construction: a switch between opens makes the next
+  // Ctrl+R search the NEW session.
+  const home = tempHome()
+  try {
+    const { VirtualTerminal } = await import('./virtual-terminal.ts')
+    const { TuiApp } = await import('../src/tui-app.ts')
+    seedHistory(home, '/work/a', [
+      { content: 'prompt from A', ts: 1, sessionId: 'ses_a' },
+      { content: 'prompt from B', ts: 2, sessionId: 'ses_b' },
+    ])
+    const vt = new VirtualTerminal(80, 24)
+    let liveSessionId: string | undefined = 'ses_a'
+    const app = new TuiApp(vt, {
+      onSubmit: () => {},
+      onExit: () => {},
+    }, {
+      historySearchSource: new FileHistorySearchSource({ dshHome: home }),
+      historySearchCwd: () => '/work/a',
+      // The runner wires the LIVE session identity getter.
+      historySearchSessionId: () => liveSessionId,
+    })
+    app.start()
+    await vt.waitForRender()
+    vt.sendInput('\x12') // Ctrl+R
+    await vt.waitForRender()
+    await waitFor(() => vt.getViewport().some(line => line.includes('prompt from A')))
+    assert.ok(!vt.getViewport().some(line => line.includes('prompt from B')),
+      'the session scope must filter by the LIVE session identity')
+    vt.sendInput('\x1b') // Esc closes the panel
+    await vt.waitForRender()
+    // "Session switch": the live identity moves before the next Ctrl+R.
+    liveSessionId = 'ses_b'
+    vt.sendInput('\x12')
+    await vt.waitForRender()
+    await waitFor(() => vt.getViewport().some(line => line.includes('prompt from B')))
+    assert.ok(!vt.getViewport().some(line => line.includes('prompt from A')),
+      'the reopened panel must search the NEW session, not the construction snapshot')
     app.stop()
   } finally {
     rmSync(home, { recursive: true, force: true })

--- a/test/history-panel.test.ts
+++ b/test/history-panel.test.ts
@@ -20,7 +20,7 @@ const visibleWidthOf = visibleWidth
 /** A controllable fake source: records calls and resolves with the rows of
  * the CURRENT query (or a preset per-call response). */
 class FakeSource implements HistorySearchSource {
-  requests: Array<{ scope: HistoryScope; query: string; cwd: string; limit: number }> = []
+  requests: Array<{ scope: HistoryScope; query: string; cwd: string; sessionId?: string; limit: number }> = []
   rows: HistorySearchResult[] = []
   delayMs = 0
   /** Per-query delay override: the SLOW query's response arrives last. */
@@ -33,7 +33,10 @@ class FakeSource implements HistorySearchSource {
    * {@link resolveNext}. Otherwise it resolves after the delay. */
   manual = false
   search(request: import('../src/history-search.ts').HistorySearchRequest): Promise<import('../src/history-search.ts').HistorySearchPage> {
-    this.requests.push({ scope: request.scope, query: request.query, cwd: request.cwd, limit: request.limit })
+    this.requests.push({
+      scope: request.scope, query: request.query, cwd: request.cwd,
+      sessionId: request.sessionId, limit: request.limit,
+    })
     if (this.fail) return Promise.reject(new Error('boom'))
     if (this.manual) {
       return new Promise<import('../src/history-search.ts').HistorySearchPage>((resolve, reject) => {
@@ -405,4 +408,89 @@ test('panel: a 500-line prompt is clamped in the detail pane (never fills the te
   // the loaded render is covered by the budget test above.
   const lines = panel.render(70)
   assert.ok(lines.length <= 16, 'the panel render is bounded by its budget')
+})
+
+// ---------------------------------------------------------------------------
+// Session scope (the Ctrl+R panel optimization): default scope, Tab cycle,
+// responsive tabs.
+// ---------------------------------------------------------------------------
+
+test('UI1: with a session identity the default scope is session', async () => {
+  const source = new FakeSource()
+  const { panel } = makePanel(source, { sessionId: 'ses_1' })
+  panel.start()
+  await settle()
+  assert.equal(source.requests[0]?.scope, 'session', 'the default scope is the current session')
+  assert.equal(source.requests[0]?.sessionId, 'ses_1', 'the request carries the captured session identity')
+})
+
+test('UI2: without a session identity the default scope is current', async () => {
+  const source = new FakeSource()
+  const { panel } = makePanel(source)
+  panel.start()
+  await settle()
+  assert.equal(source.requests[0]?.scope, 'current', 'a deferred start has no session — current is the fallback')
+  assert.equal(source.requests[0]?.sessionId, undefined)
+})
+
+test('UI3: Tab cycles session → current → all → session (query preserved)', async () => {
+  const source = new FakeSource()
+  const { panel } = makePanel(source, { sessionId: 'ses_1' })
+  panel.start()
+  await settle()
+  panel.handleInput('x')
+  await settle()
+  panel.handleInput('\t')
+  await settle()
+  assert.equal(source.requests[2]?.scope, 'current')
+  assert.equal(source.requests[2]?.query, 'x', 'the query survives the scope switch')
+  panel.handleInput('\t')
+  await settle()
+  assert.equal(source.requests[3]?.scope, 'all')
+  assert.equal(source.requests[3]?.query, 'x')
+  panel.handleInput('\t')
+  await settle()
+  assert.equal(source.requests[4]?.scope, 'session')
+  assert.equal(source.requests[4]?.sessionId, 'ses_1', 'the cycle wraps back to the session scope')
+  panel.handleInput('\t')
+  await settle()
+  assert.equal(source.requests[5]?.scope, 'current', 'the cycle is closed')
+})
+
+test('UI3b: without a session identity Tab cycles current ⇄ all only', async () => {
+  const source = new FakeSource()
+  const { panel } = makePanel(source)
+  panel.start()
+  await settle()
+  panel.handleInput('\t')
+  await settle()
+  assert.equal(source.requests[1]?.scope, 'all')
+  panel.handleInput('\t')
+  await settle()
+  assert.equal(source.requests[2]?.scope, 'current', 'no session tab without a session identity')
+})
+
+test('UI3c: the title renders the scope tabs responsively', async () => {
+  const source = new FakeSource()
+  const { panel } = makePanel(source, { sessionId: 'ses_1' })
+  panel.start()
+  await settle()
+  // Wide: the full labels fit on one line.
+  const wide = panel.render(100)
+  assert.ok(wide.some(line => line.includes('[ Current session ]')
+    && line.includes('Current directory') && line.includes('All directories')),
+  'wide terminals get the full three labels')
+  // Narrow: the short labels — three full labels must never be forced
+  // onto one line.
+  const narrow = panel.render(74)
+  assert.ok(narrow.some(line => line.includes('[ Session ]')
+    && line.includes('Directory') && line.includes('All')),
+  'narrow terminals get the short labels')
+  // Without a session identity the session tab is hidden entirely.
+  const { panel: noSession } = makePanel(source)
+  noSession.start()
+  await settle()
+  const twoTabs = noSession.render(100)
+  assert.ok(twoTabs.some(line => line.includes('Current directory') && line.includes('All directories')))
+  assert.ok(!twoTabs.some(line => line.includes('Current session')), 'no session tab without a session identity')
 })

--- a/test/history-persist.test.ts
+++ b/test/history-persist.test.ts
@@ -198,39 +198,94 @@ test('the runner\'s `!` block end to end: `!!`/bare `!` rows are sessionless, a 
   }
 })
 
-test('the runner\'s steer path end to end: the draft persists with the LIVE session id before the steer', async () => {
+test('the runner\'s steer path end to end: the draft persists with the LIVE session id after the session exists', async () => {
   // Simulates onSteer / steer-draft with the ACTUAL functions the runner
   // uses: the snapshot happens at call time (before the steer consumes
-  // the staged images) and the row carries the live session id.
+  // the staged images) and the row is written AFTER the session exists,
+  // with the session id the gate resolved.
   const home = tempHome()
   try {
     const cwd = '/work/a'
     const file = historyFilePath(home, cwd)
     const order: string[] = []
-    // The runner's persistSteeredHistory: snapshot ts + image check at
-    // call time, then persist with the live session id.
-    const persistSteered = (text: string): void => {
-      const hasImages = text.includes('[[image')
-      if (text.trim() === '' || hasImages) return
+    // The runner's makeSteerPersist: snapshot ts + image check at call
+    // time, then write under the resolved session id.
+    const persist = (sessionId: string | undefined): void => {
       order.push('persist')
       persistHistoryRecord({
-        content: text.trim(),
+        content: 'steer this draft',
         cwd,
-        sessionId: historySessionIdFor('agent-facing', 'ses_live'),
+        sessionId: historySessionIdFor('agent-facing', sessionId),
         ts: 1,
         lastContent: undefined,
-        hasImages,
+        hasImages: false,
         file,
       })
     }
-    persistSteered('steer this draft')
-    persistSteered('') // Ctrl+S with only a queue
-    persistSteered('[[image:1]] placeholder') // image-bearing draft
-    assert.deepEqual(order, ['persist'], 'only the real draft persists')
+    // The runner's steerNow gate: resolve the session FIRST, then persist.
+    await persistAfterSession(
+      async () => {
+        order.push('resolve')
+        return 'ses_live'
+      },
+      persist,
+    )
+    assert.deepEqual(order, ['resolve', 'persist'], 'the row is written AFTER the session exists')
     const records = loadHistoryRecords(file)
     assert.equal(records.length, 1)
     assert.equal(records[0]?.content, 'steer this draft')
     assert.equal(records[0]?.sessionId, 'ses_live', 'the steered draft carries the live session id')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('a deferred-start steer persists with the FINAL session id (Ctrl+S / steer-draft with no live session)', async () => {
+  // Review repro: steerNow creates the session on a deferred start — a
+  // row written BEFORE the creation would carry no sessionId and vanish
+  // from Current session. The row must be written AFTER the session
+  // exists, with the FINAL id; a rejected creation writes nothing.
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    const order: string[] = []
+    const persist = (sessionId: string | undefined): void => {
+      order.push('persist')
+      persistHistoryRecord({
+        content: 'steer me',
+        cwd,
+        sessionId: historySessionIdFor('agent-facing', sessionId),
+        ts: 1,
+        lastContent: undefined,
+        hasImages: false,
+        file,
+      })
+    }
+    await persistAfterSession(
+      async () => {
+        order.push('resolve')
+        return 'ses_new' // the session Ctrl+S just created
+      },
+      persist,
+    )
+    assert.deepEqual(order, ['resolve', 'persist'], 'the row is written AFTER the session creation')
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 1)
+    assert.equal(records[0]?.sessionId, 'ses_new',
+      'a deferred-start steer carries the FINAL session id, never undefined')
+    // A REJECTED creation persists nothing (the steer never reached a
+    // session).
+    await assert.rejects(
+      persistAfterSession(
+        async () => {
+          throw new Error('creation failed')
+        },
+        persist,
+      ),
+      /creation failed/,
+    )
+    assert.equal(loadHistoryRecords(file).length, 1, 'a rejected creation must not write a row')
   } finally {
     rmSync(home, { recursive: true, force: true })
   }

--- a/test/history-persist.test.ts
+++ b/test/history-persist.test.ts
@@ -155,6 +155,40 @@ test('a steered draft persists with the LIVE session id (Ctrl+S / steer-draft)',
   }
 })
 
+test('a sessionless command with a LIVE session still persists sessionless (/help while a session exists)', async () => {
+  // Review finding: recognized sessionless commands must never appear in
+  // Current session — even when a live session exists (they dispatch
+  // through the session's command service, but their rows stay
+  // sessionless).
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    // The runner's sessionless branch with a live agent: the persist
+    // closure always supplies undefined via the decision table, even
+    // though the dispatch gate resolves the live session id.
+    const persist = (sessionId: string | undefined): void => {
+      persistHistoryRecord({
+        content: '/help',
+        cwd,
+        sessionId: historySessionIdFor('sessionless', sessionId),
+        ts: 1,
+        lastContent: undefined,
+        hasImages: false,
+        file,
+      })
+    }
+    await persistAfterSession(async () => 'ses_live', persist)
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 1)
+    assert.equal(records[0]?.sessionId, undefined,
+      'a sessionless command must not appear in Current session even with a live session')
+    assert.equal(records[0]?.content, '/help')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
 test('the call-site decision table: agent-facing rows carry the session id, sessionless rows never do', () => {
   // The runner routes EVERY persist call through historySessionIdFor —
   // this table is the single source of truth for which submission kind

--- a/test/history-persist.test.ts
+++ b/test/history-persist.test.ts
@@ -87,6 +87,74 @@ test('a sessionless submission persists with NO sessionId field', async () => {
   }
 })
 
+test('a sessionless `!!`/bare-`!` shell row persists with NO sessionId even while a session is live', async () => {
+  // Review finding: `!!` runs purely locally (no session write) and a
+  // bare `!` is a no-op — their rows must never be attributed to the live
+  // session (they would otherwise leak into the Current session scope).
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    // The runner passes `undefined` for these branches even though a live
+    // session exists (the row must stay out of Current session).
+    for (const content of ['!!ls', '!']) {
+      persistHistoryRecord({
+        content,
+        cwd,
+        sessionId: undefined,
+        ts: 1,
+        lastContent: undefined,
+        hasImages: false,
+        file,
+      })
+    }
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 2)
+    assert.ok(records.every(record => record.sessionId === undefined),
+      'sessionless shell rows must not carry a sessionId')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('a steered draft persists with the LIVE session id (Ctrl+S / steer-draft)', async () => {
+  // Review finding: direct steer paths (Ctrl+S, the steer-draft extension
+  // action) send the draft into the RUNNING session — the row must carry
+  // the live session id, exactly like a normal submission.
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    const written = persistHistoryRecord({
+      content: 'steer me',
+      cwd,
+      sessionId: 'ses_live',
+      ts: 1,
+      lastContent: undefined,
+      hasImages: false,
+      file,
+    })
+    assert.equal(written, true)
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 1)
+    assert.equal(records[0]?.sessionId, 'ses_live', 'a steered draft carries the live session id')
+    // An EMPTY draft (Ctrl+S with only a queue) persists nothing — the
+    // queued messages were already persisted when originally submitted.
+    assert.equal(persistHistoryRecord({
+      content: '',
+      cwd,
+      sessionId: 'ses_live',
+      ts: 1,
+      lastContent: undefined,
+      hasImages: false,
+      file,
+    }), false, 'an empty steered draft is skipped')
+    assert.equal(loadHistoryRecords(file).length, 1)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
 test('persistHistoryRecord skips empty, consecutive repeats and image-bearing submissions', async () => {
   const home = tempHome()
   try {

--- a/test/history-persist.test.ts
+++ b/test/history-persist.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Headless tests for the Ctrl+R session-scope persist gate
+ * (history-persist.ts): the deferred-start ordering contract — an
+ * agent-facing submission's history row is written AFTER the session
+ * exists, with the FINAL session id (the first prompt of a fresh session
+ * must carry the session it creates) — plus the persist decision (dedupe,
+ * image guard, sessionless rows).
+ *
+ * The runner's submit path uses exactly these two functions
+ * (`persistAfterSession` around `ensureSession()` + the detached
+ * `persistHistoryRecord` write), so the merge-gate test below pins the
+ * end-to-end property: session resolution → persisted row.
+ * @module @xmoon76/dsh-pi-tui/history-persist.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { persistAfterSession, persistHistoryRecord } from '../src/history-persist.ts'
+import { historyFilePath, loadHistoryRecords } from '../src/history.ts'
+
+function tempHome(): string {
+  return mkdtempSync(join(tmpdir(), 'pi-tui-history-persist-'))
+}
+
+test('merge gate: a fresh session\'s FIRST prompt persists with the FINAL session id', async () => {
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    const order: string[] = []
+    // The runner's submit path: resolveSession = ensureSession() + the
+    // live agent's id; persist = the detached history write.
+    await persistAfterSession(
+      async () => {
+        order.push('resolve')
+        return 'ses_new' // the session the first prompt just created
+      },
+      (sessionId) => {
+        order.push('persist')
+        persistHistoryRecord({
+          content: 'hello',
+          cwd,
+          sessionId,
+          ts: 1,
+          lastContent: undefined,
+          hasImages: false,
+          file,
+        })
+      },
+    )
+    assert.deepEqual(order, ['resolve', 'persist'],
+      'the row must be persisted AFTER the session resolution, never before')
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 1)
+    assert.equal(records[0]?.sessionId, 'ses_new',
+      'the first prompt of a fresh session must carry the FINAL session id')
+    assert.equal(records[0]?.content, 'hello')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('a sessionless submission persists with NO sessionId field', async () => {
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    const written = persistHistoryRecord({
+      content: '/help',
+      cwd,
+      sessionId: undefined,
+      ts: 1,
+      lastContent: undefined,
+      hasImages: false,
+      file,
+    })
+    assert.equal(written, true)
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 1)
+    assert.equal(records[0]?.sessionId, undefined, 'a sessionless row must not carry a sessionId')
+    assert.equal(records[0]?.content, '/help')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('persistHistoryRecord skips empty, consecutive repeats and image-bearing submissions', async () => {
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    const base = {
+      cwd,
+      sessionId: 'ses_1' as string | undefined,
+      ts: 1,
+      lastContent: undefined,
+      hasImages: false,
+      file,
+    }
+    assert.equal(persistHistoryRecord({ ...base, content: '   ' }), false, 'empty content is skipped')
+    assert.equal(persistHistoryRecord({ ...base, content: 'hello' }), true)
+    assert.equal(persistHistoryRecord({ ...base, content: 'hello', lastContent: 'hello' }), false,
+      'a consecutive repeat is skipped')
+    assert.equal(persistHistoryRecord({ ...base, content: 'with image', hasImages: true }), false,
+      'an image-bearing submission is never persisted')
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 1)
+    assert.equal(records[0]?.content, 'hello')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/test/history-persist.test.ts
+++ b/test/history-persist.test.ts
@@ -18,7 +18,7 @@ import test from 'node:test'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { persistAfterSession, persistHistoryRecord } from '../src/history-persist.ts'
+import { historySessionIdFor, persistAfterSession, persistHistoryRecord } from '../src/history-persist.ts'
 import { historyFilePath, loadHistoryRecords } from '../src/history.ts'
 
 function tempHome(): string {
@@ -150,6 +150,87 @@ test('a steered draft persists with the LIVE session id (Ctrl+S / steer-draft)',
       file,
     }), false, 'an empty steered draft is skipped')
     assert.equal(loadHistoryRecords(file).length, 1)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('the call-site decision table: agent-facing rows carry the session id, sessionless rows never do', () => {
+  // The runner routes EVERY persist call through historySessionIdFor —
+  // this table is the single source of truth for which submission kind
+  // earns which session identity (a future change must update it here,
+  // not silently at a call site).
+  assert.equal(historySessionIdFor('agent-facing', 'ses_1'), 'ses_1')
+  assert.equal(historySessionIdFor('agent-facing', undefined), undefined)
+  assert.equal(historySessionIdFor('sessionless', 'ses_1'), undefined,
+    'a sessionless submission must never be attributed to a session')
+  assert.equal(historySessionIdFor('sessionless', undefined), undefined)
+})
+
+test('the runner\'s `!` block end to end: `!!`/bare `!` rows are sessionless, a contextual `!` row carries the FINAL session id', async () => {
+  // Simulates dispatchUserInput's `!` block with the ACTUAL functions the
+  // runner uses (historySessionIdFor + persistHistoryRecord + the
+  // ensureSession ordering via persistAfterSession), asserting the rows
+  // that land in the file.
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    const write = (content: string, sessionId: string | undefined): void => {
+      persistHistoryRecord({ content, cwd, sessionId, ts: 1, lastContent: undefined, hasImages: false, file })
+    }
+    // `!!` branch: sessionless even while a session is live.
+    write('!!ls', historySessionIdFor('sessionless', 'ses_live'))
+    // bare `!` branch: sessionless.
+    write('!', historySessionIdFor('sessionless', 'ses_live'))
+    // contextual `!` branch: the FINAL id, resolved AFTER the session
+    // exists (the deferred-start gate).
+    await persistAfterSession(
+      async () => 'ses_new',
+      (sessionId) => write('!ls', historySessionIdFor('agent-facing', sessionId)),
+    )
+    const records = loadHistoryRecords(file)
+    assert.deepEqual(records.map(record => record.sessionId), [undefined, undefined, 'ses_new'],
+      'the `!` block rows carry exactly the session identities the decision table earns')
+    assert.deepEqual(records.map(record => record.content), ['!!ls', '!', '!ls'])
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('the runner\'s steer path end to end: the draft persists with the LIVE session id before the steer', async () => {
+  // Simulates onSteer / steer-draft with the ACTUAL functions the runner
+  // uses: the snapshot happens at call time (before the steer consumes
+  // the staged images) and the row carries the live session id.
+  const home = tempHome()
+  try {
+    const cwd = '/work/a'
+    const file = historyFilePath(home, cwd)
+    const order: string[] = []
+    // The runner's persistSteeredHistory: snapshot ts + image check at
+    // call time, then persist with the live session id.
+    const persistSteered = (text: string): void => {
+      const hasImages = text.includes('[[image')
+      if (text.trim() === '' || hasImages) return
+      order.push('persist')
+      persistHistoryRecord({
+        content: text.trim(),
+        cwd,
+        sessionId: historySessionIdFor('agent-facing', 'ses_live'),
+        ts: 1,
+        lastContent: undefined,
+        hasImages,
+        file,
+      })
+    }
+    persistSteered('steer this draft')
+    persistSteered('') // Ctrl+S with only a queue
+    persistSteered('[[image:1]] placeholder') // image-bearing draft
+    assert.deepEqual(order, ['persist'], 'only the real draft persists')
+    const records = loadHistoryRecords(file)
+    assert.equal(records.length, 1)
+    assert.equal(records[0]?.content, 'steer this draft')
+    assert.equal(records[0]?.sessionId, 'ses_live', 'the steered draft carries the live session id')
   } finally {
     rmSync(home, { recursive: true, force: true })
   }

--- a/test/history-search.test.ts
+++ b/test/history-search.test.ts
@@ -48,9 +48,11 @@ async function search(
   scope: HistoryScope,
   cwd: string,
   query: string,
-  opts: { knownCwds?: Map<string, string>; signal?: AbortSignal } = {},
+  opts: { knownCwds?: Map<string, string>; signal?: AbortSignal; sessionId?: string } = {},
 ): Promise<HistorySearchResult[]> {
-  const page = await source(home, opts.knownCwds).search({ scope, cwd, query, limit: 100, signal: opts.signal })
+  const page = await source(home, opts.knownCwds).search({
+    scope, cwd, sessionId: opts.sessionId, query, limit: 100, signal: opts.signal,
+  })
   return page.results
 }
 
@@ -740,6 +742,145 @@ test('S21: a file shrunk under a continuation cursor is a stale-continuation err
       src.search(request, page1.continuation),
       (error: unknown) => error instanceof HistorySearchContinuationStaleError,
     )
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Session scope (the Ctrl+R panel optimization): eligibility, filtering
+// order, dedupe, continuation and cwd isolation.
+// ---------------------------------------------------------------------------
+
+test('S22: session scope returns only the requested session\'s rows (mixed file)', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', [
+      { content: 'from A one', ts: 1, sessionId: 'ses_a' },
+      { content: 'from B', ts: 2, sessionId: 'ses_b' },
+      { content: 'from A two', ts: 3, sessionId: 'ses_a' },
+    ])
+    const results = await search(home, 'session', '/a', '', { sessionId: 'ses_a' })
+    assert.deepEqual(results.map(row => row.content), ['from A two', 'from A one'])
+    assert.ok(results.every(row => row.sessionId === 'ses_a'), 'every row carries the requested session')
+    assert.ok(results.every(row => row.cwd === '/a'), 'matching rows inherit the effective cwd')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S23: session scope excludes v1 rows and v2 rows without a sessionId', async () => {
+  const home = tempHome()
+  try {
+    const file = historyFilePath(home, '/a')
+    mkdirSync(file.slice(0, file.lastIndexOf('/')), { recursive: true })
+    writeFileSync(file, [
+      JSON.stringify({ content: 'legacy' }),
+      JSON.stringify({ v: 2, content: 'no session', cwd: '/a', ts: 1 }),
+      JSON.stringify({ v: 2, content: 'mine', cwd: '/a', ts: 2, sessionId: 'ses_a' }),
+    ].join('\n') + '\n', { mode: 0o600 })
+    const results = await search(home, 'session', '/a', '', { sessionId: 'ses_a' })
+    assert.deepEqual(results.map(row => row.content), ['mine'],
+      'legacy rows and sessionless v2 rows are never guessed into a session')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S24: the session filter runs BEFORE the query filter', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', [
+      { content: 'needle from B', ts: 1, sessionId: 'ses_b' },
+      { content: 'needle from A', ts: 2, sessionId: 'ses_a' },
+      { content: 'other from A', ts: 3, sessionId: 'ses_a' },
+    ])
+    const results = await search(home, 'session', '/a', 'needle', { sessionId: 'ses_a' })
+    assert.deepEqual(results.map(row => row.content), ['needle from A'],
+      'a query match in another session must never leak through')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S25: session scope dedupes by content — the newest occurrence in the session wins', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', [
+      { content: 'same', ts: 1, sessionId: 'ses_a' },
+      { content: 'same', ts: 3, sessionId: 'ses_a' },
+      { content: 'same', ts: 2, sessionId: 'ses_b' },
+    ])
+    const results = await search(home, 'session', '/a', '', { sessionId: 'ses_a' })
+    const same = results.filter(row => row.content === 'same')
+    assert.equal(same.length, 1, 'one row per content within the session')
+    assert.equal(same[0]?.ts, 3, 'the NEWEST occurrence in the session wins')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S26: session continuation pages return only the current session', async () => {
+  const home = tempHome()
+  try {
+    // 300 rows: session A rows every 100th, session B fillers — the
+    // continuation must never let session B rows leak into the pages.
+    const rows = Array.from({ length: 300 }, (_, i) => ({
+      content: i % 100 === 0 ? `needle-${i}` : `filler-${i}`,
+      ts: i,
+      sessionId: i % 100 === 0 ? 'ses_a' : 'ses_b',
+    }))
+    writeV2(home, '/a', rows)
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100 })
+    const request = { scope: 'session' as const, cwd: '/a', sessionId: 'ses_a', query: 'needle', limit: 100 }
+    const page1 = await src.search(request)
+    assert.equal(page1.results.length, 1, 'page 1 scanned the newest 100 rows (needle-200)')
+    assert.equal(page1.exhausted, false)
+    assert.ok(page1.continuation !== undefined)
+    const all: string[] = [...page1.results.map(row => row.content)]
+    let continuation: import('../src/history-search.ts').HistorySearchContinuation | undefined = page1.continuation
+    for (let i = 0; i < 5; i += 1) {
+      const page: import('../src/history-search.ts').HistorySearchPage | undefined = continuation === undefined
+        ? undefined
+        : await src.search(request, continuation)
+      if (page === undefined) break
+      all.push(...page.results.map(row => row.content))
+      continuation = page.exhausted ? undefined : page.continuation
+    }
+    assert.deepEqual(new Set(all), new Set(['needle-200', 'needle-100', 'needle-0']),
+      'every page returns only the current session\'s rows')
+    assert.equal(continuation, undefined, 'exhausted only after the old snapshot is fully scanned')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S27: a continuation with a mismatched sessionId is a typed error', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', Array.from({ length: 1000 }, (_, i) => ({ content: `p-${i}`, ts: i, sessionId: 'ses_a' })))
+    const src = new FileHistorySearchSource({ dshHome: home, scanLimit: 100 })
+    const request = { scope: 'session' as const, cwd: '/a', sessionId: 'ses_a', query: 'zzz', limit: 100 }
+    const page = await src.search(request)
+    assert.ok(page.continuation !== undefined)
+    await assert.rejects(
+      src.search({ ...request, sessionId: 'ses_b' }, page.continuation),
+      (error: unknown) => error instanceof HistorySearchContinuationError,
+    )
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('S28: session scope never scans other cwds', async () => {
+  const home = tempHome()
+  try {
+    writeV2(home, '/a', [{ content: 'mine in a', ts: 1, sessionId: 'ses_a' }])
+    // The same session ALSO has rows in /b — the session scope opens only
+    // the live cwd's file, so /b must never be scanned.
+    writeV2(home, '/b', [{ content: 'mine in b', ts: 2, sessionId: 'ses_a' }])
+    const results = await search(home, 'session', '/a', '', { sessionId: 'ses_a' })
+    assert.deepEqual(results.map(row => row.content), ['mine in a'])
   } finally {
     rmSync(home, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

Follow-up to #17 (bounded recent-first Ctrl+R history search). The Ctrl+R panel gains a **third scope** — `Current session` — and it becomes the **default** when a live session identity exists:

```
[ Current session ]   Current directory   All directories
        ↑
      默认
```

`Tab` cycles `session → current → all → session` (query preserved). `Current session` shows only the current session's own inputs (v2 rows whose `sessionId` matches the live session id); v1 rows and v2 rows without a sessionId are excluded — never guessed. `Current directory` and `All directories` keep the cross-session reach. On a deferred start (no session yet) the panel falls back to `Current directory` and hides the session tab. The session id is captured at panel open time, so a session switch makes the next Ctrl+R search the new session.

No storage change, no migration: v2 rows already carry `sessionId`.

## The deferred-start gate

The first prompt of a deferred start creates the session — a history row written *before* creation would carry no `sessionId` and vanish from `Current session`. Agent-facing submissions (plain prompts, session commands, contextual `!`, steers) now persist their history row **after** the session exists, with the **final** session id. Sessionless submissions (`/help`, `/settings`, `/sessions`, `!!` shells, bare `!`) persist with `sessionId: undefined` and stay visible in `Current directory` / `All directories`.

The ordering contract lives in the new `src/history-persist.ts` (`persistAfterSession` + the `historySessionIdFor` decision table every persist call site routes through), pinned by the merge-gate test in `test/history-persist.test.ts`.

## Scope contract

- `HistoryScope = 'session' | 'current' | 'all'`; `HistorySearchRequest.sessionId?` and `HistorySearchContinuation.sessionId?`
- Continuation validation upgraded to scope/cwd/sessionId/query/limit (a session-A continuation reused under session B is a typed error)
- Session scope opens ONLY the live cwd's file — never a scan of all files; the 5000-line global budget, reverse reader, page/continuation and overflow mechanics are reused unchanged
- Dedupe: session/current by content (newest wins); all by (cwd, content)

## UI

- Responsive scope tabs: wide `[ Current session ]   Current directory   All directories`; narrow `[ Session ]   Directory   All`
- List shows the prompt only (cwd prefix stays in `All directories`); the detail keeps Directory/Time/Session
- `TuiApp.historySearchSessionId` getter (like `historySearchCwd`) resolved at panel open time

## Tests

- S22–S28: session eligibility, filter order, dedupe, continuation, sessionId mismatch, cwd isolation
- UI1–UI4: default scope, Tab cycle, responsive tabs, session-switch re-open
- Merge gate: a fresh session's first prompt persists with the FINAL session id; sessionless rows carry no sessionId; deferred-start steers persist with the final id; a rejected creation writes nothing
- Full suite 1917/1917, fork suite 985/985, typecheck clean

## Review

Review-fix-loop (openai-codex / gpt-5.6-luna): 5 rounds, 7 findings fixed (steer persistence, sessionless `!!`/bare-`!` attribution, sessionless commands with a live session, deferred-start steer ordering, comment accuracy, call-site test coverage), final verdict **accepted** with no findings.

Docs and changelog updated (bilingual).