### PR TITLE
ci(release): fold changelog list continuations in the release body

### DIFF
--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -58,10 +58,12 @@ function extractSection(file) {
     }
   }
 
-  const content = lines
-    .slice(start + 1, end)
-    .join('\n')
-    .trim()
+  const content = compactListContinuations(
+    lines
+      .slice(start + 1, end)
+      .join('\n')
+      .trim(),
+  )
 
   if (!content) {
     throw new Error(`Version ${version} is empty in ${file}`)
@@ -71,6 +73,42 @@ function extractSection(file) {
     heading,
     content,
   }
+}
+
+/**
+ * Fold a list item's wrapped continuation lines into single lines.
+ *
+ * The changelogs write each bullet as a wrapped paragraph (a `- ` line
+ * followed by 2-space-indented continuation lines). GitHub's file viewer
+ * folds those soft breaks, but its Release-body renderer turns them into
+ * hard `<br>` breaks, so an extracted release body shows arbitrary line
+ * breaks mid-sentence. Folding the continuations makes the Release body
+ * render as one paragraph per bullet, matching the changelog file view.
+ * Blank lines, headings, code fences and their contents are left alone.
+ */
+function compactListContinuations(content) {
+  const lines = content.split('\n')
+  const out = []
+  let inCodeFence = false
+
+  for (const line of lines) {
+    if (/^```/.test(line)) {
+      inCodeFence = !inCodeFence
+      out.push(line)
+      continue
+    }
+    if (inCodeFence) {
+      out.push(line)
+      continue
+    }
+    if (/^ {2}\S/.test(line) && /^\s*[-*]\s+\S/.test(out[out.length - 1] ?? '')) {
+      out[out.length - 1] = `${out[out.length - 1].trimEnd()} ${line.trimStart()}`
+      continue
+    }
+    out.push(line)
+  }
+
+  return out.join('\n')
 }
 
 const zh = extractSection('CHANGELOG.md')


### PR DESCRIPTION
## Summary

Fixes the "weird line breaks" in GitHub Release bodies. The changelogs write each bullet as a wrapped paragraph (`- ` line + 2-space-indented continuations). GitHub's file viewer folds those soft breaks, but the Release-body renderer emits hard `<br>` breaks, so the notes showed arbitrary mid-sentence breaks (e.g. `实时输入` / `过滤历史`).

`extractSection` in `scripts/release-notes.mjs` now folds list continuations into single lines before writing the notes file. Blank lines, `###` headings and code fences are untouched.

## Effect

- Before: 223 lines for v0.3.4 notes, every source newline rendered as `<br>`
- After: 49 lines, each bullet one paragraph — verified with GitHub's markdown renderer: **zero `<br>`**, one `<p>` per list item

Live preview of the effect: the v0.3.4 GitHub Release body was updated with the folded notes (https://github.com/XMoon/dsh-pi-tui/releases/tag/v0.3.4).

## Notes

- Changelog files themselves are unchanged — only the extracted Release body is folded.
- Release gates (tag == package.json version, bilingual sections present, headings match) are unaffected.
- No test added per request.