### PR TITLE
fix(focus): preserve historical viewport when expanding thoughts

### DIFF
--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -263,12 +263,22 @@ read the DURABLE descendant catalog, not the live-child list:
 
 The 2026-08-24 UX plan's Focus click behavior is fullscreen-only:
 
-- **Follow-end expand**: clicking a collapsed Thought in fullscreen
-  expands it and the viewport FOLLOWS THE END — the default view after
-  expansion is the latest content (the final answer or the newest process
-  output) and keeps following as it grows. **Collapse anchors the header**:
-  closing the Thought scrolls the header back near the top with follow-end
-  disabled, so the Thought stays in view.
+- **Scroll-intent expand (2026-08-25)**: clicking a collapsed Thought in
+  fullscreen expands it and the viewport policy is scroll-intent +
+  running-ness — never "expand ⇒ follow the end". A SETTLED (completed) or
+  unknown-activity Thought expansion PRESERVES the user's current
+  historical position and disables follow-end — a historical Thought has
+  no live output to chase. A RUNNING Thought expansion follows the end
+  (and keeps following) ONLY when the user was already following live
+  output; when the user has scrolled into history the running Thought
+  expands in place too. **Collapse anchors the header**: closing the
+  Thought scrolls the header back near the top with follow-end disabled,
+  so the Thought stays in view.
+- **Ctrl+O Expand Recent follows the same scroll-intent rule**: it
+  follows the end only when the user was already following AND the
+  expanded set contains a running Thought; every other case preserves the
+  current viewport. Ctrl+O Collapse All keeps the bulk-collapse anchor
+  policy.
 - **Nearest-owner click routing**: attachment > secondary > outer Thought
   > ordinary message. A compact secondary card full-reveals on click; an
   expanded secondary's body click folds ONLY that card (the root stays

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -131,9 +131,26 @@ export const EXPAND_RECENT_TURNS = 3
 /** Fullscreen Focus anchoring (plan §8.6): the collapsed Thought's header
  * lands one row below the viewport top so the previous context row stays
  * visible above it. Used on the COLLAPSE direction; the EXPAND direction
- * follows the end (plan supplement: the default view after expansion is
- * the latest content). */
+ * follows the end ONLY when the user was already following live output AND
+ * the expanded Thought is running (plan 2026-08-25: never steal a
+ * historical viewport). */
 export const FOCUS_ANCHOR_TOP_PADDING = 1
+
+/** The fullscreen viewport intent of one Focus disclosure transition (plan
+ * 2026-08-25 §8): the disclosure state (expanded/collapsed) and the
+ * viewport treatment are ORTHOGONAL — an expand must not automatically
+ * scroll to the end, and a collapse must not automatically anchor.
+ *
+ * - `'follow-end'`: update the layout, then scroll to the end and KEEP
+ *   following live output — ONLY for a running Thought when the user was
+ *   already following the end.
+ * - `'preserve'`: update the layout, keep (clamp) the pre-mutation
+ *   scrollTop and disable follow-end — the historical browsing default.
+ * - `'anchor-turn'`: update the layout, then anchor the turn's Thought
+ *   header in view with follow-end disabled (the collapse contract).
+ * - `undefined`: the caller owns the viewport (search jumps).
+ */
+export type FocusFullscreenViewportIntent = 'follow-end' | 'preserve' | 'anchor-turn'
 
 /** Whether a message is a Focus SECONDARY disclosure: a foldable process
  * card inside an expanded Thought that has its own compact/full two-state
@@ -3523,15 +3540,32 @@ export class TuiApp {
    * §16.1). Running turns are toggleable; turn/end never reverts the
    * choice. Closing is a COLLAPSE ALL: the turn's secondary expansions
    * are cleared with it (plan §6/§18), so reopening shows the process
-   * timeline compact again. In fullscreen the EXPAND direction follows
-   * the end (the user sees the latest content) and the COLLAPSE direction
-   * anchors the Thought header in view (plan supplement). */
+   * timeline compact again. In fullscreen the viewport policy is
+   * scroll-intent + running-ness (plan 2026-08-25): a SETTLED Thought
+   * expansion preserves the user's current position (never jumps to the
+   * tail); a RUNNING Thought expansion follows the end only when the user
+   * was already following live output; a collapse always anchors the
+   * Thought header in view (the PR #29 contract). */
   toggleFocusTurn(turn: number): void {
     if (this.focusExpandedTurns.has(turn)) {
-      this.collapseFocusTurn(turn, { anchorFullscreen: true })
+      this.collapseFocusTurn(turn, { fullscreenViewport: 'anchor-turn' })
       return
     }
-    this.setFocusTurnExpanded(turn, true, { anchorFullscreen: true })
+    // Snapshot the scroll intent BEFORE the disclosure mutation / rebuild
+    // (plan 2026-08-25 §23): after the layout changes the ScrollView no
+    // longer reports the user's pre-click position.
+    const scroll = this.fullscreenScroll
+    const previousScrollTop = scroll?.scrollTop ?? 0
+    const wasFollowingEnd = scroll?.isFollowingEnd === true
+    // Unknown activity state defaults to preserve — never steal the
+    // viewport on incomplete information (plan §4.3: `turnActivities.get`
+    // returning undefined is "cannot reliably judge running").
+    const activity = this.turnActivities.get(turn)
+    const shouldFollowEnd = wasFollowingEnd && activity !== undefined && !activity.completed
+    this.setFocusTurnExpanded(turn, true, {
+      fullscreenViewport: shouldFollowEnd ? 'follow-end' : 'preserve',
+      previousScrollTop,
+    })
   }
 
   /** Force one turn's Thought open (transcript-search jumps — plan §23:
@@ -3580,7 +3614,7 @@ export class TuiApp {
 
   /** The explicit user-facing Collapse All: clear the turn's secondary
    * expansions, then close the root Thought (plan §16/§18). */
-  private collapseFocusTurn(turn: number, options: { anchorFullscreen?: boolean } = {}): void {
+  private collapseFocusTurn(turn: number, options: { fullscreenViewport?: FocusFullscreenViewportIntent } = {}): void {
     this.clearFocusSecondaryExpansions(turn)
     this.setFocusTurnExpanded(turn, false, options)
   }
@@ -3628,15 +3662,32 @@ export class TuiApp {
 
   /** Ctrl+O Expand Recent (fullscreen + Focus): ONE mutation, ONE rebuild,
    * ONE viewport pass (plan §19) — mark the recent roots expanded,
-   * rebuild, then follow the fullscreen expand behavior (the end), exactly
-   * like the single-root click. Creates no secondary overrides and never
-   * writes thinkingExpanded (plan §4/§5). */
+   * rebuild, then apply the SAME scroll-intent policy as a single-root
+   * click (plan 2026-08-25 §14): follow the end ONLY when the user was
+   * already following live output AND the expanded set contains a running
+   * Thought — otherwise preserve the current viewport (never steal a
+   * historical browsing position). Creates no secondary overrides and
+   * never writes thinkingExpanded (plan §4/§5). */
   private expandRecentFullscreenFocusRoots(count: number): void {
     const recent = this.eligibleFocusRootTurns().slice(0, count)
     if (recent.length === 0) return
+    // Snapshot BEFORE the mutation / rebuild (plan §23): rebuilding with
+    // the roots expanded changes the content height, so the ScrollView no
+    // longer reports the user's pre-Ctrl+O position.
+    const scroll = this.fullscreenScroll
+    const previousScrollTop = scroll?.scrollTop ?? 0
+    const wasFollowingEnd = scroll?.isFollowingEnd === true
+    const containsRunning = recent.some(turn => {
+      const activity = this.turnActivities.get(turn)
+      return activity !== undefined && !activity.completed
+    })
     for (const turn of recent) this.focusExpandedTurns.add(turn)
     this.rebuildMessages()
-    this.applyFullscreenExpandViewport()
+    if (wasFollowingEnd && containsRunning) {
+      this.applyFullscreenFollowEndViewport()
+    } else {
+      this.applyFullscreenPreserveViewport(previousScrollTop)
+    }
     this.requestRender()
   }
 
@@ -3663,7 +3714,7 @@ export class TuiApp {
     this.clearFocusSecondaryExpansionsForTurns(expandedTurns)
     this.toolOutputExpanded = false
     this.rebuildMessages()
-    this.applyFullscreenCollapseAnchor(anchorTurn)
+    this.applyFullscreenFocusTurnAnchor(anchorTurn)
     this.requestRender()
   }
 
@@ -3710,18 +3761,24 @@ export class TuiApp {
   /**
    * The unified Focus disclosure transition (plan §8.4): every entry
    * point — header click, expanded-body click, search jumps — funnels
-   * through here. With `anchorFullscreen` (user clicks only, never the
-   * search path), the fullscreen viewport is adjusted AFTER the rebuild:
-   * the EXPAND direction follows the END (the default view after
-   * expansion is the latest content — the final answer or the newest
-   * process output — and the viewport keeps following as it grows), and
-   * the COLLAPSE direction anchors the turn's Thought header in view with
-   * follow-end disabled (plan supplement).
+   * through here. With a `fullscreenViewport` intent (user clicks only,
+   * never the search path), the fullscreen viewport is adjusted AFTER the
+   * rebuild — the intent is EXPLICIT (plan 2026-08-25 §8/§9): `'follow-end'`
+   * scrolls to the latest content and keeps following (running Thought +
+   * user already following), `'preserve'` keeps the pre-mutation scrollTop
+   * with follow-end disabled (settled / historical), `'anchor-turn'` brings
+   * the turn's Thought header into view with follow-end disabled (the
+   * collapse contract). Disclosure state never implies a viewport behavior.
    */
   private setFocusTurnExpanded(
     turn: number,
     expanded: boolean,
-    options: { anchorFullscreen?: boolean } = {},
+    options: {
+      fullscreenViewport?: FocusFullscreenViewportIntent
+      /** The scrollTop to restore under `'preserve'` — snapshot by the
+       * CALLER before the disclosure mutation (plan 2026-08-25 §23). */
+      previousScrollTop?: number
+    } = {},
   ): void {
     if (this.focusExpandedTurns.has(turn) === expanded) return
     if (expanded) this.focusExpandedTurns.add(turn)
@@ -3730,21 +3787,28 @@ export class TuiApp {
     // requests a render) → 3. re-measure the row map at the current width
     // (a thumbnail that just finished loading must not shift the anchor).
     this.rebuildMessages()
-    if (options.anchorFullscreen && this.fullscreenScroll !== undefined) {
-      if (expanded) {
-        this.applyFullscreenExpandViewport()
-      } else {
-        this.applyFullscreenCollapseAnchor(turn)
+    if (options.fullscreenViewport !== undefined && this.fullscreenScroll !== undefined) {
+      switch (options.fullscreenViewport) {
+        case 'follow-end':
+          this.applyFullscreenFollowEndViewport()
+          break
+        case 'preserve':
+          this.applyFullscreenPreserveViewport(options.previousScrollTop ?? 0)
+          break
+        case 'anchor-turn':
+          this.applyFullscreenFocusTurnAnchor(turn)
+          break
       }
     }
     this.requestRender()
   }
 
-  /** The fullscreen EXPAND viewport pass (plan supplement): re-measure the
-   * row map, feed the layout the NEW projected content height (a stale
-   * height would clamp the scroll), then follow the end — the default view
-   * after any expansion is the latest content. */
-  private applyFullscreenExpandViewport(): void {
+  /** The fullscreen FOLLOW-END viewport pass (plan 2026-08-25 §13): re-measure
+   * the row map, feed the layout the NEW projected content height (a stale
+   * height would clamp the scroll), then scroll to the end and keep
+   * following — the view for LIVE output only. Callers decide the intent;
+   * the method never assumes "expand ⇒ follow". */
+  private applyFullscreenFollowEndViewport(): void {
     if (this.fullscreenScroll === undefined) return
     this.refreshMessageRows()
     const width = this.terminal.columns
@@ -3754,14 +3818,33 @@ export class TuiApp {
     this.fullscreenScroll.scrollToEnd()
   }
 
-  /** The fullscreen COLLAPSE viewport pass (plan §8.7/§18): re-measure,
+  /** The fullscreen PRESERVE viewport pass (plan 2026-08-25 §11): re-measure,
+   * update the layout, then RESTORE the pre-mutation scrollTop (normal
+   * clamp against the new content height) with follow-end disabled — the
+   * historical-browsing default. Never scrolls to the end and never anchors
+   * a header; `scrollTo(…, { disableFollow: true })` is the SAME primitive
+   * the collapse anchor and manual scrolling already use, so no vendored
+   * ScrollView change is needed (plan §22). */
+  private applyFullscreenPreserveViewport(previousScrollTop: number): void {
+    if (this.fullscreenScroll === undefined) return
+    this.refreshMessageRows()
+    const width = this.terminal.columns
+    const contentHeight = this.messagesView.render(width).length
+    const viewportHeight = this.fullscreenScroll.viewportHeight
+    this.fullscreenScroll.updateLayout(contentHeight, viewportHeight, () => this.requestRender())
+    this.fullscreenScroll.scrollTo(previousScrollTop, { disableFollow: true })
+  }
+
+  /** The fullscreen ANCHOR viewport pass (plan §8.7/§18): re-measure,
    * update the layout, then anchor the given turn's Thought header
    * `FOCUS_ANCHOR_TOP_PADDING` rows below the viewport top (one row of
    * previous context stays visible) with follow-end disabled — the same
    * behavior for header clicks, blank-row clicks and Ctrl+O Collapse All.
    * `turn === undefined` keeps the current position (the layout is still
-   * updated and clamped against the shrunken content). */
-  private applyFullscreenCollapseAnchor(turn: number | undefined): void {
+   * updated and clamped against the shrunken content). Named for WHAT it
+   * does (anchor a Thought turn), not the collapse direction (plan
+   * 2026-08-25 §13). */
+  private applyFullscreenFocusTurnAnchor(turn: number | undefined): void {
     if (this.fullscreenScroll === undefined) return
     this.refreshMessageRows()
     const width = this.terminal.columns
@@ -4467,7 +4550,7 @@ export class TuiApp {
           }
           const owner = this.blankRowFocusCollapseOwner(entry, next)
           if (owner !== undefined) {
-            this.collapseFocusTurn(owner, { anchorFullscreen: true })
+            this.collapseFocusTurn(owner, { fullscreenViewport: 'anchor-turn' })
           }
           return
         }
@@ -4513,7 +4596,7 @@ export class TuiApp {
           // 3. outer disclosure: a NON-secondary process row (e.g. an
           // intermediate assistant) collapses the owner Thought — the
           // header stays anchored in view (plan §14 step 3).
-          this.collapseFocusTurn(entry.collapseFocusOwnerOnClick, { anchorFullscreen: true })
+          this.collapseFocusTurn(entry.collapseFocusOwnerOnClick, { fullscreenViewport: 'anchor-turn' })
           return
         }
         // 4. ordinary message toggle (the pre-Focus behavior).

--- a/test/focus-anchor.test.ts
+++ b/test/focus-anchor.test.ts
@@ -86,7 +86,7 @@ function click(vt: VirtualTerminal, x: number, y: number): void {
   vt.sendInput(`\x1b[<0;${x};${y}m`)
 }
 
-test('expanding a collapsed Thought in fullscreen FOLLOWS THE END (plan supplement)', async () => {
+test('expanding a collapsed SETTLED Thought preserves the viewport (plan 2026-08-25)', async () => {
   const { vt, app } = startApp()
   const folder = new TranscriptFolder()
   folder.apply(longThoughtTurn(0))
@@ -103,30 +103,32 @@ test('expanding a collapsed Thought in fullscreen FOLLOWS THE END (plan suppleme
   assert.ok(headerY >= 0, `collapsed Thought header missing:\n${view.join('\n')}`)
   const before = app.fullscreenScrollForTest()
   assert.equal(before?.isFollowingEnd, true, 'precondition: following the end')
-  // Click the collapsed header: the root expands and the viewport follows
-  // the END (the default view after expansion is the latest content).
+  // Click the collapsed header: the settled Thought's expansion PRESERVES
+  // the viewport (a completed Thought has no live output to chase — plan
+  // 2026-08-25 §4.2) instead of jumping to the end.
   click(vt, 3, headerY + 1)
   await vt.waitForRender()
   view = vt.getViewport()
   const joined = view.join('\n')
   assert.ok(joined.includes('🐳 Thought'), `expanded symbol missing:\n${joined}`)
   const after = app.fullscreenScrollForTest()
-  assert.equal(after?.isFollowingEnd, true, 'expansion must keep following the end')
-  assert.ok(after !== undefined && after.scrollTop === after.maxScrollTop,
-    `the viewport must sit at the end (scrollTop ${after?.scrollTop} vs max ${after?.maxScrollTop})`)
+  assert.ok(after !== undefined)
+  assert.equal(after.isFollowingEnd, false, 'a settled Thought expansion must disable follow-end')
   // The process timeline is COMPACT: the 120-line result stays hidden.
   assert.ok(!joined.includes('result line 50'), `the long result must stay hidden (compact secondary):\n${joined}`)
-  // Full-reveal the Bash secondary: the follow-end keeps the viewport at
-  // the bottom, so the result TAIL is what the user sees.
+  // Full-reveal the Bash secondary, then scroll to the bottom: the result
+  // TAIL is what the end of the transcript shows.
   const bashY = findRow(view, 'Bash seq 1 120')
   assert.ok(bashY >= 0, `compact Bash card missing:\n${view.join('\n')}`)
   click(vt, 10, bashY + 1)
   await vt.waitForRender()
+  app.scrollToBottom()
+  await vt.waitForRender()
   view = vt.getViewport()
   const expanded = view.join('\n')
-  assert.ok(expanded.includes('result line 119'), `the result tail must be visible (follow-end):\n${expanded}`)
+  assert.ok(expanded.includes('result line 119'), `the result tail must be visible at the bottom:\n${expanded}`)
   const final = app.fullscreenScrollForTest()
-  assert.equal(final?.isFollowingEnd, true, 'the viewport keeps following the end')
+  assert.equal(final?.isFollowingEnd, true, 'manual scroll to the bottom re-enables follow-end')
   app.setFullscreen(false)
   app.stop()
 })
@@ -155,11 +157,15 @@ test('clicking an expanded SECONDARY body collapses only the secondary (plan §3
   assert.ok(bashY >= 0, `compact Bash card missing:\n${view.join('\n')}`)
   click(vt, 10, bashY + 1)
   await vt.waitForRender()
+  // The settled Thought preserved the viewport, so after the full reveal
+  // scroll to the bottom: the result TAIL is what the end shows (the
+  // consumer scrolls; the viewport policy never guesses — plan 2026-08-25).
+  app.scrollToBottom()
+  await vt.waitForRender()
   view = vt.getViewport()
   const joined = view.join('\n')
-  // The follow-end viewport shows the result TAIL (the default view after
-  // expansion is the end) — the Thought header is scrolled out of view,
-  // which is the intended default.
+  // The viewport now shows the result TAIL — the Thought header is scrolled
+  // out of view, which is the intended end-of-transcript view.
   assert.ok(joined.includes('result line 99'), `the full result must appear (tail visible):\n${joined}`)
   // Click a result line: ONLY the secondary collapses.
   const bodyY = findRow(view, 'result line 99')
@@ -232,10 +238,14 @@ test('root Collapse All clears the secondary expansions (plan §6/§37)', async 
   const bashY = findRow(view, 'Bash seq 1 120')
   click(vt, 10, bashY + 1)
   await vt.waitForRender()
+  // The settled Thought preserved the viewport: scroll to the bottom to
+  // SEE the full result tail (the viewport policy never auto-follows on a
+  // settled expansion — plan 2026-08-25).
+  app.scrollToBottom()
+  await vt.waitForRender()
   view = vt.getViewport()
   assert.ok(view.join('\n').includes('result line 99'), 'precondition: the Bash secondary is full (tail visible)')
-  // The follow-end viewport sits at the bottom: scroll back to the header
-  // before the Collapse All click.
+  // Scroll back to the header before the Collapse All click.
   app.scrollToTop()
   await vt.waitForRender()
   view = vt.getViewport()
@@ -471,6 +481,10 @@ test('resize keeps the click map aligned: secondary closes first, then the root 
   view = vt.getViewport()
   const bashY = findRow(view, 'Bash seq 1 120')
   click(vt, 10, bashY + 1)
+  await vt.waitForRender()
+  // The settled Thought preserved the viewport: scroll to the bottom to
+  // SEE the full result tail before the resize resequence.
+  app.scrollToBottom()
   await vt.waitForRender()
   view = vt.getViewport()
   assert.ok(view.join('\n').includes('result line 99'), 'precondition: the Bash secondary is full (tail visible)')

--- a/test/focus-ui.test.ts
+++ b/test/focus-ui.test.ts
@@ -1459,11 +1459,14 @@ test('fullscreen Ctrl+O Collapse All clears every secondary override; the global
   await vt.waitForRender()
   joined = vt.getViewport().join('\n')
   assert.ok(joined.includes('(click to expand)'), 'precondition: the Thinking click collapsed only that card (local override)')
-  // Full-reveal the Bash card: the viewport follows the END, so the last
-  // result line proves the card is full.
+  // Full-reveal the Bash card; the settled expand preserved the viewport,
+  // so scroll to the tail — the last result line proves the card is full
+  // (plan 2026-08-25).
   const bashY = findRow(vt.getViewport(), 'Bash cmd 1')
   assert.ok(bashY >= 0, `Bash card missing:\n${joined}`)
   click(vt, 10, bashY + 1)
+  await vt.waitForRender()
+  app.scrollToBottom()
   await vt.waitForRender()
   joined = vt.getViewport().join('\n')
   assert.ok(joined.includes('out 1 line 39'), 'precondition: the Bash card is locally full (tail visible)')
@@ -1539,8 +1542,10 @@ test('blank-row collapse works when the Thought header scrolled OUT of view (pla
   show(app, folder)
   app.setFullscreen(true)
   await vt.waitForRender()
-  // Expand the root, then full-reveal the Bash card: the viewport follows
-  // the END, so the Thought header scrolls out of view.
+  // Expand the root, then full-reveal the Bash card; scroll to the bottom
+  // so the Thought header scrolls OUT of view (the settled-thought expand
+  // preserves the viewport — plan 2026-08-25 — the user scrolls to the
+  // tail).
   let y = findRow(vt.getViewport(), '🐋 Thought')
   assert.ok(y >= 0, `Thought header missing:\n${vt.getViewport().join('\n')}`)
   click(vt, 3, y + 1)
@@ -1548,6 +1553,8 @@ test('blank-row collapse works when the Thought header scrolled OUT of view (pla
   const bashY = findRow(vt.getViewport(), 'Bash seq 1 120')
   assert.ok(bashY >= 0, `Bash card missing:\n${vt.getViewport().join('\n')}`)
   click(vt, 10, bashY + 1)
+  await vt.waitForRender()
+  app.scrollToBottom()
   await vt.waitForRender()
   let view = vt.getViewport()
   assert.ok(findRow(view, '🐳 Thought') < 0, `precondition: the header must be scrolled out of view:\n${view.join('\n')}`)
@@ -1589,10 +1596,14 @@ test('a secondary content row toggles only the secondary; the adjacent blank row
   click(vt, 3, y + 1)
   await vt.waitForRender()
   // The Bash card's CONTENT row toggles only the secondary: the last
-  // result line proves the full-reveal, and the ROOT stays open.
+  // result line proves the full-reveal, and the ROOT stays open. The
+  // settled expand preserved the viewport — scroll to the tail to see the
+  // full-reveal proof (plan 2026-08-25).
   const bashY = findRow(vt.getViewport(), 'Bash cmd 1')
   assert.ok(bashY >= 0, `Bash card missing:\n${vt.getViewport().join('\n')}`)
   click(vt, 10, bashY + 1)
+  await vt.waitForRender()
+  app.scrollToBottom()
   await vt.waitForRender()
   let joined = vt.getViewport().join('\n')
   assert.ok(joined.includes('out 1 line 39'), 'the Bash secondary must full-reveal on its own row')
@@ -1798,6 +1809,10 @@ test('resize keeps the blank-row click map aligned (plan §23.8)', async () => {
   assert.ok(bashY >= 0, `Bash card missing:\n${view.join('\n')}`)
   click(vt, 10, bashY + 1)
   await vt.waitForRender()
+  // The settled expand preserved the viewport: scroll to the tail so the
+  // result tail is visible (plan 2026-08-25).
+  app.scrollToBottom()
+  await vt.waitForRender()
   view = vt.getViewport()
   assert.ok(findRow(view, 'result line 119') >= 0, 'precondition: the result tail is visible')
   // Resize: rows re-wrap — the y-regions must be re-measured, never stale.
@@ -1837,6 +1852,10 @@ test('a blank-row click BEFORE the first paint after a resize is dropped — reb
   const bashY = findRow(view, 'Bash seq 1 120')
   assert.ok(bashY >= 0, `Bash card missing:\n${view.join('\n')}`)
   click(vt, 10, bashY + 1)
+  await vt.waitForRender()
+  // The settled expand preserved the viewport: scroll to the tail so the
+  // second tool card is visible (plan 2026-08-25).
+  app.scrollToBottom()
   await vt.waitForRender()
   view = vt.getViewport()
   const preEchoY = findRow(view, 'Bash echo done')
@@ -1884,6 +1903,10 @@ test('Collapse All clears a secondary override parked on a WINDOWED-AWAY message
   const bashY = findRow(view, 'Bash cmd 1')
   assert.ok(bashY >= 0, `Bash card missing:\n${view.join('\n')}`)
   click(vt, 10, bashY + 1)
+  await vt.waitForRender()
+  // The settled expand preserved the viewport: scroll to the tail so the
+  // full-reveal proof is visible (plan 2026-08-25).
+  app.scrollToBottom()
   await vt.waitForRender()
   view = vt.getViewport()
   assert.ok(view.join('\n').includes('out 1 line 39'), 'precondition: turn-1 Bash is locally full')
@@ -2336,6 +2359,10 @@ test('editor/footer clicks are clipped OUT of the transcript hit-test when scrol
   const bashY = findRow(view, 'Bash seq 1 120')
   assert.ok(bashY >= 0, `Bash card missing:\n${view.join('\n')}`)
   click(vt, 10, bashY + 1)
+  await vt.waitForRender()
+  // The settled expand preserved the viewport: scroll to the tail so the
+  // full-reveal proof is visible (plan 2026-08-25).
+  app.scrollToBottom()
   await vt.waitForRender()
   view = vt.getViewport()
   assert.ok(view.join('\n').includes('result line 119'), 'precondition: the Bash card is full')

--- a/test/focus-viewport-policy.test.ts
+++ b/test/focus-viewport-policy.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Fullscreen + Focus viewport policy (plan 2026-08-25, the expanded
+ * viewport fix): expanding a Thought must NOT steal the user's historical
+ * viewport. The rule is scroll-intent + running-ness — never "expanded →
+ * scrollToEnd()".
+ *
+ *   - click a SETTLED Thought → preserve the current scrollTop, disable
+ *     follow-end (a completed Thought has no live output to chase);
+ *   - click a RUNNING Thought while the user is already following the end
+ *     → keep following (live-progress view);
+ *   - click a RUNNING Thought while the user has scrolled into history
+ *     → preserve the viewport (scroll intent wins);
+ *   - Ctrl+O Expand Recent → follow-end ONLY when the user was following
+ *     the end AND the expanded set contains a running Thought; every other
+ *     case preserves the viewport.
+ *
+ * Collapse (single header, blank row) keeps its PR #29 anchor behavior;
+ * search owns its own jump; Regular is untouched.
+ *
+ * Failing-on-main expectation: the SETTLED-click and history Ctrl+O tests
+ * (plan §21.1/§21.2/§21.4/§21.6/§21.7) are the discriminators — pre-fix
+ * they all end at maxScrollTop with follow-end ON.
+ * @module @xmoon76/dsh-pi-tui/focus-viewport-policy.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { CallId, MessageId } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { TranscriptFolder } from '../src/transcript.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+function startApp(columns = 100, rows = 30): { vt: VirtualTerminal; app: TuiApp } {
+  const vt = new VirtualTerminal(columns, rows)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  return { vt, app }
+}
+
+const T0 = Date.now() - 60_000
+
+function eventAt(type: string, data: Record<string, unknown>, time: number, seq: number): SessionEvent {
+  return { type, seq, time, data } as SessionEvent
+}
+
+function show(app: TuiApp, folder: TranscriptFolder): void {
+  app.setTranscript(folder.messages(), folder.turnActivities())
+}
+
+function findRow(view: readonly string[], needle: string): number {
+  return view.findIndex(line => line.includes(needle))
+}
+
+/** The LAST row (viewport y) containing `needle` — the newest projected
+ * turn's Thought header sits at the transcript bottom, so when the target
+ * is the LATEST block findRow alone may hit an older visible one. */
+function findLastRow(view: readonly string[], needle: string): number {
+  let last = -1
+  for (let i = 0; i < view.length; i += 1) {
+    if (view[i]!.includes(needle)) last = i
+  }
+  return last
+}
+
+function click(vt: VirtualTerminal, x: number, y: number): void {
+  vt.sendInput(`\x1b[<0;${x};${y}M`)
+  vt.sendInput(`\x1b[<0;${x};${y}m`)
+}
+
+/** A COMPLETED turn with reasoning + a bash tool whose result is LONG
+ * (120 rendered rows): expanding the root meaningfully grows the content
+ * height, so the preserve-vs-follow discriminator is real. */
+function settledTurn(turn: number, seqBase: number): SessionEvent[] {
+  const lines = Array.from({ length: 120 }, (_, i) => `result ${turn} line ${i}`).join('\n')
+  return [
+    eventAt('turn/start', { turn }, T0, seqBase),
+    eventAt('user/message', {
+      id: MessageId(`u${turn}`), role: 'user',
+      content: [{ type: 'text', text: `prompt ${turn}` }],
+      source: { kind: 'user' },
+    }, T0 + 1, seqBase + 1),
+    eventAt('assistant/chunk', { turn, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: `reason ${turn} A\nreason ${turn} B` } }, T0 + 2, seqBase + 2),
+    eventAt('tool/call', { turn, step: 0, callId: CallId(`c${turn}`), name: 'bash', arguments: JSON.stringify({ command: `cmd ${turn}` }) }, T0 + 3, seqBase + 3),
+    eventAt('tool/result', {
+      turn, step: 0,
+      message: {
+        id: MessageId(`r${turn}`), role: 'user',
+        content: [{ type: 'tool-result', toolCallId: CallId(`c${turn}`), content: [{ type: 'text', text: lines }] }],
+        source: { kind: 'tool', callId: CallId(`c${turn}`) },
+      },
+    }, T0 + 4, seqBase + 4),
+    eventAt('assistant/message', {
+      turn, step: 1,
+      message: {
+        id: MessageId(`a${turn}`), role: 'assistant',
+        content: [{ type: 'text', text: `done ${turn}` }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+    }, T0 + 5, seqBase + 5),
+    eventAt('turn/end', { turn, reason: { kind: 'completed' } }, T0 + 6, seqBase + 6),
+  ]
+}
+
+/** The FIRST events of a turn, left RUNNING (no turn/end yet). */
+function runningTurnStart(turn: number, seqBase: number): SessionEvent[] {
+  return [
+    eventAt('turn/start', { turn }, T0, seqBase),
+    eventAt('user/message', {
+      id: MessageId(`u${turn}`), role: 'user',
+      content: [{ type: 'text', text: `prompt ${turn}` }],
+      source: { kind: 'user' },
+    }, T0 + 1, seqBase + 1),
+    eventAt('assistant/chunk', { turn, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: `reason ${turn} A` } }, T0 + 2, seqBase + 2),
+    eventAt('tool/call', { turn, step: 0, callId: CallId(`c${turn}`), name: 'bash', arguments: JSON.stringify({ command: `cmd ${turn}` }) }, T0 + 3, seqBase + 3),
+  ]
+}
+
+/** Build a fullscreen+Focus app whose transcript holds the given turns. */
+async function fullscreenFocusApp(
+  turns: Array<{ events: SessionEvent[]; running?: boolean }>,
+): Promise<{ vt: VirtualTerminal; app: TuiApp }> {
+  const { vt, app } = startApp()
+  const folder = new TranscriptFolder()
+  for (const turn of turns) folder.apply(turn.events)
+  app.setFocusMode(true)
+  if (turns.some(turn => turn.running)) app.setWorking(true)
+  show(app, folder)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  return { vt, app }
+}
+
+// --- 21.1: a SETTLED Thought click must preserve the historical viewport
+// (the discriminator — pre-fix scrollTop lands on maxScrollTop) ---
+
+test('settled Thought expansion preserves the historical viewport (plan §21.1)', async () => {
+  // ENOUGH settled turns that one PageUp from the bottom lands strictly
+  // INSIDE the transcript (a page ≈ viewport height 25; total scroll ≥ 50).
+  const turns = [1, 2, 3, 4, 5, 6, 7, 8].map(turn => ({ events: settledTurn(turn, turn * 100) }))
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    // Start at the bottom (following), then PageUp into history: the real
+    // user gesture that LEAVES follow-end at a NONZERO mid position.
+    app.scrollToBottom()
+    await vt.waitForRender()
+    const bottom = app.fullscreenScrollForTest()
+    assert.ok(bottom !== undefined && bottom.maxScrollTop > 30, 'precondition: the transcript overflows')
+    vt.sendInput('\x1b[5~') // PageUp (legacy) — alt screen pages up
+    await vt.waitForRender()
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined, 'fullscreen scroll must exist')
+    assert.ok(before.scrollTop > 0 && before.scrollTop < before.maxScrollTop,
+      `precondition: nonzero historical position (${before.scrollTop} of ${before.maxScrollTop})`)
+    assert.equal(before.isFollowingEnd, false, 'precondition: not following the end')
+    // A settled Thought header is visible in the current band.
+    const view = vt.getViewport()
+    const headerY = findRow(view, '🐋 Thought')
+    assert.ok(headerY >= 0, `Thought header missing:\n${view.join('\n')}`)
+    click(vt, 3, headerY + 1)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.scrollTop, before.scrollTop, 'settled Thought expansion preserves scrollTop')
+    assert.equal(after.isFollowingEnd, false, 'settled Thought expansion must disable follow-end')
+    assert.ok(vt.getViewport().join('\n').includes('🐳 Thought'), 'the root must actually expand')
+  } finally {
+    app.stop()
+  }
+})
+
+// --- 21.2: the settled rule holds even when the user was at the bottom ---
+
+test('a settled Thought keeps the viewport even while at the bottom (plan §21.2)', async () => {
+  const turns = [1, 2, 3, 4].map(turn => ({ events: settledTurn(turn, turn * 100) }))
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    app.scrollToBottom()
+    await vt.waitForRender()
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined)
+    assert.equal(before.isFollowingEnd, true, 'precondition: following the end')
+    assert.equal(before.scrollTop, before.maxScrollTop, 'precondition: at the bottom')
+    // The newest settled turn's header is visible at the bottom (the LAST
+    // projected Thought header).
+    const view = vt.getViewport()
+    const headerY = findLastRow(view, '🐋 Thought')
+    assert.ok(headerY >= 0, `Thought header missing:\n${view.join('\n')}`)
+    click(vt, 3, headerY + 1)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.isFollowingEnd, false, 'a completed Thought must disable follow even when the user was following')
+    // The pre-click bottom scrollTop is preserved verbatim (a taller
+    // content may raise maxScrollTop; the position only clamps DOWN, never
+    // re-aims at the new bottom — plan §12).
+    assert.equal(after.scrollTop, before.scrollTop, 'the preserved scrollTop equals the pre-click value')
+    assert.ok(vt.getViewport().join('\n').includes('🐳 Thought'), 'the root must expand')
+  } finally {
+    app.stop()
+  }
+})
+
+// --- 21.3: running + following the end keeps following (a REGRESSION
+// guard — pre-fix AND post-fix both pass) ---
+
+test('running Thought + user following the end keeps following (plan §21.3)', async () => {
+  const turns = [
+    { events: settledTurn(1, 100) },
+    { events: settledTurn(2, 200) },
+    { events: settledTurn(3, 300) },
+    { events: runningTurnStart(4, 400), running: true },
+  ]
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    app.scrollToBottom()
+    await vt.waitForRender()
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined)
+    assert.equal(before.isFollowingEnd, true, 'precondition: following the end')
+    // The running Thought (turn 4) is the LAST projected block: its header
+    // is the LAST '🐋 Thought' in the viewport.
+    const view = vt.getViewport()
+    const headerY = findLastRow(view, '🐋 Thought')
+    assert.ok(headerY >= 0, `running Thought header missing:\n${view.join('\n')}`)
+    assert.ok(view.join('\n').includes('prompt 4'), `the running turn must be the visible one:\n${view.join('\n')}`)
+    click(vt, 3, headerY + 1)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.isFollowingEnd, true, 'running + following must keep following')
+    assert.equal(after.scrollTop, after.maxScrollTop, 'the viewport must sit at the end')
+    assert.ok(vt.getViewport().join('\n').includes('🐳 Thought'), 'the running root must expand')
+    // A new event streams in: the viewport must keep chasing the tail.
+    const folder = new TranscriptFolder()
+    for (let turn = 1; turn <= 3; turn += 1) folder.apply(settledTurn(turn, turn * 100))
+    folder.apply(runningTurnStart(4, 400))
+    folder.apply([
+      eventAt('tool/result', {
+        turn: 4, step: 0,
+        message: {
+          id: MessageId('r4'), role: 'user',
+          content: [{ type: 'tool-result', toolCallId: CallId('c4'), content: [{ type: 'text', text: 'fresh output line' }] }],
+          source: { kind: 'tool', callId: CallId('c4') },
+        },
+      }, T0 + 44000, 900),
+    ])
+    show(app, folder)
+    await vt.waitForRender()
+    const final = app.fullscreenScrollForTest()
+    assert.ok(final !== undefined)
+    assert.equal(final.isFollowingEnd, true, 'the viewport must keep following live output')
+    assert.equal(final.scrollTop, final.maxScrollTop, 'the viewport stays at the new end')
+  } finally {
+    app.stop()
+  }
+})
+
+// --- 21.4: running BUT the user scrolled into history → preserve (the
+// key discriminator: scroll intent wins over running-ness). The running
+// turn is the EARLIEST so its header sits at the top after scrollToTop. ---
+
+test('running Thought + user scrolled into history preserves the viewport (plan §21.4)', async () => {
+  const turns = [
+    { events: runningTurnStart(1, 100), running: true },
+    { events: settledTurn(2, 200) },
+    { events: settledTurn(3, 300) },
+    { events: settledTurn(4, 400) },
+  ]
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    app.scrollToTop()
+    await vt.waitForRender()
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined)
+    assert.equal(before.isFollowingEnd, false, 'precondition: scrolled away from the end')
+    // The running Thought (turn 1) is the FIRST projected block.
+    const view = vt.getViewport()
+    const headerY = findRow(view, '🐋 Thought')
+    assert.ok(headerY >= 0, `running Thought header missing:\n${view.join('\n')}`)
+    assert.ok(view.join('\n').includes('prompt 1'), `the running turn must be the visible one:\n${view.join('\n')}`)
+    click(vt, 3, headerY + 1)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.isFollowingEnd, false, 'running + scrolled-up must NOT follow')
+    assert.equal(after.scrollTop, before.scrollTop, 'running + scrolled-up must preserve scrollTop')
+    assert.ok(vt.getViewport().join('\n').includes('🐳 Thought'), 'the running root must expand')
+  } finally {
+    app.stop()
+  }
+})
+
+// --- Ctrl+O Expand Recent (plan §14/§15) ---
+
+/** Ctrl+O — fullscreen Focus root bulk toggle. */
+function ctrlO(vt: VirtualTerminal): void {
+  vt.sendInput('\x0f')
+}
+
+test('Ctrl+O Expand Recent follows the end when following + a recent root runs (plan §21.5)', async () => {
+  const turns = [
+    { events: settledTurn(1, 100) },
+    { events: settledTurn(2, 200) },
+    { events: settledTurn(3, 300) },
+    { events: settledTurn(4, 400) },
+    { events: runningTurnStart(5, 500), running: true },
+  ]
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    app.scrollToBottom()
+    await vt.waitForRender()
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined)
+    assert.equal(before.isFollowingEnd, true, 'precondition: following the end')
+    ctrlO(vt)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.isFollowingEnd, true, 'Ctrl+O must keep following (recent contains running)')
+    assert.equal(after.scrollTop, after.maxScrollTop, 'the viewport stays at the end')
+    const expanded = [...app.focusExpandedTurnsForTest()].sort((a, b) => a - b)
+    assert.deepEqual(expanded, [3, 4, 5], 'Ctrl+O must expand the recent roots')
+  } finally {
+    app.stop()
+  }
+})
+
+test('Ctrl+O at a historical position never jumps to the tail — even with a running root (plan §21.6)', async () => {
+  // ENOUGH settled turns that one PageUp from the bottom lands strictly
+  // INSIDE the transcript (a page ≈ viewport height 25; total scroll ≥ 50).
+  const turns = [
+    { events: settledTurn(1, 100) },
+    { events: settledTurn(2, 200) },
+    { events: settledTurn(3, 300) },
+    { events: settledTurn(4, 400) },
+    { events: settledTurn(5, 500) },
+    { events: settledTurn(6, 600) },
+    { events: settledTurn(7, 700) },
+    { events: runningTurnStart(8, 800), running: true },
+  ]
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    // Start at the bottom (following), then PageUp into history: the real
+    // user gesture that LEAVES follow-end.
+    app.scrollToBottom()
+    await vt.waitForRender()
+    const bottom = app.fullscreenScrollForTest()
+    assert.ok(bottom !== undefined && bottom.maxScrollTop > 30, 'precondition: the transcript overflows')
+    vt.sendInput('\x1b[5~') // PageUp (legacy) — alt screen pages up
+    await vt.waitForRender()
+    // Move to a NONZERO historical position strictly below the end: the
+    // strongest proof that Ctrl+O does not relocate.
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined)
+    assert.equal(before.isFollowingEnd, false, 'precondition: scrolled into history')
+    assert.ok(before.scrollTop > 0 && before.scrollTop < before.maxScrollTop,
+      `precondition: nonzero historical position (${before.scrollTop} of ${before.maxScrollTop})`)
+    ctrlO(vt)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.isFollowingEnd, false, 'Ctrl+O must not steal the historical position')
+    assert.equal(after.scrollTop, before.scrollTop, 'Ctrl+O must preserve scrollTop in history')
+    const expanded = [...app.focusExpandedTurnsForTest()].sort((a, b) => a - b)
+    assert.deepEqual(expanded, [6, 7, 8], 'Ctrl+O must still expand the recent roots')
+  } finally {
+    app.stop()
+  }
+})
+
+test('Ctrl+O with all-completed recent roots preserves even while at the bottom (plan §21.7)', async () => {
+  const turns = [1, 2, 3, 4, 5].map(turn => ({ events: settledTurn(turn, turn * 100) }))
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    app.scrollToBottom()
+    await vt.waitForRender()
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined)
+    assert.equal(before.isFollowingEnd, true, 'precondition: following the end')
+    ctrlO(vt)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.isFollowingEnd, false, 'all-completed recent roots must disable follow-end')
+    // The pre-Ctrl+O bottom scrollTop is preserved verbatim (a taller
+    // content may raise maxScrollTop; the position only clamps DOWN, never
+    // re-aims at the new bottom — plan §12).
+    assert.equal(after.scrollTop, before.scrollTop, 'the preserved scrollTop equals the pre-Ctrl+O value')
+    const expanded = [...app.focusExpandedTurnsForTest()].sort((a, b) => a - b)
+    assert.deepEqual(expanded, [3, 4, 5], 'Ctrl+O must still expand the recent roots')
+  } finally {
+    app.stop()
+  }
+})
+
+// --- unknown activity (§4.3): a turn whose TurnActivity is missing from
+// `turnActivities` cannot be judged running — the expansion must NEVER steal
+// the viewport (preserve + disable follow). Guarded because `toggleFocusTurn`
+// is public and hosts (or a stale snapshot) can reach it for such a turn. ---
+
+test('an unknown-activity Thought expansion preserves the viewport (plan §4.3)', async () => {
+  const turns = [1, 2, 3, 4, 5, 6, 7, 8].map(turn => ({ events: settledTurn(turn, turn * 100) }))
+  const { vt, app } = await fullscreenFocusApp(turns)
+  try {
+    app.scrollToBottom()
+    await vt.waitForRender()
+    const bottom = app.fullscreenScrollForTest()
+    assert.ok(bottom !== undefined && bottom.maxScrollTop > 30, 'precondition: the transcript overflows')
+    vt.sendInput('\x1b[5~') // PageUp: leave follow-end at a nonzero mid position
+    await vt.waitForRender()
+    const before = app.fullscreenScrollForTest()
+    assert.ok(before !== undefined)
+    assert.equal(before.isFollowingEnd, false, 'precondition: not following the end')
+    assert.ok(before.scrollTop > 0, 'precondition: at a nonzero position')
+    assert.equal(app.focusExpandedTurnsForTest().size, 0, 'precondition: nothing expanded')
+    // Turn 9 has NO TurnActivity in the folder — an unknown activity state.
+    app.toggleFocusTurn(9)
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.ok(after !== undefined)
+    assert.equal(after.scrollTop, before.scrollTop, 'unknown activity must preserve scrollTop')
+    assert.equal(after.isFollowingEnd, false, 'unknown activity must stay follow-end disabled')
+  } finally {
+    app.stop()
+  }
+})


### PR DESCRIPTION
## Summary

Fixes the fullscreen+Focus viewport theft: expanding a Thought previously scrolled to the transcript end unconditionally, stealing the user's position while browsing history.

Implements plan `temp/20260826/dsh-pi-tui-fullscreen-focus-expand-viewport-policy-plan-2026-08-25.md`.

## Behavior

- **Settled (completed) / unknown-activity Thought expansion** → preserves the current historical position (clamp down only), disables follow-end.
- **Running Thought expansion** → follows the end only when the user was already following live output; if the user scrolled into history it expands in place.
- **Ctrl+O Expand Recent** → follows the end only when `wasFollowingEnd && containsRunning`; never hijacks a historical position.
- Collapse (header / blank-row / Collapse All) keeps the PR #29 header anchor; search keeps owning its jump; Regular and Focus-OFF paths untouched.

## Implementation

- Replaced the implicit `anchorFullscreen` boolean with an explicit `FocusFullscreenViewportIntent` union (`'follow-end' | 'preserve' | 'anchor-turn'`).
- Three dedicated helpers: `applyFullscreenFollowEndViewport` / `applyFullscreenPreserveViewport` / `applyFullscreenFocusTurnAnchor`.
- `previousScrollTop` / `wasFollowingEnd` snapshotted BEFORE the disclosure mutation/rebuild.
- No vendored ScrollView change: preserve reuses `scrollTo(row, { disableFollow: true })`.

## Tests & gates

- 8 new tests in `test/focus-viewport-policy.test.ts` (5 were failing pre-fix, 8/8 now green).
- `focus-anchor.test.ts` / `focus-ui.test.ts` updated to the new contract; `docs/surface-decisions.md` synced.
- Reviewed through the review-fix loop (pre-rebase 3 rounds, post-rebase 2 rounds) — accepted.
- Bundle 2320/2320, fork 985/985, typecheck, naming gate, client-boundary gate, `git diff --check` all green.