### PR TITLE
fix(focus): keep compact tool previews single-line

### DIFF
--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -130,14 +130,30 @@ export function formatFocusHeaderLine(
  * (plan §25, aligned by visible width). */
 const FOCUS_SLOT_LABEL_WIDTH = 9
 
+/** Collapse arbitrary slot text to ONE physical terminal row: CR/LF
+ * sequences (LF, CRLF, lone CR) are normalized to the FIRST line. This is
+ * the final boundary the fullscreen compositor depends on — every
+ * string[] element a component renders is exactly one framebuffer row, so
+ * no caller-provided multiline text (bash heredocs, multiline errors, …)
+ * may ever escape a compact slot as embedded line breaks (ghost-row fix).
+ * The first line is kept rather than joining the lines with spaces: the
+ * compact preview must not smuggle later lines' content into the row, and
+ * width truncation would keep the leading lines anyway. */
+function compactSingleLine(text: string): string {
+  return text.split(/\r\n|\r|\n/)[0] ?? ''
+}
+
 /** One collapsed body slot line, truncated to the content width: the body
  * budget is the width MINUS the lead ('Think:   ' / 'Error:   '), and a
  * lead that alone exceeds the width truncates too — a preview line can
- * never wrap (the fullscreen row hit-map depends on that). */
+ * never wrap (the fullscreen row hit-map depends on that). The returned
+ * string is one PHYSICAL terminal row: CR/LF are normalized before width
+ * truncation; no caller-provided multiline text may escape. */
 function previewLine(label: string, text: string, width: number): string {
+  const singleLine = compactSingleLine(text)
   const lead = `${label}${' '.repeat(Math.max(0, FOCUS_SLOT_LABEL_WIDTH - visibleWidth(label)))}`
   const bodyBudget = width - visibleWidth(lead)
-  const body = bodyBudget > 0 ? truncateToWidth(text, bodyBudget, '…') : ''
+  const body = bodyBudget > 0 ? truncateToWidth(singleLine, bodyBudget, '…') : ''
   return truncateToWidth(`${lead}${body}`, Math.max(1, width), '…')
 }
 

--- a/src/present.ts
+++ b/src/present.ts
@@ -1102,9 +1102,13 @@ export function focusToolDisplay(
 /** The compact line from a tool-owned presentCall view: the title, plus
  * the rawInput when it is a string the title does not already carry (the
  * skill tool's title is `Load skill <name>` — appending its rawInput
- * again would duplicate). */
+ * again would duplicate). The terminal title is the FULL command, which
+ * may contain real line breaks (heredoc / python / node -); the compact
+ * Focus Tool slot is exactly ONE physical framebuffer row, so only its
+ * FIRST line may surface here — the expanded tool card still renders the
+ * full multiline command (ghost-row fix). */
 function formatOwnedCallForCompactFocus(view: ToolCallView): string {
-  if (view.card === 'terminal') return view.title
+  if (view.card === 'terminal') return firstLine(view.title.replace(/\r\n|\r/g, '\n'))
   if (view.card === 'diff') {
     const path = view.diffs[0]?.path
     return path === undefined ? view.title : `${view.title} ${path}`

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -1427,14 +1427,6 @@ const MULTILINE_BASH_COMMAND = [
 ].join('\n')
 
 test('focusToolDisplay keeps a multiline terminal title to ONE line (ghost-row fix)', () => {
-  const presenter: ToolPresenter = {
-    call(name) {
-      return name === 'bash'
-        ? { card: 'terminal', title: MULTILINE_BASH_COMMAND, description: 'Patch commands test' }
-        : undefined
-    },
-    result() { return undefined },
-  }
   // LF, CRLF and lone-CR variants all collapse to the first line.
   const variants = [
     MULTILINE_BASH_COMMAND,

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -1417,6 +1417,100 @@ test('the Tool display is presenter-first with a static fallback (plan §9/§43)
   assert.equal(focusToolDisplay({ name: 'read', args: JSON.stringify({ path: 'a.ts' }) }, { presenter: guarded }), 'Read a.ts')
 })
 
+/** A realistic multiline Bash heredoc command (the ghost-row repro shape). */
+const MULTILINE_BASH_COMMAND = [
+  "python3 - <<'PYEOF'",
+  'p = "src/commands.ts"',
+  's = open(p).read()',
+  'assert old in s',
+  'PYEOF',
+].join('\n')
+
+test('focusToolDisplay keeps a multiline terminal title to ONE line (ghost-row fix)', () => {
+  const presenter: ToolPresenter = {
+    call(name) {
+      return name === 'bash'
+        ? { card: 'terminal', title: MULTILINE_BASH_COMMAND, description: 'Patch commands test' }
+        : undefined
+    },
+    result() { return undefined },
+  }
+  // LF, CRLF and lone-CR variants all collapse to the first line.
+  const variants = [
+    MULTILINE_BASH_COMMAND,
+    MULTILINE_BASH_COMMAND.replace(/\n/g, '\r\n'),
+    MULTILINE_BASH_COMMAND.replace(/\n/g, '\r'),
+  ]
+  for (const title of variants) {
+    const display = focusToolDisplay({ name: 'bash', args: '{}' }, {
+      presenter: { call: () => ({ card: 'terminal' as const, title }), result: () => undefined },
+    })
+    assert.equal(display.includes('\n'), false, JSON.stringify(display))
+    assert.equal(display.includes('\r'), false, JSON.stringify(display))
+    assert.match(display, /python3/, JSON.stringify(display))
+    // The compact line keeps the command IDENTITY (its first line), never
+    // the heredoc continuation.
+    assert.equal(display, "python3 - <<'PYEOF'", JSON.stringify(display))
+  }
+})
+
+test('focusCollapsedBody keeps a multiline Tool slot on ONE physical row (ghost-row fix)', () => {
+  const activity = activityOf(0, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('tool/call', { turn: 0, step: 0, callId: CallId('c'), name: 'bash', arguments: '{}' }, 1001, 1),
+  ])!
+  const rows = focusCollapsedBody(activity, 100, MULTILINE_BASH_COMMAND)
+  const toolRow = rows.find(row => row.startsWith('Tool:'))
+  assert.ok(toolRow !== undefined, rows.join('|'))
+  assert.equal(toolRow.includes('\n'), false, JSON.stringify(toolRow))
+  assert.equal(toolRow.includes('\r'), false, JSON.stringify(toolRow))
+  assert.ok(visibleWidth(toolRow) <= 100, `${JSON.stringify(toolRow)} (${visibleWidth(toolRow)})`)
+  // Heredoc continuation lines must never surface in the collapsed rows
+  // (they are the ghost rows), even though they fit the width.
+  assert.equal(rows.some(row => row.includes('p = "src/commands.ts"')), false, rows.join('|'))
+  assert.equal(rows.some(row => row.includes('s = open')), false, rows.join('|'))
+})
+
+test('every compact slot is ONE physical row even with multiline input (ghost-row fix, plan §6.3)', () => {
+  const activity = activityOf(0, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'first think line\nsecond think line' } }, 1001, 1),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'first message line\r\nsecond message line' } }, 1002, 2),
+    eventAt('tool/call', { turn: 0, step: 0, callId: CallId('c'), name: 'bash', arguments: '{}' }, 1003, 3),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'error', error: { code: 'E', message: 'first error line\nsecond error line' } } }, 2000, 4),
+  ])!
+  const rows = focusCollapsedBody(activity, 80, MULTILINE_BASH_COMMAND)
+  // All four slots render, and every one is a single physical row.
+  for (const label of ['Think:', 'Message:', 'Tool:', 'Error:']) {
+    assert.ok(rows.some(row => row.startsWith(label)), `${label} missing:\n${rows.join('\n')}`)
+  }
+  for (const row of rows) {
+    assert.equal(row.includes('\n'), false, JSON.stringify(row))
+    assert.equal(row.includes('\r'), false, JSON.stringify(row))
+    assert.ok(visibleWidth(row) <= 80, `${JSON.stringify(row)} (${visibleWidth(row)})`)
+  }
+})
+
+test('FocusActivityComponent.render returns only physical rows for a multiline Tool display (plan §6.4)', () => {
+  const activity = activityOf(0, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('tool/call', { turn: 0, step: 0, callId: CallId('c'), name: 'bash', arguments: '{}' }, 1001, 1),
+  ])!
+  const component = new FocusActivityComponent({
+    activity,
+    expanded: false,
+    now: () => 35000,
+    toolDisplay: MULTILINE_BASH_COMMAND,
+  })
+  const rendered = component.render(120)
+  for (const row of rendered) {
+    assert.equal(row.includes('\n'), false, JSON.stringify(row))
+    assert.equal(row.includes('\r'), false, JSON.stringify(row))
+    assert.ok(visibleWidth(row) <= 120, `${JSON.stringify(row)} (${visibleWidth(row)})`)
+  }
+  assert.equal(rendered.some(row => row.includes('p = "src/commands.ts"')), false, rendered.join('|'))
+})
+
 test('formatTokens renders the pi abbreviation vocabulary', () => {
   assert.equal(formatTokens(847), '847')
   assert.equal(formatTokens(3200), '3.2k')

--- a/test/focus-ui.test.ts
+++ b/test/focus-ui.test.ts
@@ -13,6 +13,7 @@ import { CallId, MessageId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { TranscriptFolder } from '../src/transcript.ts'
 import { TuiApp } from '../src/tui-app.ts'
+import type { ToolPresenter } from '../src/present.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 function startApp(): { vt: VirtualTerminal; app: TuiApp } {
@@ -1071,5 +1072,164 @@ test('cache identity: the Thinking hint rebuilds on surface switches (alt+t ↔ 
   joined = vt.getViewport().join('\n')
   assert.ok(joined.includes('(alt+t to expand)'), 'regular must restore the Alt+T hint')
   assert.ok(!joined.includes('(click to expand)'), 'the click hint must not survive back into regular')
+  app.stop()
+})
+
+/** A realistic multiline Bash heredoc (the ghost-row repro shape). */
+const MULTILINE_BASH_COMMAND = [
+  "python3 - <<'PYEOF'",
+  'p = "src/commands.ts"',
+  's = open(p).read()',
+  'old = "..."',
+  'assert old in s',
+  'PYEOF',
+].join('\n')
+
+/** A presenter whose bash call returns the FULL multiline command as the
+ * terminal card title (the DSH bash presenter's real shape). */
+function bashHeredocPresenter(): ToolPresenter {
+  return {
+    call(name) {
+      return name === 'bash'
+        ? { card: 'terminal', title: MULTILINE_BASH_COMMAND, description: 'Patch commands test' }
+        : undefined
+    },
+    result() { return undefined },
+  }
+}
+
+/** A running turn with ONE multiline Bash call (no reasoning). */
+function multilineBashTurn(seqBase: number): SessionEvent[] {
+  return [
+    eventAt('turn/start', { turn: 1 }, T0, seqBase),
+    eventAt('user/message', {
+      id: MessageId('u1'), role: 'user',
+      content: [{ type: 'text', text: 'run the patch' }],
+      source: { kind: 'user' },
+    }, T0 + 1, seqBase + 1),
+    eventAt('tool/call', { turn: 1, step: 0, callId: CallId('c1'), name: 'bash', arguments: JSON.stringify({ command: MULTILINE_BASH_COMMAND }) }, T0 + 2, seqBase + 2),
+  ]
+}
+
+/** The same turn WITHOUT the tool call: the clean baseline frame that
+ * establishes the alt-screen diff state before the call arrives. */
+function noToolTurn(seqBase: number): SessionEvent[] {
+  return multilineBashTurn(seqBase).slice(0, 2)
+}
+
+/** The remaining events that settle the multiline Bash turn (✓ ok). */
+function settleMultilineBashTurn(seqBase: number): SessionEvent[] {
+  return [
+    eventAt('tool/result', {
+      turn: 1, step: 0,
+      message: {
+        id: MessageId('r1'), role: 'user',
+        content: [{ type: 'tool-result', toolCallId: CallId('c1'), content: [{ type: 'text', text: 'ok' }] }],
+        source: { kind: 'tool', callId: CallId('c1') },
+      },
+    }, T0 + 5000, seqBase + 3),
+    eventAt('assistant/message', {
+      turn: 1, step: 1,
+      message: {
+        id: MessageId('a1'), role: 'assistant',
+        content: [{ type: 'text', text: 'patched.' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+    }, T0 + 6000, seqBase + 4),
+    eventAt('turn/end', { turn: 1, reason: { kind: 'completed' } }, T0 + 7000, seqBase + 5),
+  ]
+}
+
+test('fullscreen Focus: a multiline Bash heredoc stays ONE row and never ghosts across repeated repaints (ghost-row fix)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { present: bashHeredocPresenter() })
+  app.start()
+  const folder = new TranscriptFolder()
+  // Baseline frame WITHOUT the tool: the alt screen's diff state is
+  // established cleanly (a first frame with the multiline row would be a
+  // full redraw that self-heals — the ghost only escapes when the row is
+  // written by a DIFF frame whose following rows are unchanged).
+  folder.apply(noToolTurn(0))
+  app.setFocusMode(true)
+  app.setWorking(true)
+  show(app, folder)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  const assertNoGhost = (label: string) => {
+    const joined = vt.getViewport().join('\n')
+    assert.ok(joined.includes("python3 - <<'PYEOF'"), `${label}: the Tool preview must carry the command:\n${joined}`)
+    for (const ghost of ['p = "src/commands.ts"', 's = open(p)', 'assert old']) {
+      assert.ok(!joined.includes(ghost), `${label}: heredoc line leaked as a ghost row:\n${joined}`)
+    }
+  }
+  // The multiline tool call arrives in a DIFF frame: pre-fix its embedded
+  // newlines escape onto the unchanged rows below the Tool slot.
+  folder.apply(multilineBashTurn(0).slice(2))
+  show(app, folder)
+  await vt.waitForRender()
+  assertNoGhost('tool call frame')
+  // The turn settles: the Tool row is rewritten (✓ prefix) — pre-fix that
+  // rewrite re-ghosts; the final assistant row lands below it.
+  folder.apply(settleMultilineBashTurn(0))
+  show(app, folder)
+  await vt.waitForRender()
+  assertNoGhost('settle frame')
+  // Repeated repaints (the runner's snapshot contract / streaming
+  // heartbeats) WITHOUT any resize must not accumulate ghost rows.
+  for (let i = 0; i < 3; i++) {
+    show(app, folder)
+    await vt.waitForRender()
+    assertNoGhost(`repaint ${i + 1}`)
+  }
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('fullscreen Focus expand/collapse: the expanded Bash card keeps the multiline command, collapse returns to ONE line (ghost-row fix)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { present: bashHeredocPresenter() })
+  app.start()
+  const folder = new TranscriptFolder()
+  // Same diff-frame sequence: clean baseline, then the call + settle land
+  // in one later frame (the collapsed ghost would appear here pre-fix).
+  folder.apply(noToolTurn(0))
+  app.setFocusMode(true)
+  show(app, folder)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  folder.apply([...multilineBashTurn(0).slice(1), ...settleMultilineBashTurn(0)])
+  show(app, folder)
+  await vt.waitForRender()
+  // Collapsed: the Tool slot is ONE row with the command identity only.
+  let joined = vt.getViewport().join('\n')
+  assert.ok(joined.includes("python3 - <<'PYEOF'"), `collapsed preview missing:\n${joined}`)
+  assert.ok(!joined.includes('p = "src/commands.ts"'), `heredoc leaked while collapsed:\n${joined}`)
+  // Expand the Thought: the Bash full card renders the complete multiline
+  // command (expanded mode legitimately uses multiple physical rows).
+  let y = findRow(vt.getViewport(), '🐋 Thought')
+  assert.ok(y >= 0, `Thought header missing:\n${joined}`)
+  click(vt, 3, y + 1)
+  await vt.waitForRender()
+  // The folded card caps the command; clicking the cap marker (fullscreen
+  // mouse-owned disclosure) full-reveals it.
+  let capY = findRow(vt.getViewport(), 'more command lines')
+  assert.ok(capY >= 0, `cap marker missing:\n${vt.getViewport().join('\n')}`)
+  click(vt, 10, capY + 1)
+  await vt.waitForRender()
+  joined = vt.getViewport().join('\n')
+  assert.ok(joined.includes('🐳 Thought'), `expansion failed:\n${joined}`)
+  assert.ok(joined.includes('p = "src/commands.ts"'), `expanded Bash card must keep the full command:\n${joined}`)
+  assert.ok(joined.includes('assert old in s'), `expanded Bash card must keep the full command:\n${joined}`)
+  // Collapse again: only the single-line preview may remain — the old
+  // multiline command rows must not be left behind (no resize anywhere).
+  y = findRow(vt.getViewport(), '🐳 Thought')
+  click(vt, 3, y + 1)
+  await vt.waitForRender()
+  joined = vt.getViewport().join('\n')
+  assert.ok(joined.includes('🐋 Thought'), `collapse failed:\n${joined}`)
+  assert.ok(joined.includes("python3 - <<'PYEOF'"), `collapsed preview missing after collapse:\n${joined}`)
+  assert.ok(!joined.includes('p = "src/commands.ts"'), `old multiline command rows must not survive the collapse:\n${joined}`)
+  assert.ok(!joined.includes('assert old in s'), `old multiline command rows must not survive the collapse:\n${joined}`)
+  app.setFullscreen(false)
   app.stop()
 })

--- a/test/focus-ui.test.ts
+++ b/test/focus-ui.test.ts
@@ -1190,14 +1190,15 @@ test('fullscreen Focus expand/collapse: the expanded Bash card keeps the multili
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { present: bashHeredocPresenter() })
   app.start()
   const folder = new TranscriptFolder()
-  // Same diff-frame sequence: clean baseline, then the call + settle land
-  // in one later frame (the collapsed ghost would appear here pre-fix).
+  // Same diff-frame sequence: clean baseline, then ONLY the appended
+  // suffix (tool/call + settle) lands in one later frame — a real
+  // append-only event stream, never a duplicated user/message.
   folder.apply(noToolTurn(0))
   app.setFocusMode(true)
   show(app, folder)
   app.setFullscreen(true)
   await vt.waitForRender()
-  folder.apply([...multilineBashTurn(0).slice(1), ...settleMultilineBashTurn(0)])
+  folder.apply([...multilineBashTurn(0).slice(2), ...settleMultilineBashTurn(0)])
   show(app, folder)
   await vt.waitForRender()
   // Collapsed: the Tool slot is ONE row with the command identity only.


### PR DESCRIPTION
## Problem

In fullscreen + Focus collapsed state, a Bash multiline command (heredoc / `python3 -` / `node -`) leaked its continuation lines as ghost/residual rows below the Thought card, accumulating across repaints and only healing on a terminal resize.

## Root cause

`formatOwnedCallForCompactFocus` returned the terminal card's `title` verbatim; the title IS the full command, which may contain real line breaks. The alt screen's differential renderer writes only CHANGED rows with absolute cursor positioning, so when a row containing embedded `\n` is written in a diff frame, the content after each newline lands on the unchanged rows below and is never cleared — a logical/physical framebuffer mismatch that resize-only full redraws heal.

## Fix (two-layer defense, per the fix plan)

- **Source layer (`src/present.ts`)**: the compact terminal title keeps only its FIRST line (CR/LF/CRLF normalized). The expanded Bash card still renders the full multiline command.
- **Final boundary (`src/focus-activity.ts`)**: `previewLine()` now normalizes any CR/LF to the first line before width truncation — Think / Message / Tool / Error compact slots can never escape multiline text again, regardless of future presenters.

`truncateToWidth`, the alt-screen renderer, Thinking/ScrollView state machines are untouched; no full-redraw workaround.

## Tests

- 4 new unit tests (LF/CRLF/CR variants, one-physical-row contract for all four slots, `render()` row contract).
- 2 new headless fullscreen integration tests with a real heredoc: the multiline call arrives in a DIFF frame after a clean baseline (a first-frame full redraw self-heals, so this exact sequence reproduces the ghost), then settle + repeated repaints without any resize; and the expand → full Bash card (multiline preserved) → collapse path. Both fail pre-fix with visible ghost rows and pass post-fix.
- Gates: `test:bundle` 2081 pass, `test:fork` 985 pass, docs tests, typecheck, build, `git diff --check`, naming gate, client boundary gate.

## Review

Reviewed via review-fix-loop (openai-codex / gpt-5.6-luna): **accepted**, no findings, full-diff coverage.