### PR TITLE
fix(tasks): live subagent runtime status in the task browser and badge

### DIFF
--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -204,9 +204,25 @@ read the DURABLE descendant catalog, not the live-child list:
   re-sorts a row above its parent (a running grandchild stays under its
   inactive parent). The "first running subagent" rule is a CURSOR policy
   (`TaskBrowserHandle.setItems(items, preferredValue)`), never a sort.
-- **A finished one-shot child stays reachable.** `inactive` is live-store
-  presence, never an outcome; Enter opens its persisted transcript
-  read-only. No activity filter exists in `buildTaskRows`.
+- **A finished one-shot child stays reachable.** `inactive` is never an
+  outcome; Enter opens its persisted transcript read-only. No activity
+  filter exists in `buildTaskRows`.
+- **Runtime activity is projected, never read from the catalog.**
+  `listDescendants().activity` is live-STORE presence, not driver
+  activity: an idle continuable child stays live in the session store and
+  would otherwise read as `running` forever. Every child row's
+  `running` / `inactive` is re-projected from the Agent registry
+  (`ctx.agents.get(id)?.status === 'running'`) AT COMMIT TIME by the
+  `TaskBrowserRuntime` coordinator (`projectSubagentActivity`), so a slow
+  catalog response can never overwrite a newer runtime state. The
+  coordinator splits CATALOG refreshes (subagent lifecycle events, the
+  subagent tool call, jobs changes — the only paths that re-list) from
+  RUNTIME-only refreshes (`agent/status` — the cached catalog is reused,
+  membership/tree/mode never move). The runner's `agent/status` handler
+  is membership-gated: only flips of children in the cached catalog
+  refresh the surface, so the MAIN agent's own per-turn flips never
+  repaint. A session switch closes the open browser and drops the cached
+  catalog (the fence key = session generation + id).
 - **Jobs are a separate flat group**, sorted by their own registry
   ordering; the background one-shot duplication (job row + child row with
   no cross-reference) is contract, locked in by test.
@@ -220,8 +236,16 @@ read the DURABLE descendant catalog, not the live-child list:
   there is no fallback to the main session as a nested direct parent, and
   no `ctx.agents.get(childId).followup(...)` bypass.
 - **The footer badge counts RUNNING descendants at every depth** (the user
-  cares that a deep agent is still working); durable inactive children
-  never keep the badge armed.
+  cares that a deep agent is still working), where RUNNING means the
+  registry-projected driver state — durable idle children never keep the
+  badge armed.
+- **`has children` is not rendered.** The tree connector already
+  expresses parenthood, so the extra detail line duplicated the
+  structure; the `hasChildren` data fact stays on the row for future
+  fold/disclosure work.
+- **The interrupt verb is advertised only for a continuable row whose
+  driver is running right now**: an idle continuable has no driver to
+  stop, so the UI must not advertise (or fire) a dead stop.
 
 ## Focus fullscreen disclosure
 

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -246,9 +246,18 @@ read the DURABLE descendant catalog, not the live-child list:
   expresses parenthood, so the extra detail line duplicated the
   structure; the `hasChildren` data fact stays on the row for future
   fold/disclosure work.
-- **The interrupt verb is advertised only for a continuable row whose
-  driver is running right now**: an idle continuable has no driver to
-  stop, so the UI must not advertise (or fire) a dead stop.
+- **The open browser's FIRST FRAME seeds from the cached catalog.**
+  Opening `/tasks` (or the ↓ trigger) paints the coordinator's CURRENT
+  state — cached membership + fresh jobs + fresh registry statuses —
+  synchronously (no persistence), so the panel never flashes a
+  jobs-only list that contradicts the badge, and a failed fresh listing
+  cannot leave a panel/badge mismatch. The async membership refresh
+  then calibrates in the background.
+- **The interrupt verb is advertised AND fired only for a continuable
+  row whose driver is running right now** — one predicate
+  (`isSubagentRowInterruptible`) gates both the panel hint and the
+  runner's execution path, so an idle continuable has no driver to stop
+  and the UI never advertises (or fires) a dead stop.
 
 ## Focus fullscreen disclosure
 

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -221,8 +221,11 @@ read the DURABLE descendant catalog, not the live-child list:
   membership/tree/mode never move). The runner's `agent/status` handler
   is membership-gated: only flips of children in the cached catalog
   refresh the surface, so the MAIN agent's own per-turn flips never
-  repaint. A session switch closes the open browser and drops the cached
-  catalog (the fence key = session generation + id).
+  repaint. A session switch closes the open browser, clears the badge
+  SYNCHRONOUSLY and drops the cached catalog — the old session's running
+  badge never hangs on the footer until the new session's first listing
+  lands (the fence key = session generation + id; a failed listing never
+  leaves a stale badge).
 - **Jobs are a separate flat group**, sorted by their own registry
   ordering; the background one-shot duplication (job row + child row with
   no cross-reference) is contract, locked in by test.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2778,13 +2778,19 @@ export function apply(ctx: Context, config: Config): void {
       app.clearSessionOverrides()
       // A new session owns the surface: close the task browser opened for
       // the old session (its rows would otherwise go stale — the runtime
-      // refresh is fenced to the old root) and drop the cached descendant
-      // catalog, so stale-session `agent/status` flips find no membership
-      // and the next refresh reads the new root. The coordinator is
-      // re-populated by initLiveSession → refreshAgents.
+      // refresh is fenced to the old root) and CLEAR the subagent badge
+      // SYNCHRONOUSLY — the new session's first listing is async, and the
+      // old session's running badge must not hang on the footer until it
+      // lands (a failed listing must never leave a stale badge either).
+      // The cached catalog is dropped too, so stale-session
+      // `agent/status` flips find no membership and the next refresh
+      // reads the new root. The coordinator is re-populated by
+      // initLiveSession → refreshAgents.
       activeTaskBrowser?.close()
       activeTaskBrowser = undefined
       taskRuntime?.reset()
+      app.setAgents([])
+      taskBrowserRows = []
       // A new session owns the surface: tear down the subagent viewer. The
       // old viewer's parent session is gone (the continuation contract
       // requires the EXACT live parent), so the child transcript, the
@@ -4727,10 +4733,9 @@ export function apply(ctx: Context, config: Config): void {
     // their own channel into the subagent registry. The
     // TaskBrowserRuntime coordinator owns the split:
     // - `refreshAgents` (CATALOG): event-driven — subagent lifecycle events
-    //   (start/end), subagent tool calls in the live session (the
-    //   scope-filtered lifecycle events may not reach this context), and
-    //   every jobs change (a one-shot settlement implies membership may
-    //   have moved). listDescendants is async and may read persistence for
+    //   (start/end), subagent tool calls in the live session, and every
+    //   jobs change (a one-shot settlement implies membership may have
+    //   moved). listDescendants is async and may read persistence for
     //   cold children, so the commit is session-key fenced and never lands
     //   on a newer session.
     // - `refreshAgentRuntimeOnly` (RUNTIME): the `agent/status` handler —
@@ -5516,9 +5521,11 @@ export function apply(ctx: Context, config: Config): void {
           ? event.data.arguments
           : JSON.stringify(event.data.arguments))
         // Continuable children never register jobs, and their lifecycle
-        // events are scope-filtered (may not reach this context), so the
-        // subagent tool's own call in the live session is the reliable
-        // badge-arming signal.
+        // events are scoped by the delegating parent — an UNTAGGED
+        // listener (this runner) receives them all, so the tool's own
+        // call is a REDUNDANT badge-arming signal that stays as a
+        // defensive net (it also fires when the lifecycle events are
+        // suppressed upstream).
         if (typeof event.data.name === 'string' && event.data.name.startsWith('subagent')) {
           refreshAgents()
           // Remember the pending delegation: the viewer matches one of these
@@ -5656,10 +5663,12 @@ export function apply(ctx: Context, config: Config): void {
       }
     })
     // Subagent lifecycle events drive the continuable-children half of the
-    // dock badge (they never register jobs). Scope-filtered by the
-    // delegating parent — when they do not reach this context, the
-    // tool/call fallback above still arms the badge. These are CATALOG
-    // events: membership/tree may have changed, so they re-list.
+    // dock badge (they never register jobs). The events are scoped by the
+    // delegating parent, but an UNTAGGED listener (this runner) receives
+    // every agent-scoped event — including nested descendants' — so no
+    // reachability caveat applies; the tool/call fallback above stays as
+    // a redundant safety net. These are CATALOG events: membership/tree
+    // may have changed, so they re-list.
     ctx.on('subagent/start', () => refreshAgents())
     ctx.on('subagent/end', () => refreshAgents())
     // `agent/status` is the LIVE runtime channel: a child's driver

--- a/src/index.ts
+++ b/src/index.ts
@@ -4374,8 +4374,8 @@ export function apply(ctx: Context, config: Config): void {
     // and its child row — because the two records have no cross-reference
     // to dedup; the viewable child row is the more useful one. The children
     // half enriches asynchronously: listChildren may read persistence for
-    // cold children, so the picker opens on the jobs half and setItems
-    // merges the rest in.
+    // cold children, so the picker opens on the CURRENT state and setItems
+    // merges the fresh listing in.
     //
     // The SAME browser is the `/tasks` surface (runner.openTasksBrowser):
     // the merged list + search is the single command-side entry, with
@@ -4398,7 +4398,22 @@ export function apply(ctx: Context, config: Config): void {
       // identity source is the RUNNER-level `taskBrowserRows` (kept fresh
       // by every coordinator commit), so the select/action paths below
       // never contradict a runtime refresh that already repainted.
-      taskBrowserRows = buildTaskRows(jobSnapshots, [])
+      //
+      // FIRST FRAME: seed from the coordinator's CURRENT state instead of
+      // flashing a jobs-only list — refreshRuntime() is synchronous, never
+      // touches persistence, reuses the cached catalog and re-reads the
+      // current jobs + registry statuses (activeTaskBrowser is not set
+      // yet, so it only seeds taskBrowserRows + the badge). The badge and
+      // the panel therefore agree from the first frame, and a FAILED fresh
+      // listing below cannot leave a panel that contradicts the badge.
+      // Without the runtime (no subagents service) the jobs-only fallback
+      // applies.
+      const runtime = taskRuntime
+      if (runtime !== undefined) {
+        runtime.refreshRuntime()
+      } else {
+        taskBrowserRows = buildTaskRows(jobSnapshots, [])
+      }
       const selectRow = (value: string): void => {
         const row = taskBrowserRows.find(candidate => candidate.value === value)
         if (row === undefined) return
@@ -4428,11 +4443,13 @@ export function apply(ctx: Context, config: Config): void {
       }
       const actionRow = (value: string, action: 'interrupt'): void => {
         const row = taskBrowserRows.find(candidate => candidate.value === value)
-        // ONLY continuable children are interruptible: `subagents.interrupt`
-        // on a one-shot id is an accepted no-op, so firing it for a
-        // one-shot row would be a fake action (the panel already hides the
-        // verb, this is the runner-side guard).
-        if (row === undefined || row.kind !== 'subagent' || row.mode !== 'continuable') return
+        // The EXECUTION gate is the SAME predicate as the panel's
+        // advertisement gate (`isSubagentRowInterruptible`): only a
+        // continuable child with a LIVE running driver may fire the stop
+        // verb — a one-shot id is an accepted no-op (a fake action) and an
+        // idle continuable has no driver to stop. One predicate for both
+        // layers, so a panel change can never release an idle interrupt.
+        if (row === undefined || row.kind !== 'subagent' || !isSubagentRowInterruptible(row)) return
         const service = ctx.get('subagents')
         if (service === undefined || liveAgent === undefined) {
           app.notify('subagent service unavailable', 'error')
@@ -4461,8 +4478,9 @@ export function apply(ctx: Context, config: Config): void {
       // The open triggers a CATALOG refresh (membership may have drifted
       // since the last listing): the coordinator fences it against a
       // session switch and commits through the ACTIVE handle — a browser
-      // closed while the listing is in flight is never repainted.
-      const runtime = taskRuntime
+      // closed while the listing is in flight is never repainted. The
+      // body above is synchronous, so the `runtime` captured for the
+      // first-frame seed is still the current coordinator.
       if (runtime !== undefined) {
         runOwned('task browser descendants', () => runtime.refreshCatalog(), {
           diag,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ import { createUserMessage } from '@deepseek-ai/dsh-llm'
 import type { CallId, ContentBlock } from '@deepseek-ai/dsh-llm'
 // P7d: the subagent registry merge for ctx.subagents (listChildren/interrupt).
 import type {} from '@deepseek-ai/dsh-subagent'
-import type { SubagentDescendantListEntry, SubagentListEntry } from '@deepseek-ai/dsh-subagent'
 import { SessionId } from '@deepseek-ai/dsh-session'
 import type { SessionEvent, SessionHeader } from '@deepseek-ai/dsh-session'
 // P6: the agent-preset roster — ctx.agentPresets, the session preset
@@ -82,10 +81,12 @@ import { Text } from '@xmoon76/pi-tui'
 import { SurfaceHost } from './extension/internal/surface-host.ts'
 import { PI_TUI_EXTENSIONS_SERVICE, type PiTuiExtensionService } from './extensions.ts'
 import {
-  buildTaskRows, isActiveJobStatus, rowGroup, subagentInterruptParent, taskRowLabel, taskTreePrefix, viewerAccessOf, isViewerAccessInteractive,
+  buildTaskRows, isSubagentRowInterruptible, rowGroup, subagentInterruptParent, taskRowLabel, taskTreePrefix, viewerAccessOf, isViewerAccessInteractive,
   type TaskBrowserRow, type ViewerAccess,
 } from './tasks-browser.ts'
 import type { TaskPanelItem } from './task-panel.ts'
+import { TaskBrowserRuntime } from './task-browser-runtime.ts'
+import type { TaskBrowserHandle } from './tui-app.ts'
 import { registerTuiCommands, type InitialCommandCatalog, type TuiCommandRunner } from './commands.ts'
 import { customThemeNames } from './theme.ts'
 import { diagFromEnv, dshHome, type Diag } from './diag.ts'
@@ -1297,6 +1298,55 @@ export async function recomposeBlank(
 /** Set the terminal window title (OSC 0); a no-op without a TTY. */
 function setTerminalTitle(title: string): void {
   if (process.stdout.isTTY === true) process.stdout.write(`\x1b]0;${title}\x07`)
+}
+
+/**
+ * The task-browser row → panel-item projection (runner glue, module-level
+ * so the open browser AND the runtime refresh coordinator share ONE
+ * mapping). JOB rows keep their status/detail; SUBAGENT rows carry the
+ * projected runtime activity as the status word, the durable mode as the
+ * non-truncatable suffix, and the tree connector from the catalog depth.
+ * The interrupt verb is advertised ONLY for a continuable child with a
+ * LIVE running driver (`isSubagentRowInterruptible`) — an idle
+ * continuable has no driver to stop. `has children` is deliberately NOT
+ * a detail line: the tree connector already expresses parenthood.
+ */
+function taskPanelItems(target: readonly TaskBrowserRow[]): TaskPanelItem[] {
+  return target.map(row => row.kind === 'job'
+    ? {
+        value: row.value,
+        // A `subagent`-kind job is the registry's reliable contract
+        // for a background one-shot delegation: its `one-shot` mode
+        // rides as the non-truncatable suffix, like the child rows.
+        label: row.jobKind === 'subagent' ? `subagent job · ${row.label}` : taskRowLabel(row),
+        suffix: row.jobKind === 'subagent' ? 'one-shot' : undefined,
+        status: row.status,
+        detail: row.detail,
+        startedAt: row.startedAt,
+        group: rowGroup(row),
+        // The Tab type filter: job rows filter by their job kind.
+        type: row.jobKind,
+      }
+    : {
+        value: row.value,
+        // The mode rides as the panel's non-truncatable SUFFIX
+        // (`subagent · <label> · continuable`): the label itself may
+        // truncate on a narrow screen, the mode never silently does.
+        label: `subagent · ${row.label}`,
+        suffix: row.mode,
+        status: row.activity,
+        group: rowGroup(row),
+        type: 'subagent',
+        // Only a continuable row with a LIVE running driver is
+        // interruptible (one-shot ids are accepted no-ops for the
+        // interrupt transport; an idle continuable has no driver to
+        // stop — the UI must not advertise a dead stop verb).
+        interruptible: isSubagentRowInterruptible(row),
+        // The durable descendant tree connector: indentation + branch
+        // glyph from the catalog's `depth` (plan §6.7) — a fixed
+        // region that never scrolls with the selected label.
+        treePrefix: taskTreePrefix(row.depth),
+      })
 }
 
 /**
@@ -2726,6 +2776,15 @@ export function apply(ctx: Context, config: Config): void {
       searchCurrent = -1
       app.setSearchResult(0, 0)
       app.clearSessionOverrides()
+      // A new session owns the surface: close the task browser opened for
+      // the old session (its rows would otherwise go stale — the runtime
+      // refresh is fenced to the old root) and drop the cached descendant
+      // catalog, so stale-session `agent/status` flips find no membership
+      // and the next refresh reads the new root. The coordinator is
+      // re-populated by initLiveSession → refreshAgents.
+      activeTaskBrowser?.close()
+      activeTaskBrowser = undefined
+      taskRuntime?.reset()
       // A new session owns the surface: tear down the subagent viewer. The
       // old viewer's parent session is gone (the continuation contract
       // requires the EXACT live parent), so the child transcript, the
@@ -4329,10 +4388,13 @@ export function apply(ctx: Context, config: Config): void {
       // The trigger only fires while something is ACTIVE (jobs or live
       // children), so an empty jobs half is NOT an empty browser: the
       // children half enriches below. Never early-return on row count —
-      // a children-only session would never open the browser.
-      let rows: TaskBrowserRow[] = buildTaskRows(jobSnapshots, [])
+      // a children-only session would never open the browser. The row
+      // identity source is the RUNNER-level `taskBrowserRows` (kept fresh
+      // by every coordinator commit), so the select/action paths below
+      // never contradict a runtime refresh that already repainted.
+      taskBrowserRows = buildTaskRows(jobSnapshots, [])
       const selectRow = (value: string): void => {
-        const row = rows.find(candidate => candidate.value === value)
+        const row = taskBrowserRows.find(candidate => candidate.value === value)
         if (row === undefined) return
         if (row.kind === 'subagent') {
           // The viewer target carries the row's OWN parent (plan §6.10:
@@ -4342,10 +4404,11 @@ export function apply(ctx: Context, config: Config): void {
           // to the browser root (the live main session).
           const parentSessionId = row.parentId !== '' ? row.parentId as SessionId : liveAgent?.session.id
           if (parentSessionId === undefined) return
-          // The row carries the catalog MODE + activity + DEPTH: the viewer
-          // target is pinned to them (continuable → interactive editor only
-          // at depth 1, one-shot → read-only, depth > 1 → nested read-only),
-          // and the follow-up write path to the exact parent.
+          // The row carries the catalog MODE + projected activity + DEPTH:
+          // the viewer target is pinned to them (continuable → interactive
+          // editor only at depth 1, one-shot → read-only, depth > 1 →
+          // nested read-only), and the follow-up write path to the exact
+          // parent.
           runOwned('subagent view from tasks', () => enterView(
             row.childId as SessionId, row.label, row.mode, parentSessionId, row.activity, row.depth,
           ), {
@@ -4358,7 +4421,7 @@ export function apply(ctx: Context, config: Config): void {
         openJobView(row.jobId)
       }
       const actionRow = (value: string, action: 'interrupt'): void => {
-        const row = rows.find(candidate => candidate.value === value)
+        const row = taskBrowserRows.find(candidate => candidate.value === value)
         // ONLY continuable children are interruptible: `subagents.interrupt`
         // on a one-shot id is an accepted no-op, so firing it for a
         // one-shot row would be a fake action (the panel already hides the
@@ -4379,66 +4442,25 @@ export function apply(ctx: Context, config: Config): void {
         service.interrupt(row.childId as SessionId, { kind: 'user', parentSessionId: interruptParent })
         app.notify(`interrupting ${row.label}`, 'info')
       }
-      const taskPanelItems = (target: readonly TaskBrowserRow[]): TaskPanelItem[] =>
-        target.map(row => row.kind === 'job'
-          ? {
-              value: row.value,
-              // A `subagent`-kind job is the registry's reliable contract
-              // for a background one-shot delegation: its `one-shot` mode
-              // rides as the non-truncatable suffix, like the child rows.
-              label: row.jobKind === 'subagent' ? `subagent job · ${row.label}` : taskRowLabel(row),
-              suffix: row.jobKind === 'subagent' ? 'one-shot' : undefined,
-              status: row.status,
-              detail: row.detail,
-              startedAt: row.startedAt,
-              group: rowGroup(row),
-              // The Tab type filter: job rows filter by their job kind.
-              type: row.jobKind,
-            }
-          : {
-              value: row.value,
-              // The mode rides as the panel's non-truncatable SUFFIX
-              // (`subagent · <label> · continuable`): the label itself may
-              // truncate on a narrow screen, the mode never silently does.
-              label: `subagent · ${row.label}`,
-              suffix: row.mode,
-              status: row.activity,
-              detail: row.hasChildren ? 'has children' : undefined,
-              group: rowGroup(row),
-              type: 'subagent',
-              // Only continuable children are interruptible (one-shot ids
-              // are accepted no-ops for the interrupt transport).
-              interruptible: row.mode === 'continuable',
-              // The durable descendant tree connector: indentation + branch
-              // glyph from the catalog's `depth` (plan §6.7) — a fixed
-              // region that never scrolls with the selected label.
-              treePrefix: taskTreePrefix(row.depth),
-            })
       const handle = app.openTaskBrowser(
-        taskPanelItems(rows),
-        selectRow,
-        () => {},
+        taskPanelItems(taskBrowserRows),
+        // Selection and cancel both close the overlay (the app closes it
+        // before invoking the callback): drop the active-handle reference
+        // so a later runtime refresh cannot repaint a closed browser.
+        (value) => { activeTaskBrowser = undefined; selectRow(value) },
+        () => { activeTaskBrowser = undefined },
         { header: 'tasks · subagents', enableSearch: true, onAction: actionRow },
       )
-      if (subagents !== undefined) {
-        const sessionId = liveAgent.session.id
-        const generation = sessionGeneration
-        runOwned('task browser descendants', () => subagents.listDescendants(sessionId), {
+      activeTaskBrowser = handle
+      // The open triggers a CATALOG refresh (membership may have drifted
+      // since the last listing): the coordinator fences it against a
+      // session switch and commits through the ACTIVE handle — a browser
+      // closed while the listing is in flight is never repainted.
+      const runtime = taskRuntime
+      if (runtime !== undefined) {
+        runOwned('task browser descendants', () => runtime.refreshCatalog(), {
           diag,
           sessionId: () => liveAgent?.session.id,
-          onResult: (entries) => {
-            // The browser belongs to the session it was opened for; a
-            // switch while the listing was in flight must not repaint it.
-            if (sessionGeneration !== generation || liveAgent?.session.id !== sessionId) return
-            rows = buildTaskRows(jobSnapshots, entries)
-            // Preferred cursor (plan §6.6): the first RUNNING subagent in
-            // tree order, else the first active job — the tree itself never
-            // re-sorts for the cursor.
-            const preferred = rows.find(row =>
-              row.kind === 'subagent' && row.activity === 'running')?.value
-              ?? rows.find(row => row.kind === 'job' && isActiveJobStatus(row.status))?.value
-            handle.setItems(taskPanelItems(rows), preferred)
-          },
         })
       }
     }
@@ -4665,7 +4687,23 @@ export function apply(ctx: Context, config: Config): void {
     // (openJobView, defined earlier in this closure) can refresh the badge
     // after stop/close.
     let refreshTasks: () => void = () => {}
+    // The subagent half of the dock badge + the open task browser. Two
+    // refresh modes, both hoisted like refreshTasks (the browser is
+    // defined earlier in this closure):
+    // - `refreshAgents` — a CATALOG refresh (listDescendants + commit):
+    //   subagent lifecycle events, subagent tool calls and jobs changes;
+    // - `refreshAgentRuntimeOnly` — a RUNTIME-only refresh (no listing):
+    //   the `agent/status` handler re-projects the cached catalog.
     let refreshAgents: () => void = () => {}
+    let refreshAgentRuntimeOnly: () => void = () => {}
+    // The ACTIVE task-browser overlay handle (one at a time — the ↓
+    // trigger and /tasks share the same surface) and the row-identity
+    // source the open browser's select/action paths read. Tracked at
+    // runner scope so the runtime refresh repaints the OPEN panel and a
+    // session switch closes it (see bumpSessionGeneration).
+    let activeTaskBrowser: TaskBrowserHandle | undefined
+    let taskBrowserRows: TaskBrowserRow[] = []
+    let taskRuntime: TaskBrowserRuntime | undefined
     const jobs = ctx.get('jobs')
     if (jobs !== undefined) {
       refreshTasks = (): void => {
@@ -4686,41 +4724,80 @@ export function apply(ctx: Context, config: Config): void {
     }
     // Continuable children and foreground one-shot children never register
     // jobs records (AGENTS.md), so the dock badge and the task browser need
-    // their own channel into the subagent registry. `refreshAgents` is
-    // event-driven: subagent lifecycle events (start/end), subagent tool
-    // calls in the live session (the scope-filtered lifecycle events may
-    // not reach this context), and every jobs change (a one-shot settlement
-    // implies a child may have gone inactive). listDescendants is async
-    // and may read persistence for cold children, so the commit is
-    // generation-guarded and never lands on a newer session. The badge
-    // counts every RUNNING descendant (plan §6.13) — the user cares that a
-    // deep agent is still working — while durable inactive children never
-    // keep the badge permanently armed.
+    // their own channel into the subagent registry. The
+    // TaskBrowserRuntime coordinator owns the split:
+    // - `refreshAgents` (CATALOG): event-driven — subagent lifecycle events
+    //   (start/end), subagent tool calls in the live session (the
+    //   scope-filtered lifecycle events may not reach this context), and
+    //   every jobs change (a one-shot settlement implies membership may
+    //   have moved). listDescendants is async and may read persistence for
+    //   cold children, so the commit is session-key fenced and never lands
+    //   on a newer session.
+    // - `refreshAgentRuntimeOnly` (RUNTIME): the `agent/status` handler —
+    //   NEVER re-lists. The catalog's store-presence `activity` is not an
+    //   execution state: an idle continuable child stays live in the
+    //   session store and would otherwise keep the row and the badge stuck
+    //   on `running` forever. Every child's `running`/`inactive` is
+    //   re-projected from the Agent registry (`ctx.agents.get(id)?.status`)
+    //   AT COMMIT TIME, so a slow catalog response can never overwrite a
+    //   newer runtime state (plan §7.3). The badge counts every RUNNING
+    //   descendant (plan §6.13) — the user cares that a deep agent is
+    //   still working — while durable inactive children never keep it
+    //   permanently armed.
     const subagents = ctx.get('subagents')
     if (subagents !== undefined) {
+      taskRuntime = new TaskBrowserRuntime({
+        // The session fence key: generation + session id, captured when a
+        // refresh starts and re-checked after the async listing.
+        currentKey: () => liveAgent === undefined ? undefined : `${sessionGeneration}:${liveAgent.session.id}`,
+        listDescendants: () => {
+          const sessionId = liveAgent?.session.id
+          return sessionId === undefined ? Promise.resolve([]) : subagents.listDescendants(sessionId)
+        },
+        // The merged rows re-read the CURRENT jobs snapshot at every
+        // commit, so a job settlement repaints an open browser too.
+        readJobs: () => {
+          if (jobs === undefined || liveAgent === undefined) return []
+          try {
+            return jobs.list(liveAgent)
+          } catch {
+            // The registry read is best-effort; the jobs half stays empty.
+            return []
+          }
+        },
+        // The LIVE runtime fact, read at COMMIT time: the Agent registry,
+        // never the catalog's store-presence activity.
+        agentStatusOf: (childId) => agents?.get(childId as SessionId)?.status,
+        commitRows: (rows, preferred) => {
+          // The row-identity source for the open browser's select path
+          // always reflects the latest commit (a runtime refresh that
+          // repainted the panel is never contradicted by a stale local
+          // snapshot), and the repaint targets ONLY the open handle.
+          taskBrowserRows = [...rows]
+          activeTaskBrowser?.setItems(taskPanelItems(rows), preferred)
+        },
+        commitBadge: (running) => app.setAgents(running.map(entry => ({
+          id: entry.id,
+          label: entry.label,
+          activity: 'running',
+        }))),
+      })
       refreshAgents = (): void => {
         if (liveAgent === undefined) {
           app.setAgents([])
           return
         }
-        const sessionId = liveAgent.session.id
-        const generation = sessionGeneration
-        runOwned('task browser agents refresh', () => subagents.listDescendants(sessionId), {
+        runOwned('task browser agents refresh', () => taskRuntime!.refreshCatalog(), {
           diag,
           sessionId: () => liveAgent?.session.id,
-          onResult: (entries) => {
-            if (sessionGeneration !== generation || liveAgent?.session.id !== sessionId) return
-            // Running descendants arm the badge/trigger: continuable AND
-            // one-shot children at every depth while they work (a
-            // foreground delegation is the parent's pending tool call and
-            // registers no job row). Inactive children never arm it —
-            // activity is live-store presence, not an outcome.
-            app.setAgents(entries
-              .filter((entry): entry is Extract<SubagentDescendantListEntry, { kind: 'child' }> =>
-                entry.kind === 'child' && entry.activity === 'running')
-              .map(entry => ({ id: entry.id, label: entry.label ?? entry.id, activity: entry.activity })))
-          },
         })
+      }
+      refreshAgentRuntimeOnly = (): void => {
+        if (liveAgent === undefined) {
+          app.setAgents([])
+          return
+        }
+        taskRuntime!.refreshRuntime()
       }
       refreshAgents()
     }
@@ -5581,9 +5658,26 @@ export function apply(ctx: Context, config: Config): void {
     // Subagent lifecycle events drive the continuable-children half of the
     // dock badge (they never register jobs). Scope-filtered by the
     // delegating parent — when they do not reach this context, the
-    // tool/call fallback above still arms the badge.
+    // tool/call fallback above still arms the badge. These are CATALOG
+    // events: membership/tree may have changed, so they re-list.
     ctx.on('subagent/start', () => refreshAgents())
     ctx.on('subagent/end', () => refreshAgents())
+    // `agent/status` is the LIVE runtime channel: a child's driver
+    // transition (running ↔ idle) must repaint the task browser and the
+    // badge WITHOUT a re-listing — membership changes come only from the
+    // lifecycle events above, and `listDescendants().activity` is
+    // store-presence, never execution state (an idle continuable child
+    // stays live in the session store and would otherwise read as
+    // `running` forever). The membership gate keeps this cheap and safe:
+    // only flips of children in the CACHED catalog refresh the surface —
+    // the MAIN agent's own per-turn flips (and any stale post-switch
+    // event) never repaint, and the coordinator re-projects every child
+    // from the Agent registry at commit time.
+    ctx.on('agent/status', ({ agent }) => {
+      if (liveAgent === undefined) return
+      if (taskRuntime?.has(agent.id) !== true) return
+      refreshAgentRuntimeOnly()
+    })
     // Provider-topology and credential events refresh the footer model row
     // and the welcome card: a /login /logout /add-provider (or an external
     // settings.yaml / .credentials.yaml edit) changes the live provider /

--- a/src/task-browser-runtime.ts
+++ b/src/task-browser-runtime.ts
@@ -1,0 +1,158 @@
+/**
+ * Task-browser runtime refresh coordinator — the single owner of the
+ * SUBAGENT half of the task browser / dock badge after a catalog listing
+ * lands, and the split between catalog refreshes and runtime-only
+ * refreshes:
+ *
+ * - CATALOG refresh (`refreshCatalog`): re-list the durable descendant
+ *   tree (`ctx.subagents.listDescendants`). This is the ONLY path that
+ *   changes membership / tree / mode — driven by subagent lifecycle
+ *   events (start/end), the subagent tool call in the live session, and
+ *   jobs changes (a one-shot settlement implies membership may have
+ *   moved). The listing is async and may read persistence.
+ * - RUNTIME refresh (`refreshRuntime`): NO listing — reuse the cached
+ *   catalog and re-project every child's `running` / `inactive` from the
+ *   Agent registry. Driven by `agent/status`: the registry status IS the
+ *   live driver activity; the catalog's store-presence `activity` is
+ *   never an execution state (an idle continuable child stays live in
+ *   the session store and would otherwise read as `running` forever).
+ *
+ * Stale-response protection (plan §7.3): runtime statuses are projected
+ * AT COMMIT TIME — a slow catalog response can never flip an already-
+ * idle child back to `running` with the store-presence value it captured
+ * earlier. The session fence is a key captured when a refresh starts and
+ * re-checked after the async listing: a session switch mid-flight never
+ * commits an old session's catalog onto the new surface.
+ *
+ * The coordinator never imports the runner or the app; every dependency
+ * arrives as an injected hook.
+ * @module @xmoon76/dsh-pi-tui/task-browser-runtime
+ */
+
+import type { SubagentDescendantListEntry } from '@deepseek-ai/dsh-subagent'
+import {
+  buildTaskRows,
+  isActiveJobStatus,
+  projectSubagentActivity,
+  type TaskBrowserJobInput,
+  type TaskBrowserRow,
+} from './tasks-browser.ts'
+
+/** The runtime hooks the coordinator drives (wired by the runner). */
+export interface TaskBrowserRuntimeHooks {
+  /** Session-identity key of the CURRENT live root (undefined = no live
+   * session). Captured when a refresh starts and re-checked after the
+   * async listing: a session switch mid-flight must never commit an old
+   * session's catalog onto the new surface. */
+  currentKey(): string | undefined
+  /** Read the durable descendant catalog of the current root (async; may
+   * read persistence for cold children). */
+  listDescendants(): Promise<readonly SubagentDescendantListEntry[]>
+  /** Read the CURRENT jobs snapshot (sync; re-read at every commit so a
+   * job settlement repaints the open browser). */
+  readJobs(): readonly TaskBrowserJobInput[]
+  /** Live runtime status of one child (the Agent registry). MUST be read
+   * at COMMIT time — never captured when the listing started. */
+  agentStatusOf(childId: string): string | undefined
+  /** Commit the merged rows to the OPEN task browser (no-op when closed).
+   * `preferredValue` = the first running subagent in tree order, else the
+   * first active job — the panel honors it only while the user has not
+   * moved the selection (plan §6.6). */
+  commitRows(rows: readonly TaskBrowserRow[], preferredValue?: string): void
+  /** Commit the dock badge: the RUNNING children only (id + label). */
+  commitBadge(running: ReadonlyArray<{ id: string; label: string }>): void
+}
+
+/** Structural type for the jobs the coordinator merges (a projection of
+ * the runner's `jobs.list` snapshots). */
+/**
+ * The coordinator. One instance per runner session lifetime; `reset()` on
+ * every session-generation bump.
+ */
+export class TaskBrowserRuntime {
+  // Explicit fields, not constructor parameter properties (Node's
+  // strip-only mode rejects `constructor(private readonly x: T)`).
+  private readonly hooks: TaskBrowserRuntimeHooks
+  /** The cached descendant catalog of the CURRENT root (membership/tree/
+   * mode facts). Cleared on session switch via {@link reset}. */
+  private catalog: SubagentDescendantListEntry[] = []
+  /** The last committed rows (the row-identity source for the open
+   * browser's select path — see {@link rows}). */
+  private lastRows: TaskBrowserRow[] = []
+
+  constructor(hooks: TaskBrowserRuntimeHooks) {
+    this.hooks = hooks
+  }
+
+  /** The most recently committed rows. The open browser's select path
+   * reads row facts (mode/activity/parentId/depth) from HERE, so a
+   * runtime refresh that repainted the panel is never contradicted by a
+   * stale local snapshot. */
+  rows(): readonly TaskBrowserRow[] {
+    return this.lastRows
+  }
+
+  /** Whether one child id is a member of the cached catalog. The
+   * runner's `agent/status` gate: only status flips of known descendants
+   * may refresh the surface — the MAIN agent's own per-turn flips (and
+   * any stale post-switch event) never repaint. */
+  has(childId: string): boolean {
+    return this.catalog.some(entry => entry.id === childId)
+  }
+
+  /** A CATALOG refresh: re-list the descendants, then — if the session
+   * key is still current (generation fence) — cache and commit. Runtime
+   * statuses are projected from the Agent registry AT COMMIT, so a stale
+   * catalog response can never flip an already-idle child back to
+   * `running` (plan §7.3). No live session: no-op (the runner clears the
+   * badge itself). */
+  async refreshCatalog(): Promise<void> {
+    const key = this.hooks.currentKey()
+    if (key === undefined) return
+    const entries = await this.hooks.listDescendants()
+    if (this.hooks.currentKey() !== key) return
+    this.catalog = [...entries]
+    this.apply(entries)
+  }
+
+  /** A RUNTIME-only refresh: NO descendant listing — reuse the cached
+   * catalog and re-project every child's activity from the Agent
+   * registry. Membership/tree/mode/labels/pre-order never change here;
+   * only the status words move (plan §7.5). Synchronous, so the session
+   * key is captured and consumed atomically. */
+  refreshRuntime(): void {
+    if (this.hooks.currentKey() === undefined) return
+    this.apply(this.catalog)
+  }
+
+  /** Drop the cached catalog (session switch): the next catalog refresh
+   * re-reads from the new root, and stale-session status flips find no
+   * membership. */
+  reset(): void {
+    this.catalog = []
+    this.lastRows = []
+  }
+
+  private apply(entries: readonly SubagentDescendantListEntry[]): void {
+    // The runtime projection happens HERE, at commit time: the registry
+    // is re-read for every child, so row + badge statuses always reflect
+    // the CURRENT drivers — never the listing's snapshot.
+    const projected = projectSubagentActivity(entries, (childId) => this.hooks.agentStatusOf(childId))
+    const rows = buildTaskRows(this.hooks.readJobs(), projected)
+    this.lastRows = rows
+    // Preferred cursor (plan §6.6): the first RUNNING subagent in tree
+    // order, else the first active job — the tree itself never re-sorts
+    // for the cursor (the panel honors it only while the selection is
+    // untouched).
+    const preferred = rows.find(row => row.kind === 'subagent' && row.activity === 'running')?.value
+      ?? rows.find(row => row.kind === 'job' && isActiveJobStatus(row.status))?.value
+    this.hooks.commitRows(rows, preferred)
+    // The badge counts the PROJECTED running children (the registry
+    // projection, never the catalog's store-presence activity): an idle
+    // continuable child must not keep the badge permanently armed.
+    this.hooks.commitBadge(projected
+      .filter((entry): entry is Extract<SubagentDescendantListEntry, { kind: 'child' }> =>
+        entry.kind === 'child' && entry.activity === 'running')
+      .map(entry => ({ id: entry.id, label: entry.label ?? entry.id })))
+  }
+}

--- a/src/task-browser-runtime.ts
+++ b/src/task-browser-runtime.ts
@@ -79,6 +79,11 @@ export class TaskBrowserRuntime {
   /** The last committed rows (the row-identity source for the open
    * browser's select path — see {@link rows}). */
   private lastRows: TaskBrowserRow[] = []
+  /** Monotonic catalog-request epoch: only the LATEST refresh may cache
+   * and commit, so overlapping listings of the same session can never
+   * commit out of order (an older response never overwrites newer
+   * membership). */
+  private epoch = 0
 
   constructor(hooks: TaskBrowserRuntimeHooks) {
     this.hooks = hooks
@@ -101,16 +106,22 @@ export class TaskBrowserRuntime {
   }
 
   /** A CATALOG refresh: re-list the descendants, then — if the session
-   * key is still current (generation fence) — cache and commit. Runtime
-   * statuses are projected from the Agent registry AT COMMIT, so a stale
-   * catalog response can never flip an already-idle child back to
-   * `running` (plan §7.3). No live session: no-op (the runner clears the
-   * badge itself). */
+   * key is still current AND this is still the LATEST refresh (the epoch
+   * fence) — cache and commit. Runtime statuses are projected from the
+   * Agent registry AT COMMIT, so a stale catalog response can never flip
+   * an already-idle child back to `running` (plan §7.3). The epoch
+   * orders OVERLAPPING refreshes of the same session: the initial
+   * listing and an open-browser listing may be in flight together, and
+   * an older response must never overwrite the newer membership/tree
+   * catalog (a superseded response neither caches nor commits). No live
+   * session: no-op (the runner clears the badge itself). */
   async refreshCatalog(): Promise<void> {
     const key = this.hooks.currentKey()
     if (key === undefined) return
+    const requestEpoch = ++this.epoch
     const entries = await this.hooks.listDescendants()
     if (this.hooks.currentKey() !== key) return
+    if (requestEpoch !== this.epoch) return
     this.catalog = [...entries]
     this.apply(entries)
   }
@@ -127,8 +138,11 @@ export class TaskBrowserRuntime {
 
   /** Drop the cached catalog (session switch): the next catalog refresh
    * re-reads from the new root, and stale-session status flips find no
-   * membership. */
+   * membership. The epoch is bumped too, so a listing still in flight
+   * from the old session can never commit even if its key check were
+   * somehow satisfied. */
   reset(): void {
+    this.epoch += 1
     this.catalog = []
     this.lastRows = []
   }

--- a/src/task-browser-runtime.ts
+++ b/src/task-browser-runtime.ts
@@ -79,11 +79,16 @@ export class TaskBrowserRuntime {
   /** The last committed rows (the row-identity source for the open
    * browser's select path — see {@link rows}). */
   private lastRows: TaskBrowserRow[] = []
-  /** Monotonic catalog-request epoch: only the LATEST refresh may cache
-   * and commit, so overlapping listings of the same session can never
-   * commit out of order (an older response never overwrites newer
-   * membership). */
-  private epoch = 0
+  /** Monotonic catalog-request epoch: every refreshCatalog request takes
+   * the next value. */
+  private requestEpoch = 0
+  /** The epoch of the LAST SUCCESSFULLY COMMITTED catalog. A response
+   * may commit only when its own request epoch is NOT below this — i.e.
+   * "latest successfully committed wins", never "latest requested wins":
+   * a FAILED newer request must not invalidate a valid older response
+   * (it never advances the committed epoch), while a successful newer
+   * commit still supersedes every older in-flight response. */
+  private committedEpoch = 0
 
   constructor(hooks: TaskBrowserRuntimeHooks) {
     this.hooks = hooks
@@ -106,22 +111,24 @@ export class TaskBrowserRuntime {
   }
 
   /** A CATALOG refresh: re-list the descendants, then — if the session
-   * key is still current AND this is still the LATEST refresh (the epoch
-   * fence) — cache and commit. Runtime statuses are projected from the
-   * Agent registry AT COMMIT, so a stale catalog response can never flip
-   * an already-idle child back to `running` (plan §7.3). The epoch
-   * orders OVERLAPPING refreshes of the same session: the initial
-   * listing and an open-browser listing may be in flight together, and
-   * an older response must never overwrite the newer membership/tree
-   * catalog (a superseded response neither caches nor commits). No live
-   * session: no-op (the runner clears the badge itself). */
+   * key is still current AND this request is not superseded — cache and
+   * commit. Runtime statuses are projected from the Agent registry AT
+   * COMMIT, so a stale catalog response can never flip an already-idle
+   * child back to `running` (plan §7.3). The epoch orders OVERLAPPING
+   * refreshes of the same session (the initial listing and an
+   * open-browser listing may be in flight together): only the LATEST
+   * SUCCESSFULLY COMMITTED response wins — an older success response
+   * never overwrites a newer committed membership/tree catalog, and a
+   * FAILED newer request never invalidates a valid older response. No
+   * live session: no-op (the runner clears the badge itself). */
   async refreshCatalog(): Promise<void> {
     const key = this.hooks.currentKey()
     if (key === undefined) return
-    const requestEpoch = ++this.epoch
+    const epoch = ++this.requestEpoch
     const entries = await this.hooks.listDescendants()
     if (this.hooks.currentKey() !== key) return
-    if (requestEpoch !== this.epoch) return
+    if (epoch < this.committedEpoch) return
+    this.committedEpoch = epoch
     this.catalog = [...entries]
     this.apply(entries)
   }
@@ -138,11 +145,11 @@ export class TaskBrowserRuntime {
 
   /** Drop the cached catalog (session switch): the next catalog refresh
    * re-reads from the new root, and stale-session status flips find no
-   * membership. The epoch is bumped too, so a listing still in flight
-   * from the old session can never commit even if its key check were
-   * somehow satisfied. */
+   * membership. Every in-flight request is invalidated too (the fence
+   * jumps past them), so an old-session listing can never commit even
+   * if its key check were somehow satisfied. */
   reset(): void {
-    this.epoch += 1
+    this.committedEpoch = ++this.requestEpoch
     this.catalog = []
     this.lastRows = []
   }

--- a/src/tasks-browser.ts
+++ b/src/tasks-browser.ts
@@ -11,13 +11,21 @@
  *    identity (see subagentJobTranscriptId).
  *
  * Source B — the subagent registry (`ctx.subagents.listDescendants`):
- * the durable descendant tree. Every healthy child — continuable AND
- * one-shot, running AND inactive — is a viewable row: `activity` is
- * live-store presence, never an outcome, and a finished one-shot child
- * stays reachable through its persisted transcript (plan §6.4). Rows keep
- * the DSH stable pre-order VERBATIM (plan §6.5): the tree structure comes
+ * the durable child tree. Every row — continuable AND one-shot, running
+ * AND inactive — is a viewable row: the catalog `activity` is live-store
+ * PRESENCE, never an outcome, and a finished one-shot child stays
+ * reachable through its persisted transcript (plan §6.4). Rows keep the
+ * DSH stable pre-order VERBATIM (plan §6.5): the tree structure comes
  * from `parentId` + `depth`, so no running-first re-sort may ever break
  * the lineage.
+ *
+ * Runtime activity is NOT a catalog fact: the UI projects each child's
+ * `running` / `inactive` word from the Agent registry at COMMIT time
+ * (`ctx.agents.get(id)?.status === 'running'` — see
+ * {@link projectSubagentActivity}). The catalog's store-presence
+ * `activity` must never reach a row or the badge as the execution state:
+ * an idle continuable child stays live in the session store and would
+ * otherwise read as `running` forever.
  *
  * Deliberate overlap: a running BACKGROUND one-shot has BOTH a job record
  * and a child record with no cross-reference, so it may appear twice — the
@@ -52,14 +60,22 @@ export interface TaskBrowserJobInput {
 
 /** Structural subagent-list entry (a projection of dsh's
  * SubagentDescendantListEntry). parentId/depth are the CATALOG'S OWN
- * facts (plan §6.3) — never guessed from labels or order. */
+ * facts (plan §6.3) — never guessed from labels or order. The `activity`
+ * field may carry the catalog's store-presence value on INPUT, but the
+ * caller MUST overwrite it with the live Agent-registry projection before
+ * the entry becomes a row (see {@link projectSubagentActivity}) — a row's
+ * `running`/`inactive` means "an Agent driver is executing right now". */
 export interface TaskBrowserAgentInput {
   readonly kind: 'child' | 'diagnostic'
   readonly id: string
   /** Absent for a one-shot child; continuable children always carry one. */
   readonly label?: string
   readonly mode?: 'one-shot' | 'continuable'
-  /** Absent on diagnostic rows. */
+  /** UI-PROJECTED runtime activity of the child's Agent driver
+   * (`running` = the registry reports `status === 'running'` right now;
+   * `inactive` = no live driver — idle, cold, or disposed, never
+   * completed/failed/terminal). Never interpret the catalog's
+   * store-presence value as execution state. */
   readonly activity?: 'running' | 'inactive'
   readonly hasChildren?: boolean
   /** Durable direct parent (descendant rows; absent for direct children
@@ -94,6 +110,11 @@ export type TaskBrowserRow =
        * is not necessarily one-shot. The viewer's interactivity and the
        * follow-up write path both key off this exact field. */
       readonly mode: 'one-shot' | 'continuable'
+      /** UI-PROJECTED runtime activity (see {@link projectSubagentActivity}):
+       * `running` = the child's Agent driver is executing right now;
+       * `inactive` = no live driver (idle/cold/disposed) — never
+       * completed/failed. The catalog's store-presence value never
+       * reaches a row. */
       readonly activity: 'running' | 'inactive'
       readonly hasChildren: boolean
       /** Durable direct parent ('' for a direct child — the browser's
@@ -118,8 +139,9 @@ export function isActiveJobStatus(status: string): boolean {
  * the descendant listing IS the tree, so rows are NEVER re-sorted by
  * activity — a running grandchild must not jump above its inactive
  * parent. Every healthy child (kind 'child' with a classified mode) is a
- * row: the finished one-shot filter is REMOVED (plan §6.4), because
- * `activity` is live-store presence, never an outcome.
+ * row: the finished one-shot filter is REMOVED (plan §6.4), because the
+ * projected activity is runtime-only, never an outcome — a settled
+ * one-shot's persisted transcript stays viewable.
  *
  * JOB rows keep their own registry ordering (active by startedAt,
  * terminal newest-finish first) as a separate flat group after the tree —
@@ -174,6 +196,39 @@ export function buildTaskRows(
 }
 
 /**
+ * Project the UI runtime activity of one descendant catalog onto its
+ * entries: a child's `activity` is overwritten from the live Agent
+ * registry (`agentStatusOf(id) === 'running'`), read AT COMMIT TIME —
+ * never captured when the (async) listing started. A slow catalog
+ * response must not flip an already-idle child back to `running` with
+ * the store-presence status it captured earlier (plan §7.3).
+ *
+ * EVERYTHING else is untouched: id/label/mode/hasChildren/parentId/depth
+ * and the pre-order all stay catalog facts (plan §7.5). Diagnostic rows
+ * pass through unchanged.
+ */
+export function projectSubagentActivity(
+  entries: readonly TaskBrowserAgentInput[],
+  agentStatusOf: (childId: string) => string | undefined,
+): TaskBrowserAgentInput[] {
+  return entries.map(entry =>
+    entry.kind === 'child'
+      ? { ...entry, activity: agentStatusOf(entry.id) === 'running' ? 'running' : 'inactive' }
+      : entry)
+}
+
+/** Whether a subagent row can be interrupted RIGHT NOW: only a
+ * continuable child with a LIVE running driver — an idle/inactive
+ * continuable has no driver to stop, so the UI must not advertise (or
+ * fire) the stop verb for it. One-shot rows are never interruptible (the
+ * interrupt transport is an accepted no-op for them). */
+export function isSubagentRowInterruptible(
+  row: Extract<TaskBrowserRow, { kind: 'subagent' }>,
+): boolean {
+  return row.mode === 'continuable' && row.activity === 'running'
+}
+
+/**
  * The tree connector prefix for one subagent row: indentation by depth
  * (the browser's root is depth 1) plus a stable `├─ ` branch connector.
  * The connector is a fixed layout region (plan §6.7) — it never scrolls
@@ -206,13 +261,17 @@ export function rowGroup(row: TaskBrowserRow): string {
   return row.kind === 'job' ? JOB_GROUP : SUBAGENT_GROUP
 }
 
-/** The picker description line for a row. */
+/** The picker description line for a row. The subagent line carries the
+ * PROJECTED runtime activity only — `has children` is deliberately NOT
+ * shown: the tree connector already expresses parenthood, so the text
+ * would duplicate the structure (the `hasChildren` data fact stays on
+ * the row for future fold/disclosure work). */
 export function describeTaskRow(row: TaskBrowserRow, now: number): string {
   if (row.kind === 'job') {
     const elapsed = Math.max(0, Math.floor((now - row.startedAt) / 1000))
     return `${row.status}${row.detail === undefined ? '' : ` — ${row.detail}`} · ${elapsed}s`
   }
-  return `${row.activity}${row.hasChildren ? ' · has children' : ''}${row.depth > 1 ? ` · depth ${row.depth}` : ''}`
+  return `${row.activity}${row.depth > 1 ? ` · depth ${row.depth}` : ''}`
 }
 
 /** The viewer's interaction authority for one row (plan §6.10): mode is

--- a/test/task-browser-runtime.test.ts
+++ b/test/task-browser-runtime.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for the TaskBrowserRuntime coordinator: the split between CATALOG
+ * refreshes (the only path that re-lists descendants) and RUNTIME-only
+ * refreshes (reuse the cached catalog, re-project activity from the Agent
+ * registry). These are the plan's runner-level repro cases (plan §6.2):
+ *
+ * - Case A: a continuable direct child flips running → idle while the
+ *   task browser stays open — the row must turn `inactive` WITHOUT a
+ *   re-listing (the core bug: store-presence activity read as execution
+ *   state).
+ * - Case B: an idle continuable child reactivates on followup — the row
+ *   must turn `running` again.
+ * - Case C: nested continuable children — rows and the badge follow the
+ *   registry projection; tree order never moves.
+ * - Case D: a stale catalog response must not overwrite a newer runtime
+ *   state (statuses are projected at COMMIT time), and a session switch
+ *   mid-flight must never commit (the key fence).
+ * @module @xmoon76/dsh-pi-tui/task-browser-runtime.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { SubagentDescendantListEntry } from '@deepseek-ai/dsh-subagent'
+import { SessionId } from '@deepseek-ai/dsh-session'
+import { TaskBrowserRuntime, type TaskBrowserRuntimeHooks } from '../src/task-browser-runtime.ts'
+import { AGENT_ROW_PREFIX, type TaskBrowserJobInput, type TaskBrowserRow } from '../src/tasks-browser.ts'
+
+const child = (overrides: Partial<SubagentDescendantListEntry> = {}): SubagentDescendantListEntry => ({
+  kind: 'child',
+  id: 'child-a' as SessionId,
+  label: 'research',
+  mode: 'continuable' as const,
+  activity: 'running',
+  hasChildren: false,
+  parentId: 'sess-main' as SessionId,
+  depth: 1,
+  ...overrides,
+} as SubagentDescendantListEntry)
+
+const job = (overrides: Partial<TaskBrowserJobInput> = {}): TaskBrowserJobInput => ({
+  id: 'bash-1',
+  kind: 'bash',
+  label: 'pnpm build',
+  status: 'running',
+  startedAt: 1_000,
+  ...overrides,
+})
+
+/** The activity word of one committed subagent row (undefined = no row). */
+const subagentActivity = (rows: readonly TaskBrowserRow[], childId: string): string | undefined => {
+  const row = rows.find(candidate =>
+    candidate.kind === 'subagent' && candidate.childId === childId) as
+    Extract<TaskBrowserRow, { kind: 'subagent' }> | undefined
+  return row?.activity
+}
+
+const rowValue = (rows: readonly TaskBrowserRow[]): string[] => rows.map(row => row.value)
+
+/** A harness with a DEFERRED listDescendants (the async catalog listing
+ * completes only when the test settles it), a mutable registry-status
+ * map, and commit/badge journals. */
+function makeHarness(): {
+  runtime: TaskBrowserRuntime
+  listings(): number
+  commits(): readonly TaskBrowserRow[][]
+  preferreds(): readonly (string | undefined)[]
+  badges(): readonly ReadonlyArray<{ id: string; label: string }>[]
+  setKey(key: string | undefined): void
+  setStatus(id: string, status: string | undefined): void
+  setJobs(jobs: readonly TaskBrowserJobInput[]): void
+  settleList(entries: readonly SubagentDescendantListEntry[]): void
+} {
+  let key: string | undefined = 'g1:sess-main'
+  const statuses = new Map<string, string>()
+  let jobs: TaskBrowserJobInput[] = [job()]
+  let listingCount = 0
+  let pendingResolve: ((entries: readonly SubagentDescendantListEntry[]) => void) | undefined
+  const commits: TaskBrowserRow[][] = []
+  const preferreds: (string | undefined)[] = []
+  const badges: ReadonlyArray<{ id: string; label: string }>[] = []
+  const runtime = new TaskBrowserRuntime({
+    currentKey: () => key,
+    listDescendants: () => {
+      listingCount += 1
+      return new Promise(resolve => { pendingResolve = resolve })
+    },
+    readJobs: () => jobs,
+    agentStatusOf: (id) => statuses.get(id),
+    commitRows: (rows, preferred) => {
+      commits.push([...rows])
+      preferreds.push(preferred)
+    },
+    commitBadge: (running) => badges.push([...running]),
+  })
+  return {
+    runtime,
+    listings: () => listingCount,
+    commits: () => commits,
+    preferreds: () => preferreds,
+    badges: () => badges,
+    setKey: (next) => { key = next },
+    setStatus: (id, status) => { if (status === undefined) statuses.delete(id); else statuses.set(id, status) },
+    setJobs: (next) => { jobs = [...next] },
+    settleList: (entries) => { const resolve = pendingResolve; pendingResolve = undefined; resolve?.(entries) },
+  }
+}
+
+test('Case A: a running continuable child turns inactive on agent idle without re-listing', async () => {
+  const h = makeHarness()
+  h.setStatus('child-a', 'running')
+  const listing = h.runtime.refreshCatalog()
+  h.settleList([child({ activity: 'running' })])
+  await listing
+  assert.equal(h.listings(), 1)
+  assert.equal(h.commits().length, 1)
+  assert.equal(subagentActivity(h.commits()[0]!, 'child-a'), 'running')
+  assert.deepEqual(h.badges()[0]!.map(entry => entry.id), ['child-a'])
+  // The child's turn ends: the driver goes idle while the browser stays
+  // open. A runtime-only refresh must flip the SAME row to inactive
+  // WITHOUT calling listDescendants again.
+  h.setStatus('child-a', 'idle')
+  h.runtime.refreshRuntime()
+  assert.equal(h.listings(), 1, 'a runtime refresh must never re-list')
+  assert.equal(h.commits().length, 2)
+  assert.equal(subagentActivity(h.commits()[1]!, 'child-a'), 'inactive')
+  assert.deepEqual(h.badges()[1], [], 'an idle child must leave the badge')
+})
+
+test('Case B: a followup reactivation flips an inactive row back to running', async () => {
+  const h = makeHarness()
+  h.setStatus('child-a', 'idle')
+  const listing = h.runtime.refreshCatalog()
+  h.settleList([child({ activity: 'running' })])
+  await listing
+  assert.equal(subagentActivity(h.commits()[0]!, 'child-a'), 'inactive', 'store presence never means running')
+  // The user sends a followup to the continuable child: the driver
+  // reactivates, and the runtime-only refresh flips the row back.
+  h.setStatus('child-a', 'running')
+  h.runtime.refreshRuntime()
+  assert.equal(h.listings(), 1, 'no re-listing on a runtime flip')
+  assert.equal(subagentActivity(h.commits()[1]!, 'child-a'), 'running')
+  assert.deepEqual(h.badges()[1]!.map(entry => entry.id), ['child-a'])
+})
+
+test('Case C: nested children project independently and the tree order never moves', async () => {
+  const h = makeHarness()
+  h.setJobs([])
+  // main └─ A (continuable) └─ B (continuable): B runs, A idles.
+  h.setStatus('A', 'idle')
+  h.setStatus('B', 'running')
+  const catalog = [
+    child({ id: 'A' as SessionId, activity: 'running', hasChildren: true, depth: 1 }),
+    child({ id: 'B' as SessionId, activity: 'running', hasChildren: false, parentId: 'A' as SessionId, depth: 2 }),
+  ]
+  const listing = h.runtime.refreshCatalog()
+  h.settleList(catalog)
+  await listing
+  assert.deepEqual(rowValue(h.commits()[0]!), [`${AGENT_ROW_PREFIX}A`, `${AGENT_ROW_PREFIX}B`])
+  assert.equal(subagentActivity(h.commits()[0]!, 'A'), 'inactive')
+  assert.equal(subagentActivity(h.commits()[0]!, 'B'), 'running')
+  assert.deepEqual(h.badges()[0]!.map(entry => entry.id), ['B'], 'only the running descendant arms the badge')
+  // B's turn ends: the runtime-only refresh flips it, and the TREE ORDER
+  // never moves (the row values are byte-identical).
+  h.setStatus('B', 'idle')
+  h.runtime.refreshRuntime()
+  assert.deepEqual(rowValue(h.commits()[1]!), [`${AGENT_ROW_PREFIX}A`, `${AGENT_ROW_PREFIX}B`])
+  assert.equal(subagentActivity(h.commits()[1]!, 'B'), 'inactive')
+  assert.deepEqual(h.badges()[1], [], 'the badge count drops with the driver')
+})
+
+test('Case D: a stale catalog response cannot overwrite a newer runtime state', async () => {
+  const h = makeHarness()
+  // T0: the listing starts while the driver is already idle (the flip
+  // landed while the async listing was in flight).
+  h.setStatus('child-a', 'idle')
+  const listing = h.runtime.refreshCatalog()
+  // T3: the OLD listing returns with its stale store-presence `running` —
+  // the commit must re-project from the registry and show inactive.
+  h.settleList([child({ activity: 'running' })])
+  await listing
+  assert.equal(h.commits().length, 1)
+  assert.equal(subagentActivity(h.commits()[0]!, 'child-a'), 'inactive', 'the commit reads the registry, not the response')
+  assert.deepEqual(h.badges()[0], [])
+})
+
+test('Case D2: a session switch mid-listing never commits the old catalog', async () => {
+  const h = makeHarness()
+  h.setStatus('child-a', 'running')
+  const listing = h.runtime.refreshCatalog()
+  // The user switches sessions while the listing is in flight.
+  h.setKey('g2:sess-other')
+  h.settleList([child({ activity: 'running' })])
+  await listing
+  assert.equal(h.commits().length, 0, 'the fenced listing must not commit')
+  assert.equal(h.badges().length, 0)
+  assert.equal(h.runtime.has('child-a'), false, 'nothing may be cached from the old root')
+})
+
+test('the membership gate admits only cached descendants', async () => {
+  const h = makeHarness()
+  const listing = h.runtime.refreshCatalog()
+  h.settleList([
+    child({ id: 'child-a' as SessionId, activity: 'running', depth: 1 }),
+    child({ id: 'child-b' as SessionId, activity: 'running', parentId: 'child-a' as SessionId, depth: 2 }),
+  ])
+  await listing
+  assert.equal(h.runtime.has('child-a'), true)
+  assert.equal(h.runtime.has('child-b'), true)
+  assert.equal(h.runtime.has('sess-main'), false, 'the main session is never a descendant')
+  assert.equal(h.runtime.has('child-ghost'), false)
+})
+
+test('reset() drops the cached catalog and the committed rows', async () => {
+  const h = makeHarness()
+  const listing = h.runtime.refreshCatalog()
+  h.settleList([child({ activity: 'running' })])
+  await listing
+  assert.equal(h.runtime.has('child-a'), true)
+  h.runtime.reset()
+  assert.equal(h.runtime.has('child-a'), false)
+  assert.deepEqual(h.runtime.rows(), [])
+})
+
+test('no live session: neither refresh lists nor commits', async () => {
+  const h = makeHarness()
+  h.setKey(undefined)
+  await h.runtime.refreshCatalog()
+  assert.equal(h.listings(), 0, 'no listing without a live root')
+  h.runtime.refreshRuntime()
+  assert.equal(h.commits().length, 0, 'no commit without a live root')
+})
+
+test('every commit re-reads the CURRENT jobs snapshot', async () => {
+  const h = makeHarness()
+  h.setStatus('child-a', 'running')
+  const listing = h.runtime.refreshCatalog()
+  h.settleList([child({ activity: 'running' })])
+  await listing
+  assert.deepEqual(rowValue(h.commits()[0]!), [`${AGENT_ROW_PREFIX}child-a`, 'job:bash-1'])
+  // A job settles while the browser stays open: the NEXT commit re-reads
+  // the jobs registry (the runner's jobs.onJobsChanged → refreshAgents).
+  h.setJobs([])
+  h.runtime.refreshRuntime()
+  assert.deepEqual(rowValue(h.commits()[1]!), [`${AGENT_ROW_PREFIX}child-a`])
+})
+
+test('the preferred cursor is the first running subagent, else the first active job', async () => {
+  const h = makeHarness()
+  h.setStatus('child-a', 'running')
+  h.setStatus('child-b', 'idle')
+  const listing = h.runtime.refreshCatalog()
+  h.settleList([
+    child({ id: 'child-a' as SessionId, activity: 'running', depth: 1 }),
+    child({ id: 'child-b' as SessionId, activity: 'running', parentId: 'child-a' as SessionId, depth: 2 }),
+  ])
+  await listing
+  assert.equal(h.preferreds()[0], `${AGENT_ROW_PREFIX}child-a`, 'the first running subagent in tree order')
+  // Everything idle: the first active job wins.
+  h.setStatus('child-a', 'idle')
+  h.runtime.refreshRuntime()
+  assert.equal(h.preferreds()[1], 'job:bash-1')
+  // Everything idle and no jobs: no preferred cursor.
+  h.setJobs([])
+  h.runtime.refreshRuntime()
+  assert.equal(h.preferreds()[2], undefined)
+})

--- a/test/task-browser-runtime.test.ts
+++ b/test/task-browser-runtime.test.ts
@@ -352,6 +352,36 @@ test('reset() also supersedes a listing still in flight', async () => {
   assert.equal(h.runtime.has('child-a'), false)
 })
 
+test('the open-browser FIRST FRAME reuses the cached catalog and survives a failed fresh listing (PR review P3)', async () => {
+  // The runner seeds the first frame with refreshRuntime() (the cached
+  // catalog + current jobs + registry statuses — synchronous, no
+  // persistence) BEFORE the async membership refresh starts. The seeded
+  // frame must match the badge, and a FAILED fresh listing must never
+  // leave the panel contradicting the badge (both keep the cached
+  // membership).
+  const h = makeHarness()
+  h.setStatus('child-a', 'running')
+  const listing = h.runtime.refreshCatalog()
+  h.settleListing(0, [child({ activity: 'running' })])
+  await listing
+  assert.equal(h.runtime.has('child-a'), true)
+  // Simulate the open: seed the first frame from the cache.
+  h.runtime.refreshRuntime()
+  const seed = h.runtime.rows()
+  assert.deepEqual(rowValue(seed), [`${AGENT_ROW_PREFIX}child-a`, 'job:bash-1'],
+    'the first frame must carry the cached subagent, not a jobs-only flash')
+  assert.equal(subagentActivity(seed, 'child-a'), 'running')
+  // The fresh listing the open triggers FAILS: the seeded frame (and the
+  // badge) must stay intact — no commit, cache untouched.
+  const fresh = h.runtime.refreshCatalog()
+  h.rejectListing(1, new Error('persistence read failed'))
+  await assert.rejects(fresh)
+  assert.equal(h.commits().length, 2, 'the failed listing must not commit')
+  assert.equal(h.runtime.has('child-a'), true, 'the cache keeps the child after the failure')
+  assert.deepEqual(rowValue(h.runtime.rows()), [`${AGENT_ROW_PREFIX}child-a`, 'job:bash-1'])
+  assert.deepEqual(h.badges()[0]!.map(entry => entry.id), ['child-a'])
+})
+
 // ── production wiring lock (review round 1, P2) ───────────────────────────
 // The coordinator tests alone would pass even if the runner never wired
 // `agent/status` (or wired it to the catalog refresh). The runner cannot
@@ -398,4 +428,28 @@ test('a session switch closes the open task browser, CLEARS the badge synchronou
   // SYNCHRONOUSLY.
   assert.ok(bump.includes('app.setAgents([])'), 'the session bump must clear the badge synchronously')
   assert.ok(bump.includes('taskBrowserRows = []'), 'the session bump must clear the row identity source')
+})
+
+test('openTasksBrowser seeds the FIRST FRAME from the cached runtime and gates interrupt execution with the SAME predicate (PR review P3)', () => {
+  const open = indexSource.slice(
+    indexSource.indexOf('const openTasksBrowser'),
+    indexSource.indexOf('// M3: attach the extension host'),
+  )
+  // The first frame must be seeded from the coordinator's CURRENT state
+  // (cached catalog + current jobs + registry statuses), never a
+  // jobs-only flash that could contradict the badge until the async
+  // listing lands — or after it fails.
+  assert.ok(open.includes('runtime.refreshRuntime()'),
+    'the open must seed the first frame from the cached runtime')
+  const seedStart = open.indexOf('const runtime = taskRuntime')
+  const seedBlock = open.slice(seedStart, seedStart + 220)
+  assert.ok(seedBlock.includes('buildTaskRows(jobSnapshots, [])'),
+    'the jobs-only fallback must apply only without the runtime')
+  // The interrupt EXECUTION gate must be the SAME predicate as the
+  // panel's advertisement gate — a panel change can never release an
+  // idle/one-shot interrupt.
+  assert.ok(open.includes('!isSubagentRowInterruptible(row)'),
+    'the interrupt execution gate must use isSubagentRowInterruptible')
+  assert.ok(!open.replace(/\/\/.*$/gm, '').includes("row.mode !== 'continuable'"),
+    'the interrupt execution gate must not drift back to a mode-only check')
 })

--- a/test/task-browser-runtime.test.ts
+++ b/test/task-browser-runtime.test.ts
@@ -56,9 +56,9 @@ const subagentActivity = (rows: readonly TaskBrowserRow[], childId: string): str
 
 const rowValue = (rows: readonly TaskBrowserRow[]): string[] => rows.map(row => row.value)
 
-/** A harness with a DEFERRED listDescendants (the async catalog listing
- * completes only when the test settles it), a mutable registry-status
- * map, and commit/badge journals. */
+/** A harness with a DEFERRED listDescendants (each catalog request gets
+ * its own deferred; the test settles them in any order), a mutable
+ * registry-status map, and commit/badge journals. */
 function makeHarness(): {
   runtime: TaskBrowserRuntime
   listings(): number
@@ -68,13 +68,14 @@ function makeHarness(): {
   setKey(key: string | undefined): void
   setStatus(id: string, status: string | undefined): void
   setJobs(jobs: readonly TaskBrowserJobInput[]): void
-  settleList(entries: readonly SubagentDescendantListEntry[]): void
+  /** Resolve the listing of the i-th refreshCatalog call (0-based). */
+  settleListing(index: number, entries: readonly SubagentDescendantListEntry[]): void
 } {
   let key: string | undefined = 'g1:sess-main'
   const statuses = new Map<string, string>()
   let jobs: TaskBrowserJobInput[] = [job()]
   let listingCount = 0
-  let pendingResolve: ((entries: readonly SubagentDescendantListEntry[]) => void) | undefined
+  const pendingResolves: ((entries: readonly SubagentDescendantListEntry[]) => void)[] = []
   const commits: TaskBrowserRow[][] = []
   const preferreds: (string | undefined)[] = []
   const badges: ReadonlyArray<{ id: string; label: string }>[] = []
@@ -82,7 +83,7 @@ function makeHarness(): {
     currentKey: () => key,
     listDescendants: () => {
       listingCount += 1
-      return new Promise(resolve => { pendingResolve = resolve })
+      return new Promise(resolve => { pendingResolves.push(resolve) })
     },
     readJobs: () => jobs,
     agentStatusOf: (id) => statuses.get(id),
@@ -101,7 +102,7 @@ function makeHarness(): {
     setKey: (next) => { key = next },
     setStatus: (id, status) => { if (status === undefined) statuses.delete(id); else statuses.set(id, status) },
     setJobs: (next) => { jobs = [...next] },
-    settleList: (entries) => { const resolve = pendingResolve; pendingResolve = undefined; resolve?.(entries) },
+    settleListing: (index, entries) => { pendingResolves[index]?.(entries) },
   }
 }
 
@@ -109,7 +110,7 @@ test('Case A: a running continuable child turns inactive on agent idle without r
   const h = makeHarness()
   h.setStatus('child-a', 'running')
   const listing = h.runtime.refreshCatalog()
-  h.settleList([child({ activity: 'running' })])
+  h.settleListing(0, [child({ activity: 'running' })])
   await listing
   assert.equal(h.listings(), 1)
   assert.equal(h.commits().length, 1)
@@ -130,7 +131,7 @@ test('Case B: a followup reactivation flips an inactive row back to running', as
   const h = makeHarness()
   h.setStatus('child-a', 'idle')
   const listing = h.runtime.refreshCatalog()
-  h.settleList([child({ activity: 'running' })])
+  h.settleListing(0, [child({ activity: 'running' })])
   await listing
   assert.equal(subagentActivity(h.commits()[0]!, 'child-a'), 'inactive', 'store presence never means running')
   // The user sends a followup to the continuable child: the driver
@@ -153,7 +154,7 @@ test('Case C: nested children project independently and the tree order never mov
     child({ id: 'B' as SessionId, activity: 'running', hasChildren: false, parentId: 'A' as SessionId, depth: 2 }),
   ]
   const listing = h.runtime.refreshCatalog()
-  h.settleList(catalog)
+  h.settleListing(0, catalog)
   await listing
   assert.deepEqual(rowValue(h.commits()[0]!), [`${AGENT_ROW_PREFIX}A`, `${AGENT_ROW_PREFIX}B`])
   assert.equal(subagentActivity(h.commits()[0]!, 'A'), 'inactive')
@@ -176,7 +177,7 @@ test('Case D: a stale catalog response cannot overwrite a newer runtime state', 
   const listing = h.runtime.refreshCatalog()
   // T3: the OLD listing returns with its stale store-presence `running` —
   // the commit must re-project from the registry and show inactive.
-  h.settleList([child({ activity: 'running' })])
+  h.settleListing(0, [child({ activity: 'running' })])
   await listing
   assert.equal(h.commits().length, 1)
   assert.equal(subagentActivity(h.commits()[0]!, 'child-a'), 'inactive', 'the commit reads the registry, not the response')
@@ -189,7 +190,7 @@ test('Case D2: a session switch mid-listing never commits the old catalog', asyn
   const listing = h.runtime.refreshCatalog()
   // The user switches sessions while the listing is in flight.
   h.setKey('g2:sess-other')
-  h.settleList([child({ activity: 'running' })])
+  h.settleListing(0, [child({ activity: 'running' })])
   await listing
   assert.equal(h.commits().length, 0, 'the fenced listing must not commit')
   assert.equal(h.badges().length, 0)
@@ -199,7 +200,7 @@ test('Case D2: a session switch mid-listing never commits the old catalog', asyn
 test('the membership gate admits only cached descendants', async () => {
   const h = makeHarness()
   const listing = h.runtime.refreshCatalog()
-  h.settleList([
+  h.settleListing(0, [
     child({ id: 'child-a' as SessionId, activity: 'running', depth: 1 }),
     child({ id: 'child-b' as SessionId, activity: 'running', parentId: 'child-a' as SessionId, depth: 2 }),
   ])
@@ -213,7 +214,7 @@ test('the membership gate admits only cached descendants', async () => {
 test('reset() drops the cached catalog and the committed rows', async () => {
   const h = makeHarness()
   const listing = h.runtime.refreshCatalog()
-  h.settleList([child({ activity: 'running' })])
+  h.settleListing(0, [child({ activity: 'running' })])
   await listing
   assert.equal(h.runtime.has('child-a'), true)
   h.runtime.reset()
@@ -234,7 +235,7 @@ test('every commit re-reads the CURRENT jobs snapshot', async () => {
   const h = makeHarness()
   h.setStatus('child-a', 'running')
   const listing = h.runtime.refreshCatalog()
-  h.settleList([child({ activity: 'running' })])
+  h.settleListing(0, [child({ activity: 'running' })])
   await listing
   assert.deepEqual(rowValue(h.commits()[0]!), [`${AGENT_ROW_PREFIX}child-a`, 'job:bash-1'])
   // A job settles while the browser stays open: the NEXT commit re-reads
@@ -249,7 +250,7 @@ test('the preferred cursor is the first running subagent, else the first active 
   h.setStatus('child-a', 'running')
   h.setStatus('child-b', 'idle')
   const listing = h.runtime.refreshCatalog()
-  h.settleList([
+  h.settleListing(0, [
     child({ id: 'child-a' as SessionId, activity: 'running', depth: 1 }),
     child({ id: 'child-b' as SessionId, activity: 'running', parentId: 'child-a' as SessionId, depth: 2 }),
   ])
@@ -263,4 +264,84 @@ test('the preferred cursor is the first running subagent, else the first active 
   h.setJobs([])
   h.runtime.refreshRuntime()
   assert.equal(h.preferreds()[2], undefined)
+})
+
+test('Case D3: overlapping catalog refreshes commit in REQUEST order (epoch supersede)', async () => {
+  // The initial badge refresh and an open-browser refresh can be in
+  // flight together; the NEWER request must stay authoritative even when
+  // its listing settles FIRST and the older one settles later (review
+  // round 1, P1): an older response must never overwrite newer
+  // membership/tree state.
+  const h = makeHarness()
+  h.setStatus('child-new', 'running')
+  const initial = h.runtime.refreshCatalog()
+  const openRefresh = h.runtime.refreshCatalog()
+  // The OPEN refresh (request 2) settles first with the NEWER
+  // membership: child-new exists.
+  h.settleListing(1, [child({ id: 'child-new' as SessionId, activity: 'running', depth: 1 })])
+  await openRefresh
+  assert.equal(h.commits().length, 1)
+  assert.equal(h.runtime.has('child-new'), true)
+  assert.deepEqual(rowValue(h.commits()[0]!), [`${AGENT_ROW_PREFIX}child-new`, 'job:bash-1'])
+  // The INITIAL refresh (older request) settles LAST with a STALE
+  // membership that never saw child-new: it must neither commit nor
+  // overwrite the cache (without the epoch, the stale response would
+  // drop the child from the open browser and gate out its agent/status).
+  h.settleListing(0, [child({ id: 'child-old' as SessionId, activity: 'running', depth: 1 })])
+  await initial
+  assert.equal(h.commits().length, 1, 'the superseded listing must not commit')
+  assert.equal(h.runtime.has('child-new'), true, 'the cache must keep the newer membership')
+  assert.equal(h.runtime.has('child-old'), false, 'the stale membership must never land')
+})
+
+test('reset() also supersedes a listing still in flight', async () => {
+  const h = makeHarness()
+  const listing = h.runtime.refreshCatalog()
+  h.runtime.reset()
+  h.settleListing(0, [child({ activity: 'running' })])
+  await listing
+  assert.equal(h.commits().length, 0, 'a post-reset listing must not commit')
+  assert.equal(h.runtime.has('child-a'), false)
+})
+
+// ── production wiring lock (review round 1, P2) ───────────────────────────
+// The coordinator tests alone would pass even if the runner never wired
+// `agent/status` (or wired it to the catalog refresh). The runner cannot
+// be booted headlessly, so the WIRING ITSELF is locked by a source audit
+// (the rules.test.ts precedent): the listener must exist, must be
+// membership-gated, must route to the RUNTIME-only refresh (never a
+// re-listing), and a session bump must close the open browser and reset
+// the coordinator.
+
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const indexSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'index.ts'),
+  'utf8',
+)
+
+test('the runner wires agent/status to the membership-gated RUNTIME-only refresh', () => {
+  assert.ok(indexSource.includes("ctx.on('agent/status', ({ agent }) => {"),
+    'the runner must register the agent/status listener')
+  assert.ok(indexSource.includes('if (taskRuntime?.has(agent.id) !== true) return'),
+    'the listener must be membership-gated (main-agent flips must never repaint)')
+  // The handler must route to the runtime-only refresh — a re-listing
+  // here would defeat the whole split (and the membership gate).
+  const marker = "ctx.on('agent/status', ({ agent }) => {"
+  const handler = indexSource.slice(indexSource.indexOf(marker), indexSource.indexOf(marker) + 400)
+  assert.ok(handler.includes('refreshAgentRuntimeOnly()'),
+    'agent/status must refresh RUNTIME only, never refreshAgents()')
+  assert.ok(!handler.includes('refreshAgents()'),
+    'agent/status must never trigger a catalog re-listing')
+})
+
+test('a session switch closes the open task browser and resets the runtime coordinator', () => {
+  const bump = indexSource.slice(
+    indexSource.indexOf('const bumpSessionGeneration'),
+    indexSource.indexOf('const jumpToSearchMatch'),
+  )
+  assert.ok(bump.includes('activeTaskBrowser?.close()'), 'the session bump must close the open browser')
+  assert.ok(bump.includes('taskRuntime?.reset()'), 'the session bump must drop the cached catalog')
 })

--- a/test/task-browser-runtime.test.ts
+++ b/test/task-browser-runtime.test.ts
@@ -57,8 +57,8 @@ const subagentActivity = (rows: readonly TaskBrowserRow[], childId: string): str
 const rowValue = (rows: readonly TaskBrowserRow[]): string[] => rows.map(row => row.value)
 
 /** A harness with a DEFERRED listDescendants (each catalog request gets
- * its own deferred; the test settles them in any order), a mutable
- * registry-status map, and commit/badge journals. */
+ * its own deferred; the test settles or rejects them in any order), a
+ * mutable registry-status map, and commit/badge journals. */
 function makeHarness(): {
   runtime: TaskBrowserRuntime
   listings(): number
@@ -70,12 +70,15 @@ function makeHarness(): {
   setJobs(jobs: readonly TaskBrowserJobInput[]): void
   /** Resolve the listing of the i-th refreshCatalog call (0-based). */
   settleListing(index: number, entries: readonly SubagentDescendantListEntry[]): void
+  /** Reject the listing of the i-th refreshCatalog call (0-based). */
+  rejectListing(index: number, error: Error): void
 } {
   let key: string | undefined = 'g1:sess-main'
   const statuses = new Map<string, string>()
   let jobs: TaskBrowserJobInput[] = [job()]
   let listingCount = 0
-  const pendingResolves: ((entries: readonly SubagentDescendantListEntry[]) => void)[] = []
+  const pendingSettles: ((entries: readonly SubagentDescendantListEntry[]) => void)[] = []
+  const pendingRejects: ((error: Error) => void)[] = []
   const commits: TaskBrowserRow[][] = []
   const preferreds: (string | undefined)[] = []
   const badges: ReadonlyArray<{ id: string; label: string }>[] = []
@@ -83,7 +86,10 @@ function makeHarness(): {
     currentKey: () => key,
     listDescendants: () => {
       listingCount += 1
-      return new Promise(resolve => { pendingResolves.push(resolve) })
+      return new Promise((resolve, reject) => {
+        pendingSettles.push(resolve)
+        pendingRejects.push(reject)
+      })
     },
     readJobs: () => jobs,
     agentStatusOf: (id) => statuses.get(id),
@@ -102,7 +108,8 @@ function makeHarness(): {
     setKey: (next) => { key = next },
     setStatus: (id, status) => { if (status === undefined) statuses.delete(id); else statuses.set(id, status) },
     setJobs: (next) => { jobs = [...next] },
-    settleListing: (index, entries) => { pendingResolves[index]?.(entries) },
+    settleListing: (index, entries) => { pendingSettles[index]?.(entries) },
+    rejectListing: (index, error) => { pendingRejects[index]?.(error) },
   }
 }
 
@@ -294,6 +301,47 @@ test('Case D3: overlapping catalog refreshes commit in REQUEST order (epoch supe
   assert.equal(h.runtime.has('child-old'), false, 'the stale membership must never land')
 })
 
+test('Case D4: a FAILED newer request must not invalidate a valid older response', async () => {
+  // "Latest successfully committed wins", never "latest requested wins"
+  // (PR review P2): a newer listing that REJECTS (e.g. a persistence
+  // read failure on open) must not discard an older in-flight request
+  // whose response is valid — the badge/browser would otherwise stay
+  // empty/stale until the next catalog event.
+  const h = makeHarness()
+  h.setStatus('child-a', 'running')
+  const older = h.runtime.refreshCatalog()
+  const newer = h.runtime.refreshCatalog()
+  // The newer (open-browser) listing fails first.
+  h.rejectListing(1, new Error('persistence read failed'))
+  await assert.rejects(newer)
+  // The older listing still succeeds with a valid catalog: it must
+  // commit (its epoch is not below the committed fence).
+  h.settleListing(0, [child({ activity: 'running' })])
+  await older
+  assert.equal(h.commits().length, 1, 'the older success must still commit after a newer failure')
+  assert.equal(h.runtime.has('child-a'), true)
+  assert.deepEqual(h.badges()[0]!.map(entry => entry.id), ['child-a'])
+})
+
+test('a failure never advances the committed fence for LATER requests', async () => {
+  const h = makeHarness()
+  h.setStatus('child-a', 'running')
+  const first = h.runtime.refreshCatalog()
+  const failing = h.runtime.refreshCatalog()
+  h.rejectListing(1, new Error('boom'))
+  await assert.rejects(failing)
+  // The first request commits (committed fence = its epoch).
+  h.settleListing(0, [child({ activity: 'running' })])
+  await first
+  assert.equal(h.runtime.has('child-a'), true)
+  // A LATER request after the failure still commits normally.
+  const later = h.runtime.refreshCatalog()
+  h.settleListing(2, [child({ id: 'child-later' as SessionId, activity: 'running', depth: 1 })])
+  await later
+  assert.equal(h.runtime.has('child-later'), true)
+  assert.equal(h.commits().length, 2)
+})
+
 test('reset() also supersedes a listing still in flight', async () => {
   const h = makeHarness()
   const listing = h.runtime.refreshCatalog()
@@ -337,11 +385,17 @@ test('the runner wires agent/status to the membership-gated RUNTIME-only refresh
     'agent/status must never trigger a catalog re-listing')
 })
 
-test('a session switch closes the open task browser and resets the runtime coordinator', () => {
+test('a session switch closes the open task browser, CLEARS the badge synchronously and resets the runtime coordinator', () => {
   const bump = indexSource.slice(
     indexSource.indexOf('const bumpSessionGeneration'),
     indexSource.indexOf('const jumpToSearchMatch'),
   )
   assert.ok(bump.includes('activeTaskBrowser?.close()'), 'the session bump must close the open browser')
   assert.ok(bump.includes('taskRuntime?.reset()'), 'the session bump must drop the cached catalog')
+  // PR review P2: the OLD session's running badge must not hang on the
+  // footer until the new session's async listing lands (a failed listing
+  // must never leave a stale badge either) — the bump clears it
+  // SYNCHRONOUSLY.
+  assert.ok(bump.includes('app.setAgents([])'), 'the session bump must clear the badge synchronously')
+  assert.ok(bump.includes('taskBrowserRows = []'), 'the session bump must clear the row identity source')
 })

--- a/test/task-panel.test.ts
+++ b/test/task-panel.test.ts
@@ -37,7 +37,6 @@ const subagent = (overrides: Partial<TaskPanelItem> = {}): TaskPanelItem => ({
   value: 'agent:child-1',
   label: 'subagent · research',
   status: 'running',
-  detail: 'has children',
   group: 'subagents',
   interruptible: true,
   ...overrides,

--- a/test/tasks-browser.test.ts
+++ b/test/tasks-browser.test.ts
@@ -17,7 +17,9 @@ import {
   SUBAGENT_GROUP,
   buildTaskRows,
   describeTaskRow,
+  isSubagentRowInterruptible,
   isViewerAccessInteractive,
+  projectSubagentActivity,
   resolveViewerAccess,
   rowGroup,
   subagentInterruptParent,
@@ -311,4 +313,106 @@ test('interrupt authority names the DURABLE direct parent, never the root (revie
   assert.equal(subagentInterruptParent(subagent({ parentId: '', depth: 1 }), 'session-main'), 'session-main')
   // The root is NEVER used for a nested row, whatever the depth.
   assert.equal(subagentInterruptParent(subagent({ parentId: 'session-A', depth: 3 }), 'session-main'), 'session-A')
+})
+
+// ── `has children` display removal (the tree connector already expresses
+// parenthood — the DATA fact stays for future fold/disclosure work) ───────
+
+test('a parent row never renders "has children" while the data fact survives', () => {
+  const rows = buildTaskRows([], [
+    agent({ id: 'parent', activity: 'inactive', hasChildren: true }),
+    agent({ id: 'child', mode: 'one-shot', activity: 'running', hasChildren: false, depth: 2 }),
+  ])
+  const parent = rows[0] as Extract<TaskBrowserRow, { kind: 'subagent' }>
+  // The DATA fact stays a row field…
+  assert.equal(parent.hasChildren, true)
+  assert.equal(parent.depth, 1)
+  // …but neither the description nor the label render the text.
+  assert.equal(describeTaskRow(parent, 5_000), 'inactive')
+  assert.ok(!describeTaskRow(parent, 5_000).includes('has children'))
+  assert.ok(!taskRowLabel(parent).includes('has children'))
+  // A nested row keeps its depth description (unchanged).
+  const child = rows[1] as Extract<TaskBrowserRow, { kind: 'subagent' }>
+  assert.equal(describeTaskRow(child, 5_000), 'running · depth 2')
+  assert.ok(!describeTaskRow(child, 5_000).includes('has children'))
+})
+
+// ── runtime activity projection (plan §7.3: the Agent registry decides,
+// never the catalog's store-presence activity) ─────────────────────────────
+
+test('projectSubagentActivity overwrites child activity from the Agent registry at commit time', () => {
+  // The core repro: an idle continuable child whose session is still
+  // live in the store (catalog `activity: 'running'`) must project
+  // INACTIVE — the registry says its driver is idle.
+  const entries = [
+    agent({ id: 'child-idle', activity: 'running' }),
+    agent({ id: 'child-cold', activity: 'inactive' }),
+    agent({ id: 'child-one', mode: 'one-shot', activity: 'inactive' }),
+  ]
+  const projected = projectSubagentActivity(entries, (id) =>
+    id === 'child-idle' ? 'idle' : 'running')
+  // TaskBrowserAgentInput is a single object type (kind is a union), so
+  // the child facts are read through a structural pick.
+  const child = (entry: TaskBrowserAgentInput): string =>
+    (entry as TaskBrowserAgentInput & { activity: 'running' | 'inactive' }).activity
+  assert.equal(child(projected[0]!), 'inactive')
+  assert.equal(child(projected[1]!), 'running')
+  assert.equal(child(projected[2]!), 'running')
+})
+
+test('projectSubagentActivity never touches catalog facts or the pre-order', () => {
+  const entries: TaskBrowserAgentInput[] = [
+    agent({ id: 'parent', activity: 'inactive', hasChildren: true, parentId: 'root', depth: 1 }),
+    agent({ id: 'grand', mode: 'one-shot', activity: 'inactive', hasChildren: false, parentId: 'parent', depth: 2 }),
+    { kind: 'diagnostic', id: 'child-x', reason: 'corrupt' },
+  ]
+  const projected = projectSubagentActivity(entries, () => 'running')
+  assert.deepEqual(projected.map(entry => entry.id), ['parent', 'grand', 'child-x'])
+  type ChildEntry = TaskBrowserAgentInput & { kind: 'child' }
+  const parent = projected[0] as ChildEntry
+  const grand = projected[1] as ChildEntry
+  assert.equal(parent.parentId, 'root')
+  assert.equal(parent.depth, 1)
+  assert.equal(parent.hasChildren, true)
+  assert.equal(parent.activity, 'running')
+  assert.equal(grand.parentId, 'parent')
+  assert.equal(grand.depth, 2)
+  assert.equal(grand.mode, 'one-shot')
+  // Diagnostic rows pass through unchanged (never projected).
+  assert.deepEqual(projected[2], { kind: 'diagnostic', id: 'child-x', reason: 'corrupt' })
+})
+
+test('projectSubagentActivity: an absent registry agent reads inactive (disposed/cold)', () => {
+  const projected = projectSubagentActivity([agent({ id: 'child-a', activity: 'running' })], () => undefined)
+  const child = projected[0] as TaskBrowserAgentInput & { kind: 'child' }
+  assert.equal(child.activity, 'inactive')
+})
+
+// ── interrupt authority (plan §I: only a continuable row with a LIVE
+// running driver may advertise/fire the stop verb) ─────────────────────────
+
+test('only a running continuable subagent is interruptible (plan §I)', () => {
+  const subagent = (overrides: Partial<Extract<TaskBrowserRow, { kind: 'subagent' }>> = {}): Extract<TaskBrowserRow, { kind: 'subagent' }> => ({
+    kind: 'subagent',
+    value: 'agent:child-abc',
+    childId: 'child-abc',
+    label: 'research',
+    mode: 'continuable',
+    activity: 'running',
+    hasChildren: false,
+    parentId: '',
+    depth: 1,
+    ...overrides,
+  })
+  // Running continuable: interruptible.
+  assert.equal(isSubagentRowInterruptible(subagent()), true)
+  // Idle continuable: no driver to stop — NOT interruptible (the UI must
+  // not advertise a dead stop verb).
+  assert.equal(isSubagentRowInterruptible(subagent({ activity: 'inactive' })), false)
+  // One-shot: never interruptible, running or not.
+  assert.equal(isSubagentRowInterruptible(subagent({ mode: 'one-shot', activity: 'running' })), false)
+  assert.equal(isSubagentRowInterruptible(subagent({ mode: 'one-shot', activity: 'inactive' })), false)
+  // Nested continuable rows follow the same rule (depth is orthogonal).
+  assert.equal(isSubagentRowInterruptible(subagent({ depth: 2, activity: 'running' })), true)
+  assert.equal(isSubagentRowInterruptible(subagent({ depth: 2, activity: 'inactive' })), false)
 })

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -1270,6 +1270,55 @@ test('openTaskBrowser setItems replaces rows live', async () => {
   app.stop()
 })
 
+test('openTaskBrowser repaints a subagent row in place on runtime re-projection (running -> inactive)', async () => {
+  // The runner's agent/status path: the TaskBrowserRuntime re-projects
+  // the CACHED catalog from the Agent registry and commits through
+  // handle.setItems — the open browser must flip the SAME row's status
+  // word to inactive WITHOUT closing (plan §6.2 Case A) and drop the
+  // interrupt verb with it (plan §I).
+  const { vt, app } = startApp()
+  const handle = app.openTaskBrowser(
+    [{
+      value: 'agent:child-1',
+      label: 'subagent · research',
+      suffix: 'continuable',
+      status: 'running',
+      group: 'subagents',
+      treePrefix: '├─ ',
+      interruptible: true,
+      type: 'subagent',
+    }],
+    () => {},
+    () => {},
+    { header: 'tasks · subagents', enableSearch: true },
+  )
+  await vt.waitForRender()
+  const strip = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, '').replace(/\s+$/, '')
+  let view = vt.getViewport().map(strip).join('\n')
+  assert.ok(view.includes('running'), `running row missing:\n${view}`)
+  assert.ok(view.includes('i interrupt'), `a running continuable must advertise the stop verb:\n${view}`)
+  // The child's driver goes idle: the runtime-only commit re-projects
+  // the row (SAME value, new status) — this is exactly what the runner's
+  // commitRows hook does on agent/status.
+  handle.setItems([{
+    value: 'agent:child-1',
+    label: 'subagent · research',
+    suffix: 'continuable',
+    status: 'inactive',
+    group: 'subagents',
+    treePrefix: '├─ ',
+    interruptible: false,
+    type: 'subagent',
+  }])
+  await vt.waitForRender()
+  view = vt.getViewport().map(strip).join('\n')
+  assert.ok(view.includes('inactive'), `the row must repaint to inactive in place:\n${view}`)
+  assert.ok(!view.includes('running'), `the old status word must be gone:\n${view}`)
+  assert.ok(!view.includes('i interrupt'), `an idle continuable must not advertise the stop verb:\n${view}`)
+  assert.ok(view.includes('tasks · subagents'), `the browser must stay open:\n${view}`)
+  app.stop()
+})
+
 test('openSettings revert() restores a rejected row display (M5 gate)', async () => {
   const { vt, app } = startApp()
   let revertedValue = ''


### PR DESCRIPTION
## Summary

Fixes the task browser and the dock badge treating `subagents.listDescendants().activity` (live-store presence) as driver execution state: an idle continuable child stays live in the session store, so its row and the running badge stayed stuck on `running` until the browser was reopened. Runtime activity now comes from the Agent registry (`ctx.agents.get(id)?.status === 'running'`), projected AT COMMIT TIME so a slow catalog response can never overwrite a newer state. Also removes the redundant `has children` detail line (the tree connector already expresses parenthood; the `hasChildren` data field is kept for future fold/disclosure work).

## What ships

- **Runtime projection, not catalog presence**: every child row's `running`/`inactive` is re-projected from the Agent registry at commit time (`projectSubagentActivity`). `inactive` stays "no live driver" (idle / cold / disposed) — never completed/failed; viewer interactivity still keys off the durable mode.
- **New `TaskBrowserRuntime` coordinator** (src/task-browser-runtime.ts) splits the two refresh kinds:
  - *CATALOG* refreshes (`subagent/start|end`, subagent tool calls, jobs changes) — the only paths that re-list descendants;
  - *RUNTIME-only* refreshes (`agent/status`) — the cached catalog is reused, membership/tree/mode/pre-order never move, and only the status words repaint.
- **Race protection** — session-key fence (generation + session id, re-checked after the async listing) plus a request/committed epoch pair: only the LATEST SUCCESSFULLY COMMITTED response may cache and commit — an older success never overwrites a newer committed membership/tree catalog, AND a FAILED newer listing never invalidates a valid older response (a failure never advances the fence; `reset()` jumps the fence past in-flight requests). Registry statuses are always read at commit, never captured at request time.
- **Live open browser** — `agent/status` repaints the open task browser in place via `handle.setItems` (selection/order preserved); a session switch closes the browser, CLEARS the badge synchronously (the old session's running badge never hangs on the footer until the new session's first listing lands — or if that listing fails) and resets the cached catalog; the membership gate keeps the main agent's own per-turn flips (and stale post-switch events) from ever repainting.
- **Interrupt tightening** — the `i` stop verb is advertised/fired only for continuable rows with a live running driver (an idle continuable has no driver to stop).
- **No `has children` text** — description line and panel detail cleaned up; `hasChildren` remains a row data fact.
- **Docs** — `docs/surface-decisions.md` task-browser section documents the projection split and the refresh lifecycle.

## Tests

- New `test/task-browser-runtime.test.ts` (15 tests): plan Cases A–D — running→idle without re-listing, followup reactivation, nested tree + badge with immutable order, stale-catalog-response projection, session switch mid-listing, out-of-order overlapping listings, FAILED-newer-request vs valid-older-response, failure never advancing the committed fence, membership gate, reset, no-live-session, jobs re-read per commit, preferred cursor.
- `test/tasks-browser.test.ts`: no `has children` text while the data fact survives; projection semantics; interruptibility matrix.
- `test/tui-app.test.ts`: an open task browser repaints a subagent row in place (`running → inactive`) without closing, and drops the interrupt hint.
- Production-wiring source audits (rules.test.ts precedent): the `agent/status` listener must exist, be membership-gated, route to the runtime-only refresh (never a re-listing), and the session bump must close the browser, clear the badge synchronously and reset the coordinator.

## Verification

- `pnpm typecheck:bundle` — passed
- `pnpm test:bundle` — 2191/2191 passed
- `pnpm test:docs` — 11/11 passed
- `node scripts/client-boundary-gate.mjs` — ok, no new Host coupling
- `git diff --check` — clean; no CJK in `src/`
- `pnpm verify:prepush:nofork` — passed (incl. `pack:release` tarball + declaration-leak gate)

Reviewed by codex/gpt-5.6-luna review rounds against the plan (`temp/20260825/task-ui-subagent-status-fix-plan.md`): round 1 `needs-fixes` (P1 overlapping-refresh ordering; P2 production-wiring coverage), round 2 **accepted with no findings**, plus the follow-up PR review (2 P2 items: synchronous badge clear on session switch; latest-committed-wins epoch) — both fixed in `f19280b`.
