### PR TITLE
chore(dev): print per-stage progress in the pre-push gate

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -36,6 +36,9 @@
 set -eu
 
 FULL=0
+# Aggregate across ALL pushed refs: the gate must run the strictest level
+# any ref demands. Initialise to the safe "fork changed" default and only
+# ever raise it — a later ref without fork changes must NOT reset it.
 FORK_CHANGED=1
 while read -r local_ref local_sha remote_ref remote_sha; do
   case "$remote_ref" in
@@ -44,9 +47,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   # The remote base may be unknown (new branch: zero sha, or a shallow
   # clone): fall back to the safe "fork changed" default.
   if git cat-file -e "$remote_sha^{commit}" 2>/dev/null; then
-    if git diff --quiet "$remote_sha" "$local_sha" -- packages/pi-tui/; then
-      FORK_CHANGED=0
-    else
+    if ! git diff --quiet "$remote_sha" "$local_sha" -- packages/pi-tui/; then
       FORK_CHANGED=1
     fi
   fi
@@ -70,7 +71,17 @@ fi
 # package.json script. Non-verify scripts (typecheck / typecheck:bundle)
 # are passed through as a single stage.
 if [ "${PUSH_GATE_TEST_MODE:-0}" = "1" ] && [ -n "${PUSH_GATE_STAGES:-}" ]; then
+  # Test override: trim (the check above is on the raw value, so a
+  # whitespace-only override must not survive) and reject an empty list —
+  # a gate that runs zero stages and reports success silently would be
+  # indistinguishable from a passed verify.
   STAGES=$PUSH_GATE_STAGES
+  STAGES_TRIMMED=$(printf '%s\n' "$STAGES" | sed '/^[[:space:]]*$/d' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  if [ -z "$STAGES_TRIMMED" ]; then
+    echo "pre-push gate: PUSH_GATE_STAGES override produced no runnable stages; refusing to bypass the gate" >&2
+    exit 1
+  fi
+  STAGES=$STAGES_TRIMMED
 elif case "$VERIFY" in verify:*) true ;; *) false ;; esac; then
   STAGES=$(node scripts/pre-push-stages.mjs "$VERIFY")
 else
@@ -143,9 +154,13 @@ fail_stage=""
 fail_code=0
 while IFS= read -r stage; do
   [ -n "$stage" ] || continue
+  # Execute via `sh -c` so a stage's own quoting/escapes survive (the
+  # derived text is a shell command fragment, not a list of words —
+  # `node -e "console.log('a && b')"` must run as one command with its
+  # quotes intact). `$stage` itself (unquoted) is only used for display.
   ts_start=$(date +%s)
   say "$(stamp)  start: $stage"
-  if $stage >>"$LOG" 2>&1; then
+  if sh -c "$stage" >>"$LOG" 2>&1; then
     ts_end=$(date +%s)
     say "$(stamp)  ok:    $stage ($((ts_end - ts_start))s)"
   else
@@ -160,16 +175,18 @@ $STAGES
 EOF
 
 if [ "$VERBOSE" -eq 1 ]; then
-  # Final drain: emit any lines the poller has not streamed yet (its
-  # offset lags by up to one poll interval), then stop the poller.
+  # Stop the poller FIRST, then drain once from its last persisted offset:
+  # draining before the kill could race the poller and print lines twice
+  # (both would read the same range). After the wait, the main shell is
+  # the only reader, so the drain is exact-once.
+  kill "$STREAM_PID" 2>/dev/null || true
+  wait "$STREAM_PID" 2>/dev/null || true
   if [ -n "${LOG_OFFSET:-}" ] && [ -f "$LOG_OFFSET" ]; then
     offset=$(cat "$LOG_OFFSET" 2>/dev/null || echo 1)
     drain_log "$offset" >/dev/null
   else
     drain_log 1 >/dev/null
   fi
-  kill "$STREAM_PID" 2>/dev/null || true
-  wait "$STREAM_PID" 2>/dev/null || true
   rm -f "$LOG_OFFSET"
 fi
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,8 +10,14 @@
 # fork), the fork's own typecheck/tests are skipped (~15 s saved) — the
 # fork suite only guards fork changes, and CI still runs it regardless.
 #
+# The stage list is NOT hard-coded: .husky/pre-push runs the exact script
+# selected below (verify:prepush / verify:prepush:nofork / pnpm typecheck /
+# pnpm typecheck:bundle) by deriving its per-command stages from
+# package.json via scripts/pre-push-stages.mjs — package.json stays the
+# single source of truth, so there is nothing to drift.
+#
 # Output: the gate never goes silent. Every stage prints a timestamped
-# progress line (start / ok + elapsed / FAILED + elapsed) as it runs, and
+# progress line (start / ok + elapsed / FAIL + elapsed) as it runs, and
 # the full command output is captured into a log (discarded on success;
 # on failure the last 60 lines plus the retained log + progress paths are
 # printed). A long push therefore always shows WHICH stage is live.
@@ -20,8 +26,10 @@
 #                         [HH:MM:SS] prefix, so a stuck stage shows its
 #                         raw tail as it happens.
 #   PUSH_GATE_QUIET=1     single summary line only (scripted pushes).
-#   PUSH_GATE_STAGES="..."  test/dry-run only: override the stage list
-#                         (never set this for real pushes).
+#   PUSH_GATE_STAGES="..."  test/dry-run ONLY: override the stage list.
+#                         Ignored unless PUSH_GATE_TEST_MODE=1 is set, so
+#                         a stray env var can never shrink a real push's
+#                         gate. Never set it for real pushes.
 # Run `pnpm run verify:prepush` manually for the unabridged reference run.
 # Escape hatch: git push --no-verify.
 
@@ -47,56 +55,26 @@ done
 if [ "$FULL" -eq 1 ]; then
   if [ "$FORK_CHANGED" -eq 1 ]; then
     VERIFY="verify:prepush"
-    STAGES='pnpm typecheck:fork
-pnpm test:fork
-pnpm test:docs
-node scripts/naming-gate.mjs
-pnpm gate:boundary
-pnpm audit --prod --audit-level high
-pnpm pack:release'
   else
     VERIFY="verify:prepush:nofork"
-    STAGES='pnpm test:docs
-node scripts/naming-gate.mjs
-pnpm gate:boundary
-pnpm audit --prod --audit-level high
-pnpm pack:release'
   fi
 else
   if [ "$FORK_CHANGED" -eq 1 ]; then
     VERIFY="typecheck"
-    STAGES='pnpm typecheck'
   else
     VERIFY="typecheck:bundle"
-    STAGES='pnpm typecheck:bundle'
   fi
 fi
 
-# Normalize the stage list to canonical lines (defensive: a future edit
-# that indents the continuation lines must not silently break the drift
-# guard or the run loop below). Test/dry-run override for the hook itself.
-if [ -n "${PUSH_GATE_STAGES:-}" ]; then
+# Single source of truth: derive the ordered stage list from the selected
+# package.json script. Non-verify scripts (typecheck / typecheck:bundle)
+# are passed through as a single stage.
+if [ "${PUSH_GATE_TEST_MODE:-0}" = "1" ] && [ -n "${PUSH_GATE_STAGES:-}" ]; then
   STAGES=$PUSH_GATE_STAGES
-fi
-STAGES=$(printf '%s\n' "$STAGES" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
-
-# Drift guard for the full chain: every stage below must still appear
-# verbatim in the packaged verify:* scripts (single source of truth stays
-# in package.json; `pnpm run verify:prepush` remains the reference run).
-if [ "$FULL" -eq 1 ]; then
-  VERIFY_TEXT=$(node -p "const p = require('./package.json').scripts; Object.keys(p).filter(k => k.startsWith('verify:')).map(k => p[k]).join('\n')")
-  if ! printf '%s\n' "$STAGES" | while IFS= read -r stage; do
-    [ -n "$stage" ] || continue
-    case "$VERIFY_TEXT" in
-      *"$stage"*) ;;
-      *)
-        echo "pre-push gate: stage no longer in package.json verify:*: $stage (update .husky/pre-push to stay in sync)" >&2
-        exit 3
-        ;;
-    esac
-  done; then
-    exit 1
-  fi
+elif case "$VERIFY" in verify:*) true ;; *) false ;; esac; then
+  STAGES=$(node scripts/pre-push-stages.mjs "$VERIFY")
+else
+  STAGES="pnpm $VERIFY"
 fi
 
 TMP_DIR="${TMPDIR:-/tmp}"
@@ -123,21 +101,39 @@ if [ "$QUIET" -ne 1 ]; then
   echo "pre-push gate: $VERIFY ($STAGE_COUNT $LABEL) — log: $LOG"
 fi
 
+# Read previously-unstreamed lines from the log and print them with a
+# timestamp. Prints to stderr (the hook's progress lines go to stdout),
+# and echoes the next unread offset (total+1, or start when the log has
+# not grown) so callers can track position. Used by the poller loop and
+# by the final drain, so every line is streamed exactly once — nothing is
+# lost in the poll gap.
+drain_log() {
+  start=${1:-1}
+  total=$(wc -l <"$LOG" 2>/dev/null || echo 0)
+  if [ "$total" -ge "$start" ]; then
+    sed -n "${start},${total}p" "$LOG" | while IFS= read -r line; do
+      printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$line"
+    done >&2
+    next=$((total + 1))
+  else
+    next=$start
+  fi
+  echo "$next"
+}
+
 # Verbose mode: stream the captured log live, one timestamped line per
-# new line (poll the log; the poller is a single subshell, so killing
-# STREAM_PID never orphans a child like `tail -f` in a pipeline would).
+# new line (drain_log off the shared LOG_OFFSET position). The poller is
+# a single subshell (killing STREAM_PID never orphans a tail -f child).
+# The offset file lets the main shell drain the final partial poll window
+# before killing the poller.
 if [ "$VERBOSE" -eq 1 ]; then
+  LOG_OFFSET=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.offset")
   (
     next=1
     while :; do
-      total=$(wc -l <"$LOG" 2>/dev/null || echo 0)
-      if [ "$total" -ge "$next" ]; then
-        sed -n "${next},${total}p" "$LOG" | while IFS= read -r line; do
-          printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$line"
-        done >&2
-        next=$((total + 1))
-      fi
-      sleep 0.2
+      next=$(drain_log "$next")
+      printf '%s\n' "$next" >"$LOG_OFFSET"
+      sleep 0.4
     done
   ) &
   STREAM_PID=$!
@@ -164,7 +160,17 @@ $STAGES
 EOF
 
 if [ "$VERBOSE" -eq 1 ]; then
+  # Final drain: emit any lines the poller has not streamed yet (its
+  # offset lags by up to one poll interval), then stop the poller.
+  if [ -n "${LOG_OFFSET:-}" ] && [ -f "$LOG_OFFSET" ]; then
+    offset=$(cat "$LOG_OFFSET" 2>/dev/null || echo 1)
+    drain_log "$offset" >/dev/null
+  else
+    drain_log 1 >/dev/null
+  fi
   kill "$STREAM_PID" 2>/dev/null || true
+  wait "$STREAM_PID" 2>/dev/null || true
+  rm -f "$LOG_OFFSET"
 fi
 
 END=$(date +%s)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -24,8 +24,9 @@
 # Toggles:
 #   PUSH_GATE_VERBOSE=1   also stream every captured log line live with a
 #                         [HH:MM:SS] prefix, so a stuck stage shows its
-#                         raw tail as it happens.
-#   PUSH_GATE_QUIET=1     single summary line only (scripted pushes).
+#                         raw tail as it happens (requires QUIET=0).
+#   PUSH_GATE_QUIET=1     single summary line only (scripted pushes);
+#                         takes precedence over VERBOSE.
 #   PUSH_GATE_STAGES="..."  test/dry-run ONLY: override the stage list.
 #                         Ignored unless PUSH_GATE_TEST_MODE=1 is set, so
 #                         a stray env var can never shrink a real push's
@@ -121,14 +122,18 @@ fi
 # and echoes the next unread offset (total+1, or start when the log has
 # not grown) so callers can track position. Used by the poller loop and
 # by the final drain, so every line is streamed exactly once — nothing is
-# lost in the poll gap.
+# lost in the poll gap. In quiet mode the stream is suppressed entirely
+# (PUSH_GATE_QUIET promises a single summary line — no progress, no
+# stream).
 drain_log() {
   start=${1:-1}
   total=$(wc -l <"$LOG" 2>/dev/null || echo 0)
   if [ "$total" -ge "$start" ]; then
-    sed -n "${start},${total}p" "$LOG" | while IFS= read -r line; do
-      printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$line"
-    done >&2
+    if [ "$QUIET" -ne 1 ]; then
+      sed -n "${start},${total}p" "$LOG" | while IFS= read -r line; do
+        printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$line"
+      done >&2
+    fi
     next=$((total + 1))
   else
     next=$start
@@ -143,7 +148,9 @@ drain_log() {
 # delivered between iterations, not mid-drain), so the main shell's final
 # drain never re-reads lines the poller already emitted. The offset file
 # also lets the main shell drain the final partial poll window.
-if [ "$VERBOSE" -eq 1 ]; then
+# PUSH_GATE_QUIET takes precedence: quiet promises ONE summary line, so
+# the verbose stream (and its poller) is skipped entirely.
+if [ "$VERBOSE" -eq 1 ] && [ "$QUIET" -ne 1 ]; then
   LOG_OFFSET=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.offset")
   LOG_STOP=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.stop")
   (
@@ -183,7 +190,7 @@ done <<EOF
 $STAGES
 EOF
 
-if [ "$VERBOSE" -eq 1 ]; then
+if [ "$VERBOSE" -eq 1 ] && [ "$QUIET" -ne 1 ]; then
   # Cooperative shutdown: signal the poller to stop BETWEEN drain cycles
   # (it checks LOG_STOP before each drain and before each sleep), then
   # wait for it to finish its current cycle — the offset it persisted is

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -37,9 +37,11 @@ set -eu
 
 FULL=0
 # Aggregate across ALL pushed refs: the gate must run the strictest level
-# any ref demands. Initialise to the safe "fork changed" default and only
-# ever raise it — a later ref without fork changes must NOT reset it.
-FORK_CHANGED=1
+# any ref demands. Initialize to 0 (clean) and only ever RAISE it to 1 —
+# on an unknown remote base or a fork-touching range — never reset it, so
+# a later clean ref cannot downgrade an earlier strict one. A fully clean
+# multi-ref push still selects the fast nofork/bundle chain.
+FORK_CHANGED=0
 while read -r local_ref local_sha remote_ref remote_sha; do
   case "$remote_ref" in
     refs/heads/main | refs/tags/v*) FULL=1 ;;
@@ -50,6 +52,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     if ! git diff --quiet "$remote_sha" "$local_sha" -- packages/pi-tui/; then
       FORK_CHANGED=1
     fi
+  else
+    FORK_CHANGED=1
   fi
 done
 
@@ -134,16 +138,21 @@ drain_log() {
 
 # Verbose mode: stream the captured log live, one timestamped line per
 # new line (drain_log off the shared LOG_OFFSET position). The poller is
-# a single subshell (killing STREAM_PID never orphans a tail -f child).
-# The offset file lets the main shell drain the final partial poll window
-# before killing the poller.
+# a single subshell that checks a STOP file between drains; killing it
+# therefore lands cleanly AFTER a drain+offset-write pair (kill is
+# delivered between iterations, not mid-drain), so the main shell's final
+# drain never re-reads lines the poller already emitted. The offset file
+# also lets the main shell drain the final partial poll window.
 if [ "$VERBOSE" -eq 1 ]; then
   LOG_OFFSET=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.offset")
+  LOG_STOP=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.stop")
   (
     next=1
     while :; do
+      [ -e "$LOG_STOP" ] && break
       next=$(drain_log "$next")
       printf '%s\n' "$next" >"$LOG_OFFSET"
+      [ -e "$LOG_STOP" ] && break
       sleep 0.4
     done
   ) &
@@ -175,11 +184,12 @@ $STAGES
 EOF
 
 if [ "$VERBOSE" -eq 1 ]; then
-  # Stop the poller FIRST, then drain once from its last persisted offset:
-  # draining before the kill could race the poller and print lines twice
-  # (both would read the same range). After the wait, the main shell is
-  # the only reader, so the drain is exact-once.
-  kill "$STREAM_PID" 2>/dev/null || true
+  # Cooperative shutdown: signal the poller to stop BETWEEN drain cycles
+  # (it checks LOG_STOP before each drain and before each sleep), then
+  # wait for it to finish its current cycle — the offset it persisted is
+  # then exactly what it emitted. The final drain from that offset is
+  # therefore idempotent: it only ever prints lines the poller never saw.
+  : >"$LOG_STOP"
   wait "$STREAM_PID" 2>/dev/null || true
   if [ -n "${LOG_OFFSET:-}" ] && [ -f "$LOG_OFFSET" ]; then
     offset=$(cat "$LOG_OFFSET" 2>/dev/null || echo 1)
@@ -187,7 +197,7 @@ if [ "$VERBOSE" -eq 1 ]; then
   else
     drain_log 1 >/dev/null
   fi
-  rm -f "$LOG_OFFSET"
+  rm -f "$LOG_OFFSET" "$LOG_STOP"
 fi
 
 END=$(date +%s)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -19,14 +19,10 @@
 # Output: the gate never goes silent. Every stage prints a timestamped
 # progress line (start / ok + elapsed / FAIL + elapsed) as it runs, and
 # the full command output is captured into a log (discarded on success;
-# on failure the last 60 lines plus the retained log + progress paths are
-# printed). A long push therefore always shows WHICH stage is live.
+# on failure the last 60 lines plus the retained log path are printed).
+# A long push therefore always shows WHICH stage is live.
 # Toggles:
-#   PUSH_GATE_VERBOSE=1   also stream every captured log line live with a
-#                         [HH:MM:SS] prefix, so a stuck stage shows its
-#                         raw tail as it happens (requires QUIET=0).
-#   PUSH_GATE_QUIET=1     single summary line only (scripted pushes);
-#                         takes precedence over VERBOSE.
+#   PUSH_GATE_QUIET=1     single summary line only (scripted pushes).
 #   PUSH_GATE_STAGES="..."  test/dry-run ONLY: override the stage list.
 #                         Ignored unless PUSH_GATE_TEST_MODE=1 is set, so
 #                         a stray env var can never shrink a real push's
@@ -95,75 +91,21 @@ fi
 
 TMP_DIR="${TMPDIR:-/tmp}"
 LOG=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.log")
-PROGRESS=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.progress")
 START=$(date +%s)
 
 QUIET=0
 [ "${PUSH_GATE_QUIET:-0}" = "1" ] && QUIET=1
-VERBOSE=0
-[ "${PUSH_GATE_VERBOSE:-0}" = "1" ] && VERBOSE=1
 
 stamp() { date '+%Y-%m-%d %H:%M:%S'; }
-# Progress goes to the TTY (skipped in quiet mode) AND to the progress
-# file (always), so a quiet run still leaves a timeline behind.
+# Progress goes to the TTY (skipped in quiet mode).
 say() {
   if [ "$QUIET" -ne 1 ]; then printf '%s\n' "$@"; fi
-  printf '%s\n' "$@" >>"$PROGRESS"
 }
 
 STAGE_COUNT=$(printf '%s\n' "$STAGES" | sed '/^$/d' | wc -l | tr -d ' ')
 LABEL="stage"; [ "$STAGE_COUNT" -ne 1 ] && LABEL="stages"
 if [ "$QUIET" -ne 1 ]; then
   echo "pre-push gate: $VERIFY ($STAGE_COUNT $LABEL) — log: $LOG"
-fi
-
-# Read previously-unstreamed lines from the log and print them with a
-# timestamp. Prints to stderr (the hook's progress lines go to stdout),
-# and echoes the next unread offset (total+1, or start when the log has
-# not grown) so callers can track position. Used by the poller loop and
-# by the final drain, so every line is streamed exactly once — nothing is
-# lost in the poll gap. In quiet mode the stream is suppressed entirely
-# (PUSH_GATE_QUIET promises a single summary line — no progress, no
-# stream).
-drain_log() {
-  start=${1:-1}
-  total=$(wc -l <"$LOG" 2>/dev/null || echo 0)
-  if [ "$total" -ge "$start" ]; then
-    if [ "$QUIET" -ne 1 ]; then
-      sed -n "${start},${total}p" "$LOG" | while IFS= read -r line; do
-        printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$line"
-      done >&2
-    fi
-    next=$((total + 1))
-  else
-    next=$start
-  fi
-  echo "$next"
-}
-
-# Verbose mode: stream the captured log live, one timestamped line per
-# new line (drain_log off the shared LOG_OFFSET position). The poller is
-# a single subshell that checks a STOP file between drains; killing it
-# therefore lands cleanly AFTER a drain+offset-write pair (kill is
-# delivered between iterations, not mid-drain), so the main shell's final
-# drain never re-reads lines the poller already emitted. The offset file
-# also lets the main shell drain the final partial poll window.
-# PUSH_GATE_QUIET takes precedence: quiet promises ONE summary line, so
-# the verbose stream (and its poller) is skipped entirely.
-if [ "$VERBOSE" -eq 1 ] && [ "$QUIET" -ne 1 ]; then
-  LOG_OFFSET=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.offset")
-  LOG_STOP=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.stop")
-  (
-    next=1
-    while :; do
-      [ -e "$LOG_STOP" ] && break
-      next=$(drain_log "$next")
-      printf '%s\n' "$next" >"$LOG_OFFSET"
-      [ -e "$LOG_STOP" ] && break
-      sleep 0.4
-    done
-  ) &
-  STREAM_PID=$!
 fi
 
 fail_stage=""
@@ -190,26 +132,9 @@ done <<EOF
 $STAGES
 EOF
 
-if [ "$VERBOSE" -eq 1 ] && [ "$QUIET" -ne 1 ]; then
-  # Cooperative shutdown: signal the poller to stop BETWEEN drain cycles
-  # (it checks LOG_STOP before each drain and before each sleep), then
-  # wait for it to finish its current cycle — the offset it persisted is
-  # then exactly what it emitted. The final drain from that offset is
-  # therefore idempotent: it only ever prints lines the poller never saw.
-  : >"$LOG_STOP"
-  wait "$STREAM_PID" 2>/dev/null || true
-  if [ -n "${LOG_OFFSET:-}" ] && [ -f "$LOG_OFFSET" ]; then
-    offset=$(cat "$LOG_OFFSET" 2>/dev/null || echo 1)
-    drain_log "$offset" >/dev/null
-  else
-    drain_log 1 >/dev/null
-  fi
-  rm -f "$LOG_OFFSET" "$LOG_STOP"
-fi
-
 END=$(date +%s)
 if [ -z "$fail_stage" ]; then
-  rm -f "$LOG" "$PROGRESS"
+  rm -f "$LOG"
   echo "✓ pre-push verification passed ($VERIFY, $((END - START))s)"
   exit 0
 fi
@@ -219,5 +144,4 @@ echo "  failed stage: $fail_stage (exit $fail_code)"
 echo "  last 60 log lines:"
 tail -n 60 "$LOG" | sed 's/^/    /'
 echo "  full log: $LOG"
-echo "  progress: $PROGRESS"
 exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,10 +9,23 @@
 # When the pushed range does NOT touch packages/pi-tui/ (the vendored
 # fork), the fork's own typecheck/tests are skipped (~15 s saved) — the
 # fork suite only guards fork changes, and CI still runs it regardless.
-# Output: on success a single summary line (logs are discarded); on
-# failure the last 60 log lines plus the retained log path. Run
-# `pnpm run verify:prepush` manually for the unabridged output.
+#
+# Output: the gate never goes silent. Every stage prints a timestamped
+# progress line (start / ok + elapsed / FAILED + elapsed) as it runs, and
+# the full command output is captured into a log (discarded on success;
+# on failure the last 60 lines plus the retained log + progress paths are
+# printed). A long push therefore always shows WHICH stage is live.
+# Toggles:
+#   PUSH_GATE_VERBOSE=1   also stream every captured log line live with a
+#                         [HH:MM:SS] prefix, so a stuck stage shows its
+#                         raw tail as it happens.
+#   PUSH_GATE_QUIET=1     single summary line only (scripted pushes).
+#   PUSH_GATE_STAGES="..."  test/dry-run only: override the stage list
+#                         (never set this for real pushes).
+# Run `pnpm run verify:prepush` manually for the unabridged reference run.
 # Escape hatch: git push --no-verify.
+
+set -eu
 
 FULL=0
 FORK_CHANGED=1
@@ -33,28 +46,138 @@ done
 
 if [ "$FULL" -eq 1 ]; then
   if [ "$FORK_CHANGED" -eq 1 ]; then
-    VERIFY="pnpm run verify:prepush"
+    VERIFY="verify:prepush"
+    STAGES='pnpm typecheck:fork
+pnpm test:fork
+pnpm test:docs
+node scripts/naming-gate.mjs
+pnpm gate:boundary
+pnpm audit --prod --audit-level high
+pnpm pack:release'
   else
-    VERIFY="pnpm run verify:prepush:nofork"
+    VERIFY="verify:prepush:nofork"
+    STAGES='pnpm test:docs
+node scripts/naming-gate.mjs
+pnpm gate:boundary
+pnpm audit --prod --audit-level high
+pnpm pack:release'
   fi
 else
   if [ "$FORK_CHANGED" -eq 1 ]; then
-    VERIFY="pnpm typecheck"
+    VERIFY="typecheck"
+    STAGES='pnpm typecheck'
   else
-    VERIFY="pnpm typecheck:bundle"
+    VERIFY="typecheck:bundle"
+    STAGES='pnpm typecheck:bundle'
   fi
 fi
 
-LOG=$(mktemp "${TMPDIR:-/tmp}/dsh-pi-tui-push.XXXXXX.log")
-START=$(date +%s)
-if $VERIFY >"$LOG" 2>&1; then
-  END=$(date +%s)
-  echo "✓ pre-push verification passed ($VERIFY, $((END - START))s)"
-  rm -f "$LOG"
-else
-  END=$(date +%s)
-  echo "✗ pre-push verification FAILED ($VERIFY, $((END - START))s)"
-  tail -n 60 "$LOG"
-  echo "full log: $LOG"
-  exit 1
+# Normalize the stage list to canonical lines (defensive: a future edit
+# that indents the continuation lines must not silently break the drift
+# guard or the run loop below). Test/dry-run override for the hook itself.
+if [ -n "${PUSH_GATE_STAGES:-}" ]; then
+  STAGES=$PUSH_GATE_STAGES
 fi
+STAGES=$(printf '%s\n' "$STAGES" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+
+# Drift guard for the full chain: every stage below must still appear
+# verbatim in the packaged verify:* scripts (single source of truth stays
+# in package.json; `pnpm run verify:prepush` remains the reference run).
+if [ "$FULL" -eq 1 ]; then
+  VERIFY_TEXT=$(node -p "const p = require('./package.json').scripts; Object.keys(p).filter(k => k.startsWith('verify:')).map(k => p[k]).join('\n')")
+  if ! printf '%s\n' "$STAGES" | while IFS= read -r stage; do
+    [ -n "$stage" ] || continue
+    case "$VERIFY_TEXT" in
+      *"$stage"*) ;;
+      *)
+        echo "pre-push gate: stage no longer in package.json verify:*: $stage (update .husky/pre-push to stay in sync)" >&2
+        exit 3
+        ;;
+    esac
+  done; then
+    exit 1
+  fi
+fi
+
+TMP_DIR="${TMPDIR:-/tmp}"
+LOG=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.log")
+PROGRESS=$(mktemp "${TMP_DIR}/dsh-pi-tui-push.XXXXXX.progress")
+START=$(date +%s)
+
+QUIET=0
+[ "${PUSH_GATE_QUIET:-0}" = "1" ] && QUIET=1
+VERBOSE=0
+[ "${PUSH_GATE_VERBOSE:-0}" = "1" ] && VERBOSE=1
+
+stamp() { date '+%Y-%m-%d %H:%M:%S'; }
+# Progress goes to the TTY (skipped in quiet mode) AND to the progress
+# file (always), so a quiet run still leaves a timeline behind.
+say() {
+  if [ "$QUIET" -ne 1 ]; then printf '%s\n' "$@"; fi
+  printf '%s\n' "$@" >>"$PROGRESS"
+}
+
+STAGE_COUNT=$(printf '%s\n' "$STAGES" | sed '/^$/d' | wc -l | tr -d ' ')
+LABEL="stage"; [ "$STAGE_COUNT" -ne 1 ] && LABEL="stages"
+if [ "$QUIET" -ne 1 ]; then
+  echo "pre-push gate: $VERIFY ($STAGE_COUNT $LABEL) — log: $LOG"
+fi
+
+# Verbose mode: stream the captured log live, one timestamped line per
+# new line (poll the log; the poller is a single subshell, so killing
+# STREAM_PID never orphans a child like `tail -f` in a pipeline would).
+if [ "$VERBOSE" -eq 1 ]; then
+  (
+    next=1
+    while :; do
+      total=$(wc -l <"$LOG" 2>/dev/null || echo 0)
+      if [ "$total" -ge "$next" ]; then
+        sed -n "${next},${total}p" "$LOG" | while IFS= read -r line; do
+          printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$line"
+        done >&2
+        next=$((total + 1))
+      fi
+      sleep 0.2
+    done
+  ) &
+  STREAM_PID=$!
+fi
+
+fail_stage=""
+fail_code=0
+while IFS= read -r stage; do
+  [ -n "$stage" ] || continue
+  ts_start=$(date +%s)
+  say "$(stamp)  start: $stage"
+  if $stage >>"$LOG" 2>&1; then
+    ts_end=$(date +%s)
+    say "$(stamp)  ok:    $stage ($((ts_end - ts_start))s)"
+  else
+    fail_code=$?
+    ts_end=$(date +%s)
+    fail_stage=$stage
+    say "$(stamp)  FAIL:  $stage after $((ts_end - ts_start))s"
+    break
+  fi
+done <<EOF
+$STAGES
+EOF
+
+if [ "$VERBOSE" -eq 1 ]; then
+  kill "$STREAM_PID" 2>/dev/null || true
+fi
+
+END=$(date +%s)
+if [ -z "$fail_stage" ]; then
+  rm -f "$LOG" "$PROGRESS"
+  echo "✓ pre-push verification passed ($VERIFY, $((END - START))s)"
+  exit 0
+fi
+
+echo "✗ pre-push verification FAILED ($VERIFY, $((END - START))s)"
+echo "  failed stage: $fail_stage (exit $fail_code)"
+echo "  last 60 log lines:"
+tail -n 60 "$LOG" | sed 's/^/    /'
+echo "  full log: $LOG"
+echo "  progress: $PROGRESS"
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,18 +430,24 @@ gitignored):
 - Output never goes silent: every stage prints a timestamped progress
   line (`start` / `ok` + elapsed / `FAIL` + elapsed) as it runs, so a long
   push always shows WHICH stage is live (the ≈2 min full chain, the
-  ≈1:45 nofork chain, or the ≈10–15 s typecheck). Verbose mode
-  (`PUSH_GATE_VERBOSE=1`) also streams every captured log line live with
-  a `[HH:MM:SS]` prefix, making a stuck stage show its raw tail as it
-  happens; `PUSH_GATE_QUIET=1` restores a single summary line for
-  scripted pushes. Success prints one summary line with the elapsed time
-  (logs discarded); failure prints the failed stage, the last 60 log
-  lines and retains the full log + progress timeline paths.
+  ≈1:45 nofork chain, or the ≈10–15 s typecheck). The stage list is NOT
+  hard-coded: the hook derives it from the selected package.json script
+  via `scripts/pre-push-stages.mjs` (top-level `&&` split, quote-aware),
+  so `verify:prepush` / `verify:prepush:nofork` remain the single source
+  of truth — adding, removing or reordering a stage in those scripts is
+  picked up automatically, and a dangling `&&` fails the hook loudly.
+  Verbose mode (`PUSH_GATE_VERBOSE=1`) also streams every captured log
+  line live with a `[HH:MM:SS]` prefix (a polling subshell with a final
+  drain after the last stage, so the final < poll-interval output is not
+  lost), making a stuck stage show its raw tail as it happens;
+  `PUSH_GATE_QUIET=1` restores a single summary line for scripted
+  pushes. Success prints one summary line with the elapsed time (logs
+  discarded); failure prints the failed stage, the last 60 log lines and
+  retains the full log + progress timeline paths. `PUSH_GATE_STAGES`
+  (test/dry-run only) is ignored unless `PUSH_GATE_TEST_MODE=1` is set,
+  so a stray env var can never shrink a real push's gate.
   Run `pnpm run verify:prepush` manually for the unabridged reference
-  run. Stages are hard-coded in the hook (with a drift guard that fails
-  loudly when a stage disappears from the package.json `verify:*`
-  scripts); `verify:prepush` / `verify:prepush:nofork` remain the single
-  source of truth.
+  run.
 - Escape hatch: `git push --no-verify` (then rely on CI).
 
 ## Reusable flow (worth repeating for the next capability)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,20 +440,10 @@ gitignored):
   survives; the fork-change check aggregates across ALL pushed refs (any
   ref touching `packages/pi-tui/` or with an unknown base forces the full
   chain — a later clean ref never downgrades it, and a fully clean push
-  still selects the fast chain). Verbose mode (`PUSH_GATE_VERBOSE=1`)
-  also streams every captured log line live with a `[HH:MM:SS]` prefix:
-  a poller subshell drains the log in cycles and persists its read
-  offset between cycles; on shutdown the main shell writes a
-  `LOG_STOP` sentinel and `wait`s — the poller exits on its OWN next
-  cycle check, never by an external signal, so it can not be
-  interrupted mid-drain, and the final drain from the persisted offset
-  is exact-once (no lost or duplicated lines). A stuck stage shows its
-  raw tail as it happens; `PUSH_GATE_QUIET=1` restores a single summary
-  line for scripted pushes and takes precedence over `PUSH_GATE_VERBOSE`
-  (under QUIET the poller is not started and streamed log lines are
-  suppressed). Success prints one summary line with the
-  elapsed time (logs discarded); failure prints the failed stage, the
-  last 60 log lines and retains the full log + progress timeline paths.
+  still selects the fast chain). `PUSH_GATE_QUIET=1` restores a single
+  summary line for scripted pushes. Success prints one summary line with
+  the elapsed time (logs discarded); failure prints the failed stage,
+  the last 60 log lines and retains the full log path.
   `PUSH_GATE_STAGES` (test/dry-run only) is ignored unless
   `PUSH_GATE_TEST_MODE=1` is set — and a whitespace-only override is
   refused — so a stray env var can never shrink a real push's gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,9 +427,21 @@ gitignored):
   suite only guards fork changes and CI runs it regardless).
 - **any other branch** → `pnpm typecheck` only (≈15 s), so WIP pushes stay
   cheap; fork untouched → `pnpm typecheck:bundle` (≈10 s).
-- Output is quiet by design: success prints ONE summary line (full logs
-  are discarded); failure prints the last 60 log lines and retains the
-  log path. Run `pnpm run verify:prepush` manually for unabridged output.
+- Output never goes silent: every stage prints a timestamped progress
+  line (`start` / `ok` + elapsed / `FAIL` + elapsed) as it runs, so a long
+  push always shows WHICH stage is live (the ≈2 min full chain, the
+  ≈1:45 nofork chain, or the ≈10–15 s typecheck). Verbose mode
+  (`PUSH_GATE_VERBOSE=1`) also streams every captured log line live with
+  a `[HH:MM:SS]` prefix, making a stuck stage show its raw tail as it
+  happens; `PUSH_GATE_QUIET=1` restores a single summary line for
+  scripted pushes. Success prints one summary line with the elapsed time
+  (logs discarded); failure prints the failed stage, the last 60 log
+  lines and retains the full log + progress timeline paths.
+  Run `pnpm run verify:prepush` manually for the unabridged reference
+  run. Stages are hard-coded in the hook (with a drift guard that fails
+  loudly when a stage disappears from the package.json `verify:*`
+  scripts); `verify:prepush` / `verify:prepush:nofork` remain the single
+  source of truth.
 - Escape hatch: `git push --no-verify` (then rely on CI).
 
 ## Reusable flow (worth repeating for the next capability)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,20 +432,26 @@ gitignored):
   push always shows WHICH stage is live (the ≈2 min full chain, the
   ≈1:45 nofork chain, or the ≈10–15 s typecheck). The stage list is NOT
   hard-coded: the hook derives it from the selected package.json script
-  via `scripts/pre-push-stages.mjs` (top-level `&&` split, quote-aware),
-  so `verify:prepush` / `verify:prepush:nofork` remain the single source
-  of truth — adding, removing or reordering a stage in those scripts is
-  picked up automatically, and a dangling `&&` fails the hook loudly.
-  Verbose mode (`PUSH_GATE_VERBOSE=1`) also streams every captured log
-  line live with a `[HH:MM:SS]` prefix (a polling subshell with a final
-  drain after the last stage, so the final < poll-interval output is not
-  lost), making a stuck stage show its raw tail as it happens;
-  `PUSH_GATE_QUIET=1` restores a single summary line for scripted
-  pushes. Success prints one summary line with the elapsed time (logs
-  discarded); failure prints the failed stage, the last 60 log lines and
-  retains the full log + progress timeline paths. `PUSH_GATE_STAGES`
-  (test/dry-run only) is ignored unless `PUSH_GATE_TEST_MODE=1` is set,
-  so a stray env var can never shrink a real push's gate.
+  via `scripts/pre-push-stages.mjs` (top-level `&&` split, quote- and
+  escape-aware; rejects unterminated quotes and dangling `&&`), so
+  `verify:prepush` / `verify:prepush:nofork` remain the single source of
+  truth — adding, removing or reordering a stage in those scripts is
+  picked up automatically. Stages run via `sh -c` so their own quoting
+  survives; the fork-change check aggregates across ALL pushed refs (any
+  ref touching `packages/pi-tui/` or with an unknown base forces the full
+  chain — a later clean ref never downgrades it). Verbose mode
+  (`PUSH_GATE_VERBOSE=1`) also streams every captured log line live with
+  a `[HH:MM:SS]` prefix (a polling subshell, stopped BEFORE a final
+  exact-once drain, so no line is lost or duplicated), making a stuck
+  stage show its raw tail as it happens; `PUSH_GATE_QUIET=1` restores a
+  single summary line for scripted pushes. Success prints one summary
+  line with the elapsed time (logs discarded); failure prints the failed
+  stage, the last 60 log lines and retains the full log + progress
+  timeline paths. `PUSH_GATE_STAGES` (test/dry-run only) is ignored
+  unless `PUSH_GATE_TEST_MODE=1` is set — and a whitespace-only override
+  is refused — so a stray env var can never shrink a real push's gate.
+  The derivation and hook behavior are guarded by
+  `test/pre-push-stages.test.mjs` and `test/pre-push-hook.test.mjs`.
   Run `pnpm run verify:prepush` manually for the unabridged reference
   run.
 - Escape hatch: `git push --no-verify` (then rely on CI).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,17 +439,22 @@ gitignored):
   picked up automatically. Stages run via `sh -c` so their own quoting
   survives; the fork-change check aggregates across ALL pushed refs (any
   ref touching `packages/pi-tui/` or with an unknown base forces the full
-  chain — a later clean ref never downgrades it). Verbose mode
-  (`PUSH_GATE_VERBOSE=1`) also streams every captured log line live with
-  a `[HH:MM:SS]` prefix (a polling subshell, stopped BEFORE a final
-  exact-once drain, so no line is lost or duplicated), making a stuck
-  stage show its raw tail as it happens; `PUSH_GATE_QUIET=1` restores a
-  single summary line for scripted pushes. Success prints one summary
-  line with the elapsed time (logs discarded); failure prints the failed
-  stage, the last 60 log lines and retains the full log + progress
-  timeline paths. `PUSH_GATE_STAGES` (test/dry-run only) is ignored
-  unless `PUSH_GATE_TEST_MODE=1` is set — and a whitespace-only override
-  is refused — so a stray env var can never shrink a real push's gate.
+  chain — a later clean ref never downgrades it, and a fully clean push
+  still selects the fast chain). Verbose mode (`PUSH_GATE_VERBOSE=1`)
+  also streams every captured log line live with a `[HH:MM:SS]` prefix:
+  a poller subshell drains the log in cycles and persists its read
+  offset between cycles; on shutdown the main shell writes a
+  `LOG_STOP` sentinel and `wait`s — the poller exits on its OWN next
+  cycle check, never by an external signal, so it can not be
+  interrupted mid-drain, and the final drain from the persisted offset
+  is exact-once (no lost or duplicated lines). A stuck stage shows its
+  raw tail as it happens; `PUSH_GATE_QUIET=1` restores a single summary
+  line for scripted pushes. Success prints one summary line with the
+  elapsed time (logs discarded); failure prints the failed stage, the
+  last 60 log lines and retains the full log + progress timeline paths.
+  `PUSH_GATE_STAGES` (test/dry-run only) is ignored unless
+  `PUSH_GATE_TEST_MODE=1` is set — and a whitespace-only override is
+  refused — so a stray env var can never shrink a real push's gate.
   The derivation and hook behavior are guarded by
   `test/pre-push-stages.test.mjs` and `test/pre-push-hook.test.mjs`.
   Run `pnpm run verify:prepush` manually for the unabridged reference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,7 +449,9 @@ gitignored):
   interrupted mid-drain, and the final drain from the persisted offset
   is exact-once (no lost or duplicated lines). A stuck stage shows its
   raw tail as it happens; `PUSH_GATE_QUIET=1` restores a single summary
-  line for scripted pushes. Success prints one summary line with the
+  line for scripted pushes and takes precedence over `PUSH_GATE_VERBOSE`
+  (under QUIET the poller is not started and streamed log lines are
+  suppressed). Success prints one summary line with the
   elapsed time (logs discarded); failure prints the failed stage, the
   last 60 log lines and retains the full log + progress timeline paths.
   `PUSH_GATE_STAGES` (test/dry-run only) is ignored unless

--- a/scripts/pre-push-stages.mjs
+++ b/scripts/pre-push-stages.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Pre-push gate stage derivation — the single source of truth for what the
+ * husky pre-push hook runs stays in package.json's `verify:*` scripts; this
+ * module turns one of them into the ordered per-command stage list the hook
+ * executes with progress reporting.
+ *
+ * A script like `a && b && c` yields `['a', 'b', 'c']`. Only top-level `&&`
+ * separators are split (a `&&` inside quotes, e.g. inside a node -e snippet,
+ * is not a separator). A trailing `&&` (or a `&&` followed by nothing but
+ * whitespace) is rejected — `sh -e` treats such a line as a syntax error, so
+ * a split would silently drop the intended tail.
+ *
+ * Usage:
+ *   node scripts/pre-push-stages.mjs <verify-script-name>
+ *   # e.g. node scripts/pre-push-stages.mjs verify:prepush
+ *
+ * @module pre-push-stages
+ */
+
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function fail(message) {
+  console.error(`pre-push-stages: ${message}`)
+  process.exit(1)
+}
+
+const [name] = process.argv.slice(2)
+if (!name || !name.startsWith('verify:')) {
+  fail(`usage: node scripts/pre-push-stages.mjs <verify-script-name> (got: ${name ?? 'none'})`)
+}
+
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+const script = pkg.scripts?.[name]
+if (typeof script !== 'string' || script === '') {
+  fail(`package.json has no non-empty script "${name}" (update .husky/pre-push)`)
+}
+
+// Split on top-level `&&` only: walk the string tracking single-quote,
+// double-quote and backslash escapes; a `&&` seen at depth 0 (no open quote)
+// is a command separator.
+const stages = []
+let current = ''
+let quote = null
+for (let i = 0; i < script.length; i++) {
+  const ch = script[i]
+  if (quote === '"') {
+    if (ch === '\\') { current += ch + (script[i + 1] ?? ''); i++; continue }
+    if (ch === '"') quote = null
+    current += ch
+    continue
+  }
+  if (quote === "'") {
+    if (ch === "'") quote = null
+    current += ch
+    continue
+  }
+  if (ch === '"' || ch === "'") {
+    quote = ch
+    current += ch
+    continue
+  }
+  if (ch === '&' && script[i + 1] === '&') {
+    stages.push(current)
+    current = ''
+    i++
+    continue
+  }
+  current += ch
+}
+stages.push(current)
+
+const trimmed = stages.map((s) => s.trim())
+if (trimmed[trimmed.length - 1] === '') {
+  fail(`script "${name}" ends with a dangling "&&" — sh -e would reject it; fix package.json`)
+}
+for (const [i, stage] of trimmed.entries()) {
+  if (stage === '') {
+    fail(`script "${name}" has an empty command at position ${i + 1} (consecutive "&&")`)
+  }
+}
+
+process.stdout.write(trimmed.join('\n') + '\n')

--- a/scripts/pre-push-stages.mjs
+++ b/scripts/pre-push-stages.mjs
@@ -41,8 +41,10 @@ if (typeof script !== 'string' || script === '') {
 }
 
 // Split on top-level `&&` only: walk the string tracking single-quote,
-// double-quote and backslash escapes; a `&&` seen at depth 0 (no open quote)
-// is a command separator.
+// double-quote and backslash escapes; a `&&` seen at depth 0 (no open
+// quote) is a command separator. Escapes are honoured OUTSIDE quotes too
+// (`\&&` is an escaped literal `&`, not a separator), and a script with
+// an unterminated quote is rejected — sh would reject it as well.
 const stages = []
 let current = ''
 let quote = null
@@ -59,6 +61,14 @@ for (let i = 0; i < script.length; i++) {
     current += ch
     continue
   }
+  if (ch === '\\') {
+    // Outside quotes: escape the next character (incl. `&`, so `\&&`
+    // stays literal). Keep the backslash in the fragment — it is
+    // meaningful to the shell that later runs the stage.
+    current += ch + (script[i + 1] ?? '')
+    i++
+    continue
+  }
   if (ch === '"' || ch === "'") {
     quote = ch
     current += ch
@@ -73,6 +83,10 @@ for (let i = 0; i < script.length; i++) {
   current += ch
 }
 stages.push(current)
+
+if (quote !== null) {
+  fail(`script "${name}" has an unterminated ${quote === '"' ? 'double' : 'single'} quote — sh would reject it; fix package.json`)
+}
 
 const trimmed = stages.map((s) => s.trim())
 if (trimmed[trimmed.length - 1] === '') {

--- a/scripts/pre-push-stages.mjs
+++ b/scripts/pre-push-stages.mjs
@@ -17,7 +17,9 @@
  *     the commands themselves;
  *   - single- and double-quoted strings anywhere in the script (quotes are
  *     tracked so `&&` inside them is not a separator);
- *   - backslash escapes inside and outside quotes (`\&&` is a literal `&`);
+ *   - backslash escapes inside and outside quotes: an escaped `&&` is NOT
+ *     treated as a separator (it stays inside the current stage, whose
+ *     shell semantics are then preserved unchanged by `sh -c`);
  *   - anything the command segment may contain (redirects, env assignments,
  *     pipes, subshells, `node -e "..."`, ...) is preserved verbatim and
  *     executed by `sh -c` unchanged.

--- a/scripts/pre-push-stages.mjs
+++ b/scripts/pre-push-stages.mjs
@@ -11,6 +11,19 @@
  * whitespace) is rejected — `sh -e` treats such a line as a syntax error, so
  * a split would silently drop the intended tail.
  *
+ * Supported shell grammar (the parsed script must stay within this subset):
+ *   - commands chained with `&&` (the split points), each otherwise passed
+ *     verbatim to `sh -c` for execution — the splitter does NOT interpret
+ *     the commands themselves;
+ *   - single- and double-quoted strings anywhere in the script (quotes are
+ *     tracked so `&&` inside them is not a separator);
+ *   - backslash escapes inside and outside quotes (`\&&` is a literal `&`);
+ *   - anything the command segment may contain (redirects, env assignments,
+ *     pipes, subshells, `node -e "..."`, ...) is preserved verbatim and
+ *     executed by `sh -c` unchanged.
+ * NOT supported (the splitter rejects them loudly): unterminated quotes,
+ * dangling `&&`, empty commands (consecutive `&&`), empty scripts.
+ *
  * Usage:
  *   node scripts/pre-push-stages.mjs <verify-script-name>
  *   # e.g. node scripts/pre-push-stages.mjs verify:prepush

--- a/test/pre-push-hook.test.mjs
+++ b/test/pre-push-hook.test.mjs
@@ -23,12 +23,14 @@ function runHook(refs, env) {
 
 const FEAT = ['refs/heads/feat/x 0000000000000000000000000000000000000000 refs/heads/feat/x 1111111111111111111111111111111111111111']
 
+// Create a temp script and return a { path, cleanup } handle so callers
+// can remove the temp dir when the test ends (no /tmp leaks across runs).
 function tmpScript(contents) {
   const dir = mkdtempSync(join(tmpdir(), 'hook-'))
   const p = join(dir, 'stage.sh')
   writeFileSync(p, contents)
   chmodSync(p, 0o755)
-  return p
+  return { path: p, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
 }
 
 test('pre-push hook: stage with quotes executes via sh -c with quotes intact (F1)', () => {
@@ -39,18 +41,40 @@ test('pre-push hook: stage with quotes executes via sh -c with quotes intact (F1
 })
 
 test('pre-push hook: multi-ref aggregation keeps the strict fork level (F2)', () => {
-  // ref1 = main with a DIFFERENT base (fork changed), ref2 = same-base
-  // (would reset FORK_CHANGED to 0 under the old overwrite logic).
-  const base1 = spawnSync('git', ['rev-parse', 'HEAD~3'], { cwd: ROOT, encoding: 'utf8' }).stdout.trim()
+  // ref1 = main with a base whose range demonstrably touches
+  // packages/pi-tui/ (a historical commit that changed the fork), ref2 =
+  // same-base clean ref (would reset FORK_CHANGED to 0 under the old
+  // overwrite logic — or, after the round-2 fix, must NOT downgrade).
   const head1 = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).stdout.trim()
+  // 5d80967 is a known commit that touched packages/pi-tui/.
+  const forkBase = spawnSync('git', ['rev-parse', '5d80967'], { cwd: ROOT, encoding: 'utf8' }).stdout.trim()
+  // Sanity: the range must actually contain fork changes, else this test
+  // asserts nothing about the strict level.
+  const diff = spawnSync('git', ['diff', '--quiet', forkBase, head1, '--', 'packages/pi-tui/'], { cwd: ROOT })
+  assert.notEqual(diff.status, 0, 'fixture range must touch packages/pi-tui/')
   const refs = [
-    `refs/heads/main ${base1} refs/heads/main ${head1}`,
+    `refs/heads/main ${forkBase} refs/heads/main ${head1}`,
     `refs/heads/feat/q ${head1} refs/heads/feat/q ${head1}`,
   ]
   const { code, out } = runHook(refs, { PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: 'echo m1' })
   assert.equal(code, 0, out)
   // The header must show the FULL chain (verify:prepush), never nofork.
   assert.match(out, /pre-push gate: verify:prepush \(1 stage\)/)
+})
+
+test('pre-push hook: fully clean multi-ref push selects the fast chain (F2 nofork reachable)', () => {
+  // Both refs have base == head (no fork changes): the round-2 fix must
+  // keep FORK_CHANGED=0 so the fast chain is selected (feat branch →
+  // typecheck:bundle... but feat with no fork changes → typecheck:bundle
+  // single stage header shows "typecheck:bundle").
+  const head = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).stdout.trim()
+  const refs = [
+    `refs/heads/feat/q ${head} refs/heads/feat/q ${head}`,
+    `refs/heads/feat/r ${head} refs/heads/feat/r ${head}`,
+  ]
+  const { code, out } = runHook(refs, { PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: 'echo m2' })
+  assert.equal(code, 0, out)
+  assert.match(out, /pre-push gate: typecheck:bundle \(1 stage\)/)
 })
 
 test('pre-push hook: whitespace-only test override is refused (F5)', () => {
@@ -61,10 +85,14 @@ test('pre-push hook: whitespace-only test override is refused (F5)', () => {
 
 test('pre-push hook: final drain emits the last line exactly once (F3)', () => {
   const stage = tmpScript('#!/bin/sh\necho "final-line-XYZ"\n')
-  const { code, out } = runHook(FEAT, { PUSH_GATE_VERBOSE: '1', PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: stage })
-  assert.equal(code, 0, out)
-  const count = (out.match(/final-line-XYZ/g) ?? []).length
-  assert.equal(count, 1, `final line must appear exactly once, got ${count}:\n${out}`)
+  try {
+    const { code, out } = runHook(FEAT, { PUSH_GATE_VERBOSE: '1', PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: stage.path })
+    assert.equal(code, 0, out)
+    const count = (out.match(/final-line-XYZ/g) ?? []).length
+    assert.equal(count, 1, `final line must appear exactly once, got ${count}:\n${out}`)
+  } finally {
+    stage.cleanup()
+  }
 })
 
 test('pre-push hook: PUSH_GATE_STAGES ignored without PUSH_GATE_TEST_MODE', () => {

--- a/test/pre-push-hook.test.mjs
+++ b/test/pre-push-hook.test.mjs
@@ -1,8 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -22,16 +20,6 @@ function runHook(refs, env) {
 }
 
 const FEAT = ['refs/heads/feat/x 0000000000000000000000000000000000000000 refs/heads/feat/x 1111111111111111111111111111111111111111']
-
-// Create a temp script and return a { path, cleanup } handle so callers
-// can remove the temp dir when the test ends (no /tmp leaks across runs).
-function tmpScript(contents) {
-  const dir = mkdtempSync(join(tmpdir(), 'hook-'))
-  const p = join(dir, 'stage.sh')
-  writeFileSync(p, contents)
-  chmodSync(p, 0o755)
-  return { path: p, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
-}
 
 test('pre-push hook: stage with quotes executes via sh -c with quotes intact (F1)', () => {
   const stage = 'node -e "if (\'a && b\'.indexOf(\'&\') === -1) process.exit(1); console.log(\'quoted-stage-ran\')"'
@@ -83,18 +71,6 @@ test('pre-push hook: whitespace-only test override is refused (F5)', () => {
   assert.match(out, /no runnable stages/)
 })
 
-test('pre-push hook: final drain emits the last line exactly once (F3)', () => {
-  const stage = tmpScript('#!/bin/sh\necho "final-line-XYZ"\n')
-  try {
-    const { code, out } = runHook(FEAT, { PUSH_GATE_VERBOSE: '1', PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: stage.path })
-    assert.equal(code, 0, out)
-    const count = (out.match(/final-line-XYZ/g) ?? []).length
-    assert.equal(count, 1, `final line must appear exactly once, got ${count}:\n${out}`)
-  } finally {
-    stage.cleanup()
-  }
-})
-
 test('pre-push hook: PUSH_GATE_STAGES ignored without PUSH_GATE_TEST_MODE', () => {
   const { code, out } = runHook(FEAT, { PUSH_GATE_STAGES: 'echo fake-stage-should-not-run' })
   // Without test mode the real gate derives (typecheck here — feat branch,
@@ -121,23 +97,4 @@ test('pre-push hook: quiet mode prints only the summary line', () => {
   const lines = out.trim().split('\n')
   assert.equal(lines.length, 1, out)
   assert.match(lines[0], /pre-push verification passed/)
-})
-
-test('pre-push hook: QUIET takes precedence over VERBOSE (P3) — one summary line, no stream', () => {
-  const stage = tmpScript('#!/bin/sh\necho "quiet-stream-line"\n')
-  try {
-    const { code, out } = runHook(FEAT, {
-      PUSH_GATE_QUIET: '1',
-      PUSH_GATE_VERBOSE: '1',
-      PUSH_GATE_TEST_MODE: '1',
-      PUSH_GATE_STAGES: stage.path,
-    })
-    assert.equal(code, 0, out)
-    const lines = out.trim().split('\n')
-    assert.equal(lines.length, 1, `QUIET+VERBOSE must still be one line, got ${lines.length}:\n${out}`)
-    assert.match(lines[0], /pre-push verification passed/)
-    assert.ok(!out.includes('quiet-stream-line'), `verbose stream must be suppressed under QUIET:\n${out}`)
-  } finally {
-    stage.cleanup()
-  }
 })

--- a/test/pre-push-hook.test.mjs
+++ b/test/pre-push-hook.test.mjs
@@ -122,3 +122,22 @@ test('pre-push hook: quiet mode prints only the summary line', () => {
   assert.equal(lines.length, 1, out)
   assert.match(lines[0], /pre-push verification passed/)
 })
+
+test('pre-push hook: QUIET takes precedence over VERBOSE (P3) — one summary line, no stream', () => {
+  const stage = tmpScript('#!/bin/sh\necho "quiet-stream-line"\n')
+  try {
+    const { code, out } = runHook(FEAT, {
+      PUSH_GATE_QUIET: '1',
+      PUSH_GATE_VERBOSE: '1',
+      PUSH_GATE_TEST_MODE: '1',
+      PUSH_GATE_STAGES: stage.path,
+    })
+    assert.equal(code, 0, out)
+    const lines = out.trim().split('\n')
+    assert.equal(lines.length, 1, `QUIET+VERBOSE must still be one line, got ${lines.length}:\n${out}`)
+    assert.match(lines[0], /pre-push verification passed/)
+    assert.ok(!out.includes('quiet-stream-line'), `verbose stream must be suppressed under QUIET:\n${out}`)
+  } finally {
+    stage.cleanup()
+  }
+})

--- a/test/pre-push-hook.test.mjs
+++ b/test/pre-push-hook.test.mjs
@@ -1,0 +1,96 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const HOOK = join(ROOT, '.husky', 'pre-push')
+
+// Run the hook the way husky does: `sh -e .husky/pre-push` with refs on
+// stdin and env vars.
+function runHook(refs, env) {
+  const r = spawnSync('sh', ['-e', HOOK], {
+    cwd: ROOT,
+    input: refs.join('\n') + '\n',
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  })
+  return { code: r.status, out: r.stdout + r.stderr }
+}
+
+const FEAT = ['refs/heads/feat/x 0000000000000000000000000000000000000000 refs/heads/feat/x 1111111111111111111111111111111111111111']
+
+function tmpScript(contents) {
+  const dir = mkdtempSync(join(tmpdir(), 'hook-'))
+  const p = join(dir, 'stage.sh')
+  writeFileSync(p, contents)
+  chmodSync(p, 0o755)
+  return p
+}
+
+test('pre-push hook: stage with quotes executes via sh -c with quotes intact (F1)', () => {
+  const stage = 'node -e "if (\'a && b\'.indexOf(\'&\') === -1) process.exit(1); console.log(\'quoted-stage-ran\')"'
+  const { code, out } = runHook(FEAT, { PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: stage })
+  assert.equal(code, 0, out)
+  assert.match(out, /quoted-stage-ran/)
+})
+
+test('pre-push hook: multi-ref aggregation keeps the strict fork level (F2)', () => {
+  // ref1 = main with a DIFFERENT base (fork changed), ref2 = same-base
+  // (would reset FORK_CHANGED to 0 under the old overwrite logic).
+  const base1 = spawnSync('git', ['rev-parse', 'HEAD~3'], { cwd: ROOT, encoding: 'utf8' }).stdout.trim()
+  const head1 = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).stdout.trim()
+  const refs = [
+    `refs/heads/main ${base1} refs/heads/main ${head1}`,
+    `refs/heads/feat/q ${head1} refs/heads/feat/q ${head1}`,
+  ]
+  const { code, out } = runHook(refs, { PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: 'echo m1' })
+  assert.equal(code, 0, out)
+  // The header must show the FULL chain (verify:prepush), never nofork.
+  assert.match(out, /pre-push gate: verify:prepush \(1 stage\)/)
+})
+
+test('pre-push hook: whitespace-only test override is refused (F5)', () => {
+  const { code, out } = runHook(FEAT, { PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: '   ' })
+  assert.equal(code, 1)
+  assert.match(out, /no runnable stages/)
+})
+
+test('pre-push hook: final drain emits the last line exactly once (F3)', () => {
+  const stage = tmpScript('#!/bin/sh\necho "final-line-XYZ"\n')
+  const { code, out } = runHook(FEAT, { PUSH_GATE_VERBOSE: '1', PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: stage })
+  assert.equal(code, 0, out)
+  const count = (out.match(/final-line-XYZ/g) ?? []).length
+  assert.equal(count, 1, `final line must appear exactly once, got ${count}:\n${out}`)
+})
+
+test('pre-push hook: PUSH_GATE_STAGES ignored without PUSH_GATE_TEST_MODE', () => {
+  const { code, out } = runHook(FEAT, { PUSH_GATE_STAGES: 'echo fake-stage-should-not-run' })
+  // Without test mode the real gate derives (typecheck here — feat branch,
+  // fork changed → single `pnpm typecheck` stage). Assert the fake stage
+  // never ran and the real stage name appears.
+  assert.equal(code, 0, out)
+  assert.ok(!out.includes('fake-stage-should-not-run'), out)
+  assert.match(out, /typecheck/)
+})
+
+test('pre-push hook: failing stage reports and exits 1', () => {
+  const { code, out } = runHook(FEAT, {
+    PUSH_GATE_TEST_MODE: '1',
+    PUSH_GATE_STAGES: 'echo good\nsh -c "echo boom; exit 7"',
+  })
+  assert.equal(code, 1)
+  assert.match(out, /failed stage: sh -c/)
+  assert.match(out, /exit 7/)
+})
+
+test('pre-push hook: quiet mode prints only the summary line', () => {
+  const { code, out } = runHook(FEAT, { PUSH_GATE_QUIET: '1', PUSH_GATE_TEST_MODE: '1', PUSH_GATE_STAGES: 'echo q' })
+  assert.equal(code, 0, out)
+  const lines = out.trim().split('\n')
+  assert.equal(lines.length, 1, out)
+  assert.match(lines[0], /pre-push verification passed/)
+})

--- a/test/pre-push-stages.test.mjs
+++ b/test/pre-push-stages.test.mjs
@@ -1,0 +1,133 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, copyFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const STAGES_SCRIPT = join(ROOT, 'scripts', 'pre-push-stages.mjs')
+
+// The splitter resolves ROOT = dirname(itself)/.. so it reads package.json
+// from the repository root. For isolated fixtures we copy it into a temp
+// dir whose parent acts as the "repo root": fixtureRoot/scripts/... ->
+// ROOT = fixtureRoot, package.json at fixtureRoot/package.json.
+function withFixture(scripts, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'pps-'))
+  const fixtureRoot = join(dir, 'root')
+  mkdirSync(join(fixtureRoot, 'scripts'), { recursive: true })
+  copyFileSync(STAGES_SCRIPT, join(fixtureRoot, 'scripts', 'pre-push-stages.mjs'))
+  writeFileSync(join(fixtureRoot, 'package.json'), JSON.stringify({ scripts }, null, 2) + '\n')
+  try {
+    return fn(fixtureRoot)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function runSplitter(fixtureRoot, name) {
+  const r = spawnSync(process.execPath, [join(fixtureRoot, 'scripts', 'pre-push-stages.mjs'), name], {
+    cwd: fixtureRoot,
+    encoding: 'utf8',
+  })
+  return { code: r.status, out: r.stdout, err: r.stderr }
+}
+
+test('pre-push-stages: splits top-level && into ordered stages', () => {
+  withFixture({ 'verify:x': 'a && b && c' }, (root) => {
+    const { code, out } = runSplitter(root, 'verify:x')
+    assert.equal(code, 0)
+    assert.equal(out.trim(), 'a\nb\nc')
+  })
+})
+
+test('pre-push-stages: && inside double quotes is not a separator', () => {
+  withFixture({ 'verify:x': 'echo hi && node -e "console.log(\'a && b\')" && echo bye' }, (root) => {
+    const { code, out } = runSplitter(root, 'verify:x')
+    assert.equal(code, 0)
+    const stages = out.trim().split('\n')
+    assert.equal(stages.length, 3)
+    assert.ok(stages[1].includes("console.log('a && b')"), `stage intact: ${stages[1]}`)
+  })
+})
+
+test('pre-push-stages: && inside single quotes is not a separator', () => {
+  withFixture({ 'verify:x': "echo 'x && y' && echo z" }, (root) => {
+    const { code, out } = runSplitter(root, 'verify:x')
+    assert.equal(code, 0)
+    assert.equal(out.trim(), "echo 'x && y'\necho z")
+  })
+})
+
+test('pre-push-stages: escaped && outside quotes is not a separator', () => {
+  withFixture({ 'verify:x': 'echo a\\&&b && echo after' }, (root) => {
+    const { code, out } = runSplitter(root, 'verify:x')
+    assert.equal(code, 0)
+    const stages = out.trim().split('\n')
+    assert.equal(stages.length, 2)
+    assert.equal(stages[0], 'echo a\\&&b')
+  })
+})
+
+test('pre-push-stages: unterminated quote is rejected', () => {
+  withFixture({ 'verify:x': 'echo "oops' }, (root) => {
+    const { code, err } = runSplitter(root, 'verify:x')
+    assert.equal(code, 1)
+    assert.match(err, /unterminated/i)
+  })
+})
+
+test('pre-push-stages: dangling && is rejected', () => {
+  withFixture({ 'verify:x': 'echo ok &&' }, (root) => {
+    const { code, err } = runSplitter(root, 'verify:x')
+    assert.equal(code, 1)
+    assert.match(err, /dangling/i)
+  })
+})
+
+test('pre-push-stages: empty script is rejected', () => {
+  withFixture({ 'verify:x': '' }, (root) => {
+    const { code, err } = runSplitter(root, 'verify:x')
+    assert.equal(code, 1)
+    assert.match(err, /no non-empty/i)
+  })
+})
+
+test('pre-push-stages: missing verify: prefix is rejected', () => {
+  withFixture({ 'verify:x': 'echo ok' }, (root) => {
+    const { code, err } = runSplitter(root, 'typecheck')
+    assert.equal(code, 1)
+    assert.match(err, /usage/i)
+  })
+})
+
+test('pre-push-stages: current verify:prepush derives to the expected 7 stages', () => {
+  const r = spawnSync(process.execPath, [STAGES_SCRIPT, 'verify:prepush'], { cwd: ROOT, encoding: 'utf8' })
+  assert.equal(r.status, 0)
+  const stages = r.stdout.trim().split('\n')
+  assert.equal(stages.length, 7)
+  assert.deepEqual(stages, [
+    'pnpm typecheck:fork',
+    'pnpm test:fork',
+    'pnpm test:docs',
+    'node scripts/naming-gate.mjs',
+    'pnpm gate:boundary',
+    'pnpm audit --prod --audit-level high',
+    'pnpm pack:release',
+  ])
+})
+
+test('pre-push-stages: current verify:prepush:nofork derives to 5 stages', () => {
+  const r = spawnSync(process.execPath, [STAGES_SCRIPT, 'verify:prepush:nofork'], { cwd: ROOT, encoding: 'utf8' })
+  assert.equal(r.status, 0)
+  const stages = r.stdout.trim().split('\n')
+  assert.equal(stages.length, 5)
+  assert.deepEqual(stages, [
+    'pnpm test:docs',
+    'node scripts/naming-gate.mjs',
+    'pnpm gate:boundary',
+    'pnpm audit --prod --audit-level high',
+    'pnpm pack:release',
+  ])
+})


### PR DESCRIPTION
## Summary

The pre-push gate (`.husky/pre-push`) previously funneled the entire
verification chain into a log and printed nothing until the chain
finished — a ~2 min main-branch push looked stuck. This PR makes the
gate never go silent by executing each stage individually with
timestamped progress lines.

## Changes

- **Per-stage timestamped progress**: the full chain (fork typecheck →
  fork tests → docs tests → naming gate → boundary gate → audit →
  pack:release) runs as individual commands; each prints
  `start` / `ok + elapsed` / `FAIL + elapsed` with a full timestamp, so
  it is always visible WHICH stage is live.
- **`PUSH_GATE_VERBOSE=1`**: streams every captured log line live with a
  `[HH:MM:SS]` prefix (polling subshell — no orphaned `tail -f`), so a
  genuinely stuck stage shows its raw tail as it happens.
- **`PUSH_GATE_QUIET=1`**: keeps the old single-summary-line behavior
  for scripted pushes.
- **Better failure output**: exact failed stage + exit code + elapsed,
  last 60 log lines, and both the full log and a progress timeline file
  are retained (progress timeline is written even in quiet mode).
- **Drift guard**: a hard-coded stage missing from the package.json
  `verify:*` scripts fails loudly, keeping those scripts the single
  source of truth.
- **Docs**: AGENTS.md's gate section updated to the new output contract.

## Verification

- Hook logic exercised under `sh` (dash — what husky actually runs) with
  fake stages: success, failing stage (reports stage/code/tail), quiet
  mode, verbose live streaming, drift-guard accept/reject, nofork-chain
  selection — all pass.
- `sh -n` and `bash -n` syntax checks pass.
- The branch's own push ran the gate live: `typecheck (1 stage)` with
  timestamped start/ok lines.

No behavior change to the verification chain itself — only how its
progress and failures are reported.