### PR TITLE
feat(editor): first-class `!` / `!!` shell input modes (prefix as state, never document text)

### DIFF
--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -527,6 +527,51 @@ tests, typecheck, `git diff --check`, and the pre-push gate (pack + all
 smokes) clean; the vendored fork and the public extension surface are
 unchanged.
 
+**PR review round** (human, item-by-item against the plan) — six findings,
+all fixed in follow-up commits:
+
+1. The external editor (`Ctrl+G`) now round-trips the WIRE form:
+   `launchExternalEditor` serializes the draft (`!pwd`, never the bare
+   body) and decodes the saved text through `setSeatSerializedInput`, so
+   `! ↔ !! ↔ prompt` switches made in `$EDITOR` follow (a plugin editor
+   keeps identity). Regression tests: shell-mode round-trip, prompt draft
+   edited into a shell line.
+2. **Paste normalization moved BEFORE the base document** (the undo
+   invariant): bracketed paste is captured at the raw layer, the
+   empty-prompt `!` / `!!` prefix is stripped pre-insert, and the
+   normalized content is re-wrapped as a bracketed paste for the fork's
+   full `handlePaste` path (text normalization, large-paste registry,
+   atomic undo). Undoing a normalized paste can never resurrect a raw
+   `!!` in the document — the shell-editor-mode invariant holds, and
+   large (>10 lines / >1000 chars) shell pastes enter the shell mode
+   through the paste registry. Regression tests: undo after a normalized
+   paste, large-paste registry.
+3. **Handoff cursor coordinates unified on the WIRE document**: a host
+   shell-mode cursor shifts by the mode prefix, a host prompt-mode
+   literal `!` is a document character (never shifted), a plugin cursor
+   IS the wire cursor, the decoding host restore shifts by the actually
+   stripped prefix, and a legacy raw restore keeps the wire cursor (the
+   `!` stays in the text). Regression tests for all four conversions.
+4. **A mode transition cancels the open autocomplete**: `setInputMode`
+   closes the dropdown (the completion grammar changed — a prompt-mode
+   file list must not accept suggestions into a shell body). Regression
+   tests in both directions (`!` entry, Backspace step-back).
+5. **One-shot viewers reset the host editor to prompt mode**: the
+   read-only placeholder bar routes through `setSeatSerializedInput`, so
+   a stale shell mode never renders as `! viewing subagent: …`, and the
+   preserved serialized main draft restores the shell mode on exit.
+6. **Stable autocomplete extension compatibility**: the M5 plugin-chain
+   query is adapted back to the WIRE document — a shell-mode body is
+   re-prefixed (`git che` → `!git che`, cursor shifted) with the query
+   shape unchanged, so a third-party plugin keeps parsing shell lines
+   exactly as before the feature. Regression test asserts the wire lines
+   in shell-context / shell-local / prompt.
+
+All six fixes landed with regression tests; 2055/2055 full-suite tests,
+typecheck, `git diff --check` and the pre-push gate (pack + all smokes)
+clean; the vendored fork and the public extension surface remain
+unchanged.
+
 ---
 
 ## Review record

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -675,6 +675,14 @@ rounds (codex / gpt-5.6-luna):
   modes (natural typing stays quiet, Tab lists `/usr/`, accept never
   doubles the slash), plus a provider-level multiline apply/Tab-gate
   test.
+- **Round 18** (on the round-3 fix): P1 — the Stable-extension
+  delegating provider's natural-trigger suppression still carried the
+  `cursorLine === 0` restriction, so a continuation-line `/` could still
+  consult the plugin chain mid-typing (FIXED: the suppression now covers
+  ANY line of a shell-mode document, matching the host provider's
+  shell-semantic rule; the wire query keeps the line-0-only prefix).
+  Regression test: the extension chain is never consulted on a
+  continuation-line natural `/` trigger (Tab still consults it once).
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -697,6 +697,20 @@ rounds (codex / gpt-5.6-luna):
   tests: a plugin-consumed key pushes the fresh snapshot to
   subscribers; a prompt-semantics plugin seat never gets the hidden
   host's synthetic prefix.
+- **Round 21**: P1 — the ADVANCED editor controls' `setEditorText`
+  wrote the draft RAW through the seat, so replacing a shell-mode draft
+  with plain text left the stale `!`/`!!` mode active and the
+  replacement submitted as a shell command (FIXED: the advanced setter
+  now routes through `setSeatSerializedInput` — the host editor decodes
+  serialized input, a plugin editor gets the raw text); P2 — the
+  async-polling test helpers were flagged AGAIN as fixed-delay polling
+  (BY DESIGN, re-confirmed: `waitForRender` itself — the repository's
+  established async-test helper — is a 20ms-delay flush, and the
+  same waitForDropdownRow poll-until-deadline shape ships in
+  tui-editor.test.ts; poll-until-deadline with a condition check is the
+  repository's async-UI pattern, never a timing assertion). Regression
+  test: advanced controls replace a shell-mode draft through the wire
+  boundary (plain text clears the mode; serialized text re-enters it).
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -1,6 +1,6 @@
-# Input and card polish: bash completion, local-shell sandbox, question answers, goal cards, todo dock click, JSON folded previews
+# Input and card polish: bash completion, local-shell sandbox, question answers, goal cards, todo dock click, JSON folded previews, shell editor mode
 
-Six small, independent surface improvements, designed together because they
+Seven small, independent surface improvements, designed together because they
 land in the same release cycle. Each section records the decision, the
 rationale, the exact touch points, and the guarding tests. Workflow card
 rendering (`tool-workflow/*`) is deliberately **out of scope** — reviewed and
@@ -14,6 +14,7 @@ kept as-is.
 | 4 | Goal cards (`get_goal`/`create_goal`/`update_goal`) | Folded: goal summary; expanded: field lines; named headers |
 | 5 | Todo dock click (fullscreen) | Map the dock summary row to `toggleTodoPanel()` |
 | 6 | JSON-result folded previews | Web parity audit: expanded stays verbatim, folded never leaks JSON |
+| 7 | `!` / `!!` shell editor mode | The prefix is EDITOR STATE, never document text; serialized back into the textual protocol only at host boundaries |
 
 ---
 
@@ -416,6 +417,115 @@ result text verbatim — **no JSON beautification on the web either**.
 - `present` unit tests: every tool's summary phrase, the ralph friendly
   prefix, bare-JSON ralph, error shapes, undeducible results → `undefined`.
 - Headless: folded cards show the summaries and never the raw JSON keys.
+
+---
+
+## 7. `!` / `!!` shell editor mode: the prefix is state, never document text
+
+### Why
+
+The editor used to keep the literal shell prefix in the draft (`!git status`).
+The prefix is presentation + state, not text: it must never be part of the
+document (no cursor-offset/render hacks, no debounce to distinguish `!` from
+`!!`), and the shell business layer (`src/shell-context.ts`) must keep
+receiving the exact same wire text as before. kimi's `CustomEditor` stores
+`inputMode: 'prompt' | 'bash'` and never puts the `!` in the buffer; this
+extends that two-state model to dsh-pi-tui's two-shell-semantics (`!` =
+context, `!!` = local).
+
+### Design
+
+Three explicit modes — `prompt`, `shell-context`, `shell-local` — owned by
+`TuiEditor` (`src/tui-editor.ts`), with a pure codec in
+`src/editor-input-mode.ts` (`shellPrefixForMode` / `serializeEditorInput` /
+`editorModeFromHistoryEntry`). The buffer holds the bare command body; the
+mode is serialized back into the textual `!`/`!!` protocol ONLY at host
+boundaries.
+
+**Transitions** (empty body only): `!` → shell-context, `!` → shell-local,
+Backspace steps back (`!!` → `!` → prompt), Esc cancels the whole shell mode
+(autocomplete Esc closes the dropdown first). A `!` after body text is an
+ordinary character; in shell-local an empty-body `!` is a literal body
+character (no fourth mode). Bracketed paste into an EMPTY PROMPT that starts
+with `!`/`!!` normalizes into the matching mode in one synchronous pass; a
+paste into a non-empty editor or an already-shell-mode editor is never
+reinterpreted (its `!` is body text, so the serialized wire form matches the
+pre-mode behavior).
+
+**Boundaries** (the compatibility contract):
+
+- **Submission** — Enter, Ctrl+Enter (queue), Ctrl+S (steer), the plugin
+  action sink and the subagent submit path all serialize the mode into the
+  wire form before the text leaves the app; the mode resets to `prompt`
+  BEFORE the dispatch (a synchronous rejection restores the serialized text
+  through `setEditorText`, which decodes the mode back). Emptiness checks
+  judge the SERIALIZED form, so a bare `!`/`!!` still reaches the protocol.
+- **Restores** — `setEditorText` / `setDraft` decode serialized input
+  (`setSerializedInput`); `insertIntoEditor` stays raw. The subagent viewer
+  draft slots and `mainDraftBeforeViewer` store the SERIALIZED form and
+  decode on restore.
+- **History** — entries stay serialized (no migration); recall decodes
+  (`!!` before `!`); `onHistoryDraftSave`/`onHistoryDraftRestore` keep the
+  mode across ↑/↓ browsing.
+- **Completion** — `MentionProvider` synthesizes a VIRTUAL `!`/`!!` line for
+  the shell grammar (`src/shell-completion.ts` untouched); the applied
+  completion never writes the synthetic prefix into the buffer. In a shell
+  mode a leading `/` is a PATH, never a slash command: natural triggers stay
+  quiet and Tab forces path completion (the fork's `handleTabCompletion`
+  routes a space-free leading-`/` line to slash completion, so `TuiEditor`
+  intercepts Tab in shell modes).
+- **Handoffs** — plugin editor handoffs transfer the WIRE form (a plugin's
+  document IS the wire form) and the host restore decodes it back, with the
+  flat cursor offset shifted by the prefix length (mode-derived for the
+  host, text-derived for a plugin seat). `adaptHost` exposes
+  `setSerializedInput` only when the underlying adapter implements it, so
+  older structural adapters fall back to `setText` — never a dropped draft.
+- **Esc ladder** — the busy cancel is Host-owned and runs before both the
+  shell-mode exit and a replacement editor's Esc; a DECLINED plugin Esc
+  falls through to the host cancel ladder; a CONSUMED Esc (plugin or
+  `onSingleEscape`) disarms the pending double-Esc window.
+- **Chrome** — the ↓ task-browser gate and the footer `↓ view` hint read the
+  VISIBLE seat mode (`seatInputMode()`), never the hidden host editor's
+  stale mode.
+
+**Rendering** — the mode prompt is painted over the reserved 2-cell padding:
+`❯ ` (roleUser), `! ` and `!!` (both `shellMode`) — all exactly two cells, so
+the body/cursor never jump on a mode switch. The editor border uses
+`shellMode` in shell modes via a dynamic function that reads the live palette
+(theme-switch safe). The placeholder hint renders only in prompt mode.
+
+**Touch points**
+
+- `src/editor-input-mode.ts` (new) — the pure codec.
+- `src/tui-editor.ts` — mode state, transitions, render, paste
+  normalization, history hooks, Tab routing.
+- `src/tui-app.ts` — boundary serialization/decoding, Esc ladder, seat-mode
+  routing, footer hint.
+- `src/mentions.ts` — the virtual completion prefix.
+- `src/editor-seat-holder.ts` — `getInputMode`/`setSerializedInput` on the
+  seat surface, wire-form handoff.
+
+**Tests**
+
+- `test/editor-input-mode.test.ts` — the pure codec (serialize/decode,
+  `!!` before `!`, literal `!` in the body).
+- `test/shell-editor-mode.test.ts` — transitions, paste normalization,
+  submission serialization + rejection restore, history recall/draft
+  restore, completion (virtual prefix, path-vs-slash), rendering (prompt
+  symbols, border colors, no duplicate prefix), Esc priority (busy,
+  autocomplete, plugin consume/decline, window disarm), handoff round-trips
+  (mode, cursor, bare adapters), task-browser/footer seat-mode routing.
+- `test/shell-completion.test.ts` — provider-level virtual-prefix coverage.
+
+**Review record** — nine review rounds (codex / gpt-5.6-luna, read-only,
+fresh context per round) over the feature commits: rounds 1–8 `needs-fixes`
+(busy-Esc priority, bare-`!` emptiness checks, paste normalization scope,
+handoff wire-form transfer, seat-mode routing, sink steer serialization,
+adapter capability gating, declined/consumed plugin Esc handling, cursor
+restoration), round 9 **accepted, no open findings**. 1964/1964 full-suite
+tests, typecheck, `git diff --check`, and the pre-push gate (pack + all
+smokes) clean; the vendored fork and the public extension surface are
+unchanged.
 
 ---
 

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -619,6 +619,15 @@ rounds (codex / gpt-5.6-luna):
      chain mid-typing, which would double-apply on the next Tab).
      Regression tests: `/u` → `/usr/` in both shell modes, extension
      suggestions accepted into the bare body, natural-typing suppression.
+- **Round 14** (on the round-2 fixes): P1 — `adaptHost` always exposed
+  `setInputMode` even when the underlying adapter does not implement it,
+  so a half-capable adapter (setSerializedInput without setInputMode)
+  silently discarded the decoded mode in the declined-input fallback
+  (FIXED: the mode setter is capability-gated exactly like
+  setSerializedInput, and the wire round-trip requires the FULL pair —
+  a partial adapter falls back to the raw path, so a declined `!` is
+  never dropped). Regression test: a partial adapter preserves a
+  declined `!` in the plugin document.
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -683,6 +683,20 @@ rounds (codex / gpt-5.6-luna):
   shell-semantic rule; the wire query keeps the line-0-only prefix).
   Regression test: the extension chain is never consulted on a
   continuation-line natural `/` trigger (Tab still consults it once).
+- **Round 20** (after a rebase; rounds 17/19 were stale pre-rebase diff
+  artifacts of main's own hook/runtime-migration commits): P1 — a plugin
+  editor CONSUMING input mutated its document without notifying seat
+  subscribers, so EditorHost.subscribe observers (the continuable-viewer
+  draft mirror) kept a stale snapshot and could merge an outdated draft
+  on handoff/viewer exit (FIXED: a consumed key now calls
+  `notifyChanged()` alongside `invalidate()`); P1 — the completion mode
+  adapters read the HIDDEN host editor's mode, so a stale shell mode
+  leaked into completion routing while a plugin editor occupied the seat
+  (FIXED: the MentionProvider mode source and the delegated provider's
+  getMode now read the VISIBLE seat via `seatInputMode()`). Regression
+  tests: a plugin-consumed key pushes the fresh snapshot to
+  subscribers; a prompt-semantics plugin seat never gets the hidden
+  host's synthetic prefix.
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -661,6 +661,20 @@ rounds (codex / gpt-5.6-luna):
   immediately). Regression tests: a mid-body `!` completion token keeps
   its literal `!`; an incomplete CSI tail buffers without loss and
   stitches a split sequence.
+- **PR review round 3** (human, multiline shell audit): P1 — a
+  continuation line (`! echo foo \` + `/u`) still treated a leading `/`
+  as a slash command, because the line-0-only virtual prefix was also
+  used for the host's SHELL-SEMANTIC routing (natural-trigger
+  suppression, apply classification, Tab gating). FIXED: the two
+  concepts are now split — the WIRE representation keeps the synthetic
+  prefix on line 0 only (shell-grammar parse + extension query), while a
+  SHELL-SEMANTIC context stages the prefix on the CURSOR line of ANY
+  shell-mode line and strips it from the result, so slash-vs-path
+  routing, apply classification and Tab gating treat every line as
+  shell-owned. Regression tests: continuation-line `/u` in both shell
+  modes (natural typing stays quiet, Tab lists `/usr/`, accept never
+  doubles the slash), plus a provider-level multiline apply/Tab-gate
+  test.
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -646,6 +646,21 @@ rounds (codex / gpt-5.6-luna):
   condition check, never a fixed-delay assertion). Regression tests:
   getDraft/setDraft wire symmetry incl. merge-restore round-trips, and a
   wire-prefixed extension prefix applying cleanly.
+- **Round 16**: P1 — the extension prefix normalization stripped a
+  MID-BODY literal `!` token (e.g. `echo !ch`) along with the synthetic
+  prefix (FIXED: the strip now applies ONLY when the prefix starts at
+  the WIRE line start — `cursorCol + synthetic − prefix.length === 0` —
+  so a literal document `!` is never touched); P2 — the marker-tail
+  buffering was flagged for swallowing an incomplete non-paste CSI tail
+  that never receives a continuation (BY DESIGN, documented in code and
+  here: the stitched tail flows through the normal chain when it never
+  forms a marker — which also REPAIRS split CSI sequences the fork
+  otherwise drops — and real terminals send each key's sequence
+  atomically, so an input stream ending mid-CSI does not occur in
+  practice; the upstream editor is strictly worse, losing the tail
+  immediately). Regression tests: a mid-body `!` completion token keeps
+  its literal `!`; an incomplete CSI tail buffers without loss and
+  stitches a split sequence.
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -591,10 +591,16 @@ rounds (codex / gpt-5.6-luna):
   drafts (FIXED: the wire document carries the prefix on line 0 only, and
   only a first-line cursor shifts by it); P2 — this review record went
   stale (updated here).
+- **Round 12**: P1 — Ctrl+C cleared only the shell body, leaving a stale
+  `!` / `!!` prompt on the now-empty editor (FIXED: the first Ctrl+C
+  clears the body AND resets the mode to `prompt`, treating the
+  serialized draft as non-empty — a bare `!` also clears back to the
+  prompt before the exit window arms); P2 — the recorded test count went
+  stale again (updated here).
 
-2060/2060 full-suite tests, typecheck, `git diff --check` and the pre-push
-gate (pack + all smokes) clean; the vendored fork and the public
-extension surface remain unchanged.
+The full-suite tests (2060+), typecheck, `git diff --check` and the
+pre-push gate (pack + all smokes) all pass; the vendored fork and the
+public extension surface remain unchanged.
 
 ---
 

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -768,8 +768,33 @@ rounds (codex / gpt-5.6-luna):
 - **Round 26 (fresh)**: accepted, no findings — the full 9-file sweep
   re-confirmed host execution mode, the stale-dropdown guard, the
   test-sync fix and every prior-round invariant.
+- **PR review round 5** (human, replacement-editor rejection path): P1 —
+  a SYNCHRONOUS rejection restore is clobbered by the fallback tail. The
+  fork clears the host editor BEFORE `onSubmit`; a synchronous rejection
+  (the runner's divergence-guard shape: `onSubmit` calls
+  `setEditorText(text)` and returns) rewrites the VISIBLE plugin seat
+  while the fallback dispatch is still on the stack — and the fallback
+  tail then unconditionally synced the hidden host's post-submit EMPTY
+  state back into the plugin (`!!pwd` restored → `''`). FIXED: the seat
+  holder keeps a monotonic `changeRevision` bumped by every
+  `notifyChanged`; the fallback records it before the dispatch and
+  syncs back only when nothing external rewrote the seat during it (a
+  text comparison cannot distinguish "never touched" from "explicitly
+  rewritten with the same text" — the epoch can). The successful-submit
+  path is unchanged: `runWithoutChange` suppresses the fork's onChange,
+  so an accepted submit never bumps the revision and the plugin seat is
+  cleared as before. Regression tests: a synchronous rejection restore
+  survives the fallback (`!!pwd` stays `!!pwd`, wire form submitted);
+  accepted-control asserts a successful submit clears the plugin
+  document (the epoch guard must not break the clear).
+- **Round 27**: accepted, no findings — the full 9-file sweep
+  re-confirmed the sync-restore epoch (successful submits still clear
+  the seat; rejection restores survive; the tail's own notifyChanged
+  sits AFTER the check so it cannot suppress a legitimate sync-back;
+  the viewer draft mirror only records snapshots and never rewrites the
+  seat) and every prior-round invariant.
 
-The full-suite tests (2137), typecheck, `git diff --check` and the
+The full-suite tests (2138), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the
 public extension surface remain unchanged.
 

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -567,10 +567,34 @@ all fixed in follow-up commits:
    exactly as before the feature. Regression test asserts the wire lines
    in shell-context / shell-local / prompt.
 
-All six fixes landed with regression tests; 2055/2055 full-suite tests,
-typecheck, `git diff --check` and the pre-push gate (pack + all smokes)
-clean; the vendored fork and the public extension surface remain
-unchanged.
+All six fixes landed with regression tests, followed by two more review
+rounds (codex / gpt-5.6-luna):
+
+- **Round 10** (on the PR-review fixes): P1 — residual input before the
+  opening marker / after the closing marker was forwarded straight to the
+  base editor, bypassing the shell-mode interceptions, and split opening
+  markers were not buffered (FIXED: residuals re-enter the full
+  interception chain — a leading `!` in the same chunk enters the shell
+  mode before the paste lands, trailing keys append as ordinary input —
+  and a trailing `\x1b[20`/`\x1b[200`/`\x1b[201` prefix is stitched onto
+  the next chunk, with a complete `~`-terminated marker never mistaken
+  for a split prefix); P2 — the autocomplete reopen ran before the paste
+  landed (FIXED: it now runs after the normalized paste and residuals).
+- **Round 11**: P1 — the marker tail buffering missed the `\x1b[` /
+  `\x1b[2` split boundaries (FIXED: every proper prefix of the markers is
+  buffered; a LONE `\x1b` tail is deliberately NOT buffered — it IS the
+  complete Esc key, and real terminals write a paste marker atomically);
+  P2 — per-segment recursion could overflow the stack on a chunk with
+  many paste segments (FIXED: the paste drain is iterative); P1 — the
+  Stable-extension wire adapter and the provider's virtual prefix applied
+  the prefix to the CURSOR line instead of LINE 0, breaking multiline
+  drafts (FIXED: the wire document carries the prefix on line 0 only, and
+  only a first-line cursor shifts by it); P2 — this review record went
+  stale (updated here).
+
+2060/2060 full-suite tests, typecheck, `git diff --check` and the pre-push
+gate (pack + all smokes) clean; the vendored fork and the public
+extension surface remain unchanged.
 
 ---
 

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -628,6 +628,24 @@ rounds (codex / gpt-5.6-luna):
   a partial adapter falls back to the raw path, so a declined `!` is
   never dropped). Regression test: a partial adapter preserves a
   declined `!` in the plugin document.
+- **Round 15**: P1 — `getDraft()` returned the bare body while
+  `setDraft()` decoded the wire form, so read-merge-restore callers (the
+  runner's restore paths, the dequeue merge, the steer action) silently
+  lost the shell mode (FIXED: `getDraft()` now returns the WIRE form —
+  the symmetric counterpart of `setDraft()` — and `submitDraft` consumes
+  it directly without re-serializing); P1 — a Stable extension may return
+  a completion prefix computed on the WIRE line it received (e.g. `!ch`),
+  and applying it on the bare body corrupted the result (FIXED: the
+  delegated apply normalizes a wire-prefixed prefix back to bare
+  coordinates — line 0 in a shell mode only — before the host apply, so
+  the synthetic prefix is never doubled or stripped twice); P2 — the
+  async-polling test helpers were flagged as fixed-delay polling
+  (BY DESIGN: the poll-until-deadline helpers are the repository's
+  established async-UI pattern — the same waitForDropdownRow shape used
+  across tui-editor/rendering tests — with a bounded deadline and a
+  condition check, never a fixed-delay assertion). Regression tests:
+  getDraft/setDraft wire symmetry incl. merge-restore round-trips, and a
+  wire-prefixed extension prefix applying cleanly.
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -711,8 +711,65 @@ rounds (codex / gpt-5.6-luna):
   repository's async-UI pattern, never a timing assertion). Regression
   test: advanced controls replace a shell-mode draft through the wire
   boundary (plain text clears the mode; serialized text re-enters it).
+- **Round 22**: accepted, no open findings (on the rebased HEAD).
+- **PR review round 4** (human, replacement-editor execution context): P1 —
+  the fallback mixed the VISIBLE seat mode into HOST-owned callbacks.
+  The host editor's `onSubmit` serialized through `serializeSeatDraft`,
+  which reads the VISIBLE seat (`'prompt'` for a mode-less plugin), so a
+  declined-Enter submit of a `!!pwd` plugin document degraded into a
+  plain `pwd` — a LOCAL-ONLY command leaking into the model path. The
+  completion mode source read the same visible seat, so a declined
+  `!gi` Tab lost the shell completion grammar and the extension query
+  lost the `!` wire prefix. FIXED: the split is now explicit — HOST
+  EXECUTION MODE (the host editor's own state, authoritative for its
+  callbacks: `onSubmit` serializes from `this.editor.getInputMode()`,
+  the MentionProvider mode source and the delegated getMode read the
+  host editor's mode — always freshly decoded from the plugin wire
+  document before a forwarded key) vs VISIBLE SEAT MODE (`seatInputMode()`
+  stays for the ↓ task-browser gate, the Ctrl+C clear, the viewer lock
+  and the footer badge). Regression tests: a replacement editor keeps
+  `!pwd` / `!!pwd` / plain prose on Enter submits; a replacement Tab
+  runs the shell compgen grammar and hands the extension chain the wire
+  line with the shifted cursor; the round-20 "ch" prompt-seat test is
+  unchanged and still passes.
+- **Round 23**: accepted-with-followups — P2: a fixed `setTimeout(50)`
+  before the second Tab in the replacement-completion test (FIXED: the
+  test now synchronizes on `waitForRender` — the repository's settle
+  helper — after polling the compgen spy, so the microtask chain and the
+  render pipeline drain before the next Tab; no timing race).
+- **Round 24**: accepted-with-followups — P2: STALE DROPDOWN — the
+  fallback stages with `setTextAndCursor`, which deliberately preserves
+  the host autocomplete state, so an earlier declined Tab's dropdown
+  survived into later keys; the fork's refresh is async, and a Tab
+  landing before it resolved ACCEPTED a stale candidate into the new
+  text (`!echo $gs` became the corrupted `!echo $$git `). FIXED: the
+  fallback cancels the host dropdown/pending request when the staged
+  document differs from the host text/cursor, or when the forwarded key
+  is not a dropdown interaction and the dropdown is open; an unchanged
+  document with a Tab/Enter/arrow keeps it (the Tab+Tab accept stays
+  synchronous). `TuiEditor.cancelHostAutocomplete()` is deliberately
+  distinct from the fork's private `cancelAutocomplete` (a same-named
+  override shadowed it and recursed). Regression test: a variable-
+  completion dropdown (uncached compgen) stays pending while the user
+  edits `!echo $g` → `!echo $gs`; the next Tab must not accept the stale
+  candidate, and the fresh dropdown applies after the refresh resolves.
+- **Round 25**: accepted-with-follow-ups — P2: pageUp/pageDown are
+  SelectList interactions too and must not force-close the dropdown
+  (FIXED: both guard sites include them; regression test proves a
+  declined pageUp keeps the dropdown alive — the next Tab accepts
+  synchronously with no fresh completion request; verified to fail
+  without the fix). The fork's editor itself does NOT forward
+  pageUp/pageDown into the dropdown list (upstream behavior — the keys
+  page-scroll the editor and the dropdown refreshes asynchronously), so
+  no further consumer-side change is warranted (fork stays pristine).
+- **Round 26**: a reviewer fragment (truncated, not a verdict) claimed
+  pageUp/pageDown are not forwarded to the SelectList — adjudicated
+  against the fork code as upstream semantics; re-launched fresh.
+- **Round 26 (fresh)**: accepted, no findings — the full 9-file sweep
+  re-confirmed host execution mode, the stale-dropdown guard, the
+  test-sync fix and every prior-round invariant.
 
-The full-suite tests (2060+), typecheck, `git diff --check` and the
+The full-suite tests (2137), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the
 public extension surface remain unchanged.
 

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -597,6 +597,28 @@ rounds (codex / gpt-5.6-luna):
   serialized draft as non-empty — a bare `!` also clears back to the
   prompt before the exit window arms); P2 — the recorded test count went
   stale again (updated here).
+- **PR review round 2** (human, wire-form boundary audit): two P1
+  findings, both fixed —
+  1. The replacement-editor declined-input fallback
+     (`EditorSeatHolder.handleHostFallbackInput`) treated the plugin's
+     wire document as the host's bare body: a declined `!` was consumed
+     into the host mode state and VANISHED from the plugin. The fallback
+     now round-trips through the wire coordinates (decode the staged
+     draft via the narrow setTextAndCursor seam + the decoded mode, run
+     the host editor, serialize the result back with the cursor shifted
+     by the prefix). Regression tests: declined `!`/`!!`/Backspace
+     round-trips on the plugin document.
+  2. The autocomplete wire adapter only covered get/query, not apply:
+     accepting an absolute-path suggestion in a shell mode ran the fork's
+     apply on the BARE body, so `/u` was mistaken for a slash command
+     (`//usr/ `), and Stable-extension suggestions suffered the same
+     asymmetry. The apply is now SYMMETRIC: non-shell applies run on the
+     VIRTUAL wire document and the synthetic prefix is stripped from the
+     result. The delegated provider also inherits the shell-mode
+     natural-trigger suppression (a leading `/` never consults the plugin
+     chain mid-typing, which would double-apply on the next Tab).
+     Regression tests: `/u` → `/usr/` in both shell modes, extension
+     suggestions accepted into the bare body, natural-typing suppression.
 
 The full-suite tests (2060+), typecheck, `git diff --check` and the
 pre-push gate (pack + all smokes) all pass; the vendored fork and the

--- a/src/editor-input-mode.ts
+++ b/src/editor-input-mode.ts
@@ -1,0 +1,46 @@
+/**
+ * The editor's input-mode codec: `!` / `!!` are EDITOR STATE, never
+ * document text (the shell-editor-mode plan). The editor buffer holds the
+ * bare command body; the mode is serialized back into the existing textual
+ * `!` / `!!` protocol ONLY at host boundaries (submission, history,
+ * completion), so the shell business layer (`shell-context.ts`) keeps its
+ * authoritative classification unchanged.
+ *
+ * This module is deliberately pure and dependency-free: every transition
+ * and codec rule is testable without a terminal.
+ * @module @xmoon76/dsh-pi-tui/editor-input-mode
+ */
+
+/** The three editor input modes. */
+export type EditorInputMode =
+  | 'prompt'
+  | 'shell-context'
+  | 'shell-local'
+
+/** The visible/serialized prefix of one mode ('' for the prompt). */
+export function shellPrefixForMode(mode: EditorInputMode): '' | '!' | '!!' {
+  if (mode === 'shell-context') return '!'
+  if (mode === 'shell-local') return '!!'
+  return ''
+}
+
+/**
+ * Serialize a mode + body back into the wire form the shell dispatch
+ * understands: `prompt + "hello" -> "hello"`, `shell-context + "pwd" ->
+ * "!pwd"`, `shell-local + "pwd" -> "!!pwd"`.
+ */
+export function serializeEditorInput(mode: EditorInputMode, text: string): string {
+  return shellPrefixForMode(mode) + text
+}
+
+/**
+ * Decode a serialized user input line (a history entry, a pasted shell
+ * line, a restored submission) into mode + body. The `!!` check runs
+ * before `!`; a bare `!` / `!!` decodes to the matching shell mode with an
+ * empty body. Any other text is a plain prompt line.
+ */
+export function editorModeFromHistoryEntry(entry: string): { mode: EditorInputMode; text: string } {
+  if (entry.startsWith('!!')) return { mode: 'shell-local', text: entry.slice(2) }
+  if (entry.startsWith('!')) return { mode: 'shell-context', text: entry.slice(1) }
+  return { mode: 'prompt', text: entry }
+}

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -672,11 +672,15 @@ export class EditorSeatHolder {
           //   mutation or cursor move invalidates the selection the
           //   moment the key runs.
           // An UNCHANGED document with a Tab/Enter/arrow keeps the
-          // dropdown (the Tab+Tab accept stays synchronous).
+          // dropdown (the Tab+Tab accept stays synchronous). pageUp/
+          // pageDown are dropdown interactions too (the vendored
+          // SelectList navigates its selection on them — fork parity:
+          // they must reach the open dropdown, never force-close it).
           const contextBefore = { text: host.getText(), cursor: host.getCursor?.() ?? 0 }
           const stagedDiffers = contextBefore.text !== decoded.text || contextBefore.cursor !== stagedCursor
           const dropdownInteraction = matchesKey(data, 'tab') || matchesKey(data, 'enter')
             || matchesKey(data, 'up') || matchesKey(data, 'down')
+            || matchesKey(data, 'pageUp') || matchesKey(data, 'pageDown')
           host.setTextAndCursor(decoded.text, stagedCursor)
           host.setInputMode?.(decoded.mode)
           if (host.cancelAutocomplete !== undefined
@@ -696,6 +700,7 @@ export class EditorSeatHolder {
           const stagedDiffers = contextBefore.text !== wireText || contextBefore.cursor !== wireCursor
           const dropdownInteraction = matchesKey(data, 'tab') || matchesKey(data, 'enter')
             || matchesKey(data, 'up') || matchesKey(data, 'down')
+            || matchesKey(data, 'pageUp') || matchesKey(data, 'pageDown')
           host.setTextAndCursor(wireText, wireCursor)
           if (host.cancelAutocomplete !== undefined
             && (stagedDiffers || (!dropdownInteraction && host.isShowingAutocomplete?.() === true))) {

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -68,6 +68,9 @@ export interface SeatEditor {
    * escape branch passes Esc through while it is open so the editor can
    * close it (kimi parity). */
   isShowingAutocomplete?(): boolean
+  /** The occupant's editor input mode (the host editor always answers; a
+   * plugin editor has no mode — absent means prompt semantics). */
+  getInputMode?(): import('./editor-input-mode.ts').EditorInputMode
   /** P1-5: the occupant's input channel — a PLUGIN editor with a
    * handleInput hook receives routed SEMANTIC events here (the host has
    * already decoded the terminal protocol — legacy/CSI-u/modifyOtherKeys
@@ -84,6 +87,8 @@ export interface HostEditorAdapter {
   setText(text: string): void
   /** Whether the host editor's autocomplete dropdown is open. */
   isShowingAutocomplete?(): boolean
+  /** The host editor's current input mode (shell-mode serialization). */
+  getInputMode?(): import('./editor-input-mode.ts').EditorInputMode
   getCursor?(): number
   /** Best-effort cursor setter for the host editor. */
   setCursor?(offset: number): void
@@ -230,6 +235,7 @@ export class EditorSeatHolder {
       getText: () => editor.getText(),
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete?.() ?? false,
+      getInputMode: () => editor.getInputMode?.() ?? 'prompt',
       getCursor: () => editor.getCursor?.() ?? 0,
       setCursor: (offset) => editor.setCursor?.(offset),
       insertTextAtCursor: (text) => editor.insertTextAtCursor?.(text),

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -687,15 +687,30 @@ export class EditorSeatHolder {
             && (stagedDiffers || (!dropdownInteraction && host.isShowingAutocomplete?.() === true))) {
             host.cancelAutocomplete()
           }
+          // SYNC-RESTORE GUARD (review round 27): the fork clears the
+          // host editor BEFORE onSubmit fires, and onSubmit may
+          // SYNCHRONOUSLY restore the draft through the wire boundary
+          // (the runner's rejection paths call setEditorText(text) and
+          // return) — that restore lands in the VISIBLE seat while this
+          // dispatch is still on the stack. The sync-back below would
+          // then clobber it with the post-submit EMPTY host state. The
+          // seat's change revision distinguishes "nothing external
+          // touched the seat" (sync back) from "the seat was explicitly
+          // rewritten during the dispatch" (skip — the restore is
+          // authoritative), even when the restored text equals the
+          // pre-dispatch document.
+          const revisionBeforeDispatch = this.changeRevision
           host.handleInput!(data)
           const mode = host.getInputMode?.() ?? 'prompt'
           const prefix = shellPrefixForMode(mode)
-          current.setText(prefix + host.getText())
-          current.setCursor((host.getCursor?.() ?? 0) + prefix.length)
+          if (this.changeRevision === revisionBeforeDispatch) {
+            current.setText(prefix + host.getText())
+            current.setCursor((host.getCursor?.() ?? 0) + prefix.length)
+          }
         } else {
           // Legacy raw fallback: the host document stays raw (no mode),
           // so wire and host coordinates are the same bytes. Same stale
-          // dropdown guard (see above).
+          // dropdown guard and sync-restore guard (see above).
           const contextBefore = { text: host.getText(), cursor: host.getCursor?.() ?? 0 }
           const stagedDiffers = contextBefore.text !== wireText || contextBefore.cursor !== wireCursor
           const dropdownInteraction = matchesKey(data, 'tab') || matchesKey(data, 'enter')
@@ -706,9 +721,12 @@ export class EditorSeatHolder {
             && (stagedDiffers || (!dropdownInteraction && host.isShowingAutocomplete?.() === true))) {
             host.cancelAutocomplete()
           }
+          const revisionBeforeDispatch = this.changeRevision
           host.handleInput!(data)
-          current.setText(host.getText())
-          current.setCursor(host.getCursor?.() ?? 0)
+          if (this.changeRevision === revisionBeforeDispatch) {
+            current.setText(host.getText())
+            current.setCursor(host.getCursor?.() ?? 0)
+          }
         }
       })
       // The host adapter may invoke the normal host onChange for a mutation,
@@ -754,6 +772,14 @@ export class EditorSeatHolder {
     }
   }
 
+  /** Monotonic seat-mutation epoch (review round 27): EVERY notifyChanged
+   * bumps it, so an external path that rewrote the visible seat DURING a
+   * fallback dispatch (a synchronous rejection restore through
+   * setEditorText) is distinguishable from the fallback's own sync-back —
+   * even when the restored text equals the pre-dispatch document, a text
+   * comparison cannot tell "never touched" from "explicitly rewritten
+   * with the same text", the epoch can. */
+  private changeRevision = 0
   /** Change listeners (host-driven notifications). */
   private readonly changeListeners = new Set<ChangeSubscription>()
 
@@ -761,6 +787,7 @@ export class EditorSeatHolder {
    * with the CURRENT snapshot (bounded — the fork's editor onChange). */
   notifyChanged(): void {
     if (this.disposed) return
+    this.changeRevision += 1
     const replacementId = this.current.id === 'host' ? undefined : this.current.id
     const snapshot = this.snapshotOf(replacementId ?? '')
     // P2-02: per-listener isolation — a throwing plugin listener must

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -271,28 +271,26 @@ export class EditorSeatHolder {
   }
 
   /**
-   * The WIRE form of one occupant's draft: mode + body serialized (the
-   * host editor's shell mode prefixes the body; a plugin editor has no
-   * mode — its text IS the wire form). Handoffs transfer this form so a
-   * shell-mode draft round-trips through a plugin editor with its mode,
-   * and a plugin draft that starts with `!` decodes back into the shell
-   * mode the user intended. The prefix length lets the caller shift the
-   * flat cursor offset between the two representations: for the host it
-   * is the mode's prefix; for a plugin it is derived from the TEXT
-   * itself (a plugin draft may begin with `!` / `!!` even though the
-   * plugin has no mode).
+   * The WIRE form + cursor of one occupant's draft, expressed in ONE
+   * coordinate system (the wire document — what the shell dispatch and a
+   * plugin editor's document both mean):
+   * - host shell mode: mode prefix + body, cursor shifted by the prefix;
+   * - host prompt mode: the body IS the wire document (a literal `!` in
+   *   prompt text is a document character, never a synthetic prefix);
+   * - plugin editor: its document IS the wire form, cursor unchanged.
+   * Each handoff target converts back: a plugin keeps the wire cursor;
+   * the host DECODE shifts it by the actually stripped prefix; a legacy
+   * raw restore keeps it (the `!` remains in the text).
    */
-  private wireDraftOf(seat: SeatEditor): { text: string; prefixLength: number } {
+  private wireCursorOf(seat: SeatEditor): { wireText: string; wireCursor: number } {
     const mode = seat.getInputMode?.() ?? 'prompt'
     if (mode !== 'prompt') {
       return {
-        text: serializeEditorInput(mode, seat.getText()),
-        prefixLength: shellPrefixForMode(mode).length,
+        wireText: serializeEditorInput(mode, seat.getText()),
+        wireCursor: seat.getCursor() + shellPrefixForMode(mode).length,
       }
     }
-    const text = seat.getText()
-    const decoded = editorModeFromHistoryEntry(text)
-    return { text, prefixLength: text.length - decoded.text.length }
+    return { wireText: seat.getText(), wireCursor: seat.getCursor() }
   }
 
   /** The current seat snapshot (Phase 2: the ADVANCED editor controls
@@ -341,24 +339,29 @@ export class EditorSeatHolder {
       // remains available and the handoff stays atomic.
       let host: SeatEditor
       try {
-        // The handoff transfers the WIRE form (mode + body serialized):
-        // a plugin editor's document IS the wire form (its submissions
-        // are raw), so a shell-mode host draft round-trips through the
-        // plugin with its mode, and a plugin draft that happens to start
-        // with `!` decodes back into the shell mode the user intended.
-        // The cursor offset shifts by the synthetic prefix length.
-        const wire = this.wireDraftOf(previous)
-        const cursor = previous.getCursor()
+        // The handoff transfers the WIRE form + cursor (one coordinate
+        // system): a plugin editor's document IS the wire form (its
+        // submissions are raw), so a shell-mode host draft round-trips
+        // through the plugin with its mode, and a plugin draft that
+        // happens to start with `!` decodes back into the shell mode the
+        // user intended.
+        const wire = this.wireCursorOf(previous)
         host = this.adaptHost()
         if (host.setSerializedInput !== undefined) {
-          host.setSerializedInput(wire.text)
+          host.setSerializedInput(wire.wireText)
+          // The decode strips the wire prefix (if any): the host cursor
+          // shifts back by the ACTUALLY stripped length.
+          const decoded = editorModeFromHistoryEntry(wire.wireText)
+          host.setCursor(Math.max(0, wire.wireCursor - (wire.wireText.length - decoded.text.length)))
         } else {
-          host.setText(wire.text)
+          // Legacy raw restore keeps the `!` in the document: the cursor
+          // stays in wire coordinates (no shift). Restore both draft and
+          // cursor through the host adapter — older structural adapters
+          // may still implement setCursor as a no-op, but the vendored
+          // fork's adapter preserves the active cursor as well.
+          host.setText(wire.wireText)
+          host.setCursor(Math.max(0, wire.wireCursor))
         }
-        // Restore both draft and cursor through the host adapter. Older
-        // structural adapters may still implement setCursor as a no-op, but
-        // the vendored fork's adapter preserves the active cursor as well.
-        host.setCursor(Math.max(0, cursor - wire.prefixLength))
       } catch (error) {
         this.reportHostError(error)
         return
@@ -415,14 +418,14 @@ export class EditorSeatHolder {
     // extends to EVERY post-create step, never a leak).
     try {
       if (this.disposed || !lease.active) throw new Error('editor seat disposed during handoff')
-      // The handoff transfers the WIRE form (see the host-restore branch):
-      // the plugin's document is the wire form, so a shell-mode host draft
-      // keeps its mode across the round-trip. The cursor offset shifts by
-      // the synthetic prefix length.
-      const wire = this.wireDraftOf(previous)
-      const cursor = previous.getCursor()
-      created.setText(wire.text)
-      created.setCursor?.(cursor + wire.prefixLength)
+      // The handoff transfers the WIRE form + cursor (see the
+      // host-restore branch): the plugin's document is the wire form, so
+      // a shell-mode host draft keeps its mode across the round-trip and
+      // the cursor stays in wire coordinates (a host prompt-mode literal
+      // `!` is a document character — never shifted).
+      const wire = this.wireCursorOf(previous)
+      created.setText(wire.wireText)
+      created.setCursor?.(wire.wireCursor)
     } catch (error) {
       try {
         created.dispose()

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -72,6 +72,8 @@ export interface SeatEditor {
   /** The occupant's editor input mode (the host editor always answers; a
    * plugin editor has no mode — absent means prompt semantics). */
   getInputMode?(): import('./editor-input-mode.ts').EditorInputMode
+  /** Set the occupant's input mode (host editor only). */
+  setInputMode?(mode: import('./editor-input-mode.ts').EditorInputMode): void
   /** Replace the occupant's draft from a SERIALIZED user input (the host
    * editor decodes mode + body; a plugin editor has no mode and receives
    * the raw text). */
@@ -94,6 +96,9 @@ export interface HostEditorAdapter {
   isShowingAutocomplete?(): boolean
   /** The host editor's current input mode (shell-mode serialization). */
   getInputMode?(): import('./editor-input-mode.ts').EditorInputMode
+  /** Set the host editor's input mode (the declined-key fallback stages
+   * the decoded mode alongside the body). */
+  setInputMode?(mode: import('./editor-input-mode.ts').EditorInputMode): void
   /** Replace the host draft from a SERIALIZED user input (`!x` / `!!x`
    * decode into mode + body — the handoff restore path). */
   setSerializedInput?(text: string): void
@@ -244,6 +249,7 @@ export class EditorSeatHolder {
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete?.() ?? false,
       getInputMode: () => editor.getInputMode?.() ?? 'prompt',
+      setInputMode: (mode) => editor.setInputMode?.(mode),
       // Only expose the serialized-input setter when the underlying
       // adapter implements it: a wrapper that silently no-ops would make
       // the handoff's capability check pass and DROP the transferred
@@ -612,19 +618,38 @@ export class EditorSeatHolder {
     try {
       const host = this.hostAdapter()
       if (host.handleInput === undefined) return false
-      const text = current.getText()
-      const cursor = current.getCursor()
+      const wireText = current.getText()
+      const wireCursor = current.getCursor()
       const run = <T>(task: () => T): T => {
         if (host.runWithoutChange !== undefined) return host.runWithoutChange(task)
         return task()
       }
       run(() => {
-        host.setTextAndCursor(text, cursor)
-        host.handleInput!(data)
-        const nextText = host.getText()
-        const nextCursor = host.getCursor?.() ?? 0
-        current.setText(nextText)
-        current.setCursor(nextCursor)
+        if (host.setSerializedInput !== undefined) {
+          // The plugin document IS the wire form, the host document is
+          // mode + body: decode the staged draft (through the narrow
+          // setTextAndCursor seam — no undo/autocomplete side effects —
+          // plus the decoded mode), run the host editor, then serialize
+          // the result back into the plugin's wire document. Without the
+          // round-trip a declined `!` would be consumed into the host's
+          // mode state and VANISH from the plugin (the shell-editor-mode
+          // representation boundary).
+          const decoded = editorModeFromHistoryEntry(wireText)
+          host.setTextAndCursor(decoded.text, Math.max(0, wireCursor - (wireText.length - decoded.text.length)))
+          host.setInputMode?.(decoded.mode)
+          host.handleInput!(data)
+          const mode = host.getInputMode?.() ?? 'prompt'
+          const prefix = shellPrefixForMode(mode)
+          current.setText(prefix + host.getText())
+          current.setCursor((host.getCursor?.() ?? 0) + prefix.length)
+        } else {
+          // Legacy raw fallback: the host document stays raw (no mode),
+          // so wire and host coordinates are the same bytes.
+          host.setTextAndCursor(wireText, wireCursor)
+          host.handleInput!(data)
+          current.setText(host.getText())
+          current.setCursor(host.getCursor?.() ?? 0)
+        }
       })
       // The host adapter may invoke the normal host onChange for a mutation,
       // and the fallback itself is also a seat mutation. The host callback is

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -23,6 +23,7 @@
  */
 
 import type { Component } from '@xmoon76/pi-tui'
+import { matchesKey } from '@xmoon76/pi-tui'
 import type { EditorHost, EditorSnapshot, ExtensionEditor } from './extension/public-types.ts'
 import { compileView } from './extension/internal/component-compiler.ts'
 import { editorModeFromHistoryEntry, serializeEditorInput, shellPrefixForMode } from './editor-input-mode.ts'
@@ -111,6 +112,9 @@ export interface HostEditorAdapter {
   setTextAndCursor(text: string, cursor: number): void
   /** Forward one declined replacement-editor key through the host editor. */
   handleInput?(data: string): void
+  /** Close the host editor's autocomplete dropdown / pending request (the
+   * stale-context guard — see handleHostFallbackInput). */
+  cancelAutocomplete?(): void
   /** Temporarily suppress the host adapter's normal change callback. */
   runWithoutChange?<T>(task: () => T): T
   readonly focused: boolean
@@ -652,8 +656,33 @@ export class EditorSeatHolder {
           // mode state and VANISH from the plugin (the shell-editor-mode
           // representation boundary).
           const decoded = editorModeFromHistoryEntry(wireText)
-          host.setTextAndCursor(decoded.text, Math.max(0, wireCursor - (wireText.length - decoded.text.length)))
+          const stagedCursor = Math.max(0, wireCursor - (wireText.length - decoded.text.length))
+          // STALE-AUTOCOMPLETE GUARD (review round 24): setTextAndCursor
+          // deliberately preserves the host's autocomplete state, so an
+          // EARLIER declined Tab's dropdown survives into this key. Its
+          // candidates belong to the document BEFORE this key — the
+          // fork's own refresh (updateAutocomplete) is async, and a Tab
+          // landing before it resolves would ACCEPT a stale candidate
+          // into the new text. Cancel the dropdown/request when either:
+          // - the staged document differs from the host's current
+          //   text/cursor (a programmatic plugin change — even Tab would
+          //   apply the old selection against the new document), or
+          // - the forwarded key is NOT the dropdown's own interaction
+          //   (Tab = accept, Enter = confirm, Up/Down = selection): a
+          //   mutation or cursor move invalidates the selection the
+          //   moment the key runs.
+          // An UNCHANGED document with a Tab/Enter/arrow keeps the
+          // dropdown (the Tab+Tab accept stays synchronous).
+          const contextBefore = { text: host.getText(), cursor: host.getCursor?.() ?? 0 }
+          const stagedDiffers = contextBefore.text !== decoded.text || contextBefore.cursor !== stagedCursor
+          const dropdownInteraction = matchesKey(data, 'tab') || matchesKey(data, 'enter')
+            || matchesKey(data, 'up') || matchesKey(data, 'down')
+          host.setTextAndCursor(decoded.text, stagedCursor)
           host.setInputMode?.(decoded.mode)
+          if (host.cancelAutocomplete !== undefined
+            && (stagedDiffers || (!dropdownInteraction && host.isShowingAutocomplete?.() === true))) {
+            host.cancelAutocomplete()
+          }
           host.handleInput!(data)
           const mode = host.getInputMode?.() ?? 'prompt'
           const prefix = shellPrefixForMode(mode)
@@ -661,8 +690,17 @@ export class EditorSeatHolder {
           current.setCursor((host.getCursor?.() ?? 0) + prefix.length)
         } else {
           // Legacy raw fallback: the host document stays raw (no mode),
-          // so wire and host coordinates are the same bytes.
+          // so wire and host coordinates are the same bytes. Same stale
+          // dropdown guard (see above).
+          const contextBefore = { text: host.getText(), cursor: host.getCursor?.() ?? 0 }
+          const stagedDiffers = contextBefore.text !== wireText || contextBefore.cursor !== wireCursor
+          const dropdownInteraction = matchesKey(data, 'tab') || matchesKey(data, 'enter')
+            || matchesKey(data, 'up') || matchesKey(data, 'down')
           host.setTextAndCursor(wireText, wireCursor)
+          if (host.cancelAutocomplete !== undefined
+            && (stagedDiffers || (!dropdownInteraction && host.isShowingAutocomplete?.() === true))) {
+            host.cancelAutocomplete()
+          }
           host.handleInput!(data)
           current.setText(host.getText())
           current.setCursor(host.getCursor?.() ?? 0)

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -25,7 +25,7 @@
 import type { Component } from '@xmoon76/pi-tui'
 import type { EditorHost, EditorSnapshot, ExtensionEditor } from './extension/public-types.ts'
 import { compileView } from './extension/internal/component-compiler.ts'
-import { serializeEditorInput, shellPrefixForMode } from './editor-input-mode.ts'
+import { editorModeFromHistoryEntry, serializeEditorInput, shellPrefixForMode } from './editor-input-mode.ts'
 
 function safeEditorErrorMessage(error: unknown): string {
   try {
@@ -277,14 +277,22 @@ export class EditorSeatHolder {
    * shell-mode draft round-trips through a plugin editor with its mode,
    * and a plugin draft that starts with `!` decodes back into the shell
    * mode the user intended. The prefix length lets the caller shift the
-   * flat cursor offset between the two representations.
+   * flat cursor offset between the two representations: for the host it
+   * is the mode's prefix; for a plugin it is derived from the TEXT
+   * itself (a plugin draft may begin with `!` / `!!` even though the
+   * plugin has no mode).
    */
   private wireDraftOf(seat: SeatEditor): { text: string; prefixLength: number } {
     const mode = seat.getInputMode?.() ?? 'prompt'
-    return {
-      text: serializeEditorInput(mode, seat.getText()),
-      prefixLength: shellPrefixForMode(mode).length,
+    if (mode !== 'prompt') {
+      return {
+        text: serializeEditorInput(mode, seat.getText()),
+        prefixLength: shellPrefixForMode(mode).length,
+      }
     }
+    const text = seat.getText()
+    const decoded = editorModeFromHistoryEntry(text)
+    return { text, prefixLength: text.length - decoded.text.length }
   }
 
   /** The current seat snapshot (Phase 2: the ADVANCED editor controls

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -25,6 +25,7 @@
 import type { Component } from '@xmoon76/pi-tui'
 import type { EditorHost, EditorSnapshot, ExtensionEditor } from './extension/public-types.ts'
 import { compileView } from './extension/internal/component-compiler.ts'
+import { serializeEditorInput, shellPrefixForMode } from './editor-input-mode.ts'
 
 function safeEditorErrorMessage(error: unknown): string {
   try {
@@ -71,6 +72,10 @@ export interface SeatEditor {
   /** The occupant's editor input mode (the host editor always answers; a
    * plugin editor has no mode — absent means prompt semantics). */
   getInputMode?(): import('./editor-input-mode.ts').EditorInputMode
+  /** Replace the occupant's draft from a SERIALIZED user input (the host
+   * editor decodes mode + body; a plugin editor has no mode and receives
+   * the raw text). */
+  setSerializedInput?(text: string): void
   /** P1-5: the occupant's input channel — a PLUGIN editor with a
    * handleInput hook receives routed SEMANTIC events here (the host has
    * already decoded the terminal protocol — legacy/CSI-u/modifyOtherKeys
@@ -89,6 +94,9 @@ export interface HostEditorAdapter {
   isShowingAutocomplete?(): boolean
   /** The host editor's current input mode (shell-mode serialization). */
   getInputMode?(): import('./editor-input-mode.ts').EditorInputMode
+  /** Replace the host draft from a SERIALIZED user input (`!x` / `!!x`
+   * decode into mode + body — the handoff restore path). */
+  setSerializedInput?(text: string): void
   getCursor?(): number
   /** Best-effort cursor setter for the host editor. */
   setCursor?(offset: number): void
@@ -236,6 +244,7 @@ export class EditorSeatHolder {
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete?.() ?? false,
       getInputMode: () => editor.getInputMode?.() ?? 'prompt',
+      setSerializedInput: (text) => editor.setSerializedInput?.(text),
       getCursor: () => editor.getCursor?.() ?? 0,
       setCursor: (offset) => editor.setCursor?.(offset),
       insertTextAtCursor: (text) => editor.insertTextAtCursor?.(text),
@@ -253,6 +262,23 @@ export class EditorSeatHolder {
   /** The current occupant. */
   currentEditor(): SeatEditor {
     return this.current
+  }
+
+  /**
+   * The WIRE form of one occupant's draft: mode + body serialized (the
+   * host editor's shell mode prefixes the body; a plugin editor has no
+   * mode — its text IS the wire form). Handoffs transfer this form so a
+   * shell-mode draft round-trips through a plugin editor with its mode,
+   * and a plugin draft that starts with `!` decodes back into the shell
+   * mode the user intended. The prefix length lets the caller shift the
+   * flat cursor offset between the two representations.
+   */
+  private wireDraftOf(seat: SeatEditor): { text: string; prefixLength: number } {
+    const mode = seat.getInputMode?.() ?? 'prompt'
+    return {
+      text: serializeEditorInput(mode, seat.getText()),
+      prefixLength: shellPrefixForMode(mode).length,
+    }
   }
 
   /** The current seat snapshot (Phase 2: the ADVANCED editor controls
@@ -301,14 +327,24 @@ export class EditorSeatHolder {
       // remains available and the handoff stays atomic.
       let host: SeatEditor
       try {
-        const draft = previous.getText()
+        // The handoff transfers the WIRE form (mode + body serialized):
+        // a plugin editor's document IS the wire form (its submissions
+        // are raw), so a shell-mode host draft round-trips through the
+        // plugin with its mode, and a plugin draft that happens to start
+        // with `!` decodes back into the shell mode the user intended.
+        // The cursor offset shifts by the synthetic prefix length.
+        const wire = this.wireDraftOf(previous)
         const cursor = previous.getCursor()
         host = this.adaptHost()
-        host.setText(draft)
+        if (host.setSerializedInput !== undefined) {
+          host.setSerializedInput(wire.text)
+        } else {
+          host.setText(wire.text)
+        }
         // Restore both draft and cursor through the host adapter. Older
         // structural adapters may still implement setCursor as a no-op, but
         // the vendored fork's adapter preserves the active cursor as well.
-        host.setCursor(cursor)
+        host.setCursor(Math.max(0, cursor - wire.prefixLength))
       } catch (error) {
         this.reportHostError(error)
         return
@@ -365,10 +401,14 @@ export class EditorSeatHolder {
     // extends to EVERY post-create step, never a leak).
     try {
       if (this.disposed || !lease.active) throw new Error('editor seat disposed during handoff')
-      const draft = previous.getText()
+      // The handoff transfers the WIRE form (see the host-restore branch):
+      // the plugin's document is the wire form, so a shell-mode host draft
+      // keeps its mode across the round-trip. The cursor offset shifts by
+      // the synthetic prefix length.
+      const wire = this.wireDraftOf(previous)
       const cursor = previous.getCursor()
-      created.setText(draft)
-      created.setCursor?.(cursor)
+      created.setText(wire.text)
+      created.setCursor?.(cursor + wire.prefixLength)
     } catch (error) {
       try {
         created.dispose()

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -588,6 +588,12 @@ export class EditorSeatHolder {
               if (consumed) {
                 holder.clearEditorError(id)
                 holder.current.invalidate()
+                // A consumed key may have MUTATED the plugin's document:
+                // seat subscribers (EditorHost.subscribe observers, the
+                // continuable-viewer draft mirror) must observe the new
+                // text/cursor snapshot — a stale snapshot would merge an
+                // outdated draft on handoff/viewer exit and lose edits.
+                holder.notifyChanged()
               }
               return consumed
             } catch (error) {

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -244,7 +244,13 @@ export class EditorSeatHolder {
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete?.() ?? false,
       getInputMode: () => editor.getInputMode?.() ?? 'prompt',
-      setSerializedInput: (text) => editor.setSerializedInput?.(text),
+      // Only expose the serialized-input setter when the underlying
+      // adapter implements it: a wrapper that silently no-ops would make
+      // the handoff's capability check pass and DROP the transferred
+      // draft on older structural adapters.
+      setSerializedInput: editor.setSerializedInput === undefined
+        ? undefined
+        : (text) => editor.setSerializedInput!(text),
       getCursor: () => editor.getCursor?.() ?? 0,
       setCursor: (offset) => editor.setCursor?.(offset),
       insertTextAtCursor: (text) => editor.insertTextAtCursor?.(text),

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -249,7 +249,13 @@ export class EditorSeatHolder {
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete?.() ?? false,
       getInputMode: () => editor.getInputMode?.() ?? 'prompt',
-      setInputMode: (mode) => editor.setInputMode?.(mode),
+      // Only expose the mode setter when the underlying adapter implements
+      // it — a silently no-op wrapper would make the fallback's capability
+      // check pass while the decoded mode is discarded (same rule as the
+      // setSerializedInput gate below).
+      setInputMode: editor.setInputMode === undefined
+        ? undefined
+        : (mode) => editor.setInputMode!(mode),
       // Only expose the serialized-input setter when the underlying
       // adapter implements it: a wrapper that silently no-ops would make
       // the handoff's capability check pass and DROP the transferred
@@ -625,7 +631,12 @@ export class EditorSeatHolder {
         return task()
       }
       run(() => {
-        if (host.setSerializedInput !== undefined) {
+        // The wire round-trip needs the FULL capability pair: the decode
+        // (setSerializedInput) AND the mode sync (setInputMode). An
+        // adapter with only one of them falls back to the raw path — a
+        // silently discarded mode would serialize with a stale prefix and
+        // DROP the declined shell input.
+        if (host.setSerializedInput !== undefined && host.setInputMode !== undefined) {
           // The plugin document IS the wire form, the host document is
           // mode + body: decode the staged draft (through the narrow
           // setTextAndCursor seam — no undo/autocomplete side effects —

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -532,15 +532,31 @@ export class MentionProvider implements AutocompleteProvider {
     return { line: prefix + line, cursorCol: cursorCol + prefix.length, prefixLength: prefix.length }
   }
 
-  /** The virtual shell line ONLY for the first document line (see
-   * {@link virtualShellLine}); later lines complete without a prefix. */
-  private virtualShellContext(
+  /** The WIRE representation: the synthetic `!` / `!!` prefix belongs to
+   * LINE 0 only — the serialized wire document carries it once, and a
+   * body continuation line is ordinary text. Used for the shell-grammar
+   * parse and the Stable-extension wire query. Null in prompt mode or on
+   * a later line. */
+  private virtualWireShellContext(
     lines: string[],
     cursorLine: number,
     cursorCol: number,
   ): { line: string; cursorCol: number; prefixLength: number } | null {
     if (cursorLine !== 0) return null
     return this.virtualShellLine(lines[0] ?? '', cursorCol)
+  }
+
+  /** The SHELL SEMANTIC context: EVERY line of a shell-mode document is
+   * part of the shell command, so slash-vs-path routing, the apply
+   * classification and the Tab gating treat any line as shell-owned. The
+   * synthetic prefix is staged on the cursor line and stripped from the
+   * result — the wire document itself never changes. Null in prompt
+   * mode. */
+  private virtualShellSemanticContext(
+    currentLine: string,
+    cursorCol: number,
+  ): { line: string; cursorCol: number; prefixLength: number } | null {
+    return this.virtualShellLine(currentLine, cursorCol)
   }
 
   async getSuggestions(
@@ -568,22 +584,25 @@ export class MentionProvider implements AutocompleteProvider {
     // shell MODE the buffer holds the bare body, so the shell grammar
     // receives the VIRTUAL serialized line (the synthetic prefix — line 0
     // only, matching the wire document); in prompt mode the line is
-    // parsed as-is (a literal `!` draft).
-    const virtual = this.virtualShellContext(lines, cursorLine, cursorCol)
-    const shellLine = virtual ?? { line: currentLine, cursorCol, prefixLength: 0 }
+    // parsed as-is (a literal `!` draft). The leading-`/` suppression is
+    // SHELL-SEMANTIC: EVERY line of a shell-mode document is shell-owned,
+    // so a path on any line stays a path (never a slash command).
+    const wire = this.virtualWireShellContext(lines, cursorLine, cursorCol)
+    const shellLine = wire ?? { line: currentLine, cursorCol, prefixLength: 0 }
     const shellContext = shellCompletionContext(shellLine.line, shellLine.cursorCol)
     if (shellContext !== undefined) {
       const suggestions = await suggestShellCompletion(shellContext, this.workDir, options)
       if (suggestions !== null) return suggestions
       // No shell suggestions (or the shell is unavailable): fall through —
       // a path position still gets the fork's file completion.
-    } else if (virtual !== null && !options.force && currentLine.startsWith('/')) {
+    } else if (this.virtualShellSemanticContext(currentLine, cursorCol) !== null
+      && !options.force && currentLine.startsWith('/')) {
       // A NATURAL trigger on a leading `/` in a shell mode is a PATH,
       // never a slash command: the fork's slash-command branch must not
-      // flash the command list while the user types `/usr/lo`. Stay quiet
-      // until Tab (which routes through the path branch below) — this
-      // matches the pre-mode behavior, where the literal `!` prefix kept
-      // the fork's slash branch off.
+      // flash the command list while the user types `/usr/lo` — on ANY
+      // line. Stay quiet until Tab (which routes through the path branch
+      // below) — this matches the pre-mode behavior, where the literal
+      // `!` prefix kept the fork's slash branch off.
       return null
     }
     try {
@@ -609,8 +628,8 @@ export class MentionProvider implements AutocompleteProvider {
     // itself operates on the REAL line: the completion prefix sits after
     // the synthetic `!`, so it is identical in both forms and no prefix
     // stripping is needed — the synthetic prefix never enters the buffer.
-    const virtual = this.virtualShellContext(lines, cursorLine, cursorCol)
-    const shellLine = virtual ?? { line: currentLine, cursorCol, prefixLength: 0 }
+    const wire = this.virtualWireShellContext(lines, cursorLine, cursorCol)
+    const shellLine = wire ?? { line: currentLine, cursorCol, prefixLength: 0 }
     if (shellCompletionContext(shellLine.line, shellLine.cursorCol) !== undefined) {
       const before = currentLine.slice(0, cursorCol - prefix.length)
       const after = currentLine.slice(cursorCol)
@@ -623,22 +642,24 @@ export class MentionProvider implements AutocompleteProvider {
         cursorCol: before.length + item.value.length + 1,
       }
     }
-    if (virtual !== null) {
-      // SYMMETRIC wire adapter: every non-shell apply (path completion,
-      // Stable-extension suggestions) runs on the VIRTUAL wire document —
-      // the fork's line-start judgments then see the `!` prefix (an
-      // absolute path like `/u` is never mistaken for a slash command,
-      // and an extension prefix computed on the wire line stays
-      // coordinate-consistent). The synthetic prefix is stripped from the
-      // applied result, so it never enters the buffer.
-      const wireLines = lines.map((line, index) => index === 0 ? virtual.line : line)
-      const applied = this.inner.applyCompletion(wireLines, cursorLine, virtual.cursorCol, item, prefix)
+    // SYMMETRIC SHELL-SEMANTIC adapter: every non-shell apply (path
+    // completion, Stable-extension suggestions) on ANY line of a
+    // shell-mode document runs on the virtual line — the fork's
+    // line-start judgments then see the `!` prefix (an absolute path
+    // like `/u` is never mistaken for a slash command, on line 0 or a
+    // continuation line, and an extension prefix computed on the wire
+    // line stays coordinate-consistent). The synthetic prefix is
+    // stripped from the applied result, so it never enters the buffer.
+    const semantic = this.virtualShellSemanticContext(currentLine, cursorCol)
+    if (semantic !== null) {
+      const wireLines = lines.map((line, index) => index === cursorLine ? semantic.line : line)
+      const applied = this.inner.applyCompletion(wireLines, cursorLine, semantic.cursorCol, item, prefix)
       const resultLines = [...applied.lines]
-      resultLines[0] = resultLines[0]!.slice(virtual.prefixLength)
+      resultLines[cursorLine] = resultLines[cursorLine]!.slice(semantic.prefixLength)
       return {
         lines: resultLines,
         cursorLine: applied.cursorLine,
-        cursorCol: Math.max(0, applied.cursorCol - virtual.prefixLength),
+        cursorCol: Math.max(0, applied.cursorCol - semantic.prefixLength),
       }
     }
     return this.inner.applyCompletion(lines, cursorLine, cursorCol, item, prefix)
@@ -668,14 +689,13 @@ export class MentionProvider implements AutocompleteProvider {
     }
     // In a shell MODE a leading `/` is a PATH, never a slash command: the
     // fork's bare-slash-command block (`/usr/lo` has no space) must not
-    // swallow Tab. The VIRTUAL serialized line keeps the fork's own
-    // judgment on the line the shell dispatch would see — the wire
-    // document carries the prefix on LINE 0 only, so a body continuation
-    // line keeps the fork's plain judgment.
-    const virtual = this.virtualShellContext(lines, cursorLine, cursorCol)
-    if (virtual !== null) {
-      const virtualLines = lines.map((line, index) => index === 0 ? virtual.line : line)
-      return this.inner.shouldTriggerFileCompletion?.(virtualLines, cursorLine, virtual.cursorCol) ?? true
+    // swallow Tab. The VIRTUAL SHELL-SEMANTIC line keeps the fork's own
+    // judgment on the cursor line — on ANY line of the shell document
+    // (the wire representation still carries the prefix on line 0 only).
+    const semantic = this.virtualShellSemanticContext(currentLine, cursorCol)
+    if (semantic !== null) {
+      const virtualLines = lines.map((line, index) => index === cursorLine ? semantic.line : line)
+      return this.inner.shouldTriggerFileCompletion?.(virtualLines, cursorLine, semantic.cursorCol) ?? true
     }
     return this.inner.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true
   }

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -517,9 +517,11 @@ export class MentionProvider implements AutocompleteProvider {
     )
   }
 
-  /** The virtual serialized line for a shell-mode editor position: the
-   * synthetic `!` / `!!` prefix plus the shifted cursor column. Null in
-   * prompt mode. */
+  /** The virtual serialized line for a shell-mode editor position on the
+   * FIRST document line: the synthetic `!` / `!!` prefix plus the shifted
+   * cursor column. Null in prompt mode or on a LATER line — the wire
+   * document carries the prefix on line 0 only, so a body continuation
+   * line completes as ordinary text (paths), exactly like the wire. */
   private virtualShellLine(
     line: string,
     cursorCol: number,
@@ -528,6 +530,17 @@ export class MentionProvider implements AutocompleteProvider {
     if (mode === 'prompt') return null
     const prefix = shellPrefixForMode(mode)
     return { line: prefix + line, cursorCol: cursorCol + prefix.length, prefixLength: prefix.length }
+  }
+
+  /** The virtual shell line ONLY for the first document line (see
+   * {@link virtualShellLine}); later lines complete without a prefix. */
+  private virtualShellContext(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+  ): { line: string; cursorCol: number; prefixLength: number } | null {
+    if (cursorLine !== 0) return null
+    return this.virtualShellLine(lines[0] ?? '', cursorCol)
   }
 
   async getSuggestions(
@@ -553,9 +566,10 @@ export class MentionProvider implements AutocompleteProvider {
     // from the real-shell compgen bridge (docs/input-and-card-polish.md §1);
     // path positions fall through to the fork's fd completion below. In a
     // shell MODE the buffer holds the bare body, so the shell grammar
-    // receives the VIRTUAL serialized line (the synthetic prefix); in
-    // prompt mode the line is parsed as-is (a literal `!` draft).
-    const virtual = this.virtualShellLine(currentLine, cursorCol)
+    // receives the VIRTUAL serialized line (the synthetic prefix — line 0
+    // only, matching the wire document); in prompt mode the line is
+    // parsed as-is (a literal `!` draft).
+    const virtual = this.virtualShellContext(lines, cursorLine, cursorCol)
     const shellLine = virtual ?? { line: currentLine, cursorCol, prefixLength: 0 }
     const shellContext = shellCompletionContext(shellLine.line, shellLine.cursorCol)
     if (shellContext !== undefined) {
@@ -595,7 +609,7 @@ export class MentionProvider implements AutocompleteProvider {
     // itself operates on the REAL line: the completion prefix sits after
     // the synthetic `!`, so it is identical in both forms and no prefix
     // stripping is needed — the synthetic prefix never enters the buffer.
-    const virtual = this.virtualShellLine(currentLine, cursorCol)
+    const virtual = this.virtualShellContext(lines, cursorLine, cursorCol)
     const shellLine = virtual ?? { line: currentLine, cursorCol, prefixLength: 0 }
     if (shellCompletionContext(shellLine.line, shellLine.cursorCol) !== undefined) {
       const before = currentLine.slice(0, cursorCol - prefix.length)
@@ -637,10 +651,12 @@ export class MentionProvider implements AutocompleteProvider {
     // In a shell MODE a leading `/` is a PATH, never a slash command: the
     // fork's bare-slash-command block (`/usr/lo` has no space) must not
     // swallow Tab. The VIRTUAL serialized line keeps the fork's own
-    // judgment on the line the shell dispatch would see.
-    const virtual = this.virtualShellLine(currentLine, cursorCol)
+    // judgment on the line the shell dispatch would see — the wire
+    // document carries the prefix on LINE 0 only, so a body continuation
+    // line keeps the fork's plain judgment.
+    const virtual = this.virtualShellContext(lines, cursorLine, cursorCol)
     if (virtual !== null) {
-      const virtualLines = lines.map((line, index) => index === cursorLine ? virtual.line : line)
+      const virtualLines = lines.map((line, index) => index === 0 ? virtual.line : line)
       return this.inner.shouldTriggerFileCompletion?.(virtualLines, cursorLine, virtual.cursorCol) ?? true
     }
     return this.inner.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -623,6 +623,24 @@ export class MentionProvider implements AutocompleteProvider {
         cursorCol: before.length + item.value.length + 1,
       }
     }
+    if (virtual !== null) {
+      // SYMMETRIC wire adapter: every non-shell apply (path completion,
+      // Stable-extension suggestions) runs on the VIRTUAL wire document —
+      // the fork's line-start judgments then see the `!` prefix (an
+      // absolute path like `/u` is never mistaken for a slash command,
+      // and an extension prefix computed on the wire line stays
+      // coordinate-consistent). The synthetic prefix is stripped from the
+      // applied result, so it never enters the buffer.
+      const wireLines = lines.map((line, index) => index === 0 ? virtual.line : line)
+      const applied = this.inner.applyCompletion(wireLines, cursorLine, virtual.cursorCol, item, prefix)
+      const resultLines = [...applied.lines]
+      resultLines[0] = resultLines[0]!.slice(virtual.prefixLength)
+      return {
+        lines: resultLines,
+        cursorLine: applied.cursorLine,
+        cursorCol: Math.max(0, applied.cursorCol - virtual.prefixLength),
+      }
+    }
     return this.inner.applyCompletion(lines, cursorLine, cursorCol, item, prefix)
   }
 

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -22,6 +22,7 @@ import {
   type SlashCommand,
 } from '@xmoon76/pi-tui'
 import { shellCompletionContext, suggestShellCompletion } from './shell-completion.ts'
+import { shellPrefixForMode, type EditorInputMode } from './editor-input-mode.ts'
 
 /** Token separators: `@` must sit at the start of the current token. */
 const PATH_DELIMITERS = new Set([' ', '\t', '"', "'", '='])
@@ -493,20 +494,40 @@ export class MentionProvider implements AutocompleteProvider {
    * a trailing-space argument as a Tab file-completion site — every other
    * command keeps the fork's judgment. */
   private readonly pathArgumentCommands: ReadonlySet<string>
+  /** The live editor input mode (the shell-editor-mode plan): the editor
+   * buffer no longer contains the `!` / `!!` prefix, so the provider
+   * synthesizes a VIRTUAL serialized line at the completion boundary —
+   * the shell grammar in shell-completion.ts stays untouched. */
+  private readonly inputModeSource: () => EditorInputMode
 
   constructor(
     slashCommands: readonly SlashCommand[],
     workDir: string,
     fdPath: string | null,
+    inputModeSource: () => EditorInputMode = () => 'prompt',
   ) {
     this.workDir = workDir
     this.fdPath = fdPath
+    this.inputModeSource = inputModeSource
     this.inner = new CombinedAutocompleteProvider([...slashCommands], workDir, fdPath)
     this.pathArgumentCommands = new Set(
       slashCommands
         .filter(command => command.getArgumentCompletions !== undefined)
         .map(command => command.name),
     )
+  }
+
+  /** The virtual serialized line for a shell-mode editor position: the
+   * synthetic `!` / `!!` prefix plus the shifted cursor column. Null in
+   * prompt mode. */
+  private virtualShellLine(
+    line: string,
+    cursorCol: number,
+  ): { line: string; cursorCol: number; prefixLength: number } | null {
+    const mode = this.inputModeSource()
+    if (mode === 'prompt') return null
+    const prefix = shellPrefixForMode(mode)
+    return { line: prefix + line, cursorCol: cursorCol + prefix.length, prefixLength: prefix.length }
   }
 
   async getSuggestions(
@@ -530,13 +551,26 @@ export class MentionProvider implements AutocompleteProvider {
     }
     // `!`/`!!` shell lines: command names, subcommands and `$VAR` names come
     // from the real-shell compgen bridge (docs/input-and-card-polish.md §1);
-    // path positions fall through to the fork's fd completion below.
-    const shellContext = shellCompletionContext(currentLine, cursorCol)
+    // path positions fall through to the fork's fd completion below. In a
+    // shell MODE the buffer holds the bare body, so the shell grammar
+    // receives the VIRTUAL serialized line (the synthetic prefix); in
+    // prompt mode the line is parsed as-is (a literal `!` draft).
+    const virtual = this.virtualShellLine(currentLine, cursorCol)
+    const shellLine = virtual ?? { line: currentLine, cursorCol, prefixLength: 0 }
+    const shellContext = shellCompletionContext(shellLine.line, shellLine.cursorCol)
     if (shellContext !== undefined) {
       const suggestions = await suggestShellCompletion(shellContext, this.workDir, options)
       if (suggestions !== null) return suggestions
       // No shell suggestions (or the shell is unavailable): fall through —
       // a path position still gets the fork's file completion.
+    } else if (virtual !== null && !options.force && currentLine.startsWith('/')) {
+      // A NATURAL trigger on a leading `/` in a shell mode is a PATH,
+      // never a slash command: the fork's slash-command branch must not
+      // flash the command list while the user types `/usr/lo`. Stay quiet
+      // until Tab (which routes through the path branch below) — this
+      // matches the pre-mode behavior, where the literal `!` prefix kept
+      // the fork's slash branch off.
+      return null
     }
     try {
       return await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
@@ -556,8 +590,14 @@ export class MentionProvider implements AutocompleteProvider {
     // A shell-completion item replaces the current word only (command
     // names, subcommands, `$VAR` names all land as one plain word); the
     // `!` prefix and everything before the word stay untouched. Same
-    // pattern as the fork's slash-command apply.
-    if (shellCompletionContext(currentLine, cursorCol) !== undefined) {
+    // pattern as the fork's slash-command apply. In a shell MODE the
+    // context check runs on the VIRTUAL serialized line, but the apply
+    // itself operates on the REAL line: the completion prefix sits after
+    // the synthetic `!`, so it is identical in both forms and no prefix
+    // stripping is needed — the synthetic prefix never enters the buffer.
+    const virtual = this.virtualShellLine(currentLine, cursorCol)
+    const shellLine = virtual ?? { line: currentLine, cursorCol, prefixLength: 0 }
+    if (shellCompletionContext(shellLine.line, shellLine.cursorCol) !== undefined) {
       const before = currentLine.slice(0, cursorCol - prefix.length)
       const after = currentLine.slice(cursorCol)
       const newLine = `${before}${item.value} ${after}`
@@ -593,6 +633,15 @@ export class MentionProvider implements AutocompleteProvider {
         const commandName = trimmedStart.slice(1, separatorIndex)
         if (this.pathArgumentCommands.has(commandName)) return true
       }
+    }
+    // In a shell MODE a leading `/` is a PATH, never a slash command: the
+    // fork's bare-slash-command block (`/usr/lo` has no space) must not
+    // swallow Tab. The VIRTUAL serialized line keeps the fork's own
+    // judgment on the line the shell dispatch would see.
+    const virtual = this.virtualShellLine(currentLine, cursorCol)
+    if (virtual !== null) {
+      const virtualLines = lines.map((line, index) => index === cursorLine ? virtual.line : line)
+      return this.inner.shouldTriggerFileCompletion?.(virtualLines, cursorLine, virtual.cursorCol) ?? true
     }
     return this.inner.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true
   }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -5090,7 +5090,12 @@ export class TuiApp {
       getEditorState: () => app.editorSeatHolder.snapshot(),
       setEditorText: (text) => {
         if (app.disposed) return
-        app.seatEditor().setText(text)
+        // The shell-editor-mode boundary: the host editor decodes a
+        // SERIALIZED draft (`!pwd` → shell mode + body) — a raw write
+        // would leave the previous shell mode active and submit the
+        // replacement as a shell command. A plugin editor (no mode)
+        // receives the raw text.
+        app.setSeatSerializedInput(text)
         app.editorSeatHolder.notifyChanged()
       },
       setEditorCursor: (offset) => {

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2473,8 +2473,14 @@ export class TuiApp {
         return undefined
       }
       // The host may consume the first Esc (runner-owned modes like the
-      // subagent viewer); otherwise it arms the double-Esc cancel.
-      if (this.events.onSingleEscape?.() === true) return { consume: true }
+      // subagent viewer); otherwise it arms the double-Esc cancel. A
+      // CONSUMED Esc is a fresh action: it disarms any pending window (a
+      // prior declined Esc may have armed it — the consumed Esc must not
+      // leave a stale cancel armed for an unrelated later press).
+      if (this.events.onSingleEscape?.() === true) {
+        this.lastEscapeAt = undefined
+        return { consume: true }
+      }
       // pi parity: a SINGLE Esc while the agent is busy stops the current
       // activity (turn, tool run, compaction) — partial content stays on
       // screen. Idle keeps the double-Esc cancel. The busy cancel is
@@ -2494,7 +2500,12 @@ export class TuiApp {
       // fallback (which includes this cancel path on re-entry).
       if (this.seatEditor().handleInput !== undefined) {
         const routed = this.handleReplacementEditorInput(data, this.inputRouterContext(), true)
-        if (routed !== undefined) return routed
+        if (routed !== undefined) {
+          // A CONSUMED plugin Esc is a fresh action: disarm any pending
+          // double-Esc window (a prior declined Esc may have armed it).
+          this.lastEscapeAt = undefined
+          return routed
+        }
         // The plugin DECLINED Esc: continue through the host Esc fallback
         // (shell-mode exit, double-Esc cancel) instead of dropping the
         // key — a dropped Esc would never arm the cancel.

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7358,20 +7358,25 @@ export class TuiApp {
     this.requestRender()
   }
 
-  /** The editor's current draft text (the Alt+↑ dequeue merge reads it).
-   * In a continuable viewer the VISIBLE editor is the authority — it is
-   * exactly what the user sees and submits: a replacement editor's edits
-   * (through its own handleInput) never mirror through the host's
-   * onChange, so the per-child slot may lag and must never be submitted
-   * in the visible text's place. The slot remains the CROSS-SESSION
-   * store (park on exit/switch, map-only stale restores, re-entry seed);
-   * the visible text is the CURRENT-session truth. A one-shot viewer
-   * returns the preserved main draft. */
+  /** The editor's current draft in its WIRE form (mode + body serialized
+   * — the symmetric counterpart of {@link setDraft}, which decodes).
+   * Callers that read, merge and restore drafts (the runner's restore
+   * paths, the Alt+↑ dequeue, the steer action) therefore never lose the
+   * shell mode: a shell-mode draft reads back as `!pwd` and restores as
+   * shell mode. In a continuable viewer the VISIBLE editor is the
+   * authority — it is exactly what the user sees and submits: a
+   * replacement editor's edits (through its own handleInput) never
+   * mirror through the host's onChange, so the per-child slot may lag and
+   * must never be submitted in the visible text's place. The slot
+   * remains the CROSS-SESSION store (park on exit/switch, map-only stale
+   * restores, re-entry seed); the visible text is the CURRENT-session
+   * truth. A one-shot viewer returns the preserved main draft (already
+   * the wire form). */
   getDraft(): string {
     const target = this.viewerMode
-    if (target === undefined) return this.seatEditor().getText()
+    if (target === undefined) return this.serializeSeatDraft(this.seatEditor().getText())
     if (isViewerAccessInteractive(resolveViewerAccess(target.mode, target.access))) {
-      return this.seatEditor().getText()
+      return this.serializeSeatDraft(this.seatEditor().getText())
     }
     return this.mainDraftBeforeViewer ?? ''
   }
@@ -7391,10 +7396,10 @@ export class TuiApp {
     // session-side effect after teardown.
     if (this.disposed) return
     const target = this.viewerMode
-    const text = this.getDraft()
-    // The shell-editor-mode boundary: the visible body is re-serialized
-    // into the wire form (`!` / `!!` prefixes) before it leaves the app.
-    const serialized = this.serializeSeatDraft(text)
+    // getDraft returns the WIRE form (the symmetric counterpart of
+    // setDraft), so no re-serialization happens here — the text is
+    // already the `!` / `!!` prefixed form the protocol expects.
+    const serialized = this.getDraft()
     // Emptiness is judged on the SERIALIZED wire form: a bare `!` / `!!`
     // shell mode has an empty BODY but a non-empty wire form, and must
     // reach the existing protocol like the literal prefix did before the
@@ -7749,8 +7754,21 @@ export class TuiApp {
           force: options.force,
         })
       },
-      applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
-        base.applyCompletion(lines, cursorLine, cursorCol, item, prefix),
+      applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
+        // A Stable plugin computes its prefix on the WIRE document it
+        // received (line 0 carries the synthetic `!` / `!!`), so its
+        // prefix may legitimately include it (`!ch` for `!checkout`).
+        // Normalize back to BARE coordinates before the host apply —
+        // the base adapter adds its own virtual prefix and strips it
+        // exactly once; a doubled prefix would corrupt the result
+        // (`checkout` → `heckout`).
+        const mode = getMode()
+        const barePrefix = mode !== 'prompt' && cursorLine === 0
+          && (prefix.startsWith('!!') || prefix.startsWith('!'))
+          ? prefix.slice(prefix.startsWith('!!') ? 2 : 1)
+          : prefix
+        return base.applyCompletion(lines, cursorLine, cursorCol, item, barePrefix)
+      },
       shouldTriggerFileCompletion: (lines, cursorLine, cursorCol) =>
         base.shouldTriggerFileCompletion(lines, cursorLine, cursorCol),
     }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -34,7 +34,6 @@ import {
   visibleWidth,
   wrapTextWithAnsi,
   type Component,
-  type Editor,
   type Focusable,
   type OverlayHandle,
   type OverlayOptions,
@@ -117,6 +116,7 @@ import type { RendererRegistry } from './renderer-registry.ts'
 import { OverlayBroker } from './overlay-broker.ts'
 import { EditorSeatHolder } from './editor-seat-holder.ts'
 import { TuiEditor } from './tui-editor.ts'
+import { serializeEditorInput, type EditorInputMode } from './editor-input-mode.ts'
 import type { EditorRegistry } from './editor-registry.ts'
 import { compileView } from './extension/internal/component-compiler.ts'
 import { AdvancedOverlayComponent } from './extension/internal/advanced-overlay.ts'
@@ -1326,7 +1326,7 @@ export class TuiApp {
   /** The extension surface host (M2), when the runner attached one. */
   private readonly extensionHost: SurfaceHost | undefined
   private readonly tui: TuiMainScreen
-  private readonly editor: Editor
+  private readonly editor: TuiEditor
   /**
    * The surface GENERATION: incremented only when a genuinely NEW surface
    * attaches (a fresh TuiApp / SurfaceHost), never by start/stop, fullscreen
@@ -1801,6 +1801,14 @@ export class TuiApp {
     this.editor = new TuiEditor(this.tui, editorTheme)
     this.editorBorder = this.editor.borderColor
     this.editor.onSubmit = (text) => {
+      // The shell-editor-mode boundary: the editor buffer holds the bare
+      // command body, so the wire form is re-serialized here — the shell
+      // dispatch (shellModeOf) must keep receiving the exact same text as
+      // before the mode feature. The mode is read at submit time (the
+      // fork clears the editor BEFORE onSubmit fires) and reset to the
+      // prompt afterwards; a rejected submission restores the serialized
+      // text through setEditorText, which decodes the mode back.
+      const serialized = this.serializeSeatDraft(text)
       // DEFENSE IN DEPTH: the app-level guard consumes Enter while a
       // continuable viewer is up, so the host editor's own onSubmit never
       // fires there — but a replacement editor's submit routes through
@@ -1812,21 +1820,28 @@ export class TuiApp {
       const target = this.viewerMode
       if (target !== undefined && isViewerAccessInteractive(resolveViewerAccess(target.mode, target.access))) {
         this.clearNotify()
+        this.resetEditorMode()
         this.events.onSubagentSubmit?.({
           parentSessionId: target.parentSessionId,
           childSessionId: target.childSessionId,
-          text,
+          text: serialized,
         })
         return
       }
-      this.rememberInput(text)
+      this.rememberInput(serialized)
       // Fresh user input supersedes any transient notice (a stale error
       // from the previous submission must not outlive the next one).
       this.clearNotify()
       // Issue #8: a successful submit is a fresh explicit action — the
       // armed exit chord (and its footer hint) must not survive.
       this.clearCtrlCExit()
-      this.events.onSubmit(text)
+      // The mode resets BEFORE the dispatch: a SYNCHRONOUS rejection
+      // (e.g. the transition fence) restores the serialized text through
+      // setEditorText, which decodes the mode back — an async rejection
+      // does the same later. Resetting after the dispatch would clobber a
+      // synchronous restore.
+      this.resetEditorMode()
+      this.events.onSubmit(serialized)
     }
     this.editor.onChange = () => {
       // The footer's task badge advertises the ↓ browser ONLY while the
@@ -1836,9 +1851,11 @@ export class TuiApp {
       // The visible editor IS the child draft while a continuable viewer
       // is up: mirror every change into the per-child slot (the runner's
       // restore and stale guards read the slot, not the live component).
+      // The slot stores the SERIALIZED wire form (mode + body), so a
+      // shell-mode draft round-trips through the viewer with its mode.
       const viewer = this.viewerMode
       if (viewer !== undefined && isViewerAccessInteractive(resolveViewerAccess(viewer.mode, viewer.access))) {
-        this.subagentDrafts.set(viewer.childSessionId, this.seatEditor().getText())
+        this.subagentDrafts.set(viewer.childSessionId, this.serializeSeatDraft(this.seatEditor().getText()))
       }
       // P1-11: every HOST-driven editor mutation notifies the seat
       // holder's subscribers (the fork Editor's own typing/editing flows
@@ -2417,14 +2434,18 @@ export class TuiApp {
       if (this.events.onQueueSubmit === undefined) return undefined
       const text = this.seatEditor().getText()
       if (text.trim() === '') return undefined
-      this.rememberInput(text)
+      const serialized = this.serializeSeatDraft(text)
+      this.rememberInput(serialized)
       this.clearNotify()
       this.seatEditor().setText('')
       this.editorSeatHolder.notifyChanged()
+      // Reset BEFORE the dispatch: a synchronous rejection restores the
+      // serialized text (and with it the mode) through setEditorText.
+      this.resetEditorMode()
       // Consumed at the app level: request the frame ourselves (the
       // stale-clear trap — see the Ctrl+C branch).
       this.requestRender()
-      this.events.onQueueSubmit(text)
+      this.events.onQueueSubmit(serialized)
       return { consume: true }
     }
     if (matchesKey(data, 'escape')) {
@@ -2449,6 +2470,15 @@ export class TuiApp {
       // The host may consume the first Esc (runner-owned modes like the
       // subagent viewer); otherwise it arms the double-Esc cancel.
       if (this.events.onSingleEscape?.() === true) return { consume: true }
+      // Shell-mode exit: the host editor in a shell mode with an EMPTY
+      // body owns Esc — it cancels the shell mode (the double-Esc cancel
+      // must not fire while the user is composing a shell command). The
+      // pass-through lets the focused editor handle the key, exactly like
+      // the autocomplete branch above. Host-owned priorities (the viewer's
+      // onSingleEscape, overlays) keep their precedence.
+      if (this.seatEditor().id === 'host' && this.editor.getInputMode() !== 'prompt' && this.seatEditor().getText() === '') {
+        return undefined
+      }
       // pi parity: a SINGLE Esc while the agent is busy stops the current
       // activity (turn, tool run, compaction) — partial content stays on
       // screen. Idle keeps the double-Esc cancel.
@@ -2513,12 +2543,14 @@ export class TuiApp {
       // key when there is nothing to send at all.
       if (this.activeScreen.hasOverlayEntries) return { consume: true }
       const draft = this.seatEditor().getText()
+      const serialized = this.serializeSeatDraft(draft)
       this.seatEditor().setText('')
       this.editorSeatHolder.notifyChanged()
+      this.resetEditorMode()
       // Consumed at the app level: request the frame ourselves (the
       // stale-clear trap — see the Ctrl+C branch).
       this.requestRender()
-      this.events.onSteer?.(draft)
+      this.events.onSteer?.(serialized)
       return { consume: true }
     }
     if (matchesKey(data, 'down')) {
@@ -4168,16 +4200,20 @@ export class TuiApp {
   /**
    * Replace the editor draft. The runner restores a submission that the
    * divergence guard blocked, so the user's text survives for a retry.
-   * While a CONTINUABLE subagent viewer covers the editor, the write goes
-   * to the CHILD's draft slot + the visible editor (the main draft stays
-   * untouched); a ONE-SHOT viewer keeps the main draft write (the
-   * placeholder bar stays up; the main draft is restored on exit).
+   * The text is a SERIALIZED user input (`!x` / `!!x`), so the host
+   * editor decodes it into mode + body (the shell-editor-mode boundary);
+   * a plugin editor (no mode) receives the raw text. While a CONTINUABLE
+   * subagent viewer covers the editor, the write goes to the CHILD's
+   * draft slot (serialized form) + the visible editor (decoded body; the
+   * main draft stays untouched); a ONE-SHOT viewer keeps the main draft
+   * write (the placeholder bar stays up; the main draft is restored on
+   * exit).
    */
   setEditorText(text: string): void {
     const target = this.viewerMode
     if (target !== undefined && isViewerAccessInteractive(resolveViewerAccess(target.mode, target.access))) {
       this.subagentDrafts.set(target.childSessionId, text)
-      this.seatEditor().setText(text)
+      this.setSeatSerializedInput(text)
       this.editorSeatHolder.notifyChanged()
       this.requestRender()
       return
@@ -4188,7 +4224,7 @@ export class TuiApp {
     }
     // M9: every public draft mutation targets the visible seat occupant, not
     // the hidden host editor left behind by an editor handoff.
-    this.seatEditor().setText(text)
+    this.setSeatSerializedInput(text)
     this.editorSeatHolder.notifyChanged()
     this.requestRender()
   }
@@ -4260,11 +4296,13 @@ export class TuiApp {
       }
       // M9 (round-2 finding 1): the viewer restore writes the preserved
       // main draft to the CURRENT seat occupant (a plugin editor's draft
-      // returns to the plugin, never to a hidden host editor).
+      // returns to the plugin, never to a hidden host editor). The
+      // preserved draft is the SERIALIZED wire form, so the host editor
+      // decodes it back into mode + body.
       const seat = this.seatEditor()
       seat.borderColor = this.editorBorder
       this.clearViewerPlaceholder()
-      seat.setText(this.mainDraftBeforeViewer ?? '')
+      this.setSeatSerializedInput(this.mainDraftBeforeViewer ?? '')
       this.mainDraftBeforeViewer = undefined
       seat.invalidate()
       this.editorSeatHolder.notifyChanged()
@@ -4274,7 +4312,9 @@ export class TuiApp {
       return
     }
     if (this.viewerMode === undefined) {
-      this.mainDraftBeforeViewer = this.seatEditor().getText()
+      // Preserve the main draft in its SERIALIZED wire form, so a
+      // shell-mode draft round-trips through the viewer with its mode.
+      this.mainDraftBeforeViewer = this.serializeSeatDraft(this.seatEditor().getText())
       // The viewer renders ONLY the child transcript: the main session's
       // local cards (`!` shell runs) must never leak into it. The runner
       // repaints the child folder right after, so the cleared list is
@@ -4294,9 +4334,11 @@ export class TuiApp {
     seat.borderColor = color.accent
     if (isViewerAccessInteractive(resolveViewerAccess(mode.mode, mode.access))) {
       // The empty-draft placeholder advertises the viewer's OWN verbs
-      // (Enter sends to the CHILD — never the parent — Esc returns).
+      // (Enter sends to the CHILD — never the parent — Esc returns). The
+      // child slot holds the SERIALIZED wire form, decoded into mode +
+      // body for the visible editor.
       this.setViewerPlaceholder(`Message ${mode.label}… — Enter send · Esc back`)
-      seat.setText(this.subagentDrafts.get(mode.childSessionId) ?? '')
+      this.setSeatSerializedInput(this.subagentDrafts.get(mode.childSessionId) ?? '')
     } else {
       this.clearViewerPlaceholder()
       seat.setText(`viewing subagent: ${mode.label} — ${viewerAccessHint(mode.mode, resolveViewerAccess(mode.mode, mode.access))} · Esc returns`)
@@ -4341,7 +4383,9 @@ export class TuiApp {
    *   visible text is appended beneath the map, nothing is lost.
    * Exact equality short-circuits as "already parked". */
   private parkSubagentDraft(childSessionId: string): void {
-    const visible = this.seatEditor().getText()
+    // The slot stores the SERIALIZED wire form (mode + body), so the
+    // visible text is serialized the same way before comparing/folding.
+    const visible = this.serializeSeatDraft(this.seatEditor().getText())
     const slotted = this.subagentDrafts.get(childSessionId)
     if (visible === slotted) return
     if (slotted === undefined || slotted === '') {
@@ -4386,6 +4430,10 @@ export class TuiApp {
     if (this.events.onSubagentSubmit === undefined) return
     const text = this.seatEditor().getText()
     if (text.trim() === '') return
+    // The shell-editor-mode boundary: the visible body is re-serialized
+    // into the wire form before it leaves the app (a shell-mode draft
+    // reaches the child exactly as the user would have typed it).
+    const serialized = this.serializeSeatDraft(text)
     this.clearNotify()
     // Issue #8: a successful submit is a fresh explicit action — the armed
     // exit chord (and its footer hint) must not survive into the next
@@ -4399,11 +4447,12 @@ export class TuiApp {
     this.subagentDrafts.set(target.childSessionId, '')
     this.seatEditor().setText('')
     this.editorSeatHolder.notifyChanged()
+    this.resetEditorMode()
     this.requestRender()
     this.events.onSubagentSubmit({
       parentSessionId: target.parentSessionId,
       childSessionId: target.childSessionId,
-      text,
+      text: serialized,
     })
   }
 
@@ -4435,12 +4484,12 @@ export class TuiApp {
    * only — it is NEVER part of the draft text). A replacement editor in
    * the seat has no placeholder surface; the hint is host-editor-only. */
   private setViewerPlaceholder(text: string): void {
-    ;(this.editor as import('./tui-editor.ts').TuiEditor).setPlaceholder(text)
+    this.editor.setPlaceholder(text)
   }
 
   /** Clear the host editor's render-time placeholder. */
   private clearViewerPlaceholder(): void {
-    ;(this.editor as import('./tui-editor.ts').TuiEditor).setPlaceholder('')
+    this.editor.setPlaceholder('')
   }
 
   /**
@@ -5287,6 +5336,7 @@ export class TuiApp {
       getText: () => editor.getText(),
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete(),
+      getInputMode: () => editor.getInputMode(),
       getCursor: () => {
         const cursor = editor.getCursor()
         const lines = editor.getText().split('\n')
@@ -5410,6 +5460,40 @@ export class TuiApp {
     return this.editorSeatHolder.currentEditor()
   }
 
+  /**
+   * The shell-editor-mode boundary: serialize a seat draft into the wire
+   * form the shell dispatch understands. The HOST editor's mode prefixes
+   * the body (`!` / `!!`); a plugin editor has no mode — its text IS the
+   * wire form (a stale hidden-host mode must never leak into a plugin
+   * editor's submission).
+   */
+  private serializeSeatDraft(text: string): string {
+    const seat = this.seatEditor()
+    const mode = seat.id === 'host' ? this.editor.getInputMode() : 'prompt'
+    return serializeEditorInput(mode, text)
+  }
+
+  /**
+   * Decode a SERIALIZED user input (`!x` / `!!x`) into the seat editor:
+   * the host editor restores mode + body; a plugin editor (no mode) gets
+   * the raw text. The single decode point for every host restore path.
+   */
+  private setSeatSerializedInput(text: string): void {
+    const seat = this.seatEditor()
+    if (seat.id === 'host') {
+      this.editor.setSerializedInput(text)
+    } else {
+      seat.setText(text)
+    }
+  }
+
+  /** After an accepted submission the editor returns to the prompt mode
+   * (a rejected submission restores the serialized text — and with it
+   * the mode — through setEditorText). */
+  private resetEditorMode(): void {
+    this.editor.setInputMode('prompt')
+  }
+
   /** M9 public hook: reconcile the seat with the registry's winner NOW
    * (tests + the runner call it after a winner change; the render-path
    * reconcile is the live fallback). */
@@ -5421,6 +5505,11 @@ export class TuiApp {
    * seat actually renders — getDraft preserves the viewer draft). */
   seatTextForTest(): string {
     return this.seatEditor().getText()
+  }
+
+  /** Shell-editor-mode test hook: the host editor's current input mode. */
+  inputModeForTest(): EditorInputMode {
+    return this.editor.getInputMode()
   }
 
   /** M9 test hook: the CURRENT seat occupant (component rendering probe). */
@@ -7171,16 +7260,19 @@ export class TuiApp {
 
   /**
    * Replace the editor draft wholesale (the Alt+↑ dequeue path pulls every
-   * queued message back into the editor for editing). While a CONTINUABLE
-   * subagent viewer covers the editor, the write goes to the CHILD's
-   * draft slot + the visible editor; a ONE-SHOT viewer keeps the main
-   * draft write (restored on exit).
+   * queued message back into the editor for editing). The text is a
+   * SERIALIZED user input (queued messages keep their `!` / `!!` wire
+   * form), so the host editor decodes it into mode + body. While a
+   * CONTINUABLE subagent viewer covers the editor, the write goes to the
+   * CHILD's draft slot (serialized form) + the visible editor (decoded
+   * body); a ONE-SHOT viewer keeps the main draft write (restored on
+   * exit).
    */
   setDraft(text: string): void {
     const target = this.viewerMode
     if (target !== undefined && isViewerAccessInteractive(resolveViewerAccess(target.mode, target.access))) {
       this.subagentDrafts.set(target.childSessionId, text)
-      this.seatEditor().setText(text)
+      this.setSeatSerializedInput(text)
       this.editorSeatHolder.notifyChanged()
       this.requestRender()
       return
@@ -7190,7 +7282,7 @@ export class TuiApp {
       return
     }
     // M9: write the CURRENT seat occupant (host default or plugin editor).
-    this.seatEditor().setText(text)
+    this.setSeatSerializedInput(text)
     this.editorSeatHolder.notifyChanged()
     this.requestRender()
   }
@@ -7232,6 +7324,9 @@ export class TuiApp {
     // An image-only draft is NOT empty: the placeholder expansion resolves
     // it to real content blocks at submission (plan §11.1).
     if (text.trim() === '' && this.events.isImageDraft?.() !== true) return
+    // The shell-editor-mode boundary: the visible body is re-serialized
+    // into the wire form (`!` / `!!` prefixes) before it leaves the app.
+    const serialized = this.serializeSeatDraft(text)
     this.clearNotify()
     // Issue #8: a successful submit is a fresh explicit action — the armed
     // exit chord (and its footer hint) must not survive into the next
@@ -7250,11 +7345,12 @@ export class TuiApp {
       this.subagentDrafts.set(target.childSessionId, '')
       this.seatEditor().setText('')
       this.editorSeatHolder.notifyChanged()
+      this.resetEditorMode()
       this.requestRender()
       this.events.onSubagentSubmit?.({
         parentSessionId: target.parentSessionId,
         childSessionId: target.childSessionId,
-        text,
+        text: serialized,
       })
       return
     }
@@ -7264,15 +7360,18 @@ export class TuiApp {
       // draft intact and does NOT fire a parent submit.
       return
     }
-    this.rememberInput(text)
+    this.rememberInput(serialized)
     // Clear the draft like a normal Enter submit (the runner's dispatch
     // owns the session/guard path). M9: clear the CURRENT seat occupant.
     this.seatEditor().setText('')
     this.editorSeatHolder.notifyChanged()
+    // Reset BEFORE the dispatch: a synchronous rejection restores the
+    // serialized text (and with it the mode) through setEditorText.
+    this.resetEditorMode()
     if (forceQueue) {
-      this.events.onQueueSubmit?.(text)
+      this.events.onQueueSubmit?.(serialized)
     } else {
-      this.events.onSubmit(text)
+      this.events.onSubmit(serialized)
     }
     this.requestRender()
   }
@@ -7525,7 +7624,7 @@ export class TuiApp {
       force?: boolean
     }) => Promise<{ items: import('@xmoon76/pi-tui').AutocompleteItem[]; prefix: string } | null>,
   ): void {
-    const base = new MentionProvider([...commands], cwd, fdPath)
+    const base = new MentionProvider([...commands], cwd, fdPath, () => this.editor.getInputMode())
     if (extensionSuggest === undefined) {
       this.editor.setAutocompleteProvider(base)
       return

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -5452,6 +5452,7 @@ export class TuiApp {
         const targetLine = Math.min(line, Math.max(0, lines.length - 1))
         editor.setTextAndCursor(normalized, { line: targetLine, col: remaining })
       },
+      cancelAutocomplete: () => editor.cancelHostAutocomplete(),
       insertTextAtCursor: (text) => editor.insertTextAtCursor(text),
       handleInput: (data) => editor.handleInput(data),
       runWithoutChange: <T>(task: () => T): T => {

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1808,7 +1808,14 @@ export class TuiApp {
       // fork clears the editor BEFORE onSubmit fires) and reset to the
       // prompt afterwards; a rejected submission restores the serialized
       // text through setEditorText, which decodes the mode back.
-      const serialized = this.serializeSeatDraft(text)
+      // HOST EXECUTION MODE (review round 23): this callback is owned by
+      // the HOST editor, and the text IS the host editor's body — so the
+      // wire form is serialized from the HOST editor's own mode, NEVER
+      // from the visible seat's mode. A replacement editor in the seat
+      // (the declined-key Enter fallback) has no mode: serializing with
+      // the visible-seat semantics would collapse `!!pwd` into a plain
+      // `pwd` and turn a local-only command into a normal prompt submit.
+      const serialized = serializeEditorInput(this.editor.getInputMode(), text)
       // DEFENSE IN DEPTH: the app-level guard consumes Enter while a
       // continuable viewer is up, so the host editor's own onSubmit never
       // fires there — but a replacement editor's submit routes through
@@ -5526,11 +5533,14 @@ export class TuiApp {
   }
 
   /**
-   * The shell-editor-mode boundary: serialize a seat draft into the wire
-   * form the shell dispatch understands. The HOST editor's mode prefixes
-   * the body (`!` / `!!`); a plugin editor has no mode — its text IS the
-   * wire form (a stale hidden-host mode must never leak into a plugin
-   * editor's submission).
+   * The shell-editor-mode boundary: serialize a VISIBLE SEAT draft into
+   * the wire form the shell dispatch understands. The HOST editor's mode
+   * prefixes the draft (`!` / `!!`); a plugin editor has no mode — its
+   * text IS the wire form (a stale hidden-host mode must never leak into
+   * a plugin editor's submission). Every caller passes text read from the
+   * VISIBLE seat. The HOST editor's own onSubmit does NOT use this: its
+   * text is the host editor's body and serializes from the host editor's
+   * mode (host execution mode — see the onSubmit wiring).
    */
   private serializeSeatDraft(text: string): string {
     const seat = this.seatEditor()
@@ -7713,7 +7723,7 @@ export class TuiApp {
       force?: boolean
     }) => Promise<{ items: import('@xmoon76/pi-tui').AutocompleteItem[]; prefix: string } | null>,
   ): void {
-    const base = new MentionProvider([...commands], cwd, fdPath, () => this.seatInputMode())
+    const base = new MentionProvider([...commands], cwd, fdPath, () => this.editor.getInputMode())
     if (extensionSuggest === undefined) {
       this.editor.setAutocompleteProvider(base)
       return
@@ -7722,10 +7732,17 @@ export class TuiApp {
     // plugin chain (M5 AutocompleteRegistry) is consulted only when the
     // host provider has nothing. applyCompletion always delegates to the
     // host provider (the fork's completion semantics own the editor).
-    // The VISIBLE seat decides the mode: a replacement editor in the seat
-    // has no shell mode (prompt semantics) — the hidden host editor's
-    // stale mode must never leak into completion routing (round-20).
-    const getMode = (): EditorInputMode => this.seatInputMode()
+    // HOST EXECUTION MODE (review round 23): the provider is attached to
+    // the HOST editor, and every forwarded key into it (the declined-key
+    // fallback) re-DECODES the visible plugin wire document into the host
+    // editor's mode first — so the host editor's mode is the
+    // authoritative completion mode. Reading the VISIBLE seat mode here
+    // would see a mode-less plugin and drop the shell semantics of a
+    // declined `!gi` Tab (no shell completion, no `!` wire prefix in the
+    // extension query). `seatInputMode()` stays for the genuine
+    // visible-seat consumers (the ↓ task-browser gate, the Ctrl+C clear,
+    // the footer badge).
+    const getMode = (): EditorInputMode => this.editor.getInputMode()
     const delegated: import('@xmoon76/pi-tui').AutocompleteProvider = {
       async getSuggestions(lines, cursorLine, cursorCol, options) {
         const host = await base.getSuggestions(lines, cursorLine, cursorCol, options)

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2628,8 +2628,14 @@ export class TuiApp {
       // footer hint for EXACTLY the exit window (armCtrlCExit), and the
       // exit path disarms it — the hint never outlives the window.
       const text = this.seatEditor().getText()
-      if (text !== '') {
+      // A shell-mode draft is non-empty in its SERIALIZED form: the
+      // first press clears BOTH the body and the mode — an empty `! ` /
+      // `!!` editor would otherwise show a cleared body under a stale
+      // shell prompt, and the next Ctrl+C would exit instead of
+      // completing the pre-mode clear contract.
+      if (text !== '' || this.seatInputMode() !== 'prompt') {
         this.seatEditor().setText('')
+        this.resetEditorMode()
         this.editorSeatHolder.notifyChanged()
         this.armCtrlCExit()
         // The key is CONSUMED at the app level, so the fork's input path

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1898,13 +1898,17 @@ export class TuiApp {
         switch (action) {
           case 'submit': {
             const text = this.seatEditor().getText()
-            if (text.trim() === '') return false
+            // Emptiness is judged on the SERIALIZED wire form: a bare `!`
+            // / `!!` shell mode has an empty BODY but a non-empty wire
+            // form, and must reach the existing protocol like the literal
+            // prefix did before the mode feature.
+            if (this.serializeSeatDraft(text).trim() === '') return false
             this.submitDraft(false)
             return true
           }
           case 'queue-submit': {
             const text = this.seatEditor().getText()
-            if (text.trim() === '') return false
+            if (this.serializeSeatDraft(text).trim() === '') return false
             this.submitDraft(true)
             return true
           }
@@ -2433,8 +2437,12 @@ export class TuiApp {
       if (this.activeScreen.hasOverlayEntries) return undefined
       if (this.events.onQueueSubmit === undefined) return undefined
       const text = this.seatEditor().getText()
-      if (text.trim() === '') return undefined
       const serialized = this.serializeSeatDraft(text)
+      // Emptiness is judged on the SERIALIZED wire form: a bare `!` / `!!`
+      // shell mode has an empty BODY but a non-empty wire form, and must
+      // reach the queue protocol like the literal prefix did before the
+      // mode feature.
+      if (serialized.trim() === '') return undefined
       this.rememberInput(serialized)
       this.clearNotify()
       this.seatEditor().setText('')
@@ -2470,22 +2478,25 @@ export class TuiApp {
       // The host may consume the first Esc (runner-owned modes like the
       // subagent viewer); otherwise it arms the double-Esc cancel.
       if (this.events.onSingleEscape?.() === true) return { consume: true }
+      // pi parity: a SINGLE Esc while the agent is busy stops the current
+      // activity (turn, tool run, compaction) — partial content stays on
+      // screen. Idle keeps the double-Esc cancel. The busy cancel is
+      // Host-owned and keeps its priority over the shell-mode exit below
+      // (a shell-mode Esc while busy stops the agent, exactly like any
+      // other Esc while busy).
+      if (this.busy) {
+        this.lastEscapeAt = undefined
+        this.events.onCancel?.()
+        return { consume: true }
+      }
       // Shell-mode exit: the host editor in a shell mode with an EMPTY
       // body owns Esc — it cancels the shell mode (the double-Esc cancel
       // must not fire while the user is composing a shell command). The
       // pass-through lets the focused editor handle the key, exactly like
       // the autocomplete branch above. Host-owned priorities (the viewer's
-      // onSingleEscape, overlays) keep their precedence.
+      // onSingleEscape, the busy cancel, overlays) keep their precedence.
       if (this.seatEditor().id === 'host' && this.editor.getInputMode() !== 'prompt' && this.seatEditor().getText() === '') {
         return undefined
-      }
-      // pi parity: a SINGLE Esc while the agent is busy stops the current
-      // activity (turn, tool run, compaction) — partial content stays on
-      // screen. Idle keeps the double-Esc cancel.
-      if (this.busy) {
-        this.lastEscapeAt = undefined
-        this.events.onCancel?.()
-        return { consume: true }
       }
       const now = Date.now()
       if (this.lastEscapeAt !== undefined && now - this.lastEscapeAt < TuiApp.ESCAPE_CANCEL_WINDOW_MS) {
@@ -2559,8 +2570,11 @@ export class TuiApp {
       // present the key keeps its editing meaning; overlays own it. (The
       // former Ctrl+J chord is gone: legacy terminals send Ctrl+J as LF,
       // which the editor treats as Enter — the key was unreliable, and ↓
-      // plus `/tasks` remain the two entries.)
-      if (this.tasksActive && !this.activeScreen.hasOverlayEntries && this.seatEditor().getText().trim() === '') {
+      // plus `/tasks` remain the two entries.) A shell-mode editor with an
+      // empty BODY is composing a command — ↓ keeps its editing meaning
+      // (a no-op on the empty line), never the browser.
+      if (this.tasksActive && !this.activeScreen.hasOverlayEntries
+        && this.seatEditor().getText().trim() === '' && this.editor.getInputMode() === 'prompt') {
         this.events.onOpenTasks?.()
         return { consume: true }
       }
@@ -4429,11 +4443,14 @@ export class TuiApp {
     if (target === undefined || target.mode !== 'continuable') return
     if (this.events.onSubagentSubmit === undefined) return
     const text = this.seatEditor().getText()
-    if (text.trim() === '') return
     // The shell-editor-mode boundary: the visible body is re-serialized
     // into the wire form before it leaves the app (a shell-mode draft
     // reaches the child exactly as the user would have typed it).
     const serialized = this.serializeSeatDraft(text)
+    // Emptiness is judged on the SERIALIZED wire form: a bare `!` / `!!`
+    // shell mode has an empty BODY but a non-empty wire form, and must
+    // reach the child like the literal prefix did before the mode feature.
+    if (serialized.trim() === '') return
     this.clearNotify()
     // Issue #8: a successful submit is a fresh explicit action — the armed
     // exit chord (and its footer hint) must not survive into the next
@@ -4462,9 +4479,12 @@ export class TuiApp {
    * only input target). Esc/Ctrl+O/Enter are deliberately NOT listed —
    * they fall through to the host's exit/fold/submit paths. */
   private viewerParentLockedKey(data: string): boolean {
-    if (matchesKey(data, 'down') && this.tasksActive && this.seatEditor().getText().trim() === '') {
+    if (matchesKey(data, 'down') && this.tasksActive && this.seatEditor().getText().trim() === ''
+      && this.editor.getInputMode() === 'prompt') {
       // The empty-editor ↓ task-browser trigger must not open the
-      // PARENT's browser from inside the viewer.
+      // PARENT's browser from inside the viewer. A shell-mode editor with
+      // an empty body is composing a command — ↓ keeps its editing
+      // meaning, never the browser.
       return true
     }
     return matchesKey(data, 'ctrl+s')        // steer all (parent)
@@ -7321,12 +7341,16 @@ export class TuiApp {
     if (this.disposed) return
     const target = this.viewerMode
     const text = this.getDraft()
-    // An image-only draft is NOT empty: the placeholder expansion resolves
-    // it to real content blocks at submission (plan §11.1).
-    if (text.trim() === '' && this.events.isImageDraft?.() !== true) return
     // The shell-editor-mode boundary: the visible body is re-serialized
     // into the wire form (`!` / `!!` prefixes) before it leaves the app.
     const serialized = this.serializeSeatDraft(text)
+    // Emptiness is judged on the SERIALIZED wire form: a bare `!` / `!!`
+    // shell mode has an empty BODY but a non-empty wire form, and must
+    // reach the existing protocol like the literal prefix did before the
+    // mode feature. An image-only draft is NOT empty either: the
+    // placeholder expansion resolves it to real content blocks at
+    // submission (plan §11.1).
+    if (serialized.trim() === '' && this.events.isImageDraft?.() !== true) return
     this.clearNotify()
     // Issue #8: a successful submit is a fresh explicit action — the armed
     // exit chord (and its footer hint) must not survive into the next

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7708,7 +7708,7 @@ export class TuiApp {
       force?: boolean
     }) => Promise<{ items: import('@xmoon76/pi-tui').AutocompleteItem[]; prefix: string } | null>,
   ): void {
-    const base = new MentionProvider([...commands], cwd, fdPath, () => this.editor.getInputMode())
+    const base = new MentionProvider([...commands], cwd, fdPath, () => this.seatInputMode())
     if (extensionSuggest === undefined) {
       this.editor.setAutocompleteProvider(base)
       return
@@ -7717,7 +7717,10 @@ export class TuiApp {
     // plugin chain (M5 AutocompleteRegistry) is consulted only when the
     // host provider has nothing. applyCompletion always delegates to the
     // host provider (the fork's completion semantics own the editor).
-    const getMode = (): EditorInputMode => this.editor.getInputMode()
+    // The VISIBLE seat decides the mode: a replacement editor in the seat
+    // has no shell mode (prompt semantics) — the hidden host editor's
+    // stale mode must never leak into completion routing (round-20).
+    const getMode = (): EditorInputMode => this.seatInputMode()
     const delegated: import('@xmoon76/pi-tui').AutocompleteProvider = {
       async getSuggestions(lines, cursorLine, cursorCol, options) {
         const host = await base.getSuggestions(lines, cursorLine, cursorCol, options)

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -5357,6 +5357,7 @@ export class TuiApp {
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete(),
       getInputMode: () => editor.getInputMode(),
+      setSerializedInput: (text) => editor.setSerializedInput(text),
       getCursor: () => {
         const cursor = editor.getCursor()
         const lines = editor.getText().split('\n')
@@ -7563,7 +7564,10 @@ export class TuiApp {
     }
     const taskBadge = badgeParts.length === 0
       ? ''
-      : color.primary(`[${badgeParts.join(' · ')}${this.editor.getText().trim() === '' ? ' · ↓ view' : ''}]`)
+      // The ↓ hint matches the ↓ routing gate: only a PROMPT-mode empty
+      // editor opens the task browser — a shell-mode empty body is
+      // composing a command, so no hint is advertised.
+      : color.primary(`[${badgeParts.join(' · ')}${this.editor.getInputMode() === 'prompt' && this.editor.getText().trim() === '' ? ' · ↓ view' : ''}]`)
     const line1 = [
       permissionBadge,
       this.planMode ? color.warning('[plan]') : '',

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -116,7 +116,7 @@ import type { RendererRegistry } from './renderer-registry.ts'
 import { OverlayBroker } from './overlay-broker.ts'
 import { EditorSeatHolder } from './editor-seat-holder.ts'
 import { TuiEditor } from './tui-editor.ts'
-import { serializeEditorInput, type EditorInputMode } from './editor-input-mode.ts'
+import { serializeEditorInput, shellPrefixForMode, type EditorInputMode } from './editor-input-mode.ts'
 import type { EditorRegistry } from './editor-registry.ts'
 import { compileView } from './extension/internal/component-compiler.ts'
 import { AdvancedOverlayComponent } from './extension/internal/advanced-overlay.ts'
@@ -2865,7 +2865,13 @@ export class TuiApp {
     if (open === undefined || this.externalEditorInFlight || this.disposed) return
     this.externalEditorInFlight = true
     try {
-      const draft = this.seatEditor().getText()
+      // The external editor round-trips the WIRE form: the $EDITOR sees
+      // the same document the shell dispatch would (a shell-mode draft
+      // opens as `!pwd`, never the bare body), and the saved text comes
+      // back through the decode — the user can switch `! ↔ !! ↔ prompt`
+      // in $EDITOR and the mode follows. A plugin editor (no mode) keeps
+      // identity.
+      const draft = this.serializeSeatDraft(this.seatEditor().getText())
       this.stop()
       try {
         const next = await open(draft)
@@ -2873,7 +2879,7 @@ export class TuiApp {
         // No redundant editor update when the editor saved the draft
         // unchanged (an update would bump history/undo and repaint).
         if (next !== '' && next !== draft) {
-          this.seatEditor().setText(next)
+          this.setSeatSerializedInput(next)
           this.editorSeatHolder.notifyChanged()
         }
       } finally {
@@ -4376,7 +4382,12 @@ export class TuiApp {
       this.setSeatSerializedInput(this.subagentDrafts.get(mode.childSessionId) ?? '')
     } else {
       this.clearViewerPlaceholder()
-      seat.setText(`viewing subagent: ${mode.label} — ${viewerAccessHint(mode.mode, resolveViewerAccess(mode.mode, mode.access))} · Esc returns`)
+      // The one-shot placeholder bar is PLAIN text: route it through the
+      // serialized-input setter so the host editor returns to PROMPT
+      // mode — a stale shell mode from the pre-viewer draft must not
+      // render as `! viewing subagent: …` (the preserved main draft is
+      // serialized, so the exit restores the original mode).
+      this.setSeatSerializedInput(`viewing subagent: ${mode.label} — ${viewerAccessHint(mode.mode, resolveViewerAccess(mode.mode, mode.access))} · Esc returns`)
     }
     seat.invalidate()
     this.editorSeatHolder.notifyChanged()
@@ -7694,11 +7705,30 @@ export class TuiApp {
     // plugin chain (M5 AutocompleteRegistry) is consulted only when the
     // host provider has nothing. applyCompletion always delegates to the
     // host provider (the fork's completion semantics own the editor).
+    const getMode = (): EditorInputMode => this.editor.getInputMode()
     const delegated: import('@xmoon76/pi-tui').AutocompleteProvider = {
       async getSuggestions(lines, cursorLine, cursorCol, options) {
         const host = await base.getSuggestions(lines, cursorLine, cursorCol, options)
         if (host !== null) return host
-        return extensionSuggest({ lines, cursorLine, cursorCol, signal: options.signal, force: options.force })
+        // M5 Stable-compatibility adapter: the plugin chain's query is
+        // the WIRE document — the same lines the host exposed BEFORE the
+        // shell-editor-mode feature. A shell-mode body is re-prefixed
+        // (`git che` → `!git che`, cursor shifted), so a third-party
+        // plugin keeps parsing shell lines exactly as before and can
+        // still tell a shell line from plain prose; the query shape is
+        // unchanged (no new fields, no semantic drift).
+        const mode = getMode()
+        const prefix = shellPrefixForMode(mode)
+        const wireLines = mode === 'prompt'
+          ? lines
+          : lines.map((line, index) => index === cursorLine ? prefix + line : line)
+        return extensionSuggest({
+          lines: wireLines,
+          cursorLine,
+          cursorCol: cursorCol + (mode === 'prompt' ? 0 : prefix.length),
+          signal: options.signal,
+          force: options.force,
+        })
       },
       applyCompletion: (lines, cursorLine, cursorCol, item, prefix) =>
         base.applyCompletion(lines, cursorLine, cursorCol, item, prefix),

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1914,9 +1914,14 @@ export class TuiApp {
           }
           case 'steer': {
             const text = this.seatEditor().getText()
+            // The shell-editor-mode boundary, like the Ctrl+S path: the
+            // wire form leaves the app (identity for a plugin editor,
+            // whose document IS the wire form; defensive for a host seat).
+            const serialized = this.serializeSeatDraft(text)
             this.seatEditor().setText('')
             this.editorSeatHolder.notifyChanged()
-            this.events.onSteer?.(text)
+            this.resetEditorMode()
+            this.events.onSteer?.(serialized)
             return true
           }
           case 'open-external-editor': {

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2472,6 +2472,21 @@ export class TuiApp {
       if ((this.seatEditor() as { isShowingAutocomplete?: () => boolean }).isShowingAutocomplete?.() === true) {
         return undefined
       }
+      // The host may consume the first Esc (runner-owned modes like the
+      // subagent viewer); otherwise it arms the double-Esc cancel.
+      if (this.events.onSingleEscape?.() === true) return { consume: true }
+      // pi parity: a SINGLE Esc while the agent is busy stops the current
+      // activity (turn, tool run, compaction) — partial content stays on
+      // screen. Idle keeps the double-Esc cancel. The busy cancel is
+      // Host-owned session control and keeps its priority over BOTH the
+      // shell-mode exit below and a replacement editor's own Esc state
+      // machine (a busy Esc must stop the agent, never vanish into a
+      // plugin's modal handling).
+      if (this.busy) {
+        this.lastEscapeAt = undefined
+        this.events.onCancel?.()
+        return { consume: true }
+      }
       // P1-6: a REPLACEMENT editor owns Esc for its own modal state
       // machine (vim normal-mode entry) — route it through the editor
       // channel below instead of the host's double-Esc cancel. If the
@@ -2479,20 +2494,6 @@ export class TuiApp {
       // fallback (which includes this cancel path on re-entry).
       if (this.seatEditor().handleInput !== undefined) {
         return this.handleReplacementEditorInput(data, this.inputRouterContext(), true)
-      }
-      // The host may consume the first Esc (runner-owned modes like the
-      // subagent viewer); otherwise it arms the double-Esc cancel.
-      if (this.events.onSingleEscape?.() === true) return { consume: true }
-      // pi parity: a SINGLE Esc while the agent is busy stops the current
-      // activity (turn, tool run, compaction) — partial content stays on
-      // screen. Idle keeps the double-Esc cancel. The busy cancel is
-      // Host-owned and keeps its priority over the shell-mode exit below
-      // (a shell-mode Esc while busy stops the agent, exactly like any
-      // other Esc while busy).
-      if (this.busy) {
-        this.lastEscapeAt = undefined
-        this.events.onCancel?.()
-        return { consume: true }
       }
       // Shell-mode exit: the host editor in a shell mode with an EMPTY
       // body owns Esc — it cancels the shell mode (the double-Esc cancel

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7719,13 +7719,16 @@ export class TuiApp {
         // unchanged (no new fields, no semantic drift).
         const mode = getMode()
         const prefix = shellPrefixForMode(mode)
+        // The wire document carries the shell prefix on LINE 0 only: a
+        // body continuation line is ordinary text in the wire form too,
+        // and only the first-line cursor shifts by the prefix.
         const wireLines = mode === 'prompt'
           ? lines
-          : lines.map((line, index) => index === cursorLine ? prefix + line : line)
+          : lines.map((line, index) => index === 0 ? prefix + line : line)
         return extensionSuggest({
           lines: wireLines,
           cursorLine,
-          cursorCol: cursorCol + (mode === 'prompt' ? 0 : prefix.length),
+          cursorCol: cursorCol + (mode === 'prompt' || cursorLine > 0 ? 0 : prefix.length),
           signal: options.signal,
           force: options.force,
         })

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7723,12 +7723,14 @@ export class TuiApp {
         const host = await base.getSuggestions(lines, cursorLine, cursorCol, options)
         if (host !== null) return host
         // Preserve the shell-mode natural-trigger suppression: a leading
-        // `/` on the first line in a shell mode is a PATH, and the host
-        // provider deliberately stays quiet until Tab — the plugin chain
-        // must not flash its suggestions over it (that would reopen the
-        // dropdown mid-typing and double-apply on the next Tab).
+        // `/` on ANY line of a shell-mode document is a PATH, and the
+        // host provider deliberately stays quiet until Tab — the plugin
+        // chain must not flash its suggestions over it (that would
+        // reopen the dropdown mid-typing and double-apply on the next
+        // Tab). The wire query below still carries the prefix on line 0
+        // only.
         const mode = getMode()
-        if (mode !== 'prompt' && cursorLine === 0 && options.force !== true
+        if (mode !== 'prompt' && options.force !== true
           && (lines[cursorLine] ?? '').startsWith('/')) {
           return null
         }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -5395,6 +5395,7 @@ export class TuiApp {
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete(),
       getInputMode: () => editor.getInputMode(),
+      setInputMode: (mode) => editor.setInputMode(mode),
       setSerializedInput: (text) => editor.setSerializedInput(text),
       getCursor: () => {
         const cursor = editor.getCursor()
@@ -7716,6 +7717,16 @@ export class TuiApp {
       async getSuggestions(lines, cursorLine, cursorCol, options) {
         const host = await base.getSuggestions(lines, cursorLine, cursorCol, options)
         if (host !== null) return host
+        // Preserve the shell-mode natural-trigger suppression: a leading
+        // `/` on the first line in a shell mode is a PATH, and the host
+        // provider deliberately stays quiet until Tab — the plugin chain
+        // must not flash its suggestions over it (that would reopen the
+        // dropdown mid-typing and double-apply on the next Tab).
+        const mode = getMode()
+        if (mode !== 'prompt' && cursorLine === 0 && options.force !== true
+          && (lines[cursorLine] ?? '').startsWith('/')) {
+          return null
+        }
         // M5 Stable-compatibility adapter: the plugin chain's query is
         // the WIRE document — the same lines the host exposed BEFORE the
         // shell-editor-mode feature. A shell-mode body is re-prefixed
@@ -7723,7 +7734,6 @@ export class TuiApp {
         // plugin keeps parsing shell lines exactly as before and can
         // still tell a shell line from plain prose; the query shape is
         // unchanged (no new fields, no semantic drift).
-        const mode = getMode()
         const prefix = shellPrefixForMode(mode)
         // The wire document carries the shell prefix on LINE 0 only: a
         // body continuation line is ordinary text in the wire form too,

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2574,7 +2574,7 @@ export class TuiApp {
       // empty BODY is composing a command — ↓ keeps its editing meaning
       // (a no-op on the empty line), never the browser.
       if (this.tasksActive && !this.activeScreen.hasOverlayEntries
-        && this.seatEditor().getText().trim() === '' && this.editor.getInputMode() === 'prompt') {
+        && this.seatEditor().getText().trim() === '' && this.seatInputMode() === 'prompt') {
         this.events.onOpenTasks?.()
         return { consume: true }
       }
@@ -4480,7 +4480,7 @@ export class TuiApp {
    * they fall through to the host's exit/fold/submit paths. */
   private viewerParentLockedKey(data: string): boolean {
     if (matchesKey(data, 'down') && this.tasksActive && this.seatEditor().getText().trim() === ''
-      && this.editor.getInputMode() === 'prompt') {
+      && this.seatInputMode() === 'prompt') {
       // The empty-editor ↓ task-browser trigger must not open the
       // PARENT's browser from inside the viewer. A shell-mode editor with
       // an empty body is composing a command — ↓ keeps its editing
@@ -5492,6 +5492,17 @@ export class TuiApp {
     const seat = this.seatEditor()
     const mode = seat.id === 'host' ? this.editor.getInputMode() : 'prompt'
     return serializeEditorInput(mode, text)
+  }
+
+  /**
+   * The effective input mode of the VISIBLE seat editor: the host
+   * editor's mode, or prompt semantics for a plugin editor (which has no
+   * mode). Routing and chrome (the ↓ task-browser gate, the footer hint)
+   * must read THIS — never the hidden host editor's mode, which can be
+   * stale while a plugin occupies the seat after a shell-mode handoff.
+   */
+  private seatInputMode(): EditorInputMode {
+    return this.seatEditor().getInputMode?.() ?? 'prompt'
   }
 
   /**
@@ -7566,8 +7577,9 @@ export class TuiApp {
       ? ''
       // The ↓ hint matches the ↓ routing gate: only a PROMPT-mode empty
       // editor opens the task browser — a shell-mode empty body is
-      // composing a command, so no hint is advertised.
-      : color.primary(`[${badgeParts.join(' · ')}${this.editor.getInputMode() === 'prompt' && this.editor.getText().trim() === '' ? ' · ↓ view' : ''}]`)
+      // composing a command, so no hint is advertised. The VISIBLE seat
+      // editor decides (a plugin editor is prompt semantics).
+      : color.primary(`[${badgeParts.join(' · ')}${this.seatInputMode() === 'prompt' && this.seatEditor().getText().trim() === '' ? ' · ↓ view' : ''}]`)
     const line1 = [
       permissionBadge,
       this.planMode ? color.warning('[plan]') : '',

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2493,7 +2493,11 @@ export class TuiApp {
       // plugin DECLINES it, the editor route hands it back to the host
       // fallback (which includes this cancel path on re-entry).
       if (this.seatEditor().handleInput !== undefined) {
-        return this.handleReplacementEditorInput(data, this.inputRouterContext(), true)
+        const routed = this.handleReplacementEditorInput(data, this.inputRouterContext(), true)
+        if (routed !== undefined) return routed
+        // The plugin DECLINED Esc: continue through the host Esc fallback
+        // (shell-mode exit, double-Esc cancel) instead of dropping the
+        // key — a dropped Esc would never arm the cancel.
       }
       // Shell-mode exit: the host editor in a shell mode with an EMPTY
       // body owns Esc — it cancels the shell mode (the double-Esc cancel

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7757,14 +7757,20 @@ export class TuiApp {
       applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
         // A Stable plugin computes its prefix on the WIRE document it
         // received (line 0 carries the synthetic `!` / `!!`), so its
-        // prefix may legitimately include it (`!ch` for `!checkout`).
-        // Normalize back to BARE coordinates before the host apply —
-        // the base adapter adds its own virtual prefix and strips it
-        // exactly once; a doubled prefix would corrupt the result
-        // (`checkout` → `heckout`).
+        // prefix may include it (`!ch` for the wire line `!ch`).
+        // Normalize back to BARE coordinates before the host apply — the
+        // base adapter adds its own virtual prefix and strips it exactly
+        // once; a doubled prefix would corrupt the result. The strip
+        // applies ONLY when the prefix starts at the WIRE line start
+        // (cursorCol + synthetic length − prefix length === 0): a
+        // mid-body `!` token (e.g. `echo !ch`) is a literal document
+        // character and must never be stripped.
         const mode = getMode()
-        const barePrefix = mode !== 'prompt' && cursorLine === 0
+        const synthetic = mode === 'prompt' ? 0 : shellPrefixForMode(mode).length
+        const stripWirePrefix = mode !== 'prompt' && cursorLine === 0 && synthetic > 0
           && (prefix.startsWith('!!') || prefix.startsWith('!'))
+          && cursorCol + synthetic - prefix.length === 0
+        const barePrefix = stripWirePrefix
           ? prefix.slice(prefix.startsWith('!!') ? 2 : 1)
           : prefix
         return base.applyCompletion(lines, cursorLine, cursorCol, item, barePrefix)

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -126,10 +126,13 @@ export class TuiEditor extends Editor {
   private placeholderText = ''
   /** The current input mode: `!` / `!!` are state, never document text. */
   private inputMode: EditorInputMode = 'prompt'
-  /** Whether the editor was empty when a bracketed paste began (the
-   * paste-normalization gate: a paste into a NON-empty editor is never
-   * reinterpreted as a shell line). */
-  private pasteStartEmpty: boolean | null = null
+  /** Whether a bracketed paste began in an EMPTY PROMPT (the
+   * paste-normalization gate): only a paste that lands in an empty
+   * PROMPT-mode editor is reinterpreted as a shell line. A paste into an
+   * already-shell-mode editor is BODY text — its leading `!` is literal
+   * (the serialization adds the mode's own prefix, so the wire form
+   * matches what the user would have typed before the mode feature). */
+  private pasteStartPromptEmpty: boolean | null = null
 
   constructor(tui: TUI, theme: EditorTheme) {
     // paddingX: 2 reserves the left two cells for the mode prompt painted
@@ -216,12 +219,13 @@ export class TuiEditor extends Editor {
       ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
       return
     }
-    // Track whether the editor was empty when a bracketed paste began: a
-    // paste that lands in an EMPTY prompt and starts with `!` / `!!` is
-    // normalized into a shell-mode entry (kimi parity — typed-key
-    // interception does not cover bracketed paste). A paste into a
-    // non-empty editor is never reinterpreted.
-    if (data.includes('\x1b[200~')) this.pasteStartEmpty = this.getText() === ''
+    // Track whether a bracketed paste began in an EMPTY PROMPT: a paste
+    // that lands there and starts with `!` / `!!` is normalized into a
+    // shell-mode entry (kimi parity — typed-key interception does not
+    // cover bracketed paste). A paste into a non-empty editor, or into an
+    // already-shell-mode editor, is never reinterpreted — its `!` is
+    // ordinary body text.
+    if (data.includes('\x1b[200~')) this.pasteStartPromptEmpty = this.inputMode === 'prompt' && this.getText() === ''
     // Esc on an EMPTY shell body cancels the whole shell mode (the app
     // passes Esc through only in this state — see the app's escape
     // branch). The autocomplete branch above already won when the
@@ -274,9 +278,9 @@ export class TuiEditor extends Editor {
     // (the fork's handlePaste is private): one synchronous pass, so no
     // intermediate `❯ !!git status` frame is ever visible.
     if (data.includes('\x1b[201~')) {
-      const startedEmpty = this.pasteStartEmpty
-      this.pasteStartEmpty = null
-      if (startedEmpty === true) {
+      const startedPromptEmpty = this.pasteStartPromptEmpty
+      this.pasteStartPromptEmpty = null
+      if (startedPromptEmpty === true) {
         const { mode, text } = editorModeFromHistoryEntry(this.getText())
         if (mode !== 'prompt') {
           this.setInputMode(mode)

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -7,19 +7,24 @@
  * reopenAutocompleteAfterInput). Esc while autocomplete is active closes
  * it WITHOUT re-triggering (kimi parity).
  *
- * The editor also carries the terminal-prompt `❯ ` prefix: the fork's
- * Editor is constructed with `paddingX: 2` (kimi's CustomEditor reserves
- * padding for its `>` prompt the same way), and render() paints the
- * prompt over the first content row's leading padding — kimi's
- * injectPromptSymbol pattern, consumer-side only. The prompt reads like
- * the transcript's user messages (`❯ text`), so what the user is about
- * to send matches what their sent input looks like.
+ * The editor also carries the terminal-prompt prefix: the fork's Editor is
+ * constructed with `paddingX: 2` (kimi's CustomEditor reserves padding for
+ * its `>` prompt the same way), and render() paints the prompt over the
+ * first content row's leading padding — kimi's injectPromptSymbol
+ * pattern, consumer-side only. The prompt is MODE-DRIVEN (the
+ * shell-editor-mode plan): `❯ ` in prompt mode, `! ` in shell-context
+ * mode and `!!` in shell-local mode — all exactly two cells wide, so the
+ * editable body and cursor never jump when the mode changes. The `!` /
+ * `!!` prefixes are editor STATE, never document text: the buffer holds
+ * the bare command body, and the mode is serialized back into the
+ * existing textual `!` / `!!` protocol only at host boundaries.
  * @module @xmoon76/dsh-pi-tui/tui-editor
  */
 
-import { Editor, matchesKey, truncateToWidth, type EditorTheme, type TUI } from '@xmoon76/pi-tui'
+import { decodePrintableKey, Editor, matchesKey, truncateToWidth, type EditorTheme, type TUI } from '@xmoon76/pi-tui'
 import { color } from './theme.ts'
 import { extractAtPrefix } from './mentions.ts'
+import { editorModeFromHistoryEntry, type EditorInputMode } from './editor-input-mode.ts'
 
 /** The fork's private autocomplete surface (runtime methods; kimi's
  * CustomEditor uses the same cast idiom). */
@@ -28,8 +33,9 @@ interface AutocompleteInternals {
   requestAutocomplete(options: { force: boolean; explicitTab: boolean }): void
 }
 
-/** Visible width of the `❯ ` prompt — must equal the editor's paddingX,
- * so content and wrapped continuations start right after the prompt. */
+/** Visible width of the mode prompt — must equal the editor's paddingX,
+ * so content and wrapped continuations start right after the prompt. All
+ * three prompts (`❯ `, `! `, `!!`) are exactly this wide. */
 const PROMPT_WIDTH = 2
 
 /** Whether the text before the cursor is a slash-command line WITH an
@@ -47,22 +53,22 @@ function isSlashCommandArgument(textBeforeCursor: string): boolean {
 }
 
 /**
- * Paint the terminal-prompt `❯ ` over the first content row of the fork's
- * editor render. The fork renders every content row with `paddingX` spaces
- * on each side; the first visible content row's leading padding is replaced
- * by the prompt (kimi's injectPromptSymbol, which requires the same leading
- * padding). Wrapped continuation rows keep their padding, so they indent
- * under the prompt exactly like the transcript's user-message bullet
- * (BulletedComponent). No SGR is emitted for the trailing space, so the
- * text after the prompt keeps its own colouring.
+ * Paint the mode prompt over the first content row of the fork's editor
+ * render. The fork renders every content row with `paddingX` spaces on
+ * each side; the first visible content row's leading padding is replaced
+ * by the prompt (kimi's injectPromptSymbol, which requires the same
+ * leading padding). Wrapped continuation rows keep their padding, so they
+ * indent under the prompt exactly like the transcript's user-message
+ * bullet (BulletedComponent). No SGR is emitted for the trailing space, so
+ * the text after the prompt keeps its own colouring.
  *
  * When the draft is scrolled (the fork paints `↑ N more` as the top row),
- * the first visible row is NOT the first line of the draft, so no prompt is
- * painted — a floating `❯` on a continuation line would lie about where the
- * input starts (kimi paints unconditionally; the scroll indicator makes the
- * skip unambiguous here).
+ * the first visible row is NOT the first line of the draft, so no prompt
+ * is painted — a floating prompt on a continuation line would lie about
+ * where the input starts (kimi paints unconditionally; the scroll
+ * indicator makes the skip unambiguous here).
  */
-function injectEditorPrompt(lines: string[]): string[] {
+function injectEditorPrompt(lines: string[], mode: EditorInputMode): string[] {
   if (lines.length < 3) return lines
   // Top row: a plain border when the editor is at the top of the draft, a
   // `─── ↑ N more ───` scroll indicator when scrolled. The ↑ never appears
@@ -73,19 +79,28 @@ function injectEditorPrompt(lines: string[]): string[] {
   for (let i = 0; i < PROMPT_WIDTH; i++) {
     if (first[i] !== ' ') return lines
   }
-  lines[1] = `${color.roleUser('❯')} ${first.slice(PROMPT_WIDTH)}`
+  // All three prompts are exactly PROMPT_WIDTH cells: `❯ ` (roleUser),
+  // `! ` and `!!` (both shellMode). The trailing space of `❯ `/`! ` is
+  // unpainted so the body keeps its own colouring.
+  const prompt = mode === 'prompt'
+    ? `${color.roleUser('❯')} `
+    : mode === 'shell-context'
+      ? `${color.shellMode('!')} `
+      : color.shellMode('!!')
+  lines[1] = `${prompt}${first.slice(PROMPT_WIDTH)}`
   return lines
 }
 
 /**
- * Paint a render-time PLACEHOLDER hint over an EMPTY draft (the subagent
- * viewer's `Message <label>…` affordance): `❯ <dim hint>` with the cursor
- * block staying at its own position after the text. The placeholder is a
- * presentation-only overlay — it never becomes part of the draft
- * (`getText()` stays empty), so typing over it edits a clean buffer. Same
- * structure as {@link injectEditorPrompt}: the first content row's leading
- * padding is replaced by the prompt, the hint is inserted between the
- * prompt and the (still positioned) cursor.
+ * Paint a render-time PLACEHOLDER hint over an EMPTY prompt-mode draft
+ * (the subagent viewer's `Message <label>…` affordance): `❯ <dim hint>`
+ * with the cursor block staying at its own position after the text. The
+ * placeholder is a presentation-only overlay — it never becomes part of
+ * the draft (`getText()` stays empty), so typing over it edits a clean
+ * buffer. Same structure as {@link injectEditorPrompt}: the first content
+ * row's leading padding is replaced by the prompt, the hint is inserted
+ * between the prompt and the (still positioned) cursor. Shell modes never
+ * show a placeholder — the shell prompt itself is the affordance.
  */
 function injectEditorPlaceholder(lines: string[], placeholder: string, width: number): string[] {
   if (lines.length < 3) return lines
@@ -107,15 +122,57 @@ function injectEditorPlaceholder(lines: string[], placeholder: string, width: nu
 }
 
 export class TuiEditor extends Editor {
-  /** The render-time placeholder hint (empty draft only). */
+  /** The render-time placeholder hint (empty prompt-mode draft only). */
   private placeholderText = ''
+  /** The current input mode: `!` / `!!` are state, never document text. */
+  private inputMode: EditorInputMode = 'prompt'
+  /** Whether the editor was empty when a bracketed paste began (the
+   * paste-normalization gate: a paste into a NON-empty editor is never
+   * reinterpreted as a shell line). */
+  private pasteStartEmpty: boolean | null = null
 
   constructor(tui: TUI, theme: EditorTheme) {
-    // paddingX: 2 reserves the left two cells for the `❯ ` prompt painted
+    // paddingX: 2 reserves the left two cells for the mode prompt painted
     // by render(). Content and wrapped continuations start at column 2,
     // matching the transcript's user-message bullet indent, and the layout
     // width the fork uses for cursor navigation/wrapping stays in sync.
     super(tui, theme, { paddingX: PROMPT_WIDTH })
+    // Dynamic border: shell modes use the shellMode token, the prompt the
+    // normal border. The function reads the LIVE color helpers on every
+    // call, so a theme switch repaints correctly (never a cached Chalk
+    // function tied to a stale palette). The host's focus/plan/approval
+    // overrides keep their precedence — they replace this function while
+    // active and restore it (via the captured editorBorder) afterwards.
+    this.borderColor = (text) => this.inputMode === 'prompt' ? color.border(text) : color.shellMode(text)
+    // History recall decodes the serialized entry into mode + body; the
+    // draft save/restore pair keeps the mode across ↑/↓ browsing (a draft
+    // recalled as `!!pwd` must never come back as `❯ pwd`).
+    this.onRecall = (entry) => {
+      const { mode, text } = editorModeFromHistoryEntry(entry)
+      this.setInputMode(mode)
+      return text
+    }
+    this.onHistoryDraftSave = () => this.inputMode
+    this.onHistoryDraftRestore = (state) => {
+      if (state === 'prompt' || state === 'shell-context' || state === 'shell-local') {
+        this.setInputMode(state)
+      }
+    }
+  }
+
+  /** The current input mode (read-only for the host). */
+  getInputMode(): EditorInputMode {
+    return this.inputMode
+  }
+
+  /** Switch the input mode. A real change fires onChange (the host's
+   * viewer-draft mirror and seat subscribers must observe the wire form
+   * changing even when the body text did not). */
+  setInputMode(mode: EditorInputMode): void {
+    if (this.inputMode === mode) return
+    this.inputMode = mode
+    this.onChange?.(this.getText())
+    this.tui.requestRender()
   }
 
   /** Show a dim placeholder hint while the draft is EMPTY (e.g. the
@@ -125,22 +182,108 @@ export class TuiEditor extends Editor {
     this.placeholderText = text
   }
 
+  /**
+   * Replace the draft with a SERIALIZED user input line (`!!x` →
+   * shell-local + `x`, `!x` → shell-context + `x`, anything else →
+   * prompt + text). The single decode point for every host restore path
+   * (blocked submissions, history accepts, dequeues, viewer restores) —
+   * callers never re-implement prefix parsing.
+   */
+  setSerializedInput(text: string): void {
+    const { mode, text: body } = editorModeFromHistoryEntry(text)
+    this.setInputMode(mode)
+    this.setText(body)
+  }
+
+  /** Test seam: the current mode (read-only). */
+  inputModeForTest(): EditorInputMode {
+    return this.inputMode
+  }
+
   override render(width: number): string[] {
     const lines = super.render(width)
-    if (this.placeholderText !== '' && this.getText().trim() === '') {
+    if (this.inputMode === 'prompt' && this.placeholderText !== '' && this.getText().trim() === '') {
       return injectEditorPlaceholder(lines, this.placeholderText, width)
     }
-    return injectEditorPrompt(lines)
+    return injectEditorPrompt(lines, this.inputMode)
   }
 
   override handleInput(data: string): void {
     // Esc + autocomplete activity: close WITHOUT re-triggering (kimi
-    // parity — otherwise Esc would immediately reopen the list).
+    // parity — otherwise Esc would immediately reopen the list). This
+    // keeps its priority over the shell-mode Esc exit below.
     if (matchesKey(data, 'escape') && this.isShowingAutocomplete()) {
       ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
       return
     }
+    // Track whether the editor was empty when a bracketed paste began: a
+    // paste that lands in an EMPTY prompt and starts with `!` / `!!` is
+    // normalized into a shell-mode entry (kimi parity — typed-key
+    // interception does not cover bracketed paste). A paste into a
+    // non-empty editor is never reinterpreted.
+    if (data.includes('\x1b[200~')) this.pasteStartEmpty = this.getText() === ''
+    // Esc on an EMPTY shell body cancels the whole shell mode (the app
+    // passes Esc through only in this state — see the app's escape
+    // branch). The autocomplete branch above already won when the
+    // dropdown is open.
+    if (matchesKey(data, 'escape') && this.inputMode !== 'prompt' && this.getText() === '') {
+      this.setInputMode('prompt')
+      return
+    }
+    // Backspace on an EMPTY shell body steps the mode back:
+    // shell-local -> shell-context -> prompt. A non-empty body keeps the
+    // normal editor Backspace behavior.
+    if (matchesKey(data, 'backspace') && this.inputMode !== 'prompt' && this.getText() === '') {
+      this.setInputMode(this.inputMode === 'shell-local' ? 'shell-context' : 'prompt')
+      return
+    }
+    // A typed `!` on an EMPTY body enters the shell modes — no debounce,
+    // no ambiguous waiting state, each key produces a complete state. The
+    // consumed prefix keystrokes never reach the base editor.
+    const printable = decodePrintableKey(data) ?? (data.length === 1 && data.charCodeAt(0) >= 32 ? data : undefined)
+    if (printable === '!') {
+      if (this.inputMode === 'prompt' && this.getText() === '') {
+        this.setInputMode('shell-context')
+        return
+      }
+      if (this.inputMode === 'shell-context' && this.getText() === '') {
+        this.setInputMode('shell-local')
+        return
+      }
+      // shell-local + empty: `!` is an ordinary body character (no fourth
+      // mode — intentional, guarded by a test).
+    }
+    // Tab on a leading `/` in a shell mode is a PATH, never a slash
+    // command: the fork's handleTabCompletion routes a space-free
+    // leading-`/` line to slash-command completion, which would list
+    // commands for `/usr/lo`. Force the file-completion path instead
+    // (the provider's virtual prefix keeps the shell grammar intact).
+    // An open dropdown keeps Tab as accept — only a closed one routes.
+    if (matchesKey(data, 'tab') && !this.isShowingAutocomplete() && this.inputMode !== 'prompt') {
+      const { line, col } = this.getCursor()
+      const beforeCursor = this.getLines()[line]?.slice(0, col) ?? ''
+      const trimmed = beforeCursor.trimStart()
+      if (trimmed.startsWith('/') && !trimmed.includes(' ')) {
+        ;(this as unknown as AutocompleteInternals)
+          .requestAutocomplete({ force: true, explicitTab: true })
+        return
+      }
+    }
     super.handleInput(data)
+    // Paste normalization runs AFTER the base pipeline applied the paste
+    // (the fork's handlePaste is private): one synchronous pass, so no
+    // intermediate `❯ !!git status` frame is ever visible.
+    if (data.includes('\x1b[201~')) {
+      const startedEmpty = this.pasteStartEmpty
+      this.pasteStartEmpty = null
+      if (startedEmpty === true) {
+        const { mode, text } = editorModeFromHistoryEntry(this.getText())
+        if (mode !== 'prompt') {
+          this.setInputMode(mode)
+          this.setText(text)
+        }
+      }
+    }
     this.reopenAutocompleteAfterInput()
   }
 

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -316,9 +316,16 @@ export class TuiEditor extends Editor {
    * delay every Esc press; real terminals write a paste marker
    * atomically, so a split after the first byte is not observable in
    * practice). A complete `~`-terminated marker is never a split prefix.
-   * The tail lengths are FULL byte counts (`\x1b` is one char). A
-   * stitched sequence that never forms a real marker flows through the
-   * normal chain (upstream behavior for split CSI). */
+   * The tail lengths are FULL byte counts (`\x1b` is one char).
+   *
+   * TRADEOFF (documented): a stitched sequence that never forms a real
+   * marker flows through the normal chain — this also REPAIRS split CSI
+   * sequences (`\x1b[A` arriving as `\x1b[` + `A`), which the fork
+   * otherwise drops. The only loss is an input stream that ENDS with an
+   * incomplete CSI tail and never delivers the continuation — real
+   * terminals send each key's sequence atomically, so this does not
+   * occur in practice, and the upstream editor is strictly worse (it
+   * loses the tail immediately). */
   private bufferTrailingPasteMarker(data: string): string {
     if (data.endsWith('~')) return data
     let markerTail = 0

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -126,13 +126,11 @@ export class TuiEditor extends Editor {
   private placeholderText = ''
   /** The current input mode: `!` / `!!` are state, never document text. */
   private inputMode: EditorInputMode = 'prompt'
-  /** Whether a bracketed paste began in an EMPTY PROMPT (the
-   * paste-normalization gate): only a paste that lands in an empty
-   * PROMPT-mode editor is reinterpreted as a shell line. A paste into an
-   * already-shell-mode editor is BODY text — its leading `!` is literal
-   * (the serialization adds the mode's own prefix, so the wire form
-   * matches what the user would have typed before the mode feature). */
-  private pasteStartPromptEmpty: boolean | null = null
+  /** An in-flight bracketed paste captured at the RAW layer: whether it
+   * began in an EMPTY PROMPT (the normalization gate) and the content
+   * accumulated so far. While set, every input chunk belongs to the
+   * paste and is buffered here — never passed to the base editor. */
+  private pasteCapture: { promptEmpty: boolean; buffer: string } | null = null
 
   constructor(tui: TUI, theme: EditorTheme) {
     // paddingX: 2 reserves the left two cells for the mode prompt painted
@@ -170,10 +168,15 @@ export class TuiEditor extends Editor {
 
   /** Switch the input mode. A real change fires onChange (the host's
    * viewer-draft mirror and seat subscribers must observe the wire form
-   * changing even when the body text did not). */
+   * changing even when the body text did not) and CANCELS any open
+   * autocomplete: a mode change swaps the completion grammar, and a
+   * dropdown built for the old mode's context must not survive (a
+   * prompt-mode file list would otherwise accept suggestions into a
+   * shell body). */
   setInputMode(mode: EditorInputMode): void {
     if (this.inputMode === mode) return
     this.inputMode = mode
+    ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
     this.onChange?.(this.getText())
     this.tui.requestRender()
   }
@@ -219,13 +222,6 @@ export class TuiEditor extends Editor {
       ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
       return
     }
-    // Track whether a bracketed paste began in an EMPTY PROMPT: a paste
-    // that lands there and starts with `!` / `!!` is normalized into a
-    // shell-mode entry (kimi parity — typed-key interception does not
-    // cover bracketed paste). A paste into a non-empty editor, or into an
-    // already-shell-mode editor, is never reinterpreted — its `!` is
-    // ordinary body text.
-    if (data.includes('\x1b[200~')) this.pasteStartPromptEmpty = this.inputMode === 'prompt' && this.getText() === ''
     // Esc on an EMPTY shell body cancels the whole shell mode (the app
     // passes Esc through only in this state — see the app's escape
     // branch). The autocomplete branch above already won when the
@@ -273,22 +269,63 @@ export class TuiEditor extends Editor {
         return
       }
     }
-    super.handleInput(data)
-    // Paste normalization runs AFTER the base pipeline applied the paste
-    // (the fork's handlePaste is private): one synchronous pass, so no
-    // intermediate `❯ !!git status` frame is ever visible.
-    if (data.includes('\x1b[201~')) {
-      const startedPromptEmpty = this.pasteStartPromptEmpty
-      this.pasteStartPromptEmpty = null
-      if (startedPromptEmpty === true) {
-        const { mode, text } = editorModeFromHistoryEntry(this.getText())
-        if (mode !== 'prompt') {
-          this.setInputMode(mode)
-          this.setText(text)
-        }
-      }
+    // Bracketed paste: captured at the RAW layer BEFORE the base editor
+    // sees it. The prefix normalization therefore happens PRE-INSERT —
+    // the base editor's undo snapshots contain the NORMALIZED body, so
+    // undoing a normalized paste can never resurrect a raw `!!` in the
+    // document (the shell-editor-mode invariant: prefixes are state,
+    // never document text). Large pastes (>10 lines / >1000 chars) keep
+    // the fork's paste-registry path because the stripped content is
+    // re-wrapped as a bracketed paste below.
+    if (this.pasteCapture !== null || data.includes('\x1b[200~')) {
+      this.capturePaste(data)
+      this.reopenAutocompleteAfterInput()
+      return
     }
+    super.handleInput(data)
     this.reopenAutocompleteAfterInput()
+  }
+
+  /** Accumulate one raw bracketed-paste chunk; on the closing marker,
+   * normalize (empty-prompt `!` / `!!` prefix → shell mode, prefix
+   * stripped) and hand the stripped content to the base editor as a
+   * re-wrapped bracketed paste, so the fork's full handlePaste path
+   * (text normalization, large-paste registry, atomic undo) applies. A
+   * paste into a non-empty editor, or into an already-shell-mode editor,
+   * is never reinterpreted — its `!` is ordinary body text. */
+  private capturePaste(data: string): void {
+    if (this.pasteCapture === null) {
+      const start = data.indexOf('\x1b[200~')
+      const before = data.slice(0, start)
+      if (before !== '') {
+        // Defense: content before the opening marker (real terminals do
+        // not interleave, but a chunk boundary must not eat input).
+        super.handleInput(before)
+      }
+      this.pasteCapture = { promptEmpty: this.inputMode === 'prompt' && this.getText() === '', buffer: '' }
+      data = data.slice(start + '\x1b[200~'.length)
+    }
+    const end = data.indexOf('\x1b[201~')
+    if (end === -1) {
+      this.pasteCapture.buffer += data
+      return
+    }
+    this.pasteCapture.buffer += data.slice(0, end)
+    const capture = this.pasteCapture
+    this.pasteCapture = null
+    let content = capture.buffer
+    let mode: EditorInputMode = 'prompt'
+    if (capture.promptEmpty && content.startsWith('!!')) {
+      mode = 'shell-local'
+      content = content.slice(2)
+    } else if (capture.promptEmpty && content.startsWith('!')) {
+      mode = 'shell-context'
+      content = content.slice(1)
+    }
+    if (mode !== 'prompt') this.setInputMode(mode)
+    const remaining = data.slice(end + '\x1b[201~'.length)
+    if (content !== '') super.handleInput(`\x1b[200~${content}\x1b[201~`)
+    if (remaining !== '') super.handleInput(remaining)
   }
 
   /** Reopen `@dir/` mention completion right after a key closed it (e.g.

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -222,27 +222,9 @@ export class TuiEditor extends Editor {
     // A bracketed-paste marker split across input chunks (real terminals
     // keep markers whole, but a chunk boundary must not lose them):
     // stitch a buffered marker prefix onto this chunk, and buffer a
-    // trailing `\x1b[20` / `\x1b[200` / `\x1b[201` prefix for the next
-    // one. A stitched sequence that never forms a real marker flows
-    // through the normal chain (upstream behavior for split CSI).
-    if (this.pendingPasteMarker !== null) {
-      data = this.pendingPasteMarker + data
-      this.pendingPasteMarker = null
-    }
-    // A COMPLETE marker ends with `~` — `\x1b[200~`/`\x1b[201~` also end
-    // with the 5-char prefixes `\x1b[200`/`\x1b[201`, so the tail check
-    // must exclude a trailing `~` first (a complete closing marker is
-    // never a split prefix). The tail lengths are the FULL prefix byte
-    // counts (`\x1b` is one char): `\x1b[20` = 4, `\x1b[200`/`\x1b[201` = 5.
-    let markerTail = 0
-    if (!data.endsWith('~')) {
-      if (data.endsWith('\x1b[201') || data.endsWith('\x1b[200')) markerTail = 5
-      else if (data.endsWith('\x1b[20')) markerTail = 4
-    }
-    if (markerTail > 0) {
-      this.pendingPasteMarker = data.slice(-markerTail)
-      data = data.slice(0, -markerTail)
-    }
+    // trailing prefix for the next one.
+    data = this.stitchPendingPasteMarker(data)
+    data = this.bufferTrailingPasteMarker(data)
     // Esc + autocomplete activity: close WITHOUT re-triggering (kimi
     // parity — otherwise Esc would immediately reopen the list). This
     // keeps its priority over the shell-mode Esc exit below.
@@ -306,20 +288,69 @@ export class TuiEditor extends Editor {
     // the fork's paste-registry path because the stripped content is
     // re-wrapped as a bracketed paste below.
     if (this.pasteCapture !== null || data.includes('\x1b[200~')) {
-      const residuals = this.capturePaste(data)
-      // Residual input (trailing keys after the closing marker) goes
-      // through the FULL interception chain — never straight into the
-      // base document. The autocomplete reopen runs AFTER the normalized
-      // paste and the residuals landed, so a pasted `@dir/` reopens like
-      // ordinary input.
-      for (const residual of residuals) {
-        if (residual !== '') this.handleInput(residual)
-      }
+      // Drain paste chunks ITERATIVELY: one input chunk may carry many
+      // complete paste segments — recursion per segment would overflow
+      // the stack. The autocomplete reopen runs AFTER the normalized
+      // pastes and the residual input landed, so a pasted `@dir/` reopens
+      // like ordinary input.
+      this.processPasteChunks(data)
       this.reopenAutocompleteAfterInput()
       return
     }
     if (data !== '') super.handleInput(data)
     this.reopenAutocompleteAfterInput()
+  }
+
+  /** Stitch a buffered paste-marker prefix onto this chunk. */
+  private stitchPendingPasteMarker(data: string): string {
+    if (this.pendingPasteMarker !== null) {
+      data = this.pendingPasteMarker + data
+      this.pendingPasteMarker = null
+    }
+    return data
+  }
+
+  /** Buffer a trailing paste-marker prefix for the next chunk: any
+   * suffix that is a proper prefix of `\x1b[200~` / `\x1b[201~` — except
+   * a LONE `\x1b`, which IS the complete Esc key (buffering it would
+   * delay every Esc press; real terminals write a paste marker
+   * atomically, so a split after the first byte is not observable in
+   * practice). A complete `~`-terminated marker is never a split prefix.
+   * The tail lengths are FULL byte counts (`\x1b` is one char). A
+   * stitched sequence that never forms a real marker flows through the
+   * normal chain (upstream behavior for split CSI). */
+  private bufferTrailingPasteMarker(data: string): string {
+    if (data.endsWith('~')) return data
+    let markerTail = 0
+    if (data.endsWith('\x1b[201') || data.endsWith('\x1b[200')) markerTail = 5
+    else if (data.endsWith('\x1b[20')) markerTail = 4
+    else if (data.endsWith('\x1b[2')) markerTail = 3
+    else if (data.endsWith('\x1b[')) markerTail = 2
+    if (markerTail === 0) return data
+    this.pendingPasteMarker = data.slice(-markerTail)
+    return data.slice(0, -markerTail)
+  }
+
+  /** Drain one input chunk that contains paste markers ITERATIVELY. Each
+   * iteration re-runs the marker stitch/tail buffering, then feeds the
+   * chunk to {@link capturePaste}; the residual (trailing keys or the
+   * next paste segment) becomes the next iteration. An ordinary residual
+   * (no marker) goes through the full interception chain — exactly one
+   * level, since it cannot re-enter the paste branch without a marker. */
+  private processPasteChunks(initial: string): void {
+    let chunk = initial
+    for (;;) {
+      chunk = this.stitchPendingPasteMarker(chunk)
+      chunk = this.bufferTrailingPasteMarker(chunk)
+      if (this.pasteCapture === null && !chunk.includes('\x1b[200~')) {
+        if (chunk !== '') this.handleInput(chunk)
+        return
+      }
+      const residuals = this.capturePaste(chunk)
+      const residual = residuals.length > 0 ? residuals[0]! : ''
+      if (residual === '') return
+      chunk = residual
+    }
   }
 
   /** Accumulate one raw bracketed-paste chunk; on the closing marker,

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -170,6 +170,17 @@ export class TuiEditor extends Editor {
     return this.inputMode
   }
 
+  /** Close any open autocomplete dropdown and abort any pending completion
+   * request (the host-owned stale-context guard — the declined-key
+   * fallback cancels when the staged document differs from the host's
+   * current autocomplete context, so a stale dropdown can never accept
+   * candidates into the new document). Named distinctly: the fork's own
+   * `cancelAutocomplete` is private and MUST stay reachable for its
+   * internal callers — a same-named override would shadow it and recurse. */
+  cancelHostAutocomplete(): void {
+    ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
+  }
+
   /** Switch the input mode. A real change fires onChange (the host's
    * viewer-draft mirror and seat subscribers must observe the wire form
    * changing even when the body text did not) and CANCELS any open

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -131,6 +131,10 @@ export class TuiEditor extends Editor {
    * accumulated so far. While set, every input chunk belongs to the
    * paste and is buffered here — never passed to the base editor. */
   private pasteCapture: { promptEmpty: boolean; buffer: string } | null = null
+  /** A trailing `\x1b[20` / `\x1b[200` / `\x1b[201` chunk tail that may
+   * be a paste marker split across chunks; stitched onto the next chunk
+   * at the top of handleInput. */
+  private pendingPasteMarker: string | null = null
 
   constructor(tui: TUI, theme: EditorTheme) {
     // paddingX: 2 reserves the left two cells for the mode prompt painted
@@ -215,6 +219,30 @@ export class TuiEditor extends Editor {
   }
 
   override handleInput(data: string): void {
+    // A bracketed-paste marker split across input chunks (real terminals
+    // keep markers whole, but a chunk boundary must not lose them):
+    // stitch a buffered marker prefix onto this chunk, and buffer a
+    // trailing `\x1b[20` / `\x1b[200` / `\x1b[201` prefix for the next
+    // one. A stitched sequence that never forms a real marker flows
+    // through the normal chain (upstream behavior for split CSI).
+    if (this.pendingPasteMarker !== null) {
+      data = this.pendingPasteMarker + data
+      this.pendingPasteMarker = null
+    }
+    // A COMPLETE marker ends with `~` — `\x1b[200~`/`\x1b[201~` also end
+    // with the 5-char prefixes `\x1b[200`/`\x1b[201`, so the tail check
+    // must exclude a trailing `~` first (a complete closing marker is
+    // never a split prefix). The tail lengths are the FULL prefix byte
+    // counts (`\x1b` is one char): `\x1b[20` = 4, `\x1b[200`/`\x1b[201` = 5.
+    let markerTail = 0
+    if (!data.endsWith('~')) {
+      if (data.endsWith('\x1b[201') || data.endsWith('\x1b[200')) markerTail = 5
+      else if (data.endsWith('\x1b[20')) markerTail = 4
+    }
+    if (markerTail > 0) {
+      this.pendingPasteMarker = data.slice(-markerTail)
+      data = data.slice(0, -markerTail)
+    }
     // Esc + autocomplete activity: close WITHOUT re-triggering (kimi
     // parity — otherwise Esc would immediately reopen the list). This
     // keeps its priority over the shell-mode Esc exit below.
@@ -278,11 +306,19 @@ export class TuiEditor extends Editor {
     // the fork's paste-registry path because the stripped content is
     // re-wrapped as a bracketed paste below.
     if (this.pasteCapture !== null || data.includes('\x1b[200~')) {
-      this.capturePaste(data)
+      const residuals = this.capturePaste(data)
+      // Residual input (trailing keys after the closing marker) goes
+      // through the FULL interception chain — never straight into the
+      // base document. The autocomplete reopen runs AFTER the normalized
+      // paste and the residuals landed, so a pasted `@dir/` reopens like
+      // ordinary input.
+      for (const residual of residuals) {
+        if (residual !== '') this.handleInput(residual)
+      }
       this.reopenAutocompleteAfterInput()
       return
     }
-    super.handleInput(data)
+    if (data !== '') super.handleInput(data)
     this.reopenAutocompleteAfterInput()
   }
 
@@ -292,15 +328,20 @@ export class TuiEditor extends Editor {
    * re-wrapped bracketed paste, so the fork's full handlePaste path
    * (text normalization, large-paste registry, atomic undo) applies. A
    * paste into a non-empty editor, or into an already-shell-mode editor,
-   * is never reinterpreted — its `!` is ordinary body text. */
-  private capturePaste(data: string): void {
+   * is never reinterpreted — its `!` is ordinary body text. Returns the
+   * residual input (trailing keys after the closing marker) for the
+   * caller to route through the full interception chain. */
+  private capturePaste(data: string): string[] {
+    const residuals: string[] = []
     if (this.pasteCapture === null) {
       const start = data.indexOf('\x1b[200~')
       const before = data.slice(0, start)
       if (before !== '') {
-        // Defense: content before the opening marker (real terminals do
-        // not interleave, but a chunk boundary must not eat input).
-        super.handleInput(before)
+        // Residual input BEFORE the opening marker goes through the FULL
+        // interception chain FIRST — a `!` in the same chunk enters the
+        // shell mode and the paste then lands in that state (`!\x1b[200~cmd…`
+        // is a shell command, never a prompt with a literal `!`).
+        this.handleInput(before)
       }
       this.pasteCapture = { promptEmpty: this.inputMode === 'prompt' && this.getText() === '', buffer: '' }
       data = data.slice(start + '\x1b[200~'.length)
@@ -308,7 +349,7 @@ export class TuiEditor extends Editor {
     const end = data.indexOf('\x1b[201~')
     if (end === -1) {
       this.pasteCapture.buffer += data
-      return
+      return residuals
     }
     this.pasteCapture.buffer += data.slice(0, end)
     const capture = this.pasteCapture
@@ -323,9 +364,10 @@ export class TuiEditor extends Editor {
       content = content.slice(1)
     }
     if (mode !== 'prompt') this.setInputMode(mode)
-    const remaining = data.slice(end + '\x1b[201~'.length)
     if (content !== '') super.handleInput(`\x1b[200~${content}\x1b[201~`)
-    if (remaining !== '') super.handleInput(remaining)
+    const remaining = data.slice(end + '\x1b[201~'.length)
+    if (remaining !== '') residuals.push(remaining)
+    return residuals
   }
 
   /** Reopen `@dir/` mention completion right after a key closed it (e.g.

--- a/test/editor-input-mode.test.ts
+++ b/test/editor-input-mode.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure tests for the editor input-mode codec (src/editor-input-mode.ts):
+ * the `!` / `!!` prefixes are editor STATE, never document text — the
+ * codec serializes a mode + body back into the wire form at host
+ * boundaries and decodes serialized lines (history entries, pastes,
+ * restored submissions) into mode + body.
+ * @module @xmoon76/dsh-pi-tui/editor-input-mode.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  editorModeFromHistoryEntry,
+  serializeEditorInput,
+  shellPrefixForMode,
+} from '../src/editor-input-mode.ts'
+
+test('shellPrefixForMode maps the three modes to their prefixes', () => {
+  assert.equal(shellPrefixForMode('prompt'), '')
+  assert.equal(shellPrefixForMode('shell-context'), '!')
+  assert.equal(shellPrefixForMode('shell-local'), '!!')
+})
+
+test('serializeEditorInput produces the exact wire forms', () => {
+  assert.equal(serializeEditorInput('prompt', 'hello'), 'hello')
+  assert.equal(serializeEditorInput('shell-context', 'pwd'), '!pwd')
+  assert.equal(serializeEditorInput('shell-local', 'pwd'), '!!pwd')
+  // An empty body still serializes the prefix (a bare `!` / `!!` line).
+  assert.equal(serializeEditorInput('shell-context', ''), '!')
+  assert.equal(serializeEditorInput('shell-local', ''), '!!')
+})
+
+test('editorModeFromHistoryEntry decodes every serialized form', () => {
+  assert.deepEqual(editorModeFromHistoryEntry('hello'), { mode: 'prompt', text: 'hello' })
+  assert.deepEqual(editorModeFromHistoryEntry('!pwd'), { mode: 'shell-context', text: 'pwd' })
+  assert.deepEqual(editorModeFromHistoryEntry('!!pwd'), { mode: 'shell-local', text: 'pwd' })
+  // Bare prefixes decode to the matching shell mode with an empty body.
+  assert.deepEqual(editorModeFromHistoryEntry('!'), { mode: 'shell-context', text: '' })
+  assert.deepEqual(editorModeFromHistoryEntry('!!'), { mode: 'shell-local', text: '' })
+})
+
+test('the !! check runs before the ! check', () => {
+  assert.deepEqual(editorModeFromHistoryEntry('!!x'), { mode: 'shell-local', text: 'x' })
+  assert.deepEqual(editorModeFromHistoryEntry('!x'), { mode: 'shell-context', text: 'x' })
+})
+
+test('a literal ! inside the body is preserved, not re-parsed', () => {
+  // `!echo !` decodes to shell-context with the trailing `!` as body text.
+  assert.deepEqual(editorModeFromHistoryEntry('!echo !'), { mode: 'shell-context', text: 'echo !' })
+  assert.deepEqual(editorModeFromHistoryEntry('!!echo !'), { mode: 'shell-local', text: 'echo !' })
+  // A non-leading `!` is ordinary text.
+  assert.deepEqual(editorModeFromHistoryEntry('echo !'), { mode: 'prompt', text: 'echo !' })
+})
+
+test('serialize and decode round-trip', () => {
+  for (const [mode, body] of [
+    ['prompt', 'hello'],
+    ['shell-context', 'pwd'],
+    ['shell-local', 'pwd'],
+  ] as const) {
+    const serialized = serializeEditorInput(mode, body)
+    assert.deepEqual(editorModeFromHistoryEntry(serialized), { mode, text: body })
+  }
+})

--- a/test/shell-completion.test.ts
+++ b/test/shell-completion.test.ts
@@ -131,6 +131,74 @@ test('MentionProvider applies a shell item as a plain word replacement', async (
   assert.deepEqual(appliedVar, { lines: ['!echo $HOME '], cursorLine: 0, cursorCol: 12 })
 })
 
+// --- shell-editor-mode virtual prefix (the editor buffer no longer holds
+// the `!` / `!!` prefix; the provider synthesizes it at the boundary) ---
+
+/** A mutable mode source (the app wires it to the live editor mode). */
+function modeSource(initial: 'prompt' | 'shell-context' | 'shell-local'): {
+  source: () => 'prompt' | 'shell-context' | 'shell-local'
+  set: (mode: 'prompt' | 'shell-context' | 'shell-local') => void
+} {
+  let mode = initial
+  return { source: () => mode, set: (next) => { mode = next } }
+}
+
+test('MentionProvider completes shell words on the bare body via the virtual prefix', async () => {
+  const root = fixtureWorkspace()
+  const { source } = modeSource('shell-context')
+  const provider = new MentionProvider([], root, null, source)
+  // The buffer holds `gi` (no `!`); the provider synthesizes `!gi`.
+  const suggestions = await provider.getSuggestions(['gi'], 0, 2, { signal: abort })
+  assert.ok(suggestions !== null, 'command completion must run through the virtual prefix')
+  assert.ok(suggestions.items.some(item => item.value === 'git'), 'git must be suggested')
+  assert.equal(suggestions.prefix, 'gi', 'the suggestion prefix must be the REAL word (no synthetic !)')
+})
+
+test('MentionProvider applies a shell item without ever writing the synthetic prefix', async () => {
+  const root = fixtureWorkspace()
+  const { source } = modeSource('shell-local')
+  const provider = new MentionProvider([], root, null, source)
+  const applied = provider.applyCompletion(['git che'], 0, 7, { value: 'checkout', label: 'checkout' }, 'che')
+  assert.deepEqual(applied, { lines: ['git checkout '], cursorLine: 0, cursorCol: 13 },
+    'the applied line must be the bare body — the !! prefix never enters the buffer')
+})
+
+test('MentionProvider still completes paths on a shell-mode body (path positions reach the fork)', async () => {
+  const root = fixtureWorkspace()
+  const { source } = modeSource('shell-context')
+  const provider = new MentionProvider([], root, null, source)
+  const suggestions = await provider.getSuggestions(['cat src/de'], 0, 10, { signal: abort })
+  assert.ok(suggestions !== null, 'a path position on a shell-mode body must reach the fork provider')
+  assert.ok(suggestions.items.some(item => item.value.includes('deep-nested.ts')), `deep-nested.ts missing from ${JSON.stringify(suggestions.items.slice(0, 5))}`)
+})
+
+test('a natural trigger on a leading / in a shell mode stays quiet (never slash commands)', async () => {
+  const root = fixtureWorkspace()
+  const { source } = modeSource('shell-context')
+  const provider = new MentionProvider([{ name: 'image', description: 'Attach an image file' }], root, null, source)
+  // The fork's slash-command branch would list `image` for a natural
+  // trigger on `/`; the shell-mode routing must suppress it (a path, not
+  // a command). Tab (force) still completes the path.
+  const natural = await provider.getSuggestions(['/usr/lo'], 0, 7, { signal: abort, force: false })
+  assert.equal(natural, null, 'a natural trigger on a shell-mode path must stay quiet')
+  const forced = await provider.getSuggestions(['/usr/lo'], 0, 7, { signal: abort, force: true })
+  assert.ok(forced !== null && forced.items.length > 0, 'Tab on a shell-mode path must complete the path')
+})
+
+test('shouldTriggerFileCompletion allows Tab on a leading / in a shell mode', async () => {
+  const root = fixtureWorkspace()
+  const { source } = modeSource('shell-context')
+  const provider = new MentionProvider([], root, null, source)
+  // The fork's bare-slash-command block would return false for `/usr/lo`
+  // (no space); the virtual prefix keeps the fork's judgment on the
+  // serialized line, where `/usr/lo` is a path.
+  assert.equal(provider.shouldTriggerFileCompletion(['/usr/lo'], 0, 7), true)
+  // Prompt mode keeps the fork's judgment (a bare slash command blocks Tab).
+  const { source: promptSource } = modeSource('prompt')
+  const promptProvider = new MentionProvider([], root, null, promptSource)
+  assert.equal(promptProvider.shouldTriggerFileCompletion(['/usr/lo'], 0, 7), false)
+})
+
 // --- injected-runner determinism (review finding 4/5: failed runs must not
 // be cached, and the spawn/cache must be testable without real bash) ---
 

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1488,3 +1488,115 @@ test('Ctrl+C on a BARE ! (empty body, shell mode) clears the mode and arms the e
   assert.equal(exits, 1, 'the second press exits')
   app.stop()
 })
+
+// ── PR review round 2: declined-input fallback wire coordinate ────────────
+
+test('a plugin DECLINED ! round-trips through the host shell mode into the wire document', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'decline-all',
+    priority: 0,
+    create: () => {
+      const editor = pluginEditor()
+      // A plugin that DECLINES every key: the host fallback owns the
+      // editing semantics.
+      editor.handleInput = () => false
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  const plugin = created[0]!
+  // 1. Declined `!` on an empty plugin: the host consumes it into the
+  //    shell mode and the WIRE document reflects it.
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(plugin.getText(), '!', 'a declined ! must reach the plugin as the wire prefix')
+  // 2. Declined second `!`: shell-local.
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(plugin.getText(), '!!', 'a declined second ! reaches the plugin as !!')
+  // 3. Declined Backspace on `!!`: steps back to `!`.
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  assert.equal(plugin.getText(), '!', 'a declined Backspace steps the wire form back to !')
+  // 4. Declined Backspace on `!`: back to the empty prompt.
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  assert.equal(plugin.getText(), '', 'a declined Backspace on ! returns the empty wire document')
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})
+
+// ── PR review round 2: symmetric wire apply ───────────────────────────────
+
+test('accepting an absolute-path completion in a shell mode never doubles the slash', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  // shell-context: `/u` → Tab → accept `/usr/` — the fork's line-start
+  // judgment runs on the VIRTUAL wire line (`!/u`), so the absolute path
+  // is never mistaken for a slash command (`//usr/ ` must not happen).
+  vt.sendInput('!')
+  vt.sendInput('/u')
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'usr', 'path completion for /u in shell-context')
+  vt.sendInput('\t') // accept /usr/
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '/usr/', 'the accepted absolute path must not double the slash')
+  // shell-local: same rule.
+  app.setEditorText('')
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('!')
+  vt.sendInput('/u')
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'usr', 'path completion for /u in shell-local')
+  vt.sendInput('\t')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '/usr/', 'shell-local accepts the absolute path without a doubled slash')
+  app.stop()
+})
+
+test('a Stable extension suggestion applies through the wire adapter symmetrically', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  let queries = 0
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async () => {
+    queries += 1
+    // TWO suggestions: a single one would be auto-applied by the fork on
+    // the first Tab, so the dropdown opens and the accept path runs.
+    return {
+      items: [
+        { value: '/zzz-no-such-dir/', label: 'zzz-no-such-dir' },
+        { value: '/zzz-no-such-file', label: 'zzz-no-such-file' },
+      ],
+      prefix: '/zzz-no-such',
+    }
+  })
+  app.start()
+  await vt.waitForRender()
+  // Natural typing of the path must NOT consult the plugin chain (the
+  // shell-mode leading-/ suppression stays host-owned): no dropdown may
+  // open mid-typing, or the next Tab would double-apply.
+  vt.sendInput('!')
+  vt.sendInput('/zzz-no-such')
+  await vt.waitForRender()
+  await waitForNoDropdownRow(vt, 'zzz-no-such-dir', 'no extension dropdown during natural typing')
+  assert.equal(queries, 0, 'a natural trigger on a shell-mode path never consults the plugin chain')
+  // Tab (force) consults the plugin chain with the WIRE document, and
+  // the accepted suggestion applies symmetrically into the bare body.
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'zzz-no-such-dir', 'extension suggestion in shell mode')
+  vt.sendInput('\t') // accept
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '/zzz-no-such-dir/', 'the extension apply lands in the bare body without a doubled slash')
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1645,3 +1645,59 @@ test('a host adapter with setSerializedInput but WITHOUT setInputMode falls back
   assert.equal(plugin.getText(), '!', 'a declined ! must not vanish with a partial adapter')
   holder.dispose()
 })
+
+// ── review round: getDraft/setDraft wire symmetry ─────────────────────────
+
+test('getDraft returns the WIRE form, symmetric with setDraft (shell mode survives read/merge/restore)', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  app.setDraft('!pwd')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  assert.equal(app.getDraft(), '!pwd', 'getDraft must read back the wire form — never the bare body')
+  // A read → merge → restore round-trip keeps the shell mode: the merged
+  // wire text decodes back into shell mode + body.
+  const merged = `${app.getDraft()}\n\nhello`
+  app.setDraft(merged)
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the restored merged draft keeps the shell mode')
+  assert.equal(app.seatTextForTest(), 'pwd\n\nhello')
+  assert.equal(app.getDraft(), '!pwd\n\nhello')
+  // Prompt-mode drafts stay byte-identical (the wire form IS the body).
+  app.setDraft('plain text')
+  await vt.waitForRender()
+  assert.equal(app.getDraft(), 'plain text')
+  app.stop()
+})
+
+// ── review round: wire-prefixed extension prefixes ────────────────────────
+
+test('a Stable extension prefix computed on the WIRE line applies without corruption', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async () => ({
+    // The plugin computed this prefix on the WIRE line `!ch` — it
+    // legitimately includes the synthetic `!`.
+    items: [{ value: 'checkout', label: 'checkout' }],
+    prefix: '!ch',
+  }))
+  app.start()
+  await vt.waitForRender()
+  // Force the host provider to return null (a failed compgen run) so the
+  // plugin chain is consulted. ONE item is auto-applied by the fork on
+  // the first forced Tab — the exact path that must not corrupt.
+  setCompgenRunnerForTest(() => Promise.resolve({ ok: false, lines: [] }))
+  try {
+    vt.sendInput('!')
+    vt.sendInput('ch')
+    vt.sendInput('\t')
+    await vt.waitForRender()
+    assert.equal(app.seatTextForTest(), 'checkout ', 'a wire-prefixed extension prefix must apply cleanly')
+    assert.ok(!app.seatTextForTest().startsWith('heckout'), 'the prefix must never be doubled or stripped twice')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -540,18 +540,24 @@ test('a bare ! reaches the child via the subagent submit path', async () => {
 // ── review round 3: plugin handoff (the wire form round-trips) ────────────
 
 /** A minimal plugin editor (the editor-registry test shape). */
-function pluginEditor(initial = ''): ExtensionEditor & { text: string; disposed: boolean } {
-  const state = { text: initial, disposed: false }
+function pluginEditor(initial = ''): ExtensionEditor & {
+  text: string
+  cursor: number
+  disposed: boolean
+  setCursor: (offset: number) => void
+} {
+  const state = { text: initial, cursor: 0, disposed: false }
   return {
     get component() { return { kind: 'text' as const, spans: [{ text: state.text }] } },
     getText: () => state.text,
     setText: (text) => { state.text = text },
-    getCursor: () => 0,
-    setCursor: () => {},
+    getCursor: () => state.cursor,
+    setCursor: (offset) => { state.cursor = offset },
     get focused() { return false },
     borderColor: (text) => text,
     dispose: () => { state.disposed = true },
     get text() { return state.text },
+    get cursor() { return state.cursor },
     get disposed() { return state.disposed },
   }
 }
@@ -751,5 +757,90 @@ test('a host adapter without setSerializedInput still receives the handoff draft
   holder.handoff(undefined)
   assert.equal(holder.currentEditor().id, 'host')
   assert.equal(host.text, '!pwd', 'the draft must survive the restore through the setText fallback')
+  holder.dispose()
+})
+
+// ── review round 6: busy-Esc vs plugin editors; cursor restoration ───────
+
+test('a busy Esc cancels BEFORE a consuming plugin editor sees it', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  let cancels = 0
+  let pluginEscs = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels += 1 },
+  }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  // A plugin editor whose handleInput CONSUMES every event (vim-like).
+  const handle = registry.register({
+    id: 'esc-consuming-plugin',
+    priority: 0,
+    create: () => ({
+      component: { kind: 'text', spans: [{ text: '' }] },
+      getText: () => '',
+      setText: () => {},
+      getCursor: () => 0,
+      setCursor: () => {},
+      get focused() { return false },
+      borderColor: (text: string) => text,
+      handleInput: () => { pluginEscs += 1; return true },
+      dispose: () => {},
+    }),
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  app.setBusy(true)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(cancels, 1, 'a busy Esc must cancel the running activity, never the plugin')
+  assert.equal(pluginEscs, 0, 'the consuming plugin must not see a busy Esc')
+  app.setBusy(false)
+  // Idle: the plugin keeps its own Esc state machine.
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(pluginEscs, 1, 'an idle Esc routes to the plugin editor')
+  assert.equal(cancels, 1, 'an idle plugin Esc must not cancel')
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})
+
+test('a plugin-to-host restore shifts the cursor by the wire prefix in the TEXT', () => {
+  const host = {
+    text: '',
+    cursor: 0,
+    getText: () => host.text,
+    setText: (text: string) => { host.text = text },
+    setTextAndCursor: (text: string, cursor: number) => { host.text = text; host.cursor = cursor },
+    getCursor: () => host.cursor,
+    setCursor: (offset: number) => { host.cursor = offset },
+    focused: true,
+    borderColor: (text: string) => text,
+    invalidate: () => {},
+    addToHistory: () => {},
+    clearHistory: () => {},
+    component: new Text('host', 0, 0),
+  }
+  const holder = new EditorSeatHolder({
+    hostAdapter: () => host,
+    surfaceId: 'test-surface',
+    generation: () => 1,
+    actionSink: () => false,
+    notifyError: () => {},
+    viewSwap: () => {},
+  })
+  const plugin = pluginEditor()
+  holder.handoff({ id: 'plugin', create: () => plugin })
+  // The user typed a shell line in the plugin: the document is the wire
+  // form `!pwd` with the cursor after `!pw` (offset 3).
+  plugin.setText('!pwd')
+  plugin.setCursor(3)
+  holder.handoff(undefined)
+  assert.equal(host.text, '!pwd', 'the wire draft survives the restore')
+  assert.equal(host.cursor, 2, 'the cursor shifts back by the text-derived prefix length')
   holder.dispose()
 })

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -2097,3 +2097,70 @@ test('a replacement plugin Tab runs the shell completion grammar of the wire doc
   app.reconcileEditorNow()
   app.stop()
 })
+
+test('a text change after a declined Tab cancels the stale dropdown (no stale accept)', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'stale-dropdown-plugin',
+    priority: 0,
+    create: () => {
+      const editor = pluginEditor()
+      editor.handleInput = () => false // decline: the host fallback owns every key
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  const plugin = created[0]!
+  // Variable completion (`$VAR`) is NOT cached (unlike the command list),
+  // so the refresh after the text change really consults the stub: call 1
+  // resolves immediately (the first dropdown), call 2 stays PENDING while
+  // the user edits — the window where a stale accept could land.
+  let compgenCalls = 0
+  let resolveRefresh: ((run: { ok: boolean; lines: string[] }) => void) | undefined
+  const refresh = new Promise<{ ok: boolean; lines: string[] }>((resolve) => { resolveRefresh = resolve })
+  setCompgenRunnerForTest((_cwd, expression) => {
+    compgenCalls += 1
+    if (compgenCalls === 1) return Promise.resolve({ ok: true, lines: ['git', 'gist'] })
+    return refresh
+  })
+  try {
+    // Tab 1: the shell dropdown opens for `$g` (hidden host editor).
+    plugin.setText('!echo $g')
+    plugin.setCursor(plugin.getText().length)
+    vt.sendInput('\t')
+    await pollUntil(() => compgenCalls === 1, 'the first variable completion request ran')
+    await vt.waitForRender()
+    // The user edits the value: the staged document differs from the
+    // dropdown's context, so the fallback must cancel the stale dropdown
+    // (the fork's own refresh is async — a Tab before it resolves would
+    // accept an OLD candidate into the NEW text).
+    vt.sendInput('s')
+    await vt.waitForRender()
+    // Tab 2 must NOT accept the stale item: the document stays `!echo $gs`
+    // (pre-fix this became the corrupted `!echo $g$git `).
+    vt.sendInput('\t')
+    await vt.waitForRender()
+    assert.equal(plugin.getText(), '!echo $gs', 'a stale dropdown must never accept into the edited document')
+    // The pending refresh resolves with the FRESH candidates; the next Tab
+    // accepts through the NEW dropdown into the plugin wire document.
+    resolveRefresh!({ ok: true, lines: ['gist', 'gist'] })
+    await vt.waitForRender()
+    vt.sendInput('\t')
+    await pollUntil(() => plugin.getText() === '!echo $gist ',
+      'the fresh completion applies into the plugin wire document')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -629,3 +629,48 @@ test('a plugin draft without a shell prefix restores in PROMPT mode (no stale !)
   assert.deepEqual(submitted, ['echo'], 'the plugin draft submits as plain text')
   app.stop()
 })
+
+test('task-browser routing and the footer hint follow the VISIBLE seat editor, not the hidden host mode', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  let opened = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onOpenTasks: () => { opened += 1; app.requestRender() },
+  }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  // Enter shell mode, then hand the seat to a plugin editor (the hidden
+  // host keeps its shell mode).
+  vt.sendInput('!')
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'hint-plugin',
+    priority: 0,
+    create: (_host: EditorHost) => {
+      const editor = pluginEditor()
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  // The plugin's document is the wire form; the user clears it — the
+  // VISIBLE editor is now an empty prompt-mode editor.
+  created[0]!.setText('')
+  app.setTasks([{ id: 'bash-1', label: 'pnpm build', status: 'running', kind: 'bash' }])
+  await vt.waitForRender()
+  // The footer advertises the ↓ trigger (the visible editor is prompt).
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('↓ view'), `the footer must advertise ↓ for the visible prompt editor:\n${view}`)
+  // ↓ opens the browser despite the hidden host's stale shell mode.
+  vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  assert.equal(opened, 1, 'the visible prompt-mode editor must open the task browser')
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1844,3 +1844,98 @@ test('the extension chain is NOT consulted on a continuation-line natural / trig
   }
   app.stop()
 })
+
+// ── review round: plugin-consumed input notifies seat subscribers ─────────
+
+test('a plugin editor consuming input notifies seat subscribers (fresh snapshot)', () => {
+  const holder = new EditorSeatHolder({
+    hostAdapter: () => {
+      const h = {
+        text: '',
+        getText: () => h.text,
+        setText: (text: string) => { h.text = text },
+        setTextAndCursor: (text: string) => { h.text = text },
+        getCursor: () => 0,
+        setCursor: () => {},
+        focused: true,
+        borderColor: (text: string) => text,
+        invalidate: () => {},
+        addToHistory: () => {},
+        clearHistory: () => {},
+        component: new Text('host', 0, 0),
+      }
+      return h
+    },
+    surfaceId: 'test-surface',
+    generation: () => 1,
+    actionSink: () => false,
+    notifyError: () => {},
+    viewSwap: () => {},
+  })
+  const snapshots: string[] = []
+  const plugin = pluginEditor()
+  // A plugin that CONSUMES the event and mutates its document.
+  plugin.handleInput = () => { plugin.setText('mutated'); return true }
+  holder.handoff({
+    id: 'plugin',
+    create: (host) => {
+      host.subscribe(snapshot => snapshots.push(snapshot.text))
+      return plugin
+    },
+  })
+  // Dispatch a semantic event through the seat's input channel.
+  const seat = holder.currentEditor() as { handleInput?(event: unknown): boolean }
+  assert.equal(typeof seat.handleInput, 'function', 'the plugin seat exposes its input channel')
+  seat.handleInput!({ kind: 'text', text: 'x' })
+  assert.deepEqual(snapshots, ['mutated'],
+    'a consumed key must push the FRESH document snapshot to seat subscribers — a stale snapshot would lose edits')
+  holder.dispose()
+})
+
+// ── review round: completion mode reads the VISIBLE seat, not the hidden host ──
+
+test('completion uses the VISIBLE seat mode — a hidden host shell mode never leaks', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const queries: { lines: readonly string[] }[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async (query) => {
+    queries.push({ lines: [...query.lines] })
+    return null
+  })
+  app.start()
+  await vt.waitForRender()
+  setCompgenRunnerForTest(() => Promise.resolve({ ok: false, lines: [] }))
+  let handle: { dispose(): void } | undefined
+  try {
+    // The HOST enters shell mode, then a plugin editor takes the seat —
+    // the hidden host keeps its shell mode, but the VISIBLE editor is a
+    // prompt-semantics plugin.
+    vt.sendInput('!')
+    await vt.waitForRender()
+    const created: ReturnType<typeof pluginEditor>[] = []
+    handle = registry.register({
+      id: 'completion-plugin',
+      priority: 0,
+      create: () => {
+        const editor = pluginEditor()
+        editor.handleInput = () => false // decline: host fallback owns editing
+        created.push(editor)
+        return editor
+      },
+    }, 'plugin')
+    app.reconcileEditorNow()
+    await vt.waitForRender()
+    created[0]!.setText('ch')
+    vt.sendInput('\t')
+    await pollUntil(() => queries.length === 1, 'extension query through the plugin seat')
+    assert.deepEqual([...queries[0]!.lines], ['ch'],
+      'a prompt-semantics plugin seat must never get the hidden host\'s synthetic ! prefix')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  handle?.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -21,6 +21,7 @@ import type { EditorHost, ExtensionEditor } from '../src/extension/public-types.
 import { runOwned, type OwnedTaskOptions } from '../src/detached.ts'
 import { createDiag } from '../src/diag.ts'
 import { resetCommandCacheForTest, setCompgenRunnerForTest } from '../src/shell-completion.ts'
+import { MentionProvider } from '../src/mentions.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 /** The owned-task entry the runner wires in production (real runOwned,
@@ -29,6 +30,9 @@ const diag = createDiag({ filePath: undefined, stderrLevel: 'off' })
 const owned = <T>(label: string, task: () => T | Promise<T>, options: Omit<OwnedTaskOptions<T>, 'diag' | 'sessionId'>): void => {
   runOwned(label, task, { ...options, diag })
 }
+
+/** A never-aborted signal for direct provider calls. */
+const abort = new AbortController().signal
 
 /** A throwaway workspace (completion fixtures live under the cwd). */
 function fixtureWorkspace(): string {
@@ -1344,4 +1348,104 @@ test('a pasted @dir/ path reopens the mention dropdown like ordinary input', asy
   await waitForDropdownRow(vt, 'deep.ts', 'mention dropdown after a pasted @dir/')
   assert.equal(app.seatTextForTest(), '@src/')
   app.stop()
+})
+
+// ── review round: split markers at every boundary; iterative drain ────────
+
+test('a paste marker split at ANY prefix boundary is stitched back together', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  // The marker `\x1b[200~` split after `\x1b[` / `\x1b[2` / `\x1b[20` /
+  // `\x1b[200` — each boundary gets its own two-chunk paste with the
+  // matching second half. (A lone `\x1b` tail is NOT buffered: it IS the
+  // complete Esc key; real terminals write a paste marker atomically.)
+  const boundaries: [string, string][] = [
+    ['\x1b[', '200~'],
+    ['\x1b[2', '00~'],
+    ['\x1b[20', '0~'],
+    ['\x1b[200', '~'],
+  ]
+  for (const [index, [head, tail]] of boundaries.entries()) {
+    app.setEditorText('')
+    await vt.waitForRender()
+    vt.sendInput(head)
+    await vt.waitForRender()
+    vt.sendInput(`${tail}!git status ${index}\x1b[201~`)
+    await vt.waitForRender()
+    assert.equal(app.inputModeForTest(), 'shell-context', `split after ${JSON.stringify(head)} must open the paste`)
+    assert.equal(app.seatTextForTest(), `git status ${index}`)
+  }
+  // The closing marker split after `\x1b[201`.
+  app.setEditorText('')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!git status final\x1b[201')
+  await vt.waitForRender()
+  vt.sendInput('~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), 'git status final')
+  app.stop()
+})
+
+test('a chunk with MANY paste segments drains iteratively (no stack overflow)', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  const segments = Array.from({ length: 200 }, (_, index) => `\x1b[200~git ${index}\x1b[201~`)
+  vt.sendInput(segments.join(''))
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), Array.from({ length: 200 }, (_, index) => `git ${index}`).join(''),
+    'every segment lands, in order — the drain is iterative, never a stack overflow')
+  app.stop()
+})
+
+// ── review round: multiline wire adaptation ───────────────────────────────
+
+test('the Stable autocomplete extension query keeps the wire document on MULTILINE drafts', async () => {
+  const queries: { lines: readonly string[]; cursorLine: number; cursorCol: number }[] = []
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async (query) => {
+    queries.push({ lines: [...query.lines], cursorLine: query.cursorLine, cursorCol: query.cursorCol })
+    return null
+  })
+  app.start()
+  await vt.waitForRender()
+  setCompgenRunnerForTest(() => Promise.resolve({ ok: false, lines: [] }))
+  try {
+    // A multiline shell draft: wire line 0 carries the prefix, later
+    // lines are ordinary text.
+    vt.sendInput('!')
+    vt.sendInput('git status')
+    vt.sendInput('\n')
+    vt.sendInput('more')
+    await vt.waitForRender()
+    vt.sendInput('\t')
+    await pollUntil(() => queries.length === 1, 'multiline shell query on line 1')
+    assert.deepEqual([...queries[0]!.lines], ['!git status', 'more'],
+      'line 0 carries the wire prefix, later lines stay plain')
+    assert.equal(queries[0]!.cursorLine, 1)
+    assert.equal(queries[0]!.cursorCol, 4, 'a non-first-line cursor never shifts by the prefix')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  app.stop()
+})
+
+test('MentionProvider completes a multiline shell draft with the wire line-0 prefix only', async () => {
+  const root = fixtureWorkspace()
+  let mode: 'prompt' | 'shell-context' | 'shell-local' = 'shell-context'
+  const source = (): 'prompt' | 'shell-context' | 'shell-local' => mode
+  const provider = new MentionProvider([], root, null, source)
+  // Cursor on line 0: the virtual prefix applies.
+  const first = await provider.getSuggestions(['gi', 'more'], 0, 2, { signal: abort })
+  assert.ok(first !== null && first.items.some(item => item.value === 'git'), 'line 0 completes as a shell command')
+  // Cursor on line 1: the wire document has NO prefix there — plain path
+  // completion semantics (a non-`!` line is not a shell line).
+  const second = await provider.getSuggestions(['git', 'more'], 1, 4, { signal: abort, force: true })
+  assert.equal(second, null, 'a later body line never gets a synthetic prefix')
+  // applyCompletion on a later line must not strip anything either: the
+  // inner provider's plain word replacement (no shell trailing space).
+  const applied = provider.applyCompletion(['git', 'more'], 1, 4, { value: 'x', label: 'x' }, 'more')
+  assert.deepEqual(applied, { lines: ['git', 'x'], cursorLine: 1, cursorCol: 1 })
 })

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -844,3 +844,49 @@ test('a plugin-to-host restore shifts the cursor by the wire prefix in the TEXT'
   assert.equal(host.cursor, 2, 'the cursor shifts back by the text-derived prefix length')
   holder.dispose()
 })
+
+// ── review round 7: a DECLINED plugin Esc reaches the host fallback ───────
+
+test('a plugin editor that DECLINES Esc still arms the host double-Esc cancel', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  let cancels = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels += 1 },
+  }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  // A vim-like plugin that DECLINES Esc (returns false — it has no modal
+  // state to enter).
+  const handle = registry.register({
+    id: 'esc-declining-plugin',
+    priority: 0,
+    create: () => ({
+      component: { kind: 'text', spans: [{ text: '' }] },
+      getText: () => '',
+      setText: () => {},
+      getCursor: () => 0,
+      setCursor: () => {},
+      get focused() { return false },
+      borderColor: (text: string) => text,
+      handleInput: () => false,
+      dispose: () => {},
+    }),
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  // First Esc: the plugin declines, the host fallback arms the window.
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(cancels, 0, 'one Esc only arms the double-Esc window')
+  // Second Esc within the window: the host cancel fires.
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(cancels, 1, 'a declined plugin Esc must not swallow the host cancel')
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1701,3 +1701,47 @@ test('a Stable extension prefix computed on the WIRE line applies without corrup
   }
   app.stop()
 })
+
+// ── review round: prefix normalization never strips a mid-body ! ──────────
+
+test('a mid-body ! completion token (echo !ch) keeps its literal !', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async () => ({
+    // The word being completed is `!ch` — the `!` is a LITERAL body
+    // character (the synthetic prefix sits at the wire line start), so
+    // the extension prefix includes it and it must survive the apply.
+    items: [{ value: '!checkout', label: '!checkout' }],
+    prefix: '!ch',
+  }))
+  app.start()
+  await vt.waitForRender()
+  setCompgenRunnerForTest(() => Promise.resolve({ ok: false, lines: [] }))
+  try {
+    vt.sendInput('!')
+    vt.sendInput('echo !ch')
+    vt.sendInput('\t')
+    await vt.waitForRender()
+    assert.equal(app.seatTextForTest(), 'echo !checkout',
+      'a mid-body literal ! must never be stripped by the prefix normalization')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  app.stop()
+})
+
+test('an incomplete CSI tail buffers without loss and stitches a split sequence', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  // A lone incomplete CSI tail: buffered, never rendered, never crashes.
+  vt.sendInput('\x1b[')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '', 'an incomplete CSI tail must not enter the document')
+  // The continuation stitches it into a complete sequence (a split up
+  // arrow): processed as the key, not inserted as text.
+  vt.sendInput('A')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '', 'a stitched split CSI is handled as the key, never as text')
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Headless integration tests for the shell editor mode (the
+ * shell-editor-mode plan): `!` / `!!` are editor STATE, never document
+ * text. Covers the mode transitions (typed `!`, Backspace, Esc), paste
+ * normalization, submission serialization, history recall/draft restore,
+ * completion (virtual prefix, path-vs-slash routing) and rendering
+ * (prompt symbols, border colors, no duplicate prefix).
+ * @module @xmoon76/dsh-pi-tui/shell-editor-mode.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { TuiApp } from '../src/tui-app.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+/** A throwaway workspace (completion fixtures live under the cwd). */
+function fixtureWorkspace(): string {
+  return mkdtempSync(join(tmpdir(), 'dsh-shell-mode-'))
+}
+
+function startApp(
+  cwd: string,
+  options: { onSubmit?: (text: string) => void; commands?: { name: string; description: string }[] } = {},
+): { vt: VirtualTerminal; app: TuiApp; submitted: string[]; cancels: number } {
+  const vt = new VirtualTerminal(100, 24)
+  const submitted: string[] = []
+  let cancels = 0
+  const app = new TuiApp(vt, {
+    onSubmit: (text) => { submitted.push(text); options.onSubmit?.(text) },
+    onExit: () => {},
+    onCancel: () => { cancels += 1 },
+  })
+  app.setCommandCompletions(options.commands ?? [], cwd, null)
+  app.start()
+  return { vt, app, submitted, get cancels() { return cancels } }
+}
+
+/** Poll the viewport until the dropdown row appears (asserts on failure). */
+async function waitForDropdownRow(vt: VirtualTerminal, needle: string, label: string): Promise<string> {
+  const deadline = Date.now() + 3000
+  for (;;) {
+    const view = vt.getViewport().join('\n')
+    if (view.includes(needle)) return view
+    if (Date.now() > deadline) {
+      assert.fail(`${label}: dropdown row ${JSON.stringify(needle)} never appeared:\n${view}`)
+    }
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+/** Poll until the viewport has NO dropdown rows (asserts on failure). */
+async function waitForNoDropdownRow(vt: VirtualTerminal, needle: string, label: string): Promise<void> {
+  const deadline = Date.now() + 2000
+  for (;;) {
+    const view = vt.getViewport().join('\n')
+    if (!view.includes(needle)) return
+    if (Date.now() > deadline) {
+      assert.fail(`${label}: dropdown row ${JSON.stringify(needle)} never disappeared:\n${view}`)
+    }
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+// ── mode transitions (plan §4.1–4.4, §5.2) ───────────────────────────────
+
+test('an empty prompt + ! enters shell-context; a second ! enters shell-local', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), '', 'the prefix must never enter the buffer')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  assert.equal(app.seatTextForTest(), '', 'the second prefix must never enter the buffer')
+  app.stop()
+})
+
+test('Backspace on an empty shell body steps the mode back: !! -> ! -> prompt', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), '')
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt')
+  assert.equal(app.seatTextForTest(), '')
+  app.stop()
+})
+
+test('Esc on an empty shell body returns directly to the prompt (no cancel)', async () => {
+  const { vt, app, cancels } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  await vt.waitForRender()
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt')
+  assert.equal(app.seatTextForTest(), '')
+  assert.equal(cancels, 0, 'exiting the shell mode must not fire the host cancel')
+  // Same from shell-local.
+  vt.sendInput('!')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt')
+  assert.equal(cancels, 0)
+  app.stop()
+})
+
+test('! after command text is an ordinary body character', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('ls')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), 'ls')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), 'ls!', 'a ! after body text must be inserted literally')
+  // shell-local: same rule.
+  app.setEditorText('')
+  vt.sendInput('!')
+  vt.sendInput('!')
+  vt.sendInput('ls')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  assert.equal(app.seatTextForTest(), 'ls!')
+  app.stop()
+})
+
+test('a ! typed in shell-local with an empty body is a literal body character', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('!')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local', 'no fourth mode is invented')
+  assert.equal(app.seatTextForTest(), '!', 'the third ! is ordinary body text')
+  app.stop()
+})
+
+// ── paste normalization (plan §7.6, §12.4) ───────────────────────────────
+
+test('pasting a ! line into an empty prompt enters shell-context', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!git status\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), 'git status')
+  app.stop()
+})
+
+test('pasting a !! line into an empty prompt enters shell-local', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!!git status\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  assert.equal(app.seatTextForTest(), 'git status')
+  app.stop()
+})
+
+test('pasting plain text into an empty prompt stays in prompt mode', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~hello\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt')
+  assert.equal(app.seatTextForTest(), 'hello')
+  app.stop()
+})
+
+test('a paste beginning with ! into a NON-empty editor is never reinterpreted', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('echo ')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!x\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt', 'a non-empty editor keeps prompt mode')
+  assert.equal(app.seatTextForTest(), 'echo !x', 'the pasted ! stays literal text')
+  app.stop()
+})
+
+// ── submission serialization (plan §8.1, §8.3, §12.5) ─────────────────────
+
+test('submission serializes the mode back into the exact wire form', async () => {
+  const { vt, app, submitted } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('hello')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['hello'])
+  assert.equal(app.inputModeForTest(), 'prompt', 'mode resets after an accepted submit')
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['hello', '!pwd'])
+  assert.equal(app.inputModeForTest(), 'prompt')
+  vt.sendInput('!')
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['hello', '!pwd', '!!pwd'])
+  assert.equal(app.inputModeForTest(), 'prompt')
+  app.stop()
+})
+
+test('a rejected submission restores the serialized text AND the mode', async () => {
+  const { vt, app, submitted } = startApp(fixtureWorkspace(), {
+    onSubmit: (text) => {
+      // Simulate the runner's divergence-guard rejection: the draft comes
+      // back through setEditorText with the serialized wire form.
+      app.setEditorText(text)
+    },
+  })
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['!pwd'])
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the rejected shell draft keeps its mode')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  app.stop()
+})
+
+// ── history (plan §8.4–8.6, §12.7) ────────────────────────────────────────
+
+test('history recall decodes serialized entries into mode + body', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  app.seedInputHistory(['!!pwd', '!pwd', 'hello'])
+  vt.sendInput('\x1b[A') // ↑: most recent entry
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  vt.sendInput('\x1b[A') // ↑: older entry
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  vt.sendInput('\x1b[A') // ↑: oldest entry
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt')
+  assert.equal(app.seatTextForTest(), 'hello')
+  app.stop()
+})
+
+test('history draft restore returns the ORIGINAL mode with the draft', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  app.seedInputHistory(['!!pwd', '!pwd'])
+  vt.sendInput('hello')
+  await vt.waitForRender()
+  // The fork's ↑ on a non-empty line first moves the cursor to the line
+  // start; the second ↑ enters history browsing (kimi parity).
+  vt.sendInput('\x1b[A')
+  vt.sendInput('\x1b[A') // ↑: recall !!pwd
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  vt.sendInput('\x1b[B') // ↓: back to the draft
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt', 'the prompt draft must not come back in shell mode')
+  assert.equal(app.seatTextForTest(), 'hello')
+  app.stop()
+})
+
+test('a shell draft restores its shell mode after history browsing', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  app.seedInputHistory(['!!pwd'])
+  vt.sendInput('!')
+  vt.sendInput('git st')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  vt.sendInput('\x1b[A')
+  vt.sendInput('\x1b[A') // ↑: recall !!pwd
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  vt.sendInput('\x1b[B') // ↓: back to the shell draft
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the shell draft keeps its mode')
+  assert.equal(app.seatTextForTest(), 'git st')
+  app.stop()
+})
+
+// ── completion (plan §9, §12.8) ───────────────────────────────────────────
+
+test('shell command completion works in both shell modes and never writes the prefix', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('gi')
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'git', 'command candidates in shell-context')
+  vt.sendInput('\t') // accept the first item
+  await vt.waitForRender()
+  assert.ok(app.seatTextForTest().startsWith('git'), `the applied completion must be a git command:\n${app.seatTextForTest()}`)
+  assert.ok(!app.seatTextForTest().includes('!'), 'the synthetic prefix must never enter the buffer')
+  // shell-local: same completion path.
+  app.setEditorText('')
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('!')
+  vt.sendInput('gi')
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'git', 'command candidates in shell-local')
+  vt.sendInput('\t')
+  await vt.waitForRender()
+  assert.ok(app.seatTextForTest().startsWith('git'))
+  assert.ok(!app.seatTextForTest().includes('!'))
+  app.stop()
+})
+
+test('a leading / in a shell mode is a PATH, never a slash command', async () => {
+  const { vt, app } = startApp(fixtureWorkspace(), {
+    commands: [{ name: 'image', description: 'Attach an image file' }],
+  })
+  await vt.waitForRender()
+  vt.sendInput('!')
+  // Natural typing of a path: the slash-command list must NOT appear.
+  vt.sendInput('/usr/lo')
+  await vt.waitForRender()
+  await new Promise(resolve => setTimeout(resolve, 80))
+  const view = vt.getViewport().join('\n')
+  assert.ok(!view.includes('image'), `a shell-mode path must not open the slash-command list:\n${view}`)
+  // Tab completes the path instead.
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'local', 'path completion for /usr/lo in shell mode')
+  app.stop()
+})
+
+test('prompt-mode slash completion is unchanged', async () => {
+  const { vt, app } = startApp(fixtureWorkspace(), {
+    commands: [{ name: 'image', description: 'Attach an image file' }],
+  })
+  await vt.waitForRender()
+  vt.sendInput('/im')
+  await waitForDropdownRow(vt, 'image', 'slash-command completion in prompt mode')
+  app.stop()
+})
+
+// ── rendering (plan §10, §12.9) ───────────────────────────────────────────
+
+/** The viewport row index of the editor's FIRST CONTENT row (the row the
+ * mode prompt is painted on): the editor's top border row + 1. */
+function editorContentRow(vt: VirtualTerminal): number {
+  const lines = vt.getViewport()
+  // The editor is the bottom-most bordered block: find its top border —
+  // the last row of `─` that is followed by a non-border content row.
+  for (let row = lines.length - 2; row >= 0; row -= 1) {
+    const line = lines[row] ?? ''
+    if (line.trim() === '' || !/^─+$/.test(line.trim())) continue
+    const next = lines[row + 1] ?? ''
+    if (next.trim() !== '' && !/^─+$/.test(next.trim())) return row + 1
+  }
+  assert.fail(`editor content row not found:\n${lines.join('\n')}`)
+}
+
+test('the mode prompt renders as ❯ / ! / !! with the right colors', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  const promptRow = editorContentRow(vt)
+  let view = vt.getViewport()
+  assert.ok(view[promptRow]!.startsWith('❯ '), `prompt mode must render ❯:\n${view.join('\n')}`)
+  assert.equal(vt.getCellFgRgb(promptRow, 0), 0x679efe, 'the ❯ must be brand blue (roleUser)')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  view = vt.getViewport()
+  assert.ok(view[promptRow]!.startsWith('! '), `shell-context must render !:\n${view.join('\n')}`)
+  assert.equal(vt.getCellFgRgb(promptRow, 0), 0xbd93f9, 'the ! must use the shellMode color')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  view = vt.getViewport()
+  assert.ok(view[promptRow]!.startsWith('!!'), `shell-local must render !!:\n${view.join('\n')}`)
+  assert.equal(vt.getCellFgRgb(promptRow, 0), 0xbd93f9, 'the !! must use the shellMode color')
+  app.stop()
+})
+
+test('the shell border uses the shellMode color; the prompt border the normal one', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  const promptRow = editorContentRow(vt)
+  const borderRow = promptRow - 1
+  assert.equal(vt.getCellFgRgb(borderRow, 0), 0x5a5a5a, 'prompt-mode border uses the normal border color')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(vt.getCellFgRgb(borderRow, 0), 0xbd93f9, 'shell-mode border uses the shellMode color')
+  app.stop()
+})
+
+test('no duplicate prefix is ever rendered', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('ls')
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(!view.includes('! !ls'), `no duplicated prefix:\n${view}`)
+  assert.ok(!view.includes('❯ !ls'), `no prompt-plus-shell marker:\n${view}`)
+  app.stop()
+})
+
+// ── Esc / autocomplete priority (plan §4.4, §12.10) ───────────────────────
+
+test('Esc closes the autocomplete menu first and keeps the shell mode', async () => {
+  const { vt, app, cancels } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('gi')
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'git', 'command candidates before Esc')
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  await waitForNoDropdownRow(vt, 'git', 'dropdown after Esc')
+  assert.equal(app.inputModeForTest(), 'shell-context', 'Esc must not exit the shell mode while the menu was open')
+  assert.equal(app.seatTextForTest(), 'gi', 'Esc must not alter the body')
+  assert.equal(cancels, 0, 'closing the dropdown must not fire the host cancel')
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -10,7 +10,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { mkdtempSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { TuiApp, type SubagentViewerTarget } from '../src/tui-app.ts'
@@ -18,11 +18,30 @@ import { EditorRegistry } from '../src/editor-registry.ts'
 import { EditorSeatHolder } from '../src/editor-seat-holder.ts'
 import { Text } from '@xmoon76/pi-tui'
 import type { EditorHost, ExtensionEditor } from '../src/extension/public-types.ts'
+import { runOwned, type OwnedTaskOptions } from '../src/detached.ts'
+import { createDiag } from '../src/diag.ts'
+import { resetCommandCacheForTest, setCompgenRunnerForTest } from '../src/shell-completion.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
+
+/** The owned-task entry the runner wires in production (real runOwned,
+ * silent capture diag). */
+const diag = createDiag({ filePath: undefined, stderrLevel: 'off' })
+const owned = <T>(label: string, task: () => T | Promise<T>, options: Omit<OwnedTaskOptions<T>, 'diag' | 'sessionId'>): void => {
+  runOwned(label, task, { ...options, diag })
+}
 
 /** A throwaway workspace (completion fixtures live under the cwd). */
 function fixtureWorkspace(): string {
   return mkdtempSync(join(tmpdir(), 'dsh-shell-mode-'))
+}
+
+/** A workspace with one file (Tab completion dropdowns need candidates). */
+function fixtureWithFiles(): string {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-shell-mode-files-'))
+  writeFileSync(join(root, 'notes.txt'), 'x')
+  mkdirSync(join(root, 'src'))
+  writeFileSync(join(root, 'src', 'deep.ts'), 'x')
+  return root
 }
 
 function startApp(
@@ -58,6 +77,29 @@ function continuableViewer(): SubagentViewerTarget {
     label: 'research',
     mode: 'continuable',
     activity: 'inactive',
+  }
+}
+
+/** A one-shot (read-only) subagent viewer target. */
+function oneShotViewer(): SubagentViewerTarget {
+  return {
+    parentSessionId: 'session-main',
+    childSessionId: 'child-1',
+    label: 'research',
+    mode: 'one-shot',
+    activity: 'running',
+  }
+}
+
+/** Poll until the predicate is true (asserts on failure). */
+async function pollUntil(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 3000
+  for (;;) {
+    if (predicate()) return
+    if (Date.now() > deadline) {
+      assert.fail(`${label}: condition never became true`)
+    }
+    await new Promise(resolve => setTimeout(resolve, 10))
   }
 }
 
@@ -809,7 +851,7 @@ test('a busy Esc cancels BEFORE a consuming plugin editor sees it', async () => 
   app.stop()
 })
 
-test('a plugin-to-host restore shifts the cursor by the wire prefix in the TEXT', () => {
+test('a legacy host restore keeps the cursor in WIRE coordinates (raw ! stays in the text)', () => {
   const host = {
     text: '',
     cursor: 0,
@@ -841,7 +883,85 @@ test('a plugin-to-host restore shifts the cursor by the wire prefix in the TEXT'
   plugin.setCursor(3)
   holder.handoff(undefined)
   assert.equal(host.text, '!pwd', 'the wire draft survives the restore')
-  assert.equal(host.cursor, 2, 'the cursor shifts back by the text-derived prefix length')
+  assert.equal(host.cursor, 3,
+    'a legacy RAW restore keeps the `!` in the document — the cursor stays in wire coordinates')
+  holder.dispose()
+})
+
+test('a decoding host restore shifts the cursor by the actually stripped prefix', () => {
+  const host = {
+    text: '',
+    cursor: 0,
+    getText: () => host.text,
+    setText: (text: string) => { host.text = text },
+    setTextAndCursor: (text: string, cursor: number) => { host.text = text; host.cursor = cursor },
+    getCursor: () => host.cursor,
+    setCursor: (offset: number) => { host.cursor = offset },
+    focused: true,
+    borderColor: (text: string) => text,
+    invalidate: () => {},
+    addToHistory: () => {},
+    clearHistory: () => {},
+    // A full adapter decodes the wire form (mode + body).
+    setSerializedInput: (text: string) => {
+      host.text = text.startsWith('!!') ? text.slice(2) : text.startsWith('!') ? text.slice(1) : text
+    },
+    component: new Text('host', 0, 0),
+  }
+  const holder = new EditorSeatHolder({
+    hostAdapter: () => host,
+    surfaceId: 'test-surface',
+    generation: () => 1,
+    actionSink: () => false,
+    notifyError: () => {},
+    viewSwap: () => {},
+  })
+  const plugin = pluginEditor()
+  holder.handoff({ id: 'plugin', create: () => plugin })
+  plugin.setText('!pwd')
+  plugin.setCursor(3)
+  holder.handoff(undefined)
+  assert.equal(host.text, 'pwd', 'the decode strips the wire prefix')
+  assert.equal(host.cursor, 2, 'the cursor shifts back by the actually stripped prefix')
+  holder.dispose()
+})
+
+test('a host prompt-mode literal ! is a document character (never shifted on handoff)', () => {
+  const host = {
+    text: '!literal',
+    cursor: 4,
+    getText: () => host.text,
+    setText: (text: string) => { host.text = text },
+    setTextAndCursor: (text: string, cursor: number) => { host.text = text; host.cursor = cursor },
+    getCursor: () => host.cursor,
+    setCursor: (offset: number) => { host.cursor = offset },
+    focused: true,
+    borderColor: (text: string) => text,
+    invalidate: () => {},
+    addToHistory: () => {},
+    clearHistory: () => {},
+    getInputMode: () => 'prompt' as const,
+    component: new Text('host', 0, 0),
+  }
+  const holder = new EditorSeatHolder({
+    hostAdapter: () => host,
+    surfaceId: 'test-surface',
+    generation: () => 1,
+    actionSink: () => false,
+    notifyError: () => {},
+    viewSwap: () => {},
+  })
+  const created: ReturnType<typeof pluginEditor>[] = []
+  holder.handoff({
+    id: 'plugin',
+    create: () => {
+      const editor = pluginEditor()
+      created.push(editor)
+      return editor
+    },
+  })
+  assert.equal(created[0]!.getText(), '!literal', 'a prompt-mode draft transfers verbatim')
+  assert.equal(created[0]!.cursor, 4, 'a prompt-mode literal ! is a document character — the cursor never shifts')
   holder.dispose()
 })
 
@@ -961,5 +1081,201 @@ test('a consumed onSingleEscape disarms the pending double-Esc window', async ()
   vt.sendInput('\x1b') // not consumed again → must ARM, never cancel
   await vt.waitForRender()
   assert.equal(cancels, 0, 'a consumed onSingleEscape must disarm the stale window')
+  app.stop()
+})
+
+// ── PR review round: external editor wire boundary ─────────────────────────
+
+test('the external editor round-trips the WIRE form (shell modes switchable in $EDITOR)', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const submitted: string[] = []
+  let seenDraft = ''
+  const app = new TuiApp(vt, {
+    onSubmit: (text) => submitted.push(text),
+    onExit: () => {},
+    openExternalEditor: async (draft) => { seenDraft = draft; return '!!pwd' },
+    runOwned: owned,
+  })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  await vt.waitForRender()
+  vt.sendInput('\x07') // ctrl+g
+  await pollUntil(() => seenDraft !== '', 'external editor round-trip')
+  assert.equal(seenDraft, '!pwd', 'the $EDITOR sees the WIRE form, never the bare body')
+  // The user switched `!` → `!!` in $EDITOR: the decode follows.
+  assert.equal(app.inputModeForTest(), 'shell-local', 'the saved wire form decodes back into the mode')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['!!pwd'], 'the edited wire form submits with its new mode')
+  app.stop()
+})
+
+test('a prompt-mode draft edited into a shell line in $EDITOR comes back as shell mode', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: (text) => submitted.push(text),
+    onExit: () => {},
+    openExternalEditor: async () => '!pwd',
+    runOwned: owned,
+  })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('hello')
+  await vt.waitForRender()
+  vt.sendInput('\x07') // ctrl+g → $EDITOR rewrites the draft into a shell line
+  await pollUntil(() => app.seatTextForTest() !== 'hello', 'external editor round-trip')
+  assert.equal(app.inputModeForTest(), 'shell-context', 'a ! line written in $EDITOR enters shell mode')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['!pwd'], 'the shell line submits as a shell command')
+  app.stop()
+})
+
+// ── PR review round: paste/undo invariant ─────────────────────────────────
+
+test('undo after a normalized paste never resurrects the raw prefix in the document', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!!git status\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  assert.equal(app.seatTextForTest(), 'git status')
+  // Ctrl+-: the base editor's undo snapshots contain the NORMALIZED body
+  // (the prefix was stripped before insertion), so undo restores the
+  // pre-paste document — never `shell-local + "!!git status"`.
+  vt.sendInput('\x1f')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '', 'undo restores the pre-paste document')
+  assert.ok(!app.seatTextForTest().includes('!!'), 'the raw prefix must never re-enter the document')
+  app.stop()
+})
+
+test('a large shell paste (>10 lines) enters the shell mode through the paste registry', async () => {
+  const { vt, app, submitted } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  const lines = Array.from({ length: 12 }, (_, index) => `git log ${index}`)
+  vt.sendInput(`\x1b[200~!!${lines.join('\n')}\x1b[201~`)
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local', 'a large !! paste enters shell-local BEFORE the registry marker')
+  const body = app.seatTextForTest()
+  assert.ok(!body.startsWith('!!'), 'the raw prefix must not survive in the document')
+  assert.ok(body.startsWith('[paste #'), `large pastes keep the fork registry marker:\n${body}`)
+  vt.sendInput('\r')
+  assert.equal(submitted.length, 1)
+  assert.ok(submitted[0]!.startsWith('!!'), 'the submitted wire form keeps the shell prefix')
+  assert.ok(submitted[0]!.includes('git log 0'), 'the expanded paste body is the stripped command text')
+  assert.ok(!submitted[0]!.includes('\n!!'), 'no raw prefix survives inside the expanded body')
+  app.stop()
+})
+
+// ── PR review round: mode transitions cancel the open dropdown ────────────
+
+test('a prompt-mode dropdown closes when ! enters shell mode', async () => {
+  const { vt, app } = startApp(fixtureWithFiles())
+  await vt.waitForRender()
+  vt.sendInput('\t') // prompt-mode Tab: cwd file completion
+  await waitForDropdownRow(vt, 'notes.txt', 'file completion in prompt mode')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  await waitForNoDropdownRow(vt, 'notes.txt', 'dropdown after entering shell mode')
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the mode still transitions')
+  app.stop()
+})
+
+test('a shell-mode dropdown closes when Backspace returns to the prompt', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  // Deterministic command list (the empty-prefix list is capped at 50 and
+  // locale-sorted — a fixed fake keeps the dropdown content stable).
+  setCompgenRunnerForTest((_cwd, expression) => Promise.resolve({
+    ok: true,
+    lines: expression.includes('compgen -A command') ? ['git', 'gist', 'grep'] : [],
+  }))
+  try {
+    vt.sendInput('!')
+    await vt.waitForRender()
+    vt.sendInput('\t') // shell Tab with an empty prefix: the command list
+    await waitForDropdownRow(vt, 'git', 'shell command dropdown')
+    vt.sendInput('\x7f') // backspace on the empty shell body
+    await vt.waitForRender()
+    await waitForNoDropdownRow(vt, 'git', 'dropdown after the mode step-back')
+    assert.equal(app.inputModeForTest(), 'prompt', 'the mode steps back to the prompt')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  app.stop()
+})
+
+// ── PR review round: one-shot viewer mode ─────────────────────────────────
+
+test('a one-shot viewer resets the host editor to prompt mode and restores the shell draft on exit', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('git status')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  app.setViewerMode(oneShotViewer())
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt', 'the read-only placeholder bar must not inherit the shell mode')
+  assert.ok(app.seatTextForTest().includes('viewing subagent'), 'the placeholder bar shows')
+  app.setViewerMode(undefined)
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the preserved serialized main draft restores the shell mode')
+  assert.equal(app.seatTextForTest(), 'git status')
+  app.stop()
+})
+
+// ── PR review round: Stable autocomplete query keeps the wire document ────
+
+test('the Stable autocomplete extension query keeps the WIRE document in shell modes', async () => {
+  const queries: { lines: readonly string[]; cursorCol: number }[] = []
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async (query) => {
+    queries.push({ lines: [...query.lines], cursorCol: query.cursorCol })
+    return null
+  })
+  app.start()
+  await vt.waitForRender()
+  // Force the host provider to return null (a failed compgen run), so the
+  // plugin chain is consulted.
+  setCompgenRunnerForTest(() => Promise.resolve({ ok: false, lines: [] }))
+  try {
+    // shell-context: the plugin must see the WIRE line `!gi`, never `gi`.
+    vt.sendInput('!')
+    vt.sendInput('gi')
+    vt.sendInput('\t')
+    await pollUntil(() => queries.length === 1, 'extension query in shell-context')
+    assert.deepEqual([...queries[0]!.lines], ['!gi'], 'a shell-context body reaches the plugin as the wire line')
+    assert.equal(queries[0]!.cursorCol, 3, 'the cursor shifts by the synthetic prefix')
+    // shell-local: `!!gi`.
+    app.setEditorText('')
+    await vt.waitForRender()
+    vt.sendInput('!')
+    vt.sendInput('!')
+    vt.sendInput('gi')
+    vt.sendInput('\t')
+    await pollUntil(() => queries.length === 2, 'shell query in shell-local')
+    assert.deepEqual([...queries[1]!.lines], ['!!gi'])
+    assert.equal(queries[1]!.cursorCol, 4)
+    // prompt mode: the body is the wire document as-is.
+    app.setEditorText('')
+    await vt.waitForRender()
+    vt.sendInput('gi')
+    vt.sendInput('\t')
+    await pollUntil(() => queries.length === 3, 'prompt-mode query')
+    assert.deepEqual([...queries[2]!.lines], ['gi'])
+    assert.equal(queries[2]!.cursorCol, 2)
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
   app.stop()
 })

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -890,3 +890,76 @@ test('a plugin editor that DECLINES Esc still arms the host double-Esc cancel', 
   app.reconcileEditorNow()
   app.stop()
 })
+
+// ── review round 8: a CONSUMED Esc disarms the pending double-Esc window ──
+
+test('a consumed plugin Esc disarms a window armed by a prior declined Esc', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  let cancels = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels += 1 },
+  }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  // A plugin that DECLINES the first Esc (arming the host window) and
+  // CONSUMES every later one (vim entering normal mode).
+  let escCount = 0
+  const handle = registry.register({
+    id: 'esc-mixed-plugin',
+    priority: 0,
+    create: () => ({
+      component: { kind: 'text', spans: [{ text: '' }] },
+      getText: () => '',
+      setText: () => {},
+      getCursor: () => 0,
+      setCursor: () => {},
+      get focused() { return false },
+      borderColor: (text: string) => text,
+      handleInput: () => { escCount += 1; return escCount > 1 },
+      dispose: () => {},
+    }),
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // declined → the host window arms
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // consumed → the window must disarm
+  await vt.waitForRender()
+  // The plugin is removed; a fresh host Esc must ARM, never cancel.
+  handle.dispose()
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(cancels, 0, 'a consumed Esc must disarm the stale window')
+  app.stop()
+})
+
+test('a consumed onSingleEscape disarms the pending double-Esc window', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  let cancels = 0
+  let escCount = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels += 1 },
+    // The runner-owned mode consumes ONLY the second Esc (e.g. a viewer
+    // that opened between the presses).
+    onSingleEscape: () => { escCount += 1; return escCount === 2 },
+  })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // not consumed → the host window arms
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // consumed by onSingleEscape → the window must disarm
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // not consumed again → must ARM, never cancel
+  await vt.waitForRender()
+  assert.equal(cancels, 0, 'a consumed onSingleEscape must disarm the stale window')
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1939,3 +1939,30 @@ test('completion uses the VISIBLE seat mode — a hidden host shell mode never l
   app.reconcileEditorNow()
   app.stop()
 })
+
+// ── review round: advanced editor controls honor the shell boundary ───────
+
+test('advanced editor controls replace a shell-mode draft through the wire boundary', async () => {
+  const { vt, app, submitted } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  // A plugin replaces the draft with PLAIN text: the serialized decode
+  // must clear the shell mode, so the replacement submits as prose.
+  app.advancedEditorControls().setEditorText('plain prose')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt', 'a raw replacement must not keep the stale shell mode')
+  assert.equal(app.seatTextForTest(), 'plain prose')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['plain prose'], 'the replacement submits as plain text, never as a shell command')
+  // Replacing with a SERIALIZED draft re-enters the shell mode.
+  app.advancedEditorControls().setEditorText('!pwd')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'a serialized replacement decodes into the shell mode')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['plain prose', '!pwd'])
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -2067,9 +2067,13 @@ test('a replacement plugin Tab runs the shell completion grammar of the wire doc
     vt.sendInput('\t')
     await pollUntil(() => compgenCalls === 1, 'the shell compgen ran through the plugin seat')
     // The dropdown opens asynchronously inside the hidden host editor;
-    // the second Tab applies its selection synchronously and the fallback
-    // syncs the completed command back into the plugin wire document.
-    await new Promise(resolve => setTimeout(resolve, 50))
+    // waitForRender (the repository's settle helper: nextTick + 20ms
+    // flush) drains the completion microtask chain AND the render
+    // pipeline, so the second Tab deterministically hits an OPEN
+    // dropdown — no fixed-delay race. It then applies its selection
+    // synchronously and the fallback syncs the completed command back
+    // into the plugin wire document.
+    await vt.waitForRender()
     vt.sendInput('\t')
     await pollUntil(() => plugin.getText() === '!git ',
       'the shell completion applies into the plugin wire document')

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -218,6 +218,28 @@ test('a paste beginning with ! into a NON-empty editor is never reinterpreted', 
   app.stop()
 })
 
+test('a paste beginning with ! into an EMPTY shell mode is literal body text', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!') // shell-context, empty body
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!echo\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the shell mode is unchanged')
+  assert.equal(app.seatTextForTest(), '!echo', 'the pasted ! is body text, never re-parsed as a prefix')
+  // shell-local: same rule.
+  app.setEditorText('')
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('!')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!!echo\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  assert.equal(app.seatTextForTest(), '!!echo', 'the pasted !! is body text in shell-local')
+  app.stop()
+})
+
 // ── submission serialization (plan §8.1, §8.3, §12.5) ─────────────────────
 
 test('submission serializes the mode back into the exact wire form', async () => {
@@ -353,12 +375,12 @@ test('a leading / in a shell mode is a PATH, never a slash command', async () =>
   })
   await vt.waitForRender()
   vt.sendInput('!')
-  // Natural typing of a path: the slash-command list must NOT appear.
+  // Natural typing of a path: the slash-command list must NOT appear
+  // (polled — the natural trigger's async work settles within the
+  // deadline, and the row must never show).
   vt.sendInput('/usr/lo')
   await vt.waitForRender()
-  await new Promise(resolve => setTimeout(resolve, 80))
-  const view = vt.getViewport().join('\n')
-  assert.ok(!view.includes('image'), `a shell-mode path must not open the slash-command list:\n${view}`)
+  await waitForNoDropdownRow(vt, 'image', 'a shell-mode path must not open the slash-command list')
   // Tab completes the path instead.
   vt.sendInput('\t')
   await waitForDropdownRow(vt, 'local', 'path completion for /usr/lo in shell mode')

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1804,3 +1804,43 @@ test('provider-level: a continuation-line /u applies as a path on any shell line
   const natural = await provider.getSuggestions(['git status', '/u'], 1, 2, { signal: abort })
   assert.equal(natural, null)
 })
+
+// ── review round: extension suppression covers continuation lines ─────────
+
+test('the extension chain is NOT consulted on a continuation-line natural / trigger (only Tab)', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  let queries = 0
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async () => {
+    queries += 1
+    return {
+      items: [
+        { value: '/zzz-no-such-dir/', label: 'zzz-no-such-dir' },
+        { value: '/zzz-no-such-file', label: 'zzz-no-such-file' },
+      ],
+      prefix: '/zzz-no-such',
+    }
+  })
+  app.start()
+  await vt.waitForRender()
+  setCompgenRunnerForTest(() => Promise.resolve({ ok: false, lines: [] }))
+  try {
+    // A multiline shell draft: natural typing of a path on the
+    // CONTINUATION line must not consult the plugin chain.
+    vt.sendInput('!')
+    vt.sendInput('git status')
+    vt.sendInput('\n')
+    vt.sendInput('/zzz-no-such')
+    await vt.waitForRender()
+    await waitForNoDropdownRow(vt, 'zzz-no-such-dir', 'no extension dropdown during continuation-line typing')
+    assert.equal(queries, 0, 'a continuation-line natural / trigger never consults the plugin chain')
+    // Tab (force) still consults it with the wire document.
+    vt.sendInput('\t')
+    await waitForDropdownRow(vt, 'zzz-no-such-dir', 'extension suggestion on the continuation line via Tab')
+    assert.equal(queries, 1, 'Tab consults the plugin chain exactly once')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1279,3 +1279,69 @@ test('the Stable autocomplete extension query keeps the WIRE document in shell m
   }
   app.stop()
 })
+
+// ── review round: paste chunk boundaries + autocomplete reopen ────────────
+
+test('input before the opening marker in the same chunk enters the shell mode first', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  // `!` and the paste arrive in ONE chunk: the `!` must go through the
+  // interception chain (enter shell-context) BEFORE the paste lands.
+  vt.sendInput('!\x1b[200~cmd\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the leading ! must enter the shell mode')
+  assert.equal(app.seatTextForTest(), 'cmd', 'the paste lands as the shell body')
+  app.stop()
+})
+
+test('trailing keys after the closing marker go through the full interception chain', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!git status\x1b[201~x')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), 'git statusx', 'the trailing key appends as ordinary input')
+  // A trailing `!` must NOT be swallowed or re-parsed — it is body text.
+  app.setEditorText('')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!echo\x1b[201~!')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  assert.equal(app.seatTextForTest(), 'echo!', 'a trailing ! after the paste is a literal body character')
+  app.stop()
+})
+
+test('a paste opening marker split across chunks is stitched back together', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('\x1b[20') // first half of \x1b[200~
+  await vt.waitForRender()
+  vt.sendInput('0~!git status\x1b[201~') // second half + the paste
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the split opening marker must still open the paste')
+  assert.equal(app.seatTextForTest(), 'git status')
+  app.stop()
+})
+
+test('a paste closing marker split across chunks is stitched back together', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('\x1b[200~!git status\x1b[201') // closing marker without its final ~
+  await vt.waitForRender()
+  vt.sendInput('~')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the split closing marker must still close the paste')
+  assert.equal(app.seatTextForTest(), 'git status')
+  app.stop()
+})
+
+test('a pasted @dir/ path reopens the mention dropdown like ordinary input', async () => {
+  const { vt, app } = startApp(fixtureWithFiles())
+  await vt.waitForRender()
+  // Paste `@src/`: the reopen runs AFTER the paste landed, so the
+  // dropdown shows the directory children exactly like typed input.
+  vt.sendInput('\x1b[200~@src/\x1b[201~')
+  await waitForDropdownRow(vt, 'deep.ts', 'mention dropdown after a pasted @dir/')
+  assert.equal(app.seatTextForTest(), '@src/')
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -14,6 +14,8 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { TuiApp, type SubagentViewerTarget } from '../src/tui-app.ts'
+import { EditorRegistry } from '../src/editor-registry.ts'
+import type { EditorHost, ExtensionEditor } from '../src/extension/public-types.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 /** A throwaway workspace (completion fixtures live under the cwd). */
@@ -530,5 +532,100 @@ test('a bare ! reaches the child via the subagent submit path', async () => {
   assert.equal(childSubmits.length, 1, 'a bare ! in the viewer must submit to the child')
   assert.equal(childSubmits[0]!.text, '!', 'the child receives the serialized wire form')
   assert.equal(app.inputModeForTest(), 'prompt', 'mode resets after the child submit')
+  app.stop()
+})
+
+// ── review round 3: plugin handoff (the wire form round-trips) ────────────
+
+/** A minimal plugin editor (the editor-registry test shape). */
+function pluginEditor(initial = ''): ExtensionEditor & { text: string; disposed: boolean } {
+  const state = { text: initial, disposed: false }
+  return {
+    get component() { return { kind: 'text' as const, spans: [{ text: state.text }] } },
+    getText: () => state.text,
+    setText: (text) => { state.text = text },
+    getCursor: () => 0,
+    setCursor: () => {},
+    get focused() { return false },
+    borderColor: (text) => text,
+    dispose: () => { state.disposed = true },
+    get text() { return state.text },
+    get disposed() { return state.disposed },
+  }
+}
+
+test('a shell-mode draft round-trips through a plugin editor handoff with its mode', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text) => submitted.push(text), onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  // The plugin editor wins the seat: the handoff transfers the WIRE form.
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'handoff-plugin',
+    priority: 0,
+    create: (_host: EditorHost) => {
+      const editor = pluginEditor()
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  assert.equal(created.length, 1)
+  assert.equal(created[0]!.getText(), '!pwd', 'the plugin document is the wire form')
+  // Unload: the host restores and DECODES the wire form back into mode + body.
+  handle.dispose()
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the shell mode survives the handoff round-trip')
+  assert.equal(app.seatTextForTest(), 'pwd')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['!pwd'], 'the restored shell draft submits its wire form')
+  app.stop()
+})
+
+test('a plugin draft without a shell prefix restores in PROMPT mode (no stale !)', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text) => submitted.push(text), onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  // Enter shell mode, then let the plugin take over and REPLACE the draft
+  // with plain prose.
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'handoff-plugin-2',
+    priority: 0,
+    create: (_host: EditorHost) => {
+      const editor = pluginEditor()
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  created[0]!.setText('echo')
+  // Unload: the host restores the plugin's text — WITHOUT the stale shell
+  // mode, so `echo` submits as plain prose, never `!echo`.
+  handle.dispose()
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt', 'a prefix-free plugin draft must not inherit the shell mode')
+  assert.equal(app.seatTextForTest(), 'echo')
+  vt.sendInput('\r')
+  assert.deepEqual(submitted, ['echo'], 'the plugin draft submits as plain text')
   app.stop()
 })

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1449,3 +1449,42 @@ test('MentionProvider completes a multiline shell draft with the wire line-0 pre
   const applied = provider.applyCompletion(['git', 'more'], 1, 4, { value: 'x', label: 'x' }, 'more')
   assert.deepEqual(applied, { lines: ['git', 'x'], cursorLine: 1, cursorCol: 1 })
 })
+
+// ── review round: Ctrl+C clears the shell mode with the body ──────────────
+
+test('Ctrl+C clears BOTH the shell body and the mode (prompt returns)', async () => {
+  const { vt, app } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('pwd')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  vt.sendInput('\x03') // ctrl+c: first press clears
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '', 'the body clears')
+  assert.equal(app.inputModeForTest(), 'prompt', 'the shell mode clears with the body — no stale `! ` prompt')
+  app.stop()
+})
+
+test('Ctrl+C on a BARE ! (empty body, shell mode) clears the mode and arms the exit window', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  let exits = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => { exits += 1 },
+  })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('!')
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  vt.sendInput('\x03') // ctrl+c: the serialized draft is non-empty (the `!` prefix)
+  await vt.waitForRender()
+  assert.equal(app.inputModeForTest(), 'prompt', 'the first press clears the bare shell mode')
+  assert.equal(exits, 0, 'the first press only arms the exit window')
+  vt.sendInput('\x03') // second press within the window: exit
+  await vt.waitForRender()
+  assert.equal(exits, 1, 'the second press exits')
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1745,3 +1745,62 @@ test('an incomplete CSI tail buffers without loss and stitches a split sequence'
   assert.equal(app.seatTextForTest(), '', 'a stitched split CSI is handled as the key, never as text')
   app.stop()
 })
+
+// ── PR review round 3: multiline shell continuation lines are shell-owned ─
+
+test('a continuation-line /u in shell-context is a PATH (no slash commands, no doubled slash)', async () => {
+  const { vt, app } = startApp(fixtureWorkspace(), {
+    commands: [{ name: 'image', description: 'Attach an image file' }],
+  })
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('git status')
+  vt.sendInput('\n') // continuation line
+  vt.sendInput('/u')
+  await vt.waitForRender()
+  // Natural typing on line 1 must NOT open the slash-command list.
+  await waitForNoDropdownRow(vt, 'image', 'no slash commands on a shell continuation line')
+  assert.equal(app.inputModeForTest(), 'shell-context')
+  // Tab completes the PATH on line 1.
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'usr', 'path completion for /u on line 1')
+  vt.sendInput('\t') // accept /usr/
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), 'git status\n/usr/',
+    'the accepted path must not double the slash on a continuation line')
+  app.stop()
+})
+
+test('a continuation-line /u in shell-local is a PATH (no slash commands, no doubled slash)', async () => {
+  const { vt, app } = startApp(fixtureWorkspace(), {
+    commands: [{ name: 'image', description: 'Attach an image file' }],
+  })
+  await vt.waitForRender()
+  vt.sendInput('!')
+  vt.sendInput('!')
+  vt.sendInput('git status')
+  vt.sendInput('\n')
+  vt.sendInput('/u')
+  await vt.waitForRender()
+  await waitForNoDropdownRow(vt, 'image', 'no slash commands on a shell-local continuation line')
+  assert.equal(app.inputModeForTest(), 'shell-local')
+  vt.sendInput('\t')
+  await waitForDropdownRow(vt, 'usr', 'path completion for /u on line 1 in shell-local')
+  vt.sendInput('\t')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), 'git status\n/usr/', 'shell-local accepts the path without a doubled slash')
+  app.stop()
+})
+
+test('provider-level: a continuation-line /u applies as a path on any shell line', async () => {
+  const root = fixtureWorkspace()
+  const provider = new MentionProvider([], root, null, () => 'shell-context' as const)
+  const applied = provider.applyCompletion(['git status', '/u'], 1, 2, { value: '/usr/', label: 'usr' }, '/u')
+  assert.deepEqual(applied, { lines: ['git status', '/usr/'], cursorLine: 1, cursorCol: 5 },
+    'the synthetic prefix never enters a continuation line and the slash is never doubled')
+  // shouldTriggerFileCompletion allows Tab on the continuation line.
+  assert.equal(provider.shouldTriggerFileCompletion(['git status', '/u'], 1, 2), true)
+  // Natural triggers on the continuation line stay quiet (path semantics).
+  const natural = await provider.getSuggestions(['git status', '/u'], 1, 2, { signal: abort })
+  assert.equal(natural, null)
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1600,3 +1600,48 @@ test('a Stable extension suggestion applies through the wire adapter symmetrical
   assert.equal(app.seatTextForTest(), '/zzz-no-such-dir/', 'the extension apply lands in the bare body without a doubled slash')
   app.stop()
 })
+
+// ── review round: capability-gated mode setter in the fallback ────────────
+
+test('a host adapter with setSerializedInput but WITHOUT setInputMode falls back to the raw path (declined ! preserved)', () => {
+  const host = {
+    text: '',
+    cursor: 0,
+    getText: () => host.text,
+    setText: (text: string) => { host.text = text },
+    setTextAndCursor: (text: string, cursor: number) => { host.text = text; host.cursor = cursor },
+    getCursor: () => host.cursor,
+    setCursor: (offset: number) => { host.cursor = offset },
+    // Decodes like the real adapter, but deliberately NO setInputMode —
+    // the wire round-trip must not silently discard the decoded mode.
+    setSerializedInput: (text: string) => {
+      host.text = text.startsWith('!!') ? text.slice(2) : text.startsWith('!') ? text.slice(1) : text
+    },
+    handleInput: (data: string) => {
+      if (data === '\x7f') host.text = host.text.slice(0, -1)
+      else if (data.length === 1 && data.charCodeAt(0) >= 32) host.text += data
+    },
+    focused: true,
+    borderColor: (text: string) => text,
+    invalidate: () => {},
+    addToHistory: () => {},
+    clearHistory: () => {},
+    component: new Text('host', 0, 0),
+  }
+  const holder = new EditorSeatHolder({
+    hostAdapter: () => host,
+    surfaceId: 'test-surface',
+    generation: () => 1,
+    actionSink: () => false,
+    notifyError: () => {},
+    viewSwap: () => {},
+  })
+  const plugin = pluginEditor()
+  plugin.handleInput = () => false
+  holder.handoff({ id: 'plugin', create: () => plugin })
+  // A declined `!` must be preserved in the plugin document even when the
+  // adapter is only half-capable (the raw path keeps the bytes).
+  holder.handleHostFallbackInput('!')
+  assert.equal(plugin.getText(), '!', 'a declined ! must not vanish with a partial adapter')
+  holder.dispose()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -2008,17 +2008,20 @@ test('a replacement editor submit keeps the shell wire form through the host fal
   vt.sendInput('\r')
   await vt.waitForRender()
   assert.deepEqual([...submitted], ['!pwd'], 'a replacement !pwd submit keeps the shell-context wire form')
+  assert.equal(plugin.getText(), '', 'a successful submit clears the plugin document (accepted-control)')
   // shell-local: `!!pwd` is LOCAL-ONLY — degrading it to a plain `pwd`
   // would leak the local command into the session/model.
   plugin.setText('!!pwd')
   vt.sendInput('\r')
   await vt.waitForRender()
   assert.deepEqual([...submitted], ['!pwd', '!!pwd'], 'a replacement !!pwd submit keeps the local-only wire form')
+  assert.equal(plugin.getText(), '', 'a successful submit clears the plugin seat (accepted-control)')
   // prompt-mode wire: unchanged (identity — a plugin document is raw).
   plugin.setText('plain prose')
   vt.sendInput('\r')
   await vt.waitForRender()
   assert.deepEqual([...submitted], ['!pwd', '!!pwd', 'plain prose'])
+  assert.equal(plugin.getText(), '', 'a successful submit clears the plugin seat (accepted-control)')
   handle.dispose()
   app.reconcileEditorNow()
   app.stop()
@@ -2215,6 +2218,62 @@ test('a declined pageUp/pageDown keeps the open dropdown alive (fork parity)', a
     setCompgenRunnerForTest(undefined)
     resetCommandCacheForTest()
   }
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})
+
+// ── review round: synchronous rejection restore survives the fallback ──────
+// The fork clears the host editor BEFORE onSubmit, and a SYNCHRONOUS
+// rejection (the runner's divergence-guard shape: onSubmit restores the
+// draft through the wire boundary and returns) rewrites the VISIBLE
+// plugin seat while the fallback dispatch is still on the stack. The
+// fallback tail must not clobber that restore with the post-submit empty
+// host state — the seat's change revision distinguishes "nothing
+// external touched the seat" from "explicitly rewritten", even when the
+// restored text equals the pre-dispatch document.
+
+test('a synchronous rejection restore survives the fallback sync-back', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const submitted: string[] = []
+  let app: TuiApp
+  app = new TuiApp(vt, {
+    onSubmit: (text) => {
+      submitted.push(text)
+      // Synchronous rejection: restore the draft through the wire
+      // boundary and return (the divergence-guard shape).
+      app.setEditorText(text)
+    },
+    onExit: () => {},
+  }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'sync-reject-plugin',
+    priority: 0,
+    create: () => {
+      const editor = pluginEditor()
+      editor.handleInput = () => false // decline: the host fallback owns Enter
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  const plugin = created[0]!
+  // The plugin document is the WIRE form; the restore rewrites the SAME
+  // text, so only the mutation epoch — never a text comparison — can
+  // tell the restore apart from "nothing touched the seat".
+  plugin.setText('!!pwd')
+  plugin.setCursor(plugin.getText().length)
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual([...submitted], ['!!pwd'], 'the wire form reaches the submit event')
+  assert.equal(plugin.getText(), '!!pwd',
+    'the synchronous rejection restore must survive the fallback sync-back (the post-submit empty host state must not clobber it)')
   handle.dispose()
   app.reconcileEditorNow()
   app.stop()

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -15,6 +15,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { TuiApp, type SubagentViewerTarget } from '../src/tui-app.ts'
 import { EditorRegistry } from '../src/editor-registry.ts'
+import { EditorSeatHolder } from '../src/editor-seat-holder.ts'
+import { Text } from '@xmoon76/pi-tui'
 import type { EditorHost, ExtensionEditor } from '../src/extension/public-types.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
@@ -673,4 +675,81 @@ test('task-browser routing and the footer hint follow the VISIBLE seat editor, n
   handle.dispose()
   app.reconcileEditorNow()
   app.stop()
+})
+
+// ── review round 5: sink steer serialization + adapter fallback ──────────
+
+test('the plugin action sink steers the wire form and clears the editor', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const steered: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSteer: (text) => steered.push(text),
+  }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  // A plugin editor whose document is the wire form dispatches steer.
+  let pluginHost: EditorHost | undefined
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'steer-plugin',
+    priority: 0,
+    create: (host: EditorHost) => {
+      pluginHost = host
+      const editor = pluginEditor()
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  // The handoff transferred the (empty) host draft; the user then typed
+  // a shell line into the plugin — its document is the wire form.
+  created[0]!.setText('!pwd')
+  assert.equal(pluginHost?.dispatch('steer').kind, 'accepted')
+  assert.deepEqual(steered, ['!pwd'], 'the plugin document (the wire form) steers verbatim')
+  assert.equal(created[0]!.getText(), '', 'the steer clears the plugin document')
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})
+
+test('a host adapter without setSerializedInput still receives the handoff draft (setText fallback)', () => {
+  const host = {
+    text: 'draft',
+    getText: () => host.text,
+    setText: (text: string) => { host.text = text },
+    setTextAndCursor: (text: string) => { host.text = text },
+    getCursor: () => 0,
+    setCursor: () => {},
+    focused: true,
+    borderColor: (text: string) => text,
+    invalidate: () => {},
+    addToHistory: () => {},
+    clearHistory: () => {},
+    component: new Text('host', 0, 0),
+  }
+  const holder = new EditorSeatHolder({
+    hostAdapter: () => host,
+    surfaceId: 'test-surface',
+    generation: () => 1,
+    actionSink: () => false,
+    notifyError: () => {},
+    viewSwap: () => {},
+  })
+  const plugin = pluginEditor('!pwd')
+  holder.handoff({ id: 'plugin', create: () => plugin })
+  assert.equal(holder.currentEditor().id, 'plugin')
+  assert.equal(plugin.getText(), 'draft', 'the host draft transferred to the plugin')
+  // The user edits in the plugin; the restore must land in the host even
+  // though the bare adapter has no setSerializedInput (the setText
+  // fallback — never a silently dropped draft).
+  plugin.setText('!pwd')
+  holder.handoff(undefined)
+  assert.equal(holder.currentEditor().id, 'host')
+  assert.equal(host.text, '!pwd', 'the draft must survive the restore through the setText fallback')
+  holder.dispose()
 })

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -2164,3 +2164,58 @@ test('a text change after a declined Tab cancels the stale dropdown (no stale ac
   app.reconcileEditorNow()
   app.stop()
 })
+
+test('a declined pageUp/pageDown keeps the open dropdown alive (fork parity)', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'pageup-dropdown-plugin',
+    priority: 0,
+    create: () => {
+      const editor = pluginEditor()
+      editor.handleInput = () => false // decline: the host fallback owns every key
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  const plugin = created[0]!
+  // Variable completion (uncached) so every request consults the stub.
+  let compgenCalls = 0
+  setCompgenRunnerForTest(() => {
+    compgenCalls += 1
+    return Promise.resolve({ ok: true, lines: ['git1', 'git2'] })
+  })
+  try {
+    // Tab 1: the shell dropdown opens.
+    plugin.setText('!echo $g')
+    plugin.setCursor(plugin.getText().length)
+    vt.sendInput('\t')
+    await pollUntil(() => compgenCalls === 1, 'the variable completion request ran')
+    await vt.waitForRender()
+    // pageUp is a dropdown interaction (the vendored SelectList navigates
+    // its selection on it): it must NOT force-close the dropdown, so the
+    // next Tab accepts the still-open dropdown's selection SYNCHRONOUSLY
+    // (no fresh completion request — compgenCalls stays put).
+    vt.sendInput('\x1b[5~') // pageUp
+    await vt.waitForRender()
+    const callsAfterPageUp = compgenCalls
+    vt.sendInput('\t')
+    await pollUntil(() => plugin.getText() !== '!echo $g',
+      'the pageUp-surviving dropdown accepts on the next Tab')
+    assert.equal(compgenCalls, callsAfterPageUp,
+      'the accept after pageUp must reuse the OPEN dropdown, never fire a fresh request')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -13,7 +13,7 @@ import test from 'node:test'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { TuiApp } from '../src/tui-app.ts'
+import { TuiApp, type SubagentViewerTarget } from '../src/tui-app.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 /** A throwaway workspace (completion fixtures live under the cwd). */
@@ -23,19 +23,38 @@ function fixtureWorkspace(): string {
 
 function startApp(
   cwd: string,
-  options: { onSubmit?: (text: string) => void; commands?: { name: string; description: string }[] } = {},
-): { vt: VirtualTerminal; app: TuiApp; submitted: string[]; cancels: number } {
+  options: {
+    onSubmit?: (text: string) => void
+    onQueueSubmit?: (text: string) => void
+    onSubagentSubmit?: (request: { parentSessionId: string; childSessionId: string; text: string }) => void
+    commands?: { name: string; description: string }[]
+  } = {},
+): { vt: VirtualTerminal; app: TuiApp; submitted: string[]; queued: string[]; cancels: number } {
   const vt = new VirtualTerminal(100, 24)
   const submitted: string[] = []
+  const queued: string[] = []
   let cancels = 0
   const app = new TuiApp(vt, {
     onSubmit: (text) => { submitted.push(text); options.onSubmit?.(text) },
+    onQueueSubmit: (text) => { queued.push(text); options.onQueueSubmit?.(text) },
+    onSubagentSubmit: options.onSubagentSubmit,
     onExit: () => {},
     onCancel: () => { cancels += 1 },
   })
   app.setCommandCompletions(options.commands ?? [], cwd, null)
   app.start()
-  return { vt, app, submitted, get cancels() { return cancels } }
+  return { vt, app, submitted, queued, get cancels() { return cancels } }
+}
+
+/** A continuable subagent viewer target (the editor stays live). */
+function continuableViewer(): SubagentViewerTarget {
+  return {
+    parentSessionId: 'session-main',
+    childSessionId: 'child-1',
+    label: 'research',
+    mode: 'continuable',
+    activity: 'inactive',
+  }
 }
 
 /** Poll the viewport until the dropdown row appears (asserts on failure). */
@@ -99,7 +118,8 @@ test('Backspace on an empty shell body steps the mode back: !! -> ! -> prompt', 
 })
 
 test('Esc on an empty shell body returns directly to the prompt (no cancel)', async () => {
-  const { vt, app, cancels } = startApp(fixtureWorkspace())
+  const surface = startApp(fixtureWorkspace())
+  const { vt, app } = surface
   await vt.waitForRender()
   vt.sendInput('!')
   await vt.waitForRender()
@@ -107,7 +127,7 @@ test('Esc on an empty shell body returns directly to the prompt (no cancel)', as
   await vt.waitForRender()
   assert.equal(app.inputModeForTest(), 'prompt')
   assert.equal(app.seatTextForTest(), '')
-  assert.equal(cancels, 0, 'exiting the shell mode must not fire the host cancel')
+  assert.equal(surface.cancels, 0, 'exiting the shell mode must not fire the host cancel')
   // Same from shell-local.
   vt.sendInput('!')
   vt.sendInput('!')
@@ -115,7 +135,7 @@ test('Esc on an empty shell body returns directly to the prompt (no cancel)', as
   vt.sendInput('\x1b')
   await vt.waitForRender()
   assert.equal(app.inputModeForTest(), 'prompt')
-  assert.equal(cancels, 0)
+  assert.equal(surface.cancels, 0)
   app.stop()
 })
 
@@ -419,7 +439,8 @@ test('no duplicate prefix is ever rendered', async () => {
 // ── Esc / autocomplete priority (plan §4.4, §12.10) ───────────────────────
 
 test('Esc closes the autocomplete menu first and keeps the shell mode', async () => {
-  const { vt, app, cancels } = startApp(fixtureWorkspace())
+  const surface = startApp(fixtureWorkspace())
+  const { vt, app } = surface
   await vt.waitForRender()
   vt.sendInput('!')
   vt.sendInput('gi')
@@ -430,6 +451,62 @@ test('Esc closes the autocomplete menu first and keeps the shell mode', async ()
   await waitForNoDropdownRow(vt, 'git', 'dropdown after Esc')
   assert.equal(app.inputModeForTest(), 'shell-context', 'Esc must not exit the shell mode while the menu was open')
   assert.equal(app.seatTextForTest(), 'gi', 'Esc must not alter the body')
-  assert.equal(cancels, 0, 'closing the dropdown must not fire the host cancel')
+  assert.equal(surface.cancels, 0, 'closing the dropdown must not fire the host cancel')
+  app.stop()
+})
+
+// ── review round 1 regressions ────────────────────────────────────────────
+
+test('a busy Esc keeps its Host-owned cancel priority over the shell-mode exit', async () => {
+  const surface = startApp(fixtureWorkspace())
+  const { vt, app } = surface
+  await vt.waitForRender()
+  vt.sendInput('!')
+  await vt.waitForRender()
+  app.setBusy(true)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(surface.cancels, 1, 'a busy Esc must cancel the running activity')
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the busy cancel must not exit the shell mode')
+  app.setBusy(false)
+  app.stop()
+})
+
+test('a bare ! reaches the queue protocol via Ctrl+Enter', async () => {
+  const { vt, app, queued } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[13;5u') // kitty ctrl+enter: queue submit
+  assert.deepEqual(queued, ['!'], 'a bare ! shell mode must queue its wire form')
+  assert.equal(app.inputModeForTest(), 'prompt', 'mode resets after the queue submit')
+  app.stop()
+})
+
+test('a bare ! reaches the submit protocol via submitDraft', async () => {
+  const { vt, app, submitted } = startApp(fixtureWorkspace())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  await vt.waitForRender()
+  app.submitDraft(false)
+  assert.deepEqual(submitted, ['!'], 'a bare ! shell mode must submit its wire form')
+  assert.equal(app.inputModeForTest(), 'prompt')
+  app.stop()
+})
+
+test('a bare ! reaches the child via the subagent submit path', async () => {
+  const childSubmits: { parentSessionId: string; childSessionId: string; text: string }[] = []
+  const { vt, app } = startApp(fixtureWorkspace(), {
+    onSubagentSubmit: (request) => { childSubmits.push(request) },
+  })
+  await vt.waitForRender()
+  app.setViewerMode(continuableViewer())
+  await vt.waitForRender()
+  vt.sendInput('!')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  assert.equal(childSubmits.length, 1, 'a bare ! in the viewer must submit to the child')
+  assert.equal(childSubmits[0]!.text, '!', 'the child receives the serialized wire form')
+  assert.equal(app.inputModeForTest(), 'prompt', 'mode resets after the child submit')
   app.stop()
 })

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1966,3 +1966,130 @@ test('advanced editor controls replace a shell-mode draft through the wire bound
   assert.deepEqual(submitted, ['plain prose', '!pwd'])
   app.stop()
 })
+
+// ── review round: replacement-editor HOST EXECUTION MODE ───────────────────
+// A replacement editor in the seat has NO mode — its document IS the wire
+// form. The declined-key fallback decodes that wire document into the
+// HIDDEN host editor (mode + body) before every forwarded key, so the
+// host editor's OWN state is the authoritative execution mode for its
+// callbacks (onSubmit, the autocomplete provider). Serializing a fallback
+// submit by the VISIBLE seat mode would collapse `!!pwd` into a plain
+// `pwd` — a local-only command degrading into a model prompt.
+
+test('a replacement editor submit keeps the shell wire form through the host fallback', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text) => submitted.push(text), onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null)
+  app.start()
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'submit-fallback-plugin',
+    priority: 0,
+    create: () => {
+      const editor = pluginEditor()
+      // Decline every key: the plugin STAYS in the seat and Enter is
+      // host-owned (P1-10) — the hidden host editor submits.
+      editor.handleInput = () => false
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  const plugin = created[0]!
+  // shell-context: `!pwd` must submit as `!pwd`. The fallback decoded the
+  // wire document into the hidden host editor (shell-context + `pwd`)
+  // BEFORE Enter, and the host onSubmit must serialize from that HOST
+  // mode — never from the visible seat (which is a mode-less plugin).
+  plugin.setText('!pwd')
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual([...submitted], ['!pwd'], 'a replacement !pwd submit keeps the shell-context wire form')
+  // shell-local: `!!pwd` is LOCAL-ONLY — degrading it to a plain `pwd`
+  // would leak the local command into the session/model.
+  plugin.setText('!!pwd')
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual([...submitted], ['!pwd', '!!pwd'], 'a replacement !!pwd submit keeps the local-only wire form')
+  // prompt-mode wire: unchanged (identity — a plugin document is raw).
+  plugin.setText('plain prose')
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual([...submitted], ['!pwd', '!!pwd', 'plain prose'])
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})
+
+test('a replacement plugin Tab runs the shell completion grammar of the wire document', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(100, 24)
+  const queries: { lines: readonly string[]; cursorCol: number }[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { editorRegistry: registry })
+  app.setCommandCompletions([], fixtureWorkspace(), null, async (query) => {
+    queries.push({ lines: [...query.lines], cursorCol: query.cursorCol })
+    return null
+  })
+  app.start()
+  await vt.waitForRender()
+  const created: ReturnType<typeof pluginEditor>[] = []
+  const handle = registry.register({
+    id: 'completion-fallback-plugin',
+    priority: 0,
+    create: () => {
+      const editor = pluginEditor()
+      // Decline: the host fallback owns Tab (and every editing key).
+      editor.handleInput = () => false
+      created.push(editor)
+      return editor
+    },
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  const plugin = created[0]!
+  let compgenCalls = 0
+  try {
+    // The plugin document is the WIRE form: `!gi` is a shell-context
+    // document, so a declined Tab must run the SHELL command grammar
+    // (compgen) — the prompt-mode grammar would never invoke compgen.
+    setCompgenRunnerForTest((_cwd, expression) => {
+      compgenCalls += 1
+      return Promise.resolve({
+        ok: true,
+        lines: expression.includes('compgen -A command') ? ['git', 'gist'] : [],
+      })
+    })
+    plugin.setText('!gi')
+    plugin.setCursor(plugin.getText().length)
+    vt.sendInput('\t')
+    await pollUntil(() => compgenCalls === 1, 'the shell compgen ran through the plugin seat')
+    // The dropdown opens asynchronously inside the hidden host editor;
+    // the second Tab applies its selection synchronously and the fallback
+    // syncs the completed command back into the plugin wire document.
+    await new Promise(resolve => setTimeout(resolve, 50))
+    vt.sendInput('\t')
+    await pollUntil(() => plugin.getText() === '!git ',
+      'the shell completion applies into the plugin wire document')
+    // The extension chain (host provider returns null) sees the WIRE line
+    // with the synthetic prefix and the shifted cursor — the shell
+    // semantics must survive the plugin seat. (The compgen result cache
+    // must drop Phase A's command list, or the host provider still wins.)
+    resetCommandCacheForTest()
+    setCompgenRunnerForTest(() => Promise.resolve({ ok: false, lines: [] }))
+    plugin.setText('!gi')
+    plugin.setCursor(3)
+    vt.sendInput('\t')
+    await pollUntil(() => queries.length === 1, 'extension query through the shell wire plugin seat')
+    assert.deepEqual([...queries[0]!.lines], ['!gi'], 'the extension query sees the wire line through the plugin seat')
+    assert.equal(queries[0]!.cursorCol, 3, 'the wire cursor shifts by the synthetic prefix')
+  } finally {
+    setCompgenRunnerForTest(undefined)
+    resetCommandCacheForTest()
+  }
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})


### PR DESCRIPTION
## Summary

Implements the [shell editor mode plan](temp/20260825/dsh-pi-tui-shell-editor-mode-agent-plan-2026-08-24.md): the `!` / `!!` shell prefix becomes **editor state, never document text**. The editor buffer holds the bare command body; the mode is serialized back into the existing textual `!`/`!!` protocol only at host boundaries, so the shell business layer (`src/shell-context.ts`) and the vendored fork stay untouched.

**Mode UX**

- Empty prompt + `!` → `shell-context`; empty `shell-context` + `!` → `shell-local` (no debounce, each key is a complete state).
- Backspace on an empty shell body steps back (`!!` → `!` → `❯`); Esc on an empty shell body cancels the whole shell mode (autocomplete Esc closes the dropdown first).
- `!` after command text is an ordinary character; a `!` typed in `shell-local` with an empty body is a literal body character (no fourth mode).
- Bracketed paste into an **empty prompt** starting with `!`/`!!` normalizes into the matching mode in one synchronous pass; a paste into a non-empty editor or an already-shell-mode editor is never reinterpreted.
- Prompt rendering: `❯ ` (roleUser), `! ` and `!!` (both `shellMode`) — all exactly two cells, so the body/cursor never jump on a mode switch; the shell border uses `shellMode` via a dynamic palette-reading function.

**Compatibility boundaries**

- **Submission**: Enter, Ctrl+Enter (queue), Ctrl+S (steer), the plugin action sink and the subagent submit path serialize the mode into the wire form (`!pwd` / `!!pwd`) before the text leaves the app; the mode resets before dispatch so synchronous rejections restore both text and mode. Bare `!`/`!!` reach every submit path (emptiness judged on the serialized form). The host editor's own `onSubmit` serializes from the **host editor's mode** (host execution mode — the replacement-editor fallback decodes the plugin wire document into the hidden host before every forwarded key), never from the visible seat's mode.
- **Restores**: `setEditorText`/`setDraft` decode serialized input; viewer draft slots store the serialized form; `insertIntoEditor` stays raw; `getDraft()` returns the wire form (symmetric with `setDraft`).
- **History**: entries stay serialized (no migration); recall decodes (`!!` before `!`); `onHistoryDraftSave`/`Restore` keeps the mode across ↑/↓ browsing.
- **Completion**: the provider synthesizes a virtual `!`/`!!` line at the boundary (`shell-completion.ts` untouched); applied completions never write the synthetic prefix; in a shell mode a leading `/` is a **path**, never a slash command (natural triggers quiet on ANY line, Tab forces path completion); prompt slash + `@` mentions unchanged. The completion mode source is the **host editor's mode** (freshly decoded before every forwarded key) — a declined `!gi` Tab through a replacement editor keeps the shell grammar and hands the extension chain the wire line. A stale host dropdown is cancelled whenever the staged document changes or a non-interaction key runs (Tab/Enter/Up/Down/PageUp/PageDown keep it), so a stale candidate can never be accepted into edited text.
- **Handoffs**: plugin editor handoffs transfer the wire form (a plugin's document IS the wire form) and decode on restore, with cursor offsets shifted by the prefix length; older structural adapters fall back to `setText` (never a dropped draft); capability gates keep partial adapters from silently discarding the mode.
- **Esc ladder**: busy-Esc is Host-owned and runs before the shell-mode exit and plugin editors; a declined plugin Esc falls through to the host cancel ladder; a consumed Esc disarms the pending double-Esc window.
- **Chrome**: the ↓ task-browser gate and footer hint read the VISIBLE seat mode, never the hidden host editor's stale mode.

**Files**: `src/editor-input-mode.ts` (new, pure codec), `src/tui-editor.ts`, `src/tui-app.ts`, `src/mentions.ts`, `src/editor-seat-holder.ts`, `docs/input-and-card-polish.md` (design + review record); tests in `test/editor-input-mode.test.ts` (new), `test/shell-editor-mode.test.ts` (new, 76 tests), `test/shell-completion.test.ts` (extended).

## Verification

- `pnpm typecheck:bundle` — pass
- `pnpm test:bundle` — 2137/2137 pass
- `pnpm verify:prepush:nofork` — pass (pack + tarball, extension, advanced, phase4, unstable, vim, examples smokes)
- `git diff --check`, CJK scan — clean; vendored fork untouched; no new dependency; public extension surface unchanged

## Review history

Independent review chain (openai-codex / gpt-5.6-luna, read-only, fresh context per round) plus human PR reviews — full record in `docs/input-and-card-polish.md`:

- **External rounds 1–9**: busy-Esc Host priority, bare-`!` emptiness, paste normalization scope, handoff wire-form transfer, seat-mode routing, sink steer serialization, adapter capability gating, declined/consumed plugin Esc, cursor restoration — all fixed with regression tests. Round 9 accepted.
- **Human PR rounds 1–3**: external-editor wire round-trip; paste pre-insert normalization (undo invariant); handoff wire cursor; autocomplete cancel on mode change; one-shot viewer prompt reset; extension wire query; declined-input fallback; symmetric apply; **multiline continuation-line `/`** — the wire vs shell-semantic split (line-0-only wire prefix for the grammar/extension query vs any-line shell ownership for routing/apply/Tab gating). All closed.
- **External rounds 10–22** (incl. two stale pre-rebase diff artifacts of main's own commits, resolved by rebasing): busy/consumed Esc disarm, extension suppression on continuation lines, consumed-input notify, completion reading the visible seat, advanced editor controls through the wire boundary, getDraft/setDraft wire symmetry, extension prefix normalization at the wire line start only, split-marker stitching, iterative paste drain, multiline wire completion, Ctrl+C mode clear. Round 22 accepted.
- **PR review round 4 (human)**: replacement-editor fallback execution context — the host `onSubmit` and the completion mode source must read **host execution mode**, never the visible seat mode (a `!!pwd` plugin document must not degrade to plain `pwd`; a declined `!gi` Tab must keep the shell grammar and the wire `!` in the extension query). Fixed with the explicit HOST EXECUTION MODE vs VISIBLE SEAT MODE split + symmetric regression tests.
- **PR review round 5 (human)**: a SYNCHRONOUS rejection restore was clobbered by the fallback tail — the fork clears the host editor before `onSubmit`, a sync rejection (the divergence-guard shape: `onSubmit` → `setEditorText(text)` + return) rewrites the visible plugin seat while the dispatch is on the stack, and the tail then overwrote it with the post-submit empty state (`!!pwd` → `''`). Fixed with a seat change-revision epoch: the fallback syncs back only when nothing external rewrote the seat during the dispatch (a text comparison cannot tell "never touched" from "rewritten with the same text"); successful submits still clear the plugin (accepted-control tests).
- **External rounds 23–27**: test-sync via the render settle (no fixed delay); the stale-dropdown guard (a text change after a declined Tab cancels the old dropdown — the repro `!echo $gs` becoming `!echo $$git ` is gone); pageUp/pageDown kept in the dropdown-interaction set; a truncated fragment adjudicated against the fork (pageUp/pageDown are never forwarded into the dropdown list upstream — consumer-side behavior is correct as-is, fork stays pristine); the sync-restore epoch (round 27). **Round 27: accepted, no open findings** on the full 9-file sweep.
 test-sync via the render settle (no fixed delay); the stale-dropdown guard (a text change after a declined Tab cancels the old dropdown — the repro `!echo $gs` becoming `!echo $$git ` is gone); pageUp/pageDown kept in the dropdown-interaction set; a truncated fragment adjudicated against the fork (pageUp/pageDown are never forwarded into the dropdown list upstream — consumer-side behavior is correct as-is, fork stays pristine). **Round 26 (fresh): accepted, no open findings** on the full 9-file sweep.

