### PR TITLE
feat(keybindings): user-orchestrable semantic keybindings (M0–M6)

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -30,16 +30,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a settings edit takes effect after the reload, no restart): a string for
   one key, an array for several, `false` to disable an action's keys, and
   a `leader` key plus `<leader>X` sequences for multi-key bindings (M6).
-  A plain printable key can never be bound to a Host action; a bad entry
-  is a warning, never a startup failure (fail-soft); conflicts (same key
-  + overlapping scope + same priority) are diagnosed and deactivated —
-  never silent last-write-wins. `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores
-  all user overrides. `/keybindings` shows the effective table,
-  `/keybindings conflicts` lists conflicts, `/keybindings reload`
-  re-reads the settings (fail-soft — a throwing read keeps the
-  last-known-good keymap and reports an error), and `/keybindings reset`
-  clears the overrides through the settings service and rebuilds the
-  running keymap immediately.
+  Any user declaration REPLACES the action's builtin default keys (a
+  leader-only binding is the sole trigger rather than an addition to the
+  builtin; a mixed direct + leader keeps both user triggers; `false`
+  removes every trigger). A plain printable key can never be bound to a
+  Host action; a bad entry is a warning, never a startup failure
+  (fail-soft); conflicts (same key + overlapping scope + same priority)
+  are diagnosed and deactivated — never silent last-write-wins.
+  `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores all user overrides.
+  `/keybindings` shows the effective table, `/keybindings conflicts`
+  lists conflicts, `/keybindings reload` re-reads the settings
+  (fail-soft — a throwing read keeps the last-known-good keymap and
+  reports an error), and `/keybindings reset` clears the overrides
+  through the settings service and rebuilds the running keymap
+  immediately.
+- **The `/help` and `/settings` key copy is key-neutral.** The help rows
+  describe the SEMANTIC action (e.g. "press the interrupt action twice"
+  instead of "double-Esc") and the busy preference is "Submit while
+  busy" — never a physical Enter/Esc claim that would go stale after a
+  remap; the LABEL column always shows the effective keys.
 - **The subagent viewer guard is action-based.** The continuable viewer
   blocks PARENT actions by action id (not by physical key), so a
   remapped parent shortcut stays blocked inside the viewer — the

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -33,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Any user declaration REPLACES the action's builtin default keys (a
   leader-only binding is the sole trigger rather than an addition to the
   builtin; a mixed direct + leader keeps both user triggers; `false`
-  removes every trigger). A plain printable key can never be bound to a
+  removes every trigger). A missing or invalid `leader` key makes the
+  `<leader>X` sequences inert (a warning) and the action falls back to
+  its builtin default keys — an ignored bad config never silently
+  removes the builtin. A plain printable key can never be bound to a
   Host action; a bad entry is a warning, never a startup failure
   (fail-soft); conflicts (same key + overlapping scope + same priority)
   are diagnosed and deactivated — never silent last-write-wins.

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -22,6 +22,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance — no restart, no session reload. Third-party extensions,
   user/assistant/tool content and the image attachment marker are
   untouched.
+- **Keybindings are now user-orchestrable.** Every Host shortcut is a
+  semantic action (`app.*`) resolved through a context-aware keymap, so
+  the UI (footer hints, `/help`, `/keybindings`) always shows the
+  EFFECTIVE keys. Configure overrides in the `pi-tui` settings namespace
+  (`keybindings` field, hot-reloaded — no restart): a string for one
+  key, an array for several, `false` to disable an action's keys, and a
+  `leader` key plus `<leader>X` sequences for multi-key bindings (M6).
+  A plain printable key can never be bound to a Host action; a bad entry
+  is a warning, never a startup failure (fail-soft); conflicts (same key
+  + overlapping scope + same priority) are diagnosed and deactivated —
+  never silent last-write-wins. `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores
+  all user overrides. `/keybindings` shows the effective table,
+  `/keybindings conflicts` lists conflicts, `/keybindings reload`
+  re-reads the settings, and `/keybindings reset` clears the overrides
+  through the settings service.
+- **The subagent viewer guard is action-based.** The continuable viewer
+  blocks PARENT actions by action id (not by physical key), so a
+  remapped parent shortcut stays blocked inside the viewer — the
+  architecture no longer couples session safety to a physical key list.
+- **A static gate prevents new physical shortcuts.**
+  `scripts/check-host-keybindings.mts` (wired into `verify:prepush`)
+  fails on any new `matchesKey(data, 'ctrl+…'/'alt+…'/'shift+…')` chord
+  in the host input path, with a documented allowlist for the sanctioned
+  focused-component/protocol seams.
+
+### Changed
+
+- The question flow and the task browser route their keys through
+  semantic component actions (`question.*` / `tasks.*`); their behavior
+  and keys are unchanged.
+
 
 ## [0.3.4] - 2026-08-25
 

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -26,17 +26,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   semantic action (`app.*`) resolved through a context-aware keymap, so
   the UI (footer hints, `/help`, `/keybindings`) always shows the
   EFFECTIVE keys. Configure overrides in the `dsh-pi-tui` settings namespace
-  (`keybindings` field, hot-reloaded — no restart): a string for one
-  key, an array for several, `false` to disable an action's keys, and a
-  `leader` key plus `<leader>X` sequences for multi-key bindings (M6).
+  (`keybindings` field), then apply with `/keybindings reload` (explicit —
+  a settings edit takes effect after the reload, no restart): a string for
+  one key, an array for several, `false` to disable an action's keys, and
+  a `leader` key plus `<leader>X` sequences for multi-key bindings (M6).
   A plain printable key can never be bound to a Host action; a bad entry
   is a warning, never a startup failure (fail-soft); conflicts (same key
   + overlapping scope + same priority) are diagnosed and deactivated —
   never silent last-write-wins. `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores
   all user overrides. `/keybindings` shows the effective table,
   `/keybindings conflicts` lists conflicts, `/keybindings reload`
-  re-reads the settings, and `/keybindings reset` clears the overrides
-  through the settings service.
+  re-reads the settings (fail-soft — a throwing read keeps the
+  last-known-good keymap and reports an error), and `/keybindings reset`
+  clears the overrides through the settings service and rebuilds the
+  running keymap immediately.
 - **The subagent viewer guard is action-based.** The continuable viewer
   blocks PARENT actions by action id (not by physical key), so a
   remapped parent shortcut stays blocked inside the viewer — the

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -48,10 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   strings, with a documented allowlist for the sanctioned
   focused-component/protocol seams and fork editor-level keys.
 - **User-facing key copy follows the effective keymap.** The footer
-  hints, `/help` rows, `/settings` descriptions and the divergence-guard
-  notices render their key labels through `keyHint()`/`keysFor()` — a
-  remap updates every copy, and comments name keys only where the
-  semantics are key-specific (the Ctrl+C chord, the double-Esc window).
+  hints, the fold/queue-pane hints (`to expand`, `to steer all`), the
+  `/help` rows, `/settings` descriptions and the divergence-guard notices
+  render their key labels through `keyHint()`/`keysFor()` — a remap
+  updates every copy, and comments name keys only where the semantics
+  are key-specific (the Ctrl+C chord, the double-Esc window).
 
 ### Changed
 

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Keybindings are now user-orchestrable.** Every Host shortcut is a
   semantic action (`app.*`) resolved through a context-aware keymap, so
   the UI (footer hints, `/help`, `/keybindings`) always shows the
-  EFFECTIVE keys. Configure overrides in the `pi-tui` settings namespace
+  EFFECTIVE keys. Configure overrides in the `dsh-pi-tui` settings namespace
   (`keybindings` field, hot-reloaded — no restart): a string for one
   key, an array for several, `false` to disable an action's keys, and a
   `leader` key plus `<leader>X` sequences for multi-key bindings (M6).

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -44,8 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A static gate prevents new physical shortcuts.**
   `scripts/check-host-keybindings.mts` (wired into `verify:prepush`)
   fails on any new `matchesKey(data, 'ctrl+…'/'alt+…'/'shift+…')` chord
-  in the host input path, with a documented allowlist for the sanctioned
-  focused-component/protocol seams.
+  in the host input path and any hard-coded chord label in user-facing
+  strings, with a documented allowlist for the sanctioned
+  focused-component/protocol seams and fork editor-level keys.
+- **User-facing key copy follows the effective keymap.** The footer
+  hints, `/help` rows, `/settings` descriptions and the divergence-guard
+  notices render their key labels through `keyHint()`/`keysFor()` — a
+  remap updates every copy, and comments name keys only where the
+  semantics are key-specific (the Ctrl+C chord, the double-Esc window).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,32 @@
   最终 glyph,所以 `/settings` 切换后同一运行实例内已渲染的卡片立即换
   图标,无需重启或重新加载会话;第三方扩展、用户/assistant/tool 内容
   与图片 attachment marker 均不受影响。
+- **快捷键现在可用户编排。** 每个 Host 快捷键都是语义 action
+  (`app.*`),通过 context-aware keymap 解析,因此 UI(页脚提示、
+  `/help`、`/keybindings`)始终显示**生效**的按键。在 `pi-tui`
+  settings 命名空间的 `keybindings` 字段配置覆盖(热加载,无需重启):
+  字符串表示单个按键,数组表示多个按键,`false` 禁用某 action 的
+  按键,`leader` 键加 `<leader>X` 序列支持多键绑定(M6)。普通可打印键
+  永远不能绑定到 Host action;坏配置只是警告,绝不会导致启动失败
+  (fail-soft);冲突(同键 + 作用域重叠 + 同优先级)会被诊断并停用——
+  绝不静默 last-write-wins。`DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有
+  用户覆盖。`/keybindings` 显示生效表,`/keybindings conflicts` 列出
+  冲突,`/keybindings reload` 重新读取设置,`/keybindings reset` 通过
+  settings 服务清除覆盖。
+- **子代理查看器守卫改为基于 action。** continuable 查看器按 action id
+  (而非物理键)阻止父级 action,因此改键后的父级快捷键在查看器内依然
+  被阻止——会话安全不再与物理键列表耦合。
+- **新增静态门禁阻止物理快捷键回潮。**
+  `scripts/check-host-keybindings.mts`(已接入 `verify:prepush`)对
+  host 输入路径中新增的 `matchesKey(data, 'ctrl+…'/'alt+…'/'shift+…')`
+  和弦直接报错,并带有针对受认可的 focused-component/protocol 接缝的
+  白名单。
+
+### 变更
+
+- 问题流与任务浏览器改为通过语义组件 action(`question.*` /
+  `tasks.*`)路由按键;行为与按键保持不变。
+
 
 ## [0.3.4] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   与图片 attachment marker 均不受影响。
 - **快捷键现在可用户编排。** 每个 Host 快捷键都是语义 action
   (`app.*`),通过 context-aware keymap 解析,因此 UI(页脚提示、
-  `/help`、`/keybindings`)始终显示**生效**的按键。在 `pi-tui`
+  `/help`、`/keybindings`)始终显示**生效**的按键。在 `dsh-pi-tui`
   settings 命名空间的 `keybindings` 字段配置覆盖(热加载,无需重启):
   字符串表示单个按键,数组表示多个按键,`false` 禁用某 action 的
   按键,`leader` 键加 `<leader>X` 序列支持多键绑定(M6)。普通可打印键

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,21 @@
   settings 命名空间的 `keybindings` 字段配置覆盖,然后执行 `/keybindings
   reload` 应用(显式 reload——改设置后执行 reload 即生效,无需重启):
   字符串表示单个按键,数组表示多个按键,`false` 禁用某 action 的
-  按键,`leader` 键加 `<leader>X` 序列支持多键绑定(M6)。普通可打印键
-  永远不能绑定到 Host action;坏配置只是警告,绝不会导致启动失败
-  (fail-soft);冲突(同键 + 作用域重叠 + 同优先级)会被诊断并停用——
-  绝不静默 last-write-wins。`DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有
-  用户覆盖。`/keybindings` 显示生效表,`/keybindings conflicts` 列出
-  冲突,`/keybindings reload` 重新读取设置(fail-soft——读取异常时保留
-  last-known-good keymap 并报告错误),`/keybindings reset` 通过
-  settings 服务清除覆盖并立即重建运行中的 keymap。
+  按键,`leader` 键加 `<leader>X` 序列支持多键绑定(M6)。任何用户声明
+  都会**替换**该 action 的内置默认键(仅 leader 的绑定是唯一触发而
+  非叠加在内置键之上;直接 + leader 混合保留两个用户触发;`false`
+  移除全部触发)。普通可打印键永远不能绑定到 Host action;坏配置只是
+  警告,绝不会导致启动失败(fail-soft);冲突(同键 + 作用域重叠 +
+  同优先级)会被诊断并停用——绝不静默 last-write-wins。
+  `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖。`/keybindings`
+  显示生效表,`/keybindings conflicts` 列出冲突,`/keybindings reload`
+  重新读取设置(fail-soft——读取异常时保留 last-known-good keymap 并
+  报告错误),`/keybindings reset` 通过 settings 服务清除覆盖并立即
+  重建运行中的 keymap。
+- **`/help` 与 `/settings` 的按键文案改为语义化。** help 行描述语义
+  action(如"按两次 interrupt action"取代"double-Esc"),忙碌偏好改为
+  "Submit while busy"——绝不再写会因改键而过时的物理 Enter/Esc 文案;
+  标签列始终展示生效按键。
 - **子代理查看器守卫改为基于 action。** continuable 查看器按 action id
   (而非物理键)阻止父级 action,因此改键后的父级快捷键在查看器内依然
   被阻止——会话安全不再与物理键列表耦合。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@
   按键,`leader` 键加 `<leader>X` 序列支持多键绑定(M6)。任何用户声明
   都会**替换**该 action 的内置默认键(仅 leader 的绑定是唯一触发而
   非叠加在内置键之上;直接 + leader 混合保留两个用户触发;`false`
-  移除全部触发)。普通可打印键永远不能绑定到 Host action;坏配置只是
+  移除全部触发)。缺少或无效的 `leader` 键会让 `<leader>X` 序列失效
+  并警告,该 action 回落到内置默认键——被忽略的坏配置不会悄悄删掉
+  内置键。普通可打印键永远不能绑定到 Host action;坏配置只是
   警告,绝不会导致启动失败(fail-soft);冲突(同键 + 作用域重叠 +
   同优先级)会被诊断并停用——绝不静默 last-write-wins。
   `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖。`/keybindings`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,17 @@
 - **快捷键现在可用户编排。** 每个 Host 快捷键都是语义 action
   (`app.*`),通过 context-aware keymap 解析,因此 UI(页脚提示、
   `/help`、`/keybindings`)始终显示**生效**的按键。在 `dsh-pi-tui`
-  settings 命名空间的 `keybindings` 字段配置覆盖(热加载,无需重启):
+  settings 命名空间的 `keybindings` 字段配置覆盖,然后执行 `/keybindings
+  reload` 应用(显式 reload——改设置后执行 reload 即生效,无需重启):
   字符串表示单个按键,数组表示多个按键,`false` 禁用某 action 的
   按键,`leader` 键加 `<leader>X` 序列支持多键绑定(M6)。普通可打印键
   永远不能绑定到 Host action;坏配置只是警告,绝不会导致启动失败
   (fail-soft);冲突(同键 + 作用域重叠 + 同优先级)会被诊断并停用——
   绝不静默 last-write-wins。`DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有
   用户覆盖。`/keybindings` 显示生效表,`/keybindings conflicts` 列出
-  冲突,`/keybindings reload` 重新读取设置,`/keybindings reset` 通过
-  settings 服务清除覆盖。
+  冲突,`/keybindings reload` 重新读取设置(fail-soft——读取异常时保留
+  last-known-good keymap 并报告错误),`/keybindings reset` 通过
+  settings 服务清除覆盖并立即重建运行中的 keymap。
 - **子代理查看器守卫改为基于 action。** continuable 查看器按 action id
   (而非物理键)阻止父级 action,因此改键后的父级快捷键在查看器内依然
   被阻止——会话安全不再与物理键列表耦合。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,11 @@
   和弦、以及用户可见字符串中写死的和弦标签直接报错,并带有针对受
   认可的 focused-component/protocol 接缝与 fork 编辑器级按键的
   白名单。
-- **用户可见的键位文案跟随生效 keymap。** 页脚提示、`/help` 行、
-  `/settings` 行与 divergence-guard 通知都通过
-  `keymap.keyHint()/keysFor()` 渲染键标签——改键后所有文案自动更新;
-  注释只在语义键特有(如 Ctrl+C 和弦、双击 Esc 窗口)时保留键名。
+- **用户可见的键位文案跟随生效 keymap。** 页脚提示、折叠/队列窗格
+  提示(`to expand`、`to steer all`)、`/help` 行、`/settings` 行与
+  divergence-guard 通知都通过 `keymap.keyHint()/keysFor()` 渲染键标签
+  ——改键后所有文案自动更新;注释只在语义键特有(如 Ctrl+C 和弦、
+  双击 Esc 窗口)时保留键名。
 
 ### 变更
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,13 @@
 - **新增静态门禁阻止物理快捷键回潮。**
   `scripts/check-host-keybindings.mts`(已接入 `verify:prepush`)对
   host 输入路径中新增的 `matchesKey(data, 'ctrl+…'/'alt+…'/'shift+…')`
-  和弦直接报错,并带有针对受认可的 focused-component/protocol 接缝的
+  和弦、以及用户可见字符串中写死的和弦标签直接报错,并带有针对受
+  认可的 focused-component/protocol 接缝与 fork 编辑器级按键的
   白名单。
+- **用户可见的键位文案跟随生效 keymap。** 页脚提示、`/help` 行、
+  `/settings` 行与 divergence-guard 通知都通过
+  `keymap.keyHint()/keysFor()` 渲染键标签——改键后所有文案自动更新;
+  注释只在语义键特有(如 Ctrl+C 和弦、双击 Esc 窗口)时保留键名。
 
 ### 变更
 

--- a/README.en.md
+++ b/README.en.md
@@ -211,6 +211,11 @@ dsh-pi-tui:
 - A plain printable key can never be bound to a Host action (it would
   swallow typing); a bad entry is a warning, never a startup failure
   (fail-soft).
+- Any user declaration REPLACES the action's builtin default keys:
+  `app.input.steer: ctrl+x` makes Ctrl+X steer and Ctrl+S stop steering;
+  a leader-only `app.todo.toggle: <leader>t` makes Leader T the only
+  toggle trigger (Ctrl+T stops); `['ctrl+z', '<leader>s']` keeps both
+  USER triggers; `false` removes every trigger of the action.
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores all user overrides (builtin
   defaults only).
 - `/keybindings` shows the effective table; `/keybindings conflicts`

--- a/README.en.md
+++ b/README.en.md
@@ -192,10 +192,10 @@ Use `/help` inside the TUI for the current command and keybinding list.
 Host shortcuts are semantic actions (`app.*`) resolved through a
 context-aware keymap — the UI (footer hints, `/help`, `/keybindings`)
 always shows the EFFECTIVE keys, so a remap updates every hint. Configure
-them in the `pi-tui` settings namespace (hot-reloaded, no restart):
+them in the `dsh-pi-tui` settings namespace (hot-reloaded, no restart):
 
 ```yaml
-pi-tui:
+dsh-pi-tui:
   keybindings:
     app.input.steer: ctrl+s          # one key
     app.permission.cycle: [shift+tab, ctrl+shift+p]   # several keys

--- a/README.en.md
+++ b/README.en.md
@@ -217,6 +217,9 @@ dsh-pi-tui:
   `/keybindings reset` clears the overrides through the settings service.
 - The subagent viewer blocks PARENT actions by action id, so a remapped
   parent shortcut stays blocked inside the viewer.
+- Conditional affordances are ADDITIVE: binding `app.tasks.open: ctrl+x`
+  ADDS a trigger — the empty-editor `↓` task-browser affordance still
+  works; only `false` removes every trigger of an action.
 
 
 ## Installation

--- a/README.en.md
+++ b/README.en.md
@@ -187,6 +187,37 @@ Slash Commands registered by other plugins through `ctx.commands` are discovered
 | `!!`          | Enter local-only Shell mode                         |
 
 Use `/help` inside the TUI for the current command and keybinding list.
+### Customizing keybindings
+
+Host shortcuts are semantic actions (`app.*`) resolved through a
+context-aware keymap — the UI (footer hints, `/help`, `/keybindings`)
+always shows the EFFECTIVE keys, so a remap updates every hint. Configure
+them in the `pi-tui` settings namespace (hot-reloaded, no restart):
+
+```yaml
+pi-tui:
+  keybindings:
+    app.input.steer: ctrl+s          # one key
+    app.permission.cycle: [shift+tab, ctrl+shift+p]   # several keys
+    app.history.search: ctrl+r
+    app.transcript.toggleThinking: false   # disable the action's keys
+    leader: ctrl+x                    # M6: leader sequences
+    bindings:
+      app.tasks.open: <leader>t
+```
+
+- A plain printable key can never be bound to a Host action (it would
+  swallow typing); a bad entry is a warning, never a startup failure
+  (fail-soft).
+- `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores all user overrides (builtin
+  defaults only).
+- `/keybindings` shows the effective table; `/keybindings conflicts`
+  lists conflicts (same key + overlapping scope + same priority — never
+  silent last-write-wins); `/keybindings reload` re-reads the settings;
+  `/keybindings reset` clears the overrides through the settings service.
+- The subagent viewer blocks PARENT actions by action id, so a remapped
+  parent shortcut stays blocked inside the viewer.
+
 
 ## Installation
 

--- a/README.en.md
+++ b/README.en.md
@@ -192,7 +192,9 @@ Use `/help` inside the TUI for the current command and keybinding list.
 Host shortcuts are semantic actions (`app.*`) resolved through a
 context-aware keymap — the UI (footer hints, `/help`, `/keybindings`)
 always shows the EFFECTIVE keys, so a remap updates every hint. Configure
-them in the `dsh-pi-tui` settings namespace (hot-reloaded, no restart):
+them in the `dsh-pi-tui` settings namespace; apply with `/keybindings
+reload` (explicit — a settings edit takes effect after the reload, no
+restart):
 
 ```yaml
 dsh-pi-tui:
@@ -213,8 +215,11 @@ dsh-pi-tui:
   defaults only).
 - `/keybindings` shows the effective table; `/keybindings conflicts`
   lists conflicts (same key + overlapping scope + same priority — never
-  silent last-write-wins); `/keybindings reload` re-reads the settings;
-  `/keybindings reset` clears the overrides through the settings service.
+  silent last-write-wins); `/keybindings reload` re-reads the settings
+  (fail-soft: a bad entry is diagnosed and skipped, a throwing read is an
+  error notice — never a crash; the keymap keeps the last-known-good
+  configuration); `/keybindings reset` clears the overrides through the
+  settings service and rebuilds the running keymap immediately.
 - The subagent viewer blocks PARENT actions by action id, so a remapped
   parent shortcut stays blocked inside the viewer.
 - Conditional affordances are ADDITIVE: binding `app.tasks.open: ctrl+x`

--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ dsh-pi-tui:
 
 - 普通可打印键永远不能绑定到 Host action(会吞掉输入);坏配置只是
   警告,绝不会导致启动失败(fail-soft)。
+- 任何用户声明都会**替换**该 action 的内置默认键:`app.input.steer:
+  ctrl+x` 让 Ctrl+X steer、Ctrl+S 不再 steer;仅 leader 的
+  `app.todo.toggle: <leader>t` 让 Leader T 成为唯一切换触发(Ctrl+T
+  失效);`['ctrl+z', '<leader>s']` 同时保留两个用户触发;`false`
+  移除该 action 的全部触发。
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。
 - `/keybindings` 显示生效表;`/keybindings conflicts` 列出冲突(同键 +
   作用域重叠 + 同优先级——绝不静默 last-write-wins);`/keybindings

--- a/README.md
+++ b/README.md
@@ -186,6 +186,35 @@ TUI 使用 DSH 提供的模型和设置服务。
 | `!!`          | 进入 Local-only Shell 模式 |
 
 完整按键和命令以 TUI 中的 `/help` 为准。
+### 自定义快捷键
+
+Host 快捷键是语义 action(`app.*`),通过 context-aware keymap 解析——
+UI(页脚提示、`/help`、`/keybindings`)始终显示**生效**的按键,因此
+改键后所有提示自动更新。在 `pi-tui` settings 命名空间中配置
+(热加载,无需重启):
+
+```yaml
+pi-tui:
+  keybindings:
+    app.input.steer: ctrl+s          # 单个按键
+    app.permission.cycle: [shift+tab, ctrl+shift+p]   # 多个按键
+    app.history.search: ctrl+r
+    app.transcript.toggleThinking: false   # 禁用该 action 的按键
+    leader: ctrl+x                    # M6:leader 序列
+    bindings:
+      app.tasks.open: <leader>t
+```
+
+- 普通可打印键永远不能绑定到 Host action(会吞掉输入);坏配置只是
+  警告,绝不会导致启动失败(fail-soft)。
+- `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。
+- `/keybindings` 显示生效表;`/keybindings conflicts` 列出冲突(同键 +
+  作用域重叠 + 同优先级——绝不静默 last-write-wins);`/keybindings
+  reload` 重新读取设置;`/keybindings reset` 通过 settings 服务清除
+  覆盖。
+- 子代理查看器按 action id 阻止父级 action,因此改键后的父级快捷键
+  在查看器内依然被阻止。
+
 
 ## 安装
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ TUI 使用 DSH 提供的模型和设置服务。
 
 Host 快捷键是语义 action(`app.*`),通过 context-aware keymap 解析——
 UI(页脚提示、`/help`、`/keybindings`)始终显示**生效**的按键,因此
-改键后所有提示自动更新。在 `dsh-pi-tui` settings 命名空间中配置
-(热加载,无需重启):
+改键后所有提示自动更新。在 `dsh-pi-tui` settings 命名空间中配置,
+然后用 `/keybindings reload` 应用(显式 reload——改设置后执行 reload
+即生效,无需重启):
 
 ```yaml
 dsh-pi-tui:
@@ -210,8 +211,10 @@ dsh-pi-tui:
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。
 - `/keybindings` 显示生效表;`/keybindings conflicts` 列出冲突(同键 +
   作用域重叠 + 同优先级——绝不静默 last-write-wins);`/keybindings
-  reload` 重新读取设置;`/keybindings reset` 通过 settings 服务清除
-  覆盖。
+  reload` 重新读取设置(fail-soft:坏配置会被诊断并跳过,读取异常才会
+  给出错误提示——都不会崩溃,keymap 保留 last-known-good 配置);
+  `/keybindings reset` 通过 settings 服务清除覆盖,并立即重建运行中的
+  keymap。
 - 子代理查看器按 action id 阻止父级 action,因此改键后的父级快捷键
   在查看器内依然被阻止。
 - 条件 affordance 是**累加**的:绑定 `app.tasks.open: ctrl+x` 是**增加**

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ dsh-pi-tui:
   覆盖。
 - 子代理查看器按 action id 阻止父级 action,因此改键后的父级快捷键
   在查看器内依然被阻止。
+- 条件 affordance 是**累加**的:绑定 `app.tasks.open: ctrl+x` 是**增加**
+  一个触发——空编辑器的 `↓` 任务浏览器仍然有效;只有 `false` 才会
+  移除某 action 的全部触发。
 
 
 ## 安装

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ TUI 使用 DSH 提供的模型和设置服务。
 
 Host 快捷键是语义 action(`app.*`),通过 context-aware keymap 解析——
 UI(页脚提示、`/help`、`/keybindings`)始终显示**生效**的按键,因此
-改键后所有提示自动更新。在 `pi-tui` settings 命名空间中配置
+改键后所有提示自动更新。在 `dsh-pi-tui` settings 命名空间中配置
 (热加载,无需重启):
 
 ```yaml
-pi-tui:
+dsh-pi-tui:
   keybindings:
     app.input.steer: ctrl+s          # 单个按键
     app.permission.cycle: [shift+tab, ctrl+shift+p]   # 多个按键

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ knows where the rest lives.
 | `extension-capability-matrix.md` | plugin authors | The Pi capability reference: Pi capability → dsh equivalent → tier → status (roadmap, not a hash gate) |
 | `plugin-authoring.md` | plugin authors | The "which tier should I use?" decision tree and the authoring checklist |
 | `extension-unstable.md` | plugin authors | The UNSTABLE tier author guide (Phase 3): raw input interception, exclusive raw ownership, the emergency fail-safe, the low-level surface seam — NO compatibility guarantee |
+| `keybinding-architecture.md` | contributors | The user-orchestrable keybinding design: the semantic action inventory (`app.*`), the context-aware effective keymap, the input ladder, the leader (M6) machinery, user configuration, and the static gate |
 | `extension-tiers.md` | plugin authors | The three-tier contract table and the current tier status (`ADVANCED_API_LEVEL` / `UNSTABLE_API_LEVEL`) |
 | `tmux/` | — | Helper scripts (`ansi2html.mjs`, `tui-demo.sh`) with their own tests |
 | `dsh-pi-tui.png` | — | Screenshot used by the root README |

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -80,6 +80,28 @@ repository-private imports.
 | Managed overlay | `showOverlay(view, options)` | (always available) | M8 |
 | Editor replacement | `registerEditor(...)` | (always available) | M9 |
 
+**Keybinding registration contract (M6).** `registerKeybinding` accepts
+a normalized key (never raw terminal bytes) + one of the PUBLIC semantic
+actions (`submit-draft`, `queue-draft`, `steer-draft`,
+`cancel-activity`, `open-search`, `toggle-fullscreen`,
+`cycle-permission` — the `TuiAction` set). Registrations are validated
+and REJECTED loudly (a thrown error, nothing is silently dropped) when:
+the action is outside the public set (Host-private `app.*` actions are
+never plugin-triggerable); the key is a Host-reserved lifecycle key
+(Exit/steer/search/fold/todo/external-editor/history/clipboard/queue/
+submit/Esc/Shift+Tab/Alt+Up/Alt+T/Alt+K defaults); the key is a plain
+printable (bare letters and the spacebar never reach the plugin stage);
+or the key is a legacy-terminal collision (`ctrl+[`, `ctrl+j`,
+`ctrl+m`, `ctrl+i`, `ctrl+h`, `ctrl+_`, `ctrl+-` — on legacy terminals
+these are indistinguishable from Esc/Enter/Tab/Backspace/Ctrl+-, so the
+binding could never fire through the normalized lookup; the plugin
+registry shares the Host config parser's legacy inventory). Keys are
+canonicalized (aliases `esc`→`escape`, `return`→`enter`, modifier
+order) before every check, so a spelling variant cannot bypass the
+policy. Duplicate keys are an explicit conflict error; every
+registration is fiber-bound and removed on owner unload. Modified
+chords (e.g. `Ctrl+Alt+X`, `Ctrl+Space`) are the bindable surface.
+
 Editor replacement input is the ONE deliberate exception to the
 normalized-key rule: while a replacement occupies the seat, its optional
 `handleInput(event)` hook receives a SEMANTIC {@link EditorInputEvent} —

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -87,21 +87,26 @@ actions (`submit-draft`, `queue-draft`, `steer-draft`,
 `cycle-permission` — the `TuiAction` set). Registrations are validated
 and REJECTED loudly (a thrown error, nothing is silently dropped) when:
 the action is outside the public set (Host-private `app.*` actions are
-never plugin-triggerable); the key is a Host-reserved lifecycle key
-(Exit/steer/search/fold/todo/external-editor/history/clipboard/queue/
-submit/Esc/Shift+Tab/Alt+Up/Alt+T/Alt+K defaults); the key is a plain
-printable (bare letters and the spacebar never reach the plugin stage);
-or the key is a legacy-terminal collision (`ctrl+[`, `ctrl+j`,
-`ctrl+m`, `ctrl+i`, `ctrl+h`, `ctrl+_`, `ctrl+-` — on legacy terminals
-these are indistinguishable from Esc/Enter/Tab/Backspace/Ctrl+-, so the
-binding could never fire through the normalized lookup; the plugin
-registry shares the Host config parser's legacy inventory). Keys are
-canonicalized (aliases `esc`→`escape`, `return`→`enter`, modifier
-order) before every check, so a spelling variant cannot bypass the
-policy. Duplicate keys are an explicit conflict error; every
-registration is fiber-bound and removed on owner unload. Modified
-chords (e.g. `Ctrl+Alt+X`, `Ctrl+Space`) are the bindable surface.
-
+never plugin-triggerable); the key name is outside the host's key
+grammar (the runtime parser can never produce it, so the binding could
+never fire — e.g. `f13`, arbitrary strings); the key is a Host-reserved
+lifecycle key (Exit/steer/search/fold/todo/external-editor/history/
+clipboard/queue/submit/Esc/Shift+Tab/Alt+Up/Alt+T/Alt+K defaults); the
+key is TEXT-PRODUCING — a bare letter, digit, symbol or the spacebar,
+WITH OR WITHOUT Shift (Shift+A is the raw `A` byte on legacy terminals
+and `a`+shift on Kitty — either way it produces text, so a binding on
+it would steal the user's typing on some terminals; `Ctrl+Alt+X`-style
+chords and named keys like `Shift+Tab`/`Shift+Left`/`Shift+F5` are NOT
+text-producing and stay bindable); or the key is a legacy-terminal
+collision (`ctrl+[`, `ctrl+j`, `ctrl+m`, `ctrl+i`, `ctrl+h`, `ctrl+_`,
+`ctrl+-` — on legacy terminals these are indistinguishable from
+Esc/Enter/Tab/Backspace/Ctrl+-, so the binding could never fire through
+the normalized lookup; the plugin registry shares the Host config
+parser's legacy inventory). Keys are canonicalized (aliases
+`esc`→`escape`, `return`→`enter`, modifier order) before every check,
+so a spelling variant cannot bypass the policy. Duplicate keys are an
+explicit conflict error; every registration is fiber-bound and removed
+on owner unload.
 Editor replacement input is the ONE deliberate exception to the
 normalized-key rule: while a replacement occupies the seat, its optional
 `handleInput(event)` hook receives a SEMANTIC {@link EditorInputEvent} —

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -96,17 +96,21 @@ key is TEXT-PRODUCING — a bare letter, digit, symbol or the spacebar,
 WITH OR WITHOUT Shift (Shift+A is the raw `A` byte on legacy terminals
 and `a`+shift on Kitty — either way it produces text, so a binding on
 it would steal the user's typing on some terminals; `Ctrl+Alt+X`-style
-chords and named keys like `Shift+Tab`/`Shift+Left`/`Shift+F5` are NOT
+chords and named keys like `Shift+Left`/`Shift+F5` are NOT
 text-producing and stay bindable); or the key is a legacy-terminal
 collision (`ctrl+[`, `ctrl+j`, `ctrl+m`, `ctrl+i`, `ctrl+h`, `ctrl+_`,
 `ctrl+-` — on legacy terminals these are indistinguishable from
 Esc/Enter/Tab/Backspace/Ctrl+-, so the binding could never fire through
 the normalized lookup; the plugin registry shares the Host config
-parser's legacy inventory). Keys are canonicalized (aliases
-`esc`→`escape`, `return`→`enter`, modifier order) before every check,
-so a spelling variant cannot bypass the policy. Duplicate keys are an
-explicit conflict error; every registration is fiber-bound and removed
-on owner unload.
+parser's legacy inventory); or the key is a FORK EDITOR-owned key (Tab,
+arrows, Home/End, PageUp/PageDown, Backspace/Delete, word-moves,
+kill/yank/undo, Shift+Enter — the focused editor consumes these before
+the plugin stage on every keystroke, so the binding could never fire;
+the registry shares the `EDITOR_OWNED_KEY_IDS` inventory). Keys are
+canonicalized (aliases `esc`→`escape`, `return`→`enter`, modifier
+order) before every check, so a spelling variant cannot bypass the
+policy. Duplicate keys are an explicit conflict error; every
+registration is fiber-bound and removed on owner unload.
 Editor replacement input is the ONE deliberate exception to the
 normalized-key rule: while a replacement occupies the seat, its optional
 `handleInput(event)` hook receives a SEMANTIC {@link EditorInputEvent} —

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -98,9 +98,10 @@ and `a`+shift on Kitty — either way it produces text, so a binding on
 it would steal the user's typing on some terminals; `Ctrl+Alt+X`-style
 chords and named keys like `Shift+Left` are NOT
 text-producing and stay bindable); or the key can never be MATCHED by
-the runtime (a modified F-key or a modified Escape — the fork's matcher
-hard-rejects any modifier on F1-F12 and Esc, so the binding could never
-fire on any terminal protocol); or the key is a legacy-terminal
+the runtime (the fork matcher's capability table: any modifier on F1-F12
+or Esc is hard-rejected, and `clear` supports only exactly `shift` or
+exactly `ctrl` — all other bases accept any grammar-supported modifier
+via CSI-u/modifyOtherKeys); or the key is a legacy-terminal
 collision (`ctrl+[`, `ctrl+j`, `ctrl+m`, `ctrl+i`, `ctrl+h`, `ctrl+_`,
 `ctrl+-`, `ctrl+backspace` — on legacy terminals these are indistinguishable from
 Esc/Enter/Tab/Backspace/Ctrl+-, so the binding could never fire through

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -96,8 +96,11 @@ key is TEXT-PRODUCING — a bare letter, digit, symbol or the spacebar,
 WITH OR WITHOUT Shift (Shift+A is the raw `A` byte on legacy terminals
 and `a`+shift on Kitty — either way it produces text, so a binding on
 it would steal the user's typing on some terminals; `Ctrl+Alt+X`-style
-chords and named keys like `Shift+Left`/`Shift+F5` are NOT
-text-producing and stay bindable); or the key is a legacy-terminal
+chords and named keys like `Shift+Left` are NOT
+text-producing and stay bindable); or the key can never be MATCHED by
+the runtime (a modified F-key or a modified Escape — the fork's matcher
+hard-rejects any modifier on F1-F12 and Esc, so the binding could never
+fire on any terminal protocol); or the key is a legacy-terminal
 collision (`ctrl+[`, `ctrl+j`, `ctrl+m`, `ctrl+i`, `ctrl+h`, `ctrl+_`,
 `ctrl+-`, `ctrl+backspace` — on legacy terminals these are indistinguishable from
 Esc/Enter/Tab/Backspace/Ctrl+-, so the binding could never fire through

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -99,7 +99,7 @@ it would steal the user's typing on some terminals; `Ctrl+Alt+X`-style
 chords and named keys like `Shift+Left`/`Shift+F5` are NOT
 text-producing and stay bindable); or the key is a legacy-terminal
 collision (`ctrl+[`, `ctrl+j`, `ctrl+m`, `ctrl+i`, `ctrl+h`, `ctrl+_`,
-`ctrl+-` — on legacy terminals these are indistinguishable from
+`ctrl+-`, `ctrl+backspace` — on legacy terminals these are indistinguishable from
 Esc/Enter/Tab/Backspace/Ctrl+-, so the binding could never fire through
 the normalized lookup; the plugin registry shares the Host config
 parser's legacy inventory); or the key is a FORK EDITOR-owned key (Tab,

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -133,6 +133,15 @@ leader sequence (requires `leader`). A plain printable key can never be
 bound to a Host action (it would swallow typing). Hot reload: the runner
 watches the settings document and rebuilds the keymap without a restart.
 
+**Conditional affordances are ADDITIVE, never replaced.** A composition
+rule (the empty-editor `↓` task-browser affordance → `app.tasks.open`)
+stays live alongside a user binding of the same action: binding
+`app.tasks.open: ctrl+x` ADDS another trigger — `↓` (with an empty
+editor + active tasks) still opens the browser. Only `false` disables
+the affordance along with every other key of the action. The README
+uses "override" loosely; the effective semantics are: *a user binding
+adds a trigger for that semantic action; `false` removes them all*.
+
 ## Diagnostics
 
 `/keybindings` shows the effective table (action, keys, scope, source)

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -77,37 +77,81 @@ configurable action first (plan §3.3).
 
 ## Key decisions
 
-1. **Enter stays with the fork editor.** `app.input.submit` is
-   `hostResolved: false`: the builtin Enter rule is NOT compiled into the
-   host keymap, because the fork editor's submit path owns paste-burst
-   suppression and the backslash-newline workaround. A user-bound
-   alternate key for the action still compiles and routes through
-   `submitDraft` (which mirrors the Enter path exactly).
-2. **The viewer guard is action-based.** `viewerParentLockedKey` resolves
+1. **One canonical physical-key identity.** Every key spelling collapses
+   onto ONE canonical KeyId (`esc`→`escape`, `return`→`enter`, modifier
+   order → `ctrl`→`shift`→`alt`→`super`) at every rule entry point
+   (builtin defaults, user keys, leader prefix/completions, composition,
+   plugin rules, the fixed-overlay/terminal-unreliable inventories, rule
+   ids and conflict grouping). Aliases can never bypass conflict
+   detection, leader-prefix collision or dedup (convergence §1/§4.1).
+2. **Declared / effective / shadowed / conflicted are distinct states.**
+   The effective keymap compiles declared rules, DEDUPES same-action
+   same-canonical-key declarations, DEACTIVATES same-priority conflicts
+   (with a diagnostic), and SHADOWS lower-priority rules on an
+   overlapping key. Only EFFECTIVE rules feed `resolve`, `keysFor`,
+   `keyHint`, `hostResolves` and `snapshot` — a shadowed or conflicted
+   rule is never advertised, and no fabricated builtin fallback
+   resurrects a replaced default (convergence §2/§4.3/§4.4).
+3. **Editor-owned submit lives in the unified rule model.** `app.input
+   .submit` is `hostResolved: false` — the fork editor's submit path
+   owns paste-burst suppression and the backslash-newline workaround, so
+   the HOST ladder never consumes a direct submit key. But submit
+   PARTICIPATES in the unified model: user remaps/`false` sync into the
+   fork editor's `tui.input.submit` (`onEditorSubmitSync`), conflict and
+   shadow apply, the read model (`keysFor`/`keyHint`/`keysLabelFor`/
+   `snapshot`/`canActivate`) reports the editor-owned facts, and
+   fail-soft (a dead override restores the builtin Enter unless `false`)
+   is evaluated on the EFFECTIVE rules — never the raw config
+   (convergence §3/§4.5).
+4. **The viewer guard is action-based.** `viewerParentLockedKey` resolves
    the key through the effective keymap and blocks
-   `VIEWER_BLOCKED_PARENT_ACTIONS` — a user remap of a parent action stays
-   blocked automatically. The guard never maintains a physical key list.
-3. **The Esc path stays a host method.** `app.agent.interrupt` resolves to
-   `handleEscapeKey` (autocomplete/replacement-editor pass-through,
-   single/double-Esc, rewind) — a user remap moves the WHOLE path to the
-   new key. Same for `app.exit.request` → `handleExitKey` (Ctrl+C keeps
-   its clear-then-exit chord; every other bound key exits immediately).
-4. **Conflicts are deactivated, never last-write-wins.** A conflict
-   (same key + overlapping scope + same priority) disables BOTH rules with
-   a diagnostic; every other rule keeps working (fail-soft).
-5. **Safe mode** (`DSH_PI_TUI_SAFE_KEYBINDINGS=1`) ignores user overrides
+   `VIEWER_BLOCKED_PARENT_ACTIONS` (which includes `app.agent.interrupt`)
+   — a user remap of a parent action stays blocked automatically,
+   direct and leader triggers alike. The guard never maintains a
+   physical key list.
+5. **Semantic interrupt ≠ physical Escape.** `app.agent.interrupt` on the
+   physical Escape key runs the editor-owned Escape seams (autocomplete
+   pass-through, replacement-editor Esc, shell-mode exit — with the busy
+   cancel keeping Host priority over all of them) then the semantic
+   core; a REMAPPED interrupt key goes straight to the semantic core
+   (`handleInterruptAction` — single/double-action policy, rewind) and
+   never inherits the physical-Escape seams (convergence §5/§4.8). The
+   viewer's fixed Esc close stays independent.
+6. **A declined host action reaches the remainder — once.** When the
+   host dispatcher returns false (GENUINE feature absence, e.g.
+   `pasteMedia` with no handler), the key must reach the editor/plugin
+   remainder and is never re-reserved by the same host rule
+   (convergence §6/§4.9). HOST-GUARDED NO-OPS (empty queue, no history
+   source) are NOT declines: the host owns the key and consumes it.
+7. **Conflicts are deactivated, never last-write-wins.** A conflict
+   (same canonical key + overlapping scope + same priority) disables
+   BOTH rules with a diagnostic; every other rule keeps working
+   (fail-soft). If the highest tier is fully conflict-deactivated, the
+   next DECLARED tier survives — never a fabricated builtin.
+8. **Safe mode** (`DSH_PI_TUI_SAFE_KEYBINDINGS=1`) ignores user overrides
    and keeps the builtin defaults; plugin keybindings still load.
-6. **The leader is opt-in.** No leader key is configured by default, so
-   the pending-prefix machinery never changes ordinary input. A leader
-   sequence is cancelled by: timeout, Esc, a non-matching key (passed
-   through), a paste burst (passed through), or a focus transition
-   (question/approval/overlay/viewer/fullscreen).
-7. **The static gate** (`scripts/check-host-keybindings.mts`, wired into
-   `verify:prepush`) forbids NEW `matchesKey(data, 'ctrl+…'/'alt+…'/
-   'shift+…')` chords in `src/tui-app.ts`. The allowlist covers the
-   sanctioned seams: the read-only viewer guard, the Ctrl+C exit-chord
-   discriminator, the approval dialog keys, and the replacement-editor
-   Enter seams.
+9. **The leader is opt-in and availability-aware.** No leader key is
+   configured by default. Esc (any alias) can never be a completion
+   (it is the pending-cancel contract — parser-rejected); a leader with
+   zero EFFECTIVE completions has no machine; a completion dispatches
+   only when the action's context predicate holds (`canActivate` — the
+   ↓ tasks affordance is not bypassable); the viewer parent-action guard
+   blocks leader completions like direct keys. A leader-PREFIX key that
+   collides with an active host or editor-owned key is fail-soft
+   disabled with a diagnostic (convergence §4/§4.6/§4.7).
+10. **Reserved-but-unimplemented actions are not bindable.** The
+    session/model actions (`app.session.*`, `app.model.open`) are
+    `configurable: false` + `availability: 'reserved'`: the parser
+    rejects any user binding with a diagnostic — never a bindable no-op
+    key (convergence §7).
+11. **The static gate** (`scripts/check-host-keybindings.mts`, wired into
+    `verify:prepush`) forbids NEW hard-coded chord labels in user-facing
+    strings across ALL quote styles (single/double/backtick, either
+    casing) and new `matchesKey(data, 'ctrl+…'/'alt+…'/'shift+…')`
+    chords in `src/tui-app.ts`, with a documented allowlist for the
+    sanctioned seams (read-only viewer guard, Ctrl+C exit-chord
+    discriminator, approval dialog keys, replacement-editor Enter seams,
+    the effective-submit Shift+Enter exclusion).
 
 ## User configuration
 
@@ -185,147 +229,55 @@ the user's live bindings:
   `src/tui-app.ts`), with a documented allowlist for fork editor-level
   keys (Ctrl+Home/End).
 
-## Review chain (2026-08-25, openai-codex / gpt-5.6-luna)
+## Revision history and convergence
 
-Four review rounds on `feat/keybinding-customization`; the reviewer
-accepted at round 4 with no open findings.
+The branch went through an extended external review chain
+(openai-codex / gpt-5.6-luna) on the PR #34 diff: review rounds fixed
+per-key rule ids, printable/space leader rejection, the monotonic keymap
+revision, leader fall-through, search-toggle effective keys, the
+`dsh-pi-tui` settings namespace, `app.input.submit` real remapping
+(editor sync + cross-instance isolation + safe mode + leader-only/
+conflict fail-soft), action-driven host reservation, leader-prefix
+collision, host/plugin rule layering, the fixed viewer Esc close, the
+armed exit-chord copy, and the effective read-model (no fabricated
+fallback, no dead leader advertisement). The final round was accepted.
+This doc records the CONTRACT, not the review log. The convergence pass
+then re-derived the architecture from first principles and is what the
+current code implements:
 
-- Round 1 (needs-fixes, 7 findings): advanced-capture ordering
-  (documented by-design — the pre-migration phase contract placed the
-  host ladder before the advanced stage; AGENTS.md decision 13 keeps
-  session-safety paths Host-owned), safe mode now disables the leader
-  config, conditional-action remaps inherit their predicate and `false`
-  disables the composition rule, `false` wins over `<leader>X` bindings,
-  leader sequences cannot bypass the viewer parent-action guard, duplicate
-  action declarations are a diagnostic (never last-write-wins), CJK
-  comments translated.
-- Round 2 (needs-fixes, 1 P2): disabled actions are never advertised by
-  `keyHint()`/`snapshot()`.
-- Round 3 (accepted-with-followups, 1 P2): hints read the EFFECTIVE
-  (ambiguity-filtered) leader bindings.
-- Round 4 (accepted, none).
+**Canonical physical identity.** `esc`/`escape`, `return`/`enter` and
+modifier order collapse to ONE key identity at every rule entry point
+(`src/keybindings/key-identity.ts`) — aliases can never bypass conflict,
+leader collision or dedup.
 
-The branch was then REBASED onto the current main (M1 migration ports,
-shell-editor-mode, thinking-disclosure unify, focus-v2, the
-README/CHANGELOG language flip) and re-reviewed:
-- Round 5 (needs-fixes): per-key rule ids (a conflict on ONE key of a
-  multi-key action now deactivates only that key); printable-leader keys
-  rejected.
-- Round 6 (needs-fixes): the monotonic keymap revision joins the
-  transcript cache identity (a remap refreshes already-rendered fold
-  hints; onInvalidate rebuilds messages); the leader machine propagates
-  the dispatch result (a declined action falls through, not consumed);
-  the configurable search toggle matches EFFECTIVE keys while the fixed
-  overlay keys keep their defaults; `space` is printable (rejected as
-  leader/direct binding); the settings namespace docs corrected to
-  `dsh-pi-tui` (not `pi-tui`); `/keybindings reset` notifies success
-  only after the write resolves; hot reload keeps last-known-good;
-  definitions.ts joins the gate scan (its `defaultKeys` are the source
-  of truth, its description strings must stay key-neutral); the
-  config-port documents `keybindings` as raw pass-through extension
-  data.
-- Round 7 (needs-fixes, 3 P2): the config.ts header example namespace
-  corrected to `dsh-pi-tui`; the fixed overlay-key precedence is
-  documented and the parser warns on a collision; `/keybindings reset`
-  honors the async write outcome.
-- Round 8 (needs-fixes): the read-only viewer fold pass-through and the
-  search-overlay ownership resolve the EFFECTIVE keymap (a remap of
-  `app.transcript.toggleExpand` / `app.transcript.search` stays
-  authoritative — the router consults `matchesEffective`); leader-only
-  actions appear in the `/keybindings` snapshot with their leader
-  completing keys; the changelog namespace examples corrected to
-  `dsh-pi-tui`.
-- Round 9 (needs-fixes): MIXED direct + leader bindings
-  (`['ctrl+z', '<leader>h']`) render BOTH in the snapshot (`keys` +
-  `leaderKeys`) and in `keyHint` (`Ctrl+Z / Leader H`) — the leader
-  sequence used to vanish behind the direct key.
-- Round 10 (needs-fixes): `/help` renders through the manager's new
-  `keysLabelFor()` — ALL direct keys and ALL leader sequences of an
-  action, one shared effective-label source (a mixed action no longer
-  shows only its direct keys).
-- Round 11 (needs-fixes): `keysLabelFor()` falls back to an overlay
-  action's DEFAULTS when it has no host-keymap keys (search
-  close/next/previous, question/tasks flows — `/help` no longer shows
-  '—' for them); duplicate `<leader>X` entries of the SAME action are
-  deduped before ambiguity detection (only cross-action same-key pairs
-  are ambiguous).
-- Round 12 (accepted, none) — after the SECOND rebase onto main
-  (76c8c96, the focus-viewport policy): the reviewer swept all 39
-  changed files, verified the keybinding feature coexists with the
-  focus viewport-anchoring logic in src/tui-app.ts, re-checked every
-  prior-round fix survived both rebases, and accepted with no findings.
-- PR #34 review (REQUEST CHANGES, 2 P1 + 1 P2 + 2 followups): ALL
-  fixed —
-  1. `app.input.submit` is now REALLY configurable: the effective
-     submit keys sync into the fork editor's `tui.input.submit` binding
-     (`onEditorSubmitSync`), so a remap MOVES submission to the new key
-     and `false` makes Enter inert; the host-owned seams (continuable
-     viewer submit, replacement-editor forward) mirror the effective
-     submit key via `isSubmitKey`.
-  2. The InputRouter's runtime reservation is ACTION-driven
-     (`hostResolves` — a key is reserved only while an ACTIVE host
-     action binds it); `RESERVED_HOST_KEYS` remains ONLY the
-     plugin-registration compatibility guard. A remapped-away old key
-     (Ctrl+V after pasteMedia moved to Ctrl+P) falls through to the
-     editor/plugin instead of being swallowed.
-  3. The leader PREFIX key is collision-checked against all ACTIVE
-     host keys at rebuild: a collision (e.g. `leader: ctrl+f` vs
-     app.transcript.search) fail-soft DISABLES the leader machine with
-     a diagnostic — never a silent shadow.
-  4. Conditional affordances documented as ADDITIVE (a user binding of
-     app.tasks.open adds a trigger; only `false` removes the ↓
-     affordance) — README/README.en/architecture doc.
-  5. The armed exit-chord footer hint names Ctrl+C literally (the
-     clear-then-exit chord is Ctrl+C-specific) — never the action's
-     primary key.
-- PR review rounds 2–6 (openai-codex / gpt-5.6-luna): six more
-  review-fix rounds reached acceptance —
-  - direct submit keys stay with the fork editor (the host ladder never
-    consumes a DIRECT submit key — backslash-newline/paste-burst
-    semantics preserved);
-  - the fork's PROCESS-GLOBAL submit binding is restored per TuiApp
-    instance (constructor sync + dispose restore — no cross-instance
-    leakage);
-  - the keybinding manager dies FIRST in TuiApp.dispose (armed-leader
-    timers and teardown-time rebuilds are inert), with dispose guards on
-    the mutators;
-  - a leader-ONLY submit override removes Enter (no builtin fallback);
-  - safe mode restores the builtin Enter submit (raw overrides ignored);
-  - the leader-prefix collision check includes the editor-owned submit
-    key (`leader: enter` is caught);
-  - HOST/PLUGIN rule layering: the runtime reservation
-    (`hostResolves`), the editor submit sync (`hostKeysFor`) and the
-    leader-prefix collision (`hostActiveKeys`) all exclude PLUGIN rules
-    — a plugin binding is additive and never a Host action.
-  Final round: accepted, no findings.
-- PR review second pass (1 P1 + 1 P2 + 1 P3, then 1 more P2 — all
-  fixed):
-  - the read-only AND continuable viewers' Esc exit is a FIXED lifecycle
-    key, INDEPENDENT of the user-configurable app.agent.interrupt (a
-    remap to Ctrl+X must not break the viewer close); `app.agent.
-    interrupt` joined VIEWER_BLOCKED_PARENT_ACTIONS so a remapped
-    interrupt is inert inside a viewer;
-  - a leader-PREFIX collision clears `effectiveLeaderBindings`, so
-    keyHint / keysLabelFor / snapshot never advertise a dead leader
-    sequence (the "UI always shows the EFFECTIVE keys" contract);
-  - RESERVED_HOST_KEYS comments clarified: it is ONLY the Stable v1
-    plugin-registration guard, never the runtime reservation authority
-    (input-router header, keybinding-registry, definitions);
-  - the consumed viewer-close Esc disarms the main-session double-Esc
-    window (no stale cancel/rewind after closing a viewer).
-- PR review third pass (1 P1 + 1 P3 → accepted):
-  - `editorSubmitKeysFor()` now detects a leader-only submit override via
-    the EFFECTIVE leader bindings (not the raw parsed list): a leader
-    sequence disabled by a prefix collision or an ambiguity fail-softs
-    back to the builtin Enter — a dead leader-only submit never disables
-    submission entirely;
-  - the viewer-close/double-Esc regression test hardened to genuinely arm
-    the window (first main Esc returns false so handleEscapeKey arms it;
-    the viewer-close Esc consumes) — the disarm assertion is no longer
-    vacuous.
-  Final round verdict: accepted (188 targeted tests, all gates green).
+**Single effective rule model.** The keymap compiles `declared` rules,
+dedupes same-action canonical keys, deactivates same-priority conflicts,
+and shadows lower-priority overlapping rules. Only `effective` rules
+feed the resolver, the host reservation, the editor submit sync, the
+leader availability check and the read model — `runtime == /help ==
+/keybindings == footer` by construction. No fabricated builtin
+fallback; a guard no-op stays host-owned; a genuinely declined host
+action (pasteMedia with no handler) falls through to the editor/plugin
+remainder exactly once.
 
-Final gates after the PR review rounds: 2429 bundle tests (incl. the
-focus-viewport-policy suite), 985 fork tests, 11 docs tests, typecheck
-(fork + bundle), `check-host-keybindings` gate, `git diff --check` —
-all green.
+**Editor-owned submit as a first-class rule.** `app.input.submit` keeps
+the fork editor's execution semantics while participating in the unified
+model (canonical identity, dedupe, conflict, shadow, fail-soft, read
+model) via its owner/effective state.
+
+**Leader availability.** Escape completions are parser-rejected;
+zero-effective leaders create no machine; completions obey the action's
+context predicate (`canActivate`); direct/leader/remap are blocked in
+viewers alike.
+
+**Semantic interrupt ≠ physical Escape.** Only the physical Escape key
+owns the editor Escape seams; a remapped interrupt goes straight to the
+semantic core. The fixed viewer close stays independent.
+
+**Reserved actions.** Unimplemented session/model actions are
+`configurable: false` + `availability: 'reserved'` — never bindable
+no-ops.
+
+Final gates: 2452 bundle tests, 985 fork tests, 11 docs tests,
+typecheck (fork + bundle), `check-host-keybindings` gate (all quote
+styles, either casing), `git diff --check` — all green.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -33,7 +33,7 @@ handler.
 | `context.ts` | `deriveKeybindingContext`: the resolver's context, built in ONE place per surface. `editorEmpty` is a LAZY getter — the live editor is only read when a rule predicate needs it (the input path must not add a draft read per keystroke) |
 | `effective-keymap.ts` | The rule compiler + resolver: builtin (100) / composition (100) / user (200) / plugin (10) priorities; conflict detection; `includeScopes` (the HOST keymap resolves the non-capturing scopes only) |
 | `conflicts.ts` | The conflict model: same key + overlapping scope + same priority. Capturing scopes (question/approval/overlay/search/viewer/tasks) are mutually exclusive surfaces — they never conflict with non-capturing scopes or each other |
-| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, plain-printable-to-host-action and terminal-unreliable (Ctrl+J/M) diagnostics; fail-soft |
+| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, plain-printable-to-host-action and the SHARED legacy-terminal collision inventory (Ctrl+[ / Ctrl+J/M / Ctrl+I/H / Ctrl+_/-) diagnostics; fail-soft |
 | `manager.ts` | The stateful facade: user config, safe mode, plugin rules, leader machine, diagnostics, snapshot |
 | `action-dispatcher.ts` | The semantic action → host method router (`AppActionHost`). The dispatcher NEVER re-implements business state |
 | `leader.ts` | The M6 leader state machine: pending prefix, timeout, ambiguous prefix, cancel, paste/typing isolation |
@@ -324,9 +324,10 @@ registrations are rejected as the reserved `escape`/`enter`).
 **Legacy terminal collisions are rejected everywhere.** `ctrl+[` (Esc),
 `ctrl+j`/`ctrl+m` (Enter), `ctrl+i` (the Tab byte — `matchesKey('\t',
 'ctrl+i')` is true, so a Host binding fires on Tab presses on legacy
-terminals), `ctrl+h` (the Backspace byte) and `ctrl+_` (the same 0x1f
-byte the fork's rawCtrlChar maps Ctrl+- to) are rejected as direct
-bindings, leader prefixes and leader completions — a binding
+terminals), `ctrl+h` (the Backspace byte) and `ctrl+_`/`ctrl+-` (ONE
+0x1f byte — the fork's rawCtrlChar maps Ctrl+- to the same 31 as
+Ctrl+_, so both spellings are rejected, round-16 finding) are rejected
+as direct bindings, leader prefixes and leader completions — a binding
 indistinguishable from a fixed key on legacy terminals is unsupported,
 never a warning.
 
@@ -344,7 +345,13 @@ public `TuiAction` set (the runtime whitelist `TUI_ACTIONS` — a
 JS/`as any` plugin can never register `app.exit.request` and reach the
 Host dispatcher), and (b) plain printable keys (the spacebar and bare
 letters never reach the plugin stage — the router keeps them with the
-editor's text entry; modified chords stay bindable). The owner-aware
+editor's text entry; modified chords stay bindable), and (c) the legacy
+C0 collisions — the registry shares the config parser's legacy inventory
+(`isLegacyCollisionKeyId`), so `ctrl+i`/`ctrl+h`/`ctrl+_`/`ctrl+-`/
+`ctrl+[`/`ctrl+j`/`ctrl+m` registrations are rejected too (on a legacy
+terminal the raw byte is Tab/Backspace/0x1f/Esc/Enter — the router's
+normalized plugin lookup could never match it; the old "a plugin may
+claim Ctrl+J" exception is gone, round-13/16 findings). The owner-aware
 dispatcher NEVER routes a plugin-owner winner into the
 AppActionDispatcher: only 'host' winners execute Host-private actions,
 'editor' winners go to the fork editor, and 'plugin' winners continue to
@@ -371,7 +378,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2490 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2491 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -254,6 +254,30 @@ README/CHANGELOG language flip) and re-reviewed:
   changed files, verified the keybinding feature coexists with the
   focus viewport-anchoring logic in src/tui-app.ts, re-checked every
   prior-round fix survived both rebases, and accepted with no findings.
+- PR #34 review (REQUEST CHANGES, 2 P1 + 1 P2 + 2 followups): ALL
+  fixed —
+  1. `app.input.submit` is now REALLY configurable: the effective
+     submit keys sync into the fork editor's `tui.input.submit` binding
+     (`onEditorSubmitSync`), so a remap MOVES submission to the new key
+     and `false` makes Enter inert; the host-owned seams (continuable
+     viewer submit, replacement-editor forward) mirror the effective
+     submit key via `isSubmitKey`.
+  2. The InputRouter's runtime reservation is ACTION-driven
+     (`hostResolves` — a key is reserved only while an ACTIVE host
+     action binds it); `RESERVED_HOST_KEYS` remains ONLY the
+     plugin-registration compatibility guard. A remapped-away old key
+     (Ctrl+V after pasteMedia moved to Ctrl+P) falls through to the
+     editor/plugin instead of being swallowed.
+  3. The leader PREFIX key is collision-checked against all ACTIVE
+     host keys at rebuild: a collision (e.g. `leader: ctrl+f` vs
+     app.transcript.search) fail-soft DISABLES the leader machine with
+     a diagnostic — never a silent shadow.
+  4. Conditional affordances documented as ADDITIVE (a user binding of
+     app.tasks.open adds a trigger; only `false` removes the ↓
+     affordance) — README/README.en/architecture doc.
+  5. The armed exit-chord footer hint names Ctrl+C literally (the
+     clear-then-exit chord is Ctrl+C-specific) — never the action's
+     primary key.
 
 Final gates after the second rebase: 2413 bundle tests (incl. the
 focus-viewport-policy suite), 985 fork tests, 11 docs tests, typecheck

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -395,7 +395,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2505 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2527 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -313,6 +313,17 @@ README/CHANGELOG language flip) and re-reviewed:
     (input-router header, keybinding-registry, definitions);
   - the consumed viewer-close Esc disarms the main-session double-Esc
     window (no stale cancel/rewind after closing a viewer).
+- PR review third pass (1 P1 + 1 P3 → accepted):
+  - `editorSubmitKeysFor()` now detects a leader-only submit override via
+    the EFFECTIVE leader bindings (not the raw parsed list): a leader
+    sequence disabled by a prefix collision or an ambiguity fail-softs
+    back to the builtin Enter — a dead leader-only submit never disables
+    submission entirely;
+  - the viewer-close/double-Esc regression test hardened to genuinely arm
+    the window (first main Esc returns false so handleEscapeKey arms it;
+    the viewer-close Esc consumes) — the disarm assertion is no longer
+    vacuous.
+  Final round verdict: accepted (188 targeted tests, all gates green).
 
 Final gates after the PR review rounds: 2429 bundle tests (incl. the
 focus-viewport-policy suite), 985 fork tests, 11 docs tests, typecheck

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -103,12 +103,12 @@ non-capturing plugin keybindings
 
 ## User configuration
 
-Settings namespace `pi-tui`, field `keybindings` (the schema deliberately
+Settings namespace `dsh-pi-tui` (the TUI's own settings section — NOT the `pi-tui` profile name), field `keybindings` (the schema deliberately
 does NOT declare the field — schemastery's `z.object` keeps unknown keys,
 and the parser owns the validation):
 
 ```yaml
-pi-tui:
+dsh-pi-tui:
   keybindings:
     app.input.steer: ctrl+s
     app.permission.cycle: [shift+tab, ctrl+shift+p]

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -145,3 +145,27 @@ direct settings.yaml write). `/help` and the footer hints render through
 - The model-menu / history-panel / output-viewer focused components keep
   their component-local keys (the plan's M5 covers QuestionFlow and
   TaskBrowserPanel; the others follow the same pattern later).
+
+## Review chain (2026-08-25, openai-codex / gpt-5.6-luna)
+
+Four review rounds on `feat/keybinding-customization`; the reviewer
+accepted at round 4 with no open findings.
+
+- Round 1 (needs-fixes, 7 findings): advanced-capture ordering
+  (documented by-design — the pre-migration phase contract placed the
+  host ladder before the advanced stage; AGENTS.md decision 13 keeps
+  session-safety paths Host-owned), safe mode now disables the leader
+  config, conditional-action remaps inherit their predicate and `false`
+  disables the composition rule, `false` wins over `<leader>X` bindings,
+  leader sequences cannot bypass the viewer parent-action guard, duplicate
+  action declarations are a diagnostic (never last-write-wins), CJK
+  comments translated.
+- Round 2 (needs-fixes, 1 P2): disabled actions are never advertised by
+  `keyHint()`/`snapshot()`.
+- Round 3 (accepted-with-followups, 1 P2): hints read the EFFECTIVE
+  (ambiguity-filtered) leader bindings.
+- Round 4 (accepted, none).
+
+Final gates: 1996 bundle tests, 985 fork tests, 11 docs tests,
+typecheck (fork + bundle), `check-host-keybindings` gate, `git diff
+--check` — all green.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -223,9 +223,14 @@ README/CHANGELOG language flip) and re-reviewed:
   search-overlay ownership resolve the EFFECTIVE keymap (a remap of
   `app.transcript.toggleExpand` / `app.transcript.search` stays
   authoritative — the router consults `matchesEffective`); leader-only
-  actions appear in the `/keybindings` snapshot with the `leader` flag;
-  the changelog namespace examples corrected to `dsh-pi-tui`.
+  actions appear in the `/keybindings` snapshot with their leader
+  completing keys; the changelog namespace examples corrected to
+  `dsh-pi-tui`.
+- Round 9 (needs-fixes): MIXED direct + leader bindings
+  (`['ctrl+z', '<leader>h']`) render BOTH in the snapshot (`keys` +
+  `leaderKeys`) and in `keyHint` (`Ctrl+Z / Leader H`) — the leader
+  sequence used to vanish behind the direct key.
 
-Final gates after the rebase: 2397 bundle tests, 985 fork tests, 11
+Final gates after the rebase: 2402 bundle tests, 985 fork tests, 11
 docs tests, typecheck (fork + bundle), `check-host-keybindings` gate,
 `git diff --check` — all green.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -33,7 +33,7 @@ handler.
 | `context.ts` | `deriveKeybindingContext`: the resolver's context, built in ONE place per surface. `editorEmpty` is a LAZY getter — the live editor is only read when a rule predicate needs it (the input path must not add a draft read per keystroke) |
 | `effective-keymap.ts` | The rule compiler + resolver: builtin (100) / composition (100) / user (200) / plugin (10) priorities; conflict detection; `includeScopes` (the HOST keymap resolves the non-capturing scopes only) |
 | `conflicts.ts` | The conflict model: same key + overlapping scope + same priority. Capturing scopes (question/approval/overlay/search/viewer/tasks) are mutually exclusive surfaces — they never conflict with non-capturing scopes or each other |
-| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, plain-printable-to-host-action and the SHARED legacy-terminal collision inventory (Ctrl+[ / Ctrl+J/M / Ctrl+I/H / Ctrl+_/-) diagnostics; fail-soft |
+| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, plain-printable-to-host-action and the SHARED terminal-ambiguous key inventory (TERMINAL_AMBIGUOUS_KEY_IDS: Ctrl+[ / Ctrl+J/M / Ctrl+I/H / Ctrl+_/- / Ctrl+Backspace) diagnostics; fail-soft |
 | `manager.ts` | The stateful facade: user config, safe mode, plugin rules, leader machine, diagnostics, snapshot |
 | `action-dispatcher.ts` | The semantic action → host method router (`AppActionHost`). The dispatcher NEVER re-implements business state |
 | `leader.ts` | The M6 leader state machine: pending prefix, timeout, ambiguous prefix, cancel, paste/typing isolation |
@@ -326,7 +326,10 @@ registrations are rejected as the reserved `escape`/`enter`).
 'ctrl+i')` is true, so a Host binding fires on Tab presses on legacy
 terminals), `ctrl+h` (the Backspace byte) and `ctrl+_`/`ctrl+-` (ONE
 0x1f byte — the fork's rawCtrlChar maps Ctrl+- to the same 31 as
-Ctrl+_, so both spellings are rejected, round-16 finding) are rejected
+Ctrl+_, so both spellings are rejected, round-16 finding) and
+`ctrl+backspace` (raw 0x08 is Ctrl+Backspace on Windows Terminal but
+plain Backspace on legacy/tmux — the fork's matchesRawBackspace branches
+on the session, round-20 finding) are rejected
 as direct bindings, leader prefixes and leader completions — a binding
 indistinguishable from a fixed key on legacy terminals is unsupported,
 never a warning.
@@ -352,12 +355,13 @@ printables as text on every protocol — the router and the registry
 agree, and the user config parser rejects them too), (c) non-grammar
 key names (the runtime parser can never produce them — `f13`,
 arbitrary strings — round-17 finding), (d) the legacy
-C0 collisions — the registry shares the config parser's legacy inventory
-(`isLegacyCollisionKeyId`), so `ctrl+i`/`ctrl+h`/`ctrl+_`/`ctrl+-`/
+C0 collisions — the registry shares the config parser's terminal-
+ambiguous inventory (`TERMINAL_AMBIGUOUS_KEY_IDS` / isTerminalAmbiguous-
+KeyId), so `ctrl+i`/`ctrl+h`/`ctrl+_`/`ctrl+-`/`ctrl+backspace`/
 `ctrl+[`/`ctrl+j`/`ctrl+m` registrations are rejected too (on a legacy
 terminal the raw byte is Tab/Backspace/0x1f/Esc/Enter — the router's
 normalized plugin lookup could never match it; the old "a plugin may
-claim Ctrl+J" exception is gone, round-13/16 findings), and (e) FORK
+claim Ctrl+J" exception is gone, round-13/16/20 findings), and (e) FORK
 EDITOR-owned keys (round-19 finding): Tab, arrows, Home/End,
 PageUp/PageDown, Backspace/Delete, word-moves, kill/yank/undo,
 Shift+Enter — the InputRouter's editorAccepts probe claims the editor's
@@ -391,7 +395,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2496 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2499 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -278,8 +278,28 @@ README/CHANGELOG language flip) and re-reviewed:
   5. The armed exit-chord footer hint names Ctrl+C literally (the
      clear-then-exit chord is Ctrl+C-specific) — never the action's
      primary key.
+- PR review rounds 2–6 (openai-codex / gpt-5.6-luna): six more
+  review-fix rounds reached acceptance —
+  - direct submit keys stay with the fork editor (the host ladder never
+    consumes a DIRECT submit key — backslash-newline/paste-burst
+    semantics preserved);
+  - the fork's PROCESS-GLOBAL submit binding is restored per TuiApp
+    instance (constructor sync + dispose restore — no cross-instance
+    leakage);
+  - the keybinding manager dies FIRST in TuiApp.dispose (armed-leader
+    timers and teardown-time rebuilds are inert), with dispose guards on
+    the mutators;
+  - a leader-ONLY submit override removes Enter (no builtin fallback);
+  - safe mode restores the builtin Enter submit (raw overrides ignored);
+  - the leader-prefix collision check includes the editor-owned submit
+    key (`leader: enter` is caught);
+  - HOST/PLUGIN rule layering: the runtime reservation
+    (`hostResolves`), the editor submit sync (`hostKeysFor`) and the
+    leader-prefix collision (`hostActiveKeys`) all exclude PLUGIN rules
+    — a plugin binding is additive and never a Host action.
+  Final round: accepted, no findings.
 
-Final gates after the second rebase: 2413 bundle tests (incl. the
+Final gates after the PR review rounds: 2429 bundle tests (incl. the
 focus-viewport-policy suite), 985 fork tests, 11 docs tests, typecheck
 (fork + bundle), `check-host-keybindings` gate, `git diff --check` —
 all green.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -33,7 +33,7 @@ handler.
 | `context.ts` | `deriveKeybindingContext`: the resolver's context, built in ONE place per surface. `editorEmpty` is a LAZY getter — the live editor is only read when a rule predicate needs it (the input path must not add a draft read per keystroke) |
 | `effective-keymap.ts` | The rule compiler + resolver: builtin (100) / composition (100) / user (200) / plugin (10) priorities; conflict detection; `includeScopes` (the HOST keymap resolves the non-capturing scopes only) |
 | `conflicts.ts` | The conflict model: same key + overlapping scope + same priority. Capturing scopes (question/approval/overlay/search/viewer/tasks) are mutually exclusive surfaces — they never conflict with non-capturing scopes or each other |
-| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, the RUNTIME-BINDABLE gate (modified F-keys / modified Escape can never be matched), plain-printable-to-host-action (text-producing), the SHARED terminal-ambiguous key inventory (TERMINAL_AMBIGUOUS_KEY_IDS: Ctrl+[ / Ctrl+J/M / Ctrl+I/H / Ctrl+_/- / Ctrl+Backspace) and the editor-owned submit pre-submit set; all fail-soft |
+| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, the RUNTIME-BINDABLE gate (a capability table: modified F-keys / modified Escape / unsupported modified Clear can never be matched), plain-printable-to-host-action (text-producing), the SHARED terminal-ambiguous key inventory (TERMINAL_AMBIGUOUS_KEY_IDS: Ctrl+[ / Ctrl+J/M / Ctrl+I/H / Ctrl+_/- / Ctrl+Backspace) and the editor-owned submit pre-submit set; all fail-soft |
 | `manager.ts` | The stateful facade: user config, safe mode, plugin rules, leader machine, diagnostics, snapshot |
 | `action-dispatcher.ts` | The semantic action → host method router (`AppActionHost`). The dispatcher NEVER re-implements business state |
 | `leader.ts` | The M6 leader state machine: pending prefix, timeout, ambiguous prefix, cancel, paste/typing isolation |
@@ -395,7 +395,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2502 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2505 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -79,30 +79,46 @@ configurable action first (plan §3.3).
 
 1. **One canonical physical-key identity.** Every key spelling collapses
    onto ONE canonical KeyId (`esc`→`escape`, `return`→`enter`, modifier
-   order → `ctrl`→`shift`→`alt`→`super`) at every rule entry point
-   (builtin defaults, user keys, leader prefix/completions, composition,
-   plugin rules, the fixed-overlay/terminal-unreliable inventories, rule
-   ids and conflict grouping). Aliases can never bypass conflict
-   detection, leader-prefix collision or dedup (convergence §1/§4.1).
+   order → `ctrl`→`shift`→`alt`→`super`, and every base LOWERCASED —
+   including single characters: `A`→`a`, `ctrl+A`→`ctrl+a`) at every rule
+   entry point (builtin defaults, user keys, leader prefix/completions,
+   composition, plugin rules, the fixed-overlay/terminal-unreliable
+   inventories, rule ids and conflict grouping). Aliases and CASING can
+   never bypass conflict detection, leader-prefix collision or dedup
+   (convergence §1/§4.1; the fork's runtime parser lowercases, so
+   `ctrl+A` and `ctrl+a` are one physical key).
 2. **Declared / effective / shadowed / conflicted are distinct states.**
    The effective keymap compiles declared rules, DEDUPES same-action
    same-canonical-key declarations, DEACTIVATES same-priority conflicts
    (with a diagnostic), and SHADOWS lower-priority rules on an
-   overlapping key. Only EFFECTIVE rules feed `resolve`, `keysFor`,
-   `keyHint`, `hostResolves` and `snapshot` — a shadowed or conflicted
-   rule is never advertised, and no fabricated builtin fallback
-   resurrects a replaced default (convergence §2/§4.3/§4.4).
-3. **Editor-owned submit lives in the unified rule model.** `app.input
-   .submit` is `hostResolved: false` — the fork editor's submit path
-   owns paste-burst suppression and the backslash-newline workaround, so
-   the HOST ladder never consumes a direct submit key. But submit
-   PARTICIPATES in the unified model: user remaps/`false` sync into the
-   fork editor's `tui.input.submit` (`onEditorSubmitSync`), conflict and
-   shadow apply, the read model (`keysFor`/`keyHint`/`keysLabelFor`/
-   `snapshot`/`canActivate`) reports the editor-owned facts, and
+   overlapping key — but only UNCONDITIONAL higher rules shadow in the
+   read model: a CONDITIONAL top trigger (a context predicate exists)
+   advertises BOTH its claim and the lower rule's fallback, because the
+   fallback genuinely fires in the contexts where the predicate fails
+   (round-9 finding: the read model must never hide a key that fires).
+   Only EFFECTIVE rules feed `resolve`, `keysFor`, `keyHint`,
+   `hostResolves` and `snapshot` — and they all project from the SAME
+   visible-rule set (a working user override never leaves the replaced
+   builtin advertised anywhere), with no fabricated builtin fallback
+   (convergence §2/§4.3/§4.4).
+3. **Editor-owned submit lives in the unified rule model — winner-aware.**
+   `app.input.submit` is `hostResolved: false` — the fork editor's submit
+   path owns paste-burst suppression and the backslash-newline workaround.
+   Editor-owned rules PARTICIPATE in the winner selection on equal
+   footing with host/plugin rules (round 9 finding: the resolver used to
+   skip editor rules BEFORE picking a winner, so `submit: ctrl+s`
+   steered at runtime while the read model advertised submit). The
+   resolution carries the winner's OWNER and the caller routes execution
+   by it: 'host'/'plugin' → the host dispatcher, 'editor' → the fork
+   editor (its `tui.input.submit` is synced by `onEditorSubmitSync`).
+   `hostResolves` is winner-based — an editor-owned winner is never
+   host-reserved, so the key reaches the fork editor. User remaps/`false`
+   sync into the fork editor's binding, conflict and shadow apply,
    fail-soft (a dead override restores the builtin Enter unless `false`)
-   is evaluated on the EFFECTIVE rules — never the raw config
-   (convergence §3/§4.5).
+   is evaluated on the EFFECTIVE rules — never the raw config, and a
+   leader sequence NEVER clears the direct keys (`submit:
+   ['ctrl+z', '<leader>s']` keeps BOTH triggers; only a truly leader-only
+   override removes Enter) (convergence §3/§4.5).
 4. **The viewer guard is action-based.** `viewerParentLockedKey` resolves
    the key through the effective keymap and blocks
    `VIEWER_BLOCKED_PARENT_ACTIONS` (which includes `app.agent.interrupt`)
@@ -173,9 +189,18 @@ dsh-pi-tui:
 
 Semantics: string = one key; array = several; `false` = disable the
 action's effective binding; absent = builtin default; `<leader>X` = a
-leader sequence (requires `leader`). A plain printable key can never be
-bound to a Host action (it would swallow typing). Hot reload: the runner
-watches the settings document and rebuilds the keymap without a restart.
+leader sequence (requires `leader`). The validation pipeline is
+**grammar → canonicalize → policy → store** (round-9 finding): every
+policy check (printable, lifecycle collisions, editor-owned constraints)
+runs on the CANONICAL key, so an uppercase spelling (`SPACE`, `ctrl+A`)
+can never bypass the typing guard or the collision sets. A plain
+printable key can never be bound to a Host action (it would swallow
+typing), and `app.input.submit` can never be bound to a key the fork
+editor consumes BEFORE its submit check (tab/backspace/Ctrl+A/E/U/K/W/
+Y/C/D/Home/End/word-moves/undo/copy — the editor would consume it first,
+so the binding could never fire; rejected like Shift+Enter, other
+actions are unaffected). Hot reload: the runner watches the settings
+document and rebuilds the keymap without a restart.
 
 **Conditional affordances are ADDITIVE, never replaced.** A composition
 rule (the empty-editor `↓` task-browser affordance → `app.tasks.open`)
@@ -308,7 +333,25 @@ leader + clears the interrupt double-action window. The host editor
 submits ONLY through the synced `tui.input.submit` binding — a disabled
 submit never fires on Enter or LF (LF is a newline).
 
-Final gates: 2474 bundle tests, 985 fork tests, 11 docs tests,
+**Owner-aware winner selection (round 9).** All owners (host/editor/
+plugin) compete in the resolver on equal footing; the resolution carries
+the winner's OWNER and the app routes execution by it ('editor' → the
+fork editor, never the host dispatcher). `hostResolves` is winner-based,
+so `submit: ctrl+s` really submits and NEVER steers, and the read model
+agrees (`/keybindings` shows Ctrl+S under submit only). A submit remap
+onto a fork-editor pre-submit key (tab/backspace/Ctrl+A/E/U/K/W/Y/C/D/
+Home/End/…) is parser-rejected (it could never fire). A leader sequence
+never clears the direct submit keys — `submit: ['ctrl+z', '<leader>s']`
+keeps both triggers; only a truly leader-only override removes Enter.
+The canonical identity lowercases single-character bases too (`ctrl+A`
+≡ `ctrl+a` — one key, conflict-detected), and all policy checks run
+AFTER canonicalization (`SPACE`/`Space` are printable and rejected).
+The read model is ONE projection: `keysFor`/`keyHint`/
+`editorSubmitKeysFor`/`snapshot` all render the same visible rules (a
+working submit remap never leaves the replaced Enter advertised), and a
+CONDITIONAL top claim never permanently hides its context fallback.
+
+Final gates: 2482 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -226,12 +226,17 @@ parsed user bindings, so the effective keymap sees a real user
 declaration and suppresses the builtin (including the editor-owned
 builtin for submit — `resolve(Enter)` is undefined and
 `matches(Enter, submit)` is false for a leader-only submit; the unified
-model has ONE effective truth). The conflict fail-soft is the only
-exception: a DIRECT submit override that CONFLICTS away (all user rules
-deactivated) restores the builtin Enter — the documented convergence
-§4.5 rule, never a fabricated fallback for a working override. A dead
-leader (shadowed/ambiguous) leaves a leader-only action inert — the
-diagnostic explains why; no silent builtin restoration.
+model has ONE effective truth). The marker is written ONLY after the
+leader prefix is confirmed valid (review round 39): a missing or
+invalid leader (text-producing, runtime-unbindable, terminal-ambiguous)
+is diagnosed and ignored — fail-soft — and the action falls back to its
+builtin default; the marker must never outlive a leader that was
+rejected. The conflict fail-soft is the only exception: a DIRECT submit
+override that CONFLICTS away (all user rules deactivated) restores the
+builtin Enter — the documented convergence §4.5 rule, never a fabricated
+fallback for a working override. A dead leader (shadowed/ambiguous)
+leaves a leader-only action inert — the diagnostic explains why; no
+silent builtin restoration.
 
 **Conditional affordances are ADDITIVE, never replaced.** A composition
 rule (the empty-editor `↓` task-browser affordance → `app.tasks.open`)

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -234,7 +234,13 @@ README/CHANGELOG language flip) and re-reviewed:
   `keysLabelFor()` — ALL direct keys and ALL leader sequences of an
   action, one shared effective-label source (a mixed action no longer
   shows only its direct keys).
+- Round 11 (needs-fixes): `keysLabelFor()` falls back to an overlay
+  action's DEFAULTS when it has no host-keymap keys (search
+  close/next/previous, question/tasks flows — `/help` no longer shows
+  '—' for them); duplicate `<leader>X` entries of the SAME action are
+  deduped before ambiguity detection (only cross-action same-key pairs
+  are ambiguous).
 
-Final gates after the rebase: 2403 bundle tests, 985 fork tests, 11
+Final gates after the rebase: 2405 bundle tests, 985 fork tests, 11
 docs tests, typecheck (fork + bundle), `check-host-keybindings` gate,
 `git diff --check` — all green.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -281,11 +281,34 @@ no-ops.
 **Remapped interrupt is semantic.** Only the physical Escape key runs
 the editor Escape seams; a remapped interrupt key goes straight to the
 semantic core AND keeps its own consecutive-press idle semantics (its
-first press does not disarm its own double-action window). Shift+Enter
-can never be bound to submit (the fork editor's fixed newline key —
-parser-rejected, aliases included).
+first press does not disarm its own double-action window; an intervening
+non-trigger key does). Shift+Enter can never be bound to submit (the
+fork editor's fixed newline key — parser-rejected, aliases included).
 
-Final gates: 2455 bundle tests, 985 fork tests, 11 docs tests,
+**Canonical identity is case-insensitive everywhere.** `canonicalizeKeyId`
+lowercases before the alias map (`ESC`→`esc`→`escape`,
+`ctrl+RETURN`→`ctrl+enter`), named keys canonicalize to lowercase
+(`pageUp`→`pageup`, displayed as `PageUp` — the runtime parser
+lowercases, the fork's matchesKey is case-insensitive), config parsing
+accepts either named-key casing, and the registry canonicalizes the
+plugin NormalizedKey shape at register/storage/lookup (including the
+reserved-key check, which runs AFTER canonicalization so `esc`/`return`
+registrations are rejected as the reserved `escape`/`enter`).
+
+**Legacy terminal collisions are rejected everywhere.** `ctrl+[` (Esc)
+and `ctrl+j`/`ctrl+m` (Enter) are rejected as direct bindings, leader
+prefixes and leader completions — a binding indistinguishable from a
+lifecycle key on legacy terminals is unsupported, never a warning.
+
+**Dynamic plugin lifecycle + edge hardening.** Plugin keybinding rules
+resync on every registry register/dispose (subscribe), plugin rule ids
+are namespaced (`plugin:…`) so they can never deactivate a host rule,
+the manager's leaderTimeoutMs is applied, and stop() cancels a pending
+leader + clears the interrupt double-action window. The host editor
+submits ONLY through the synced `tui.input.submit` binding — a disabled
+submit never fires on Enter or LF (LF is a newline).
+
+Final gates: 2474 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -351,13 +351,20 @@ terminals; the shared `isTextProducingKeyId` policy treats shift-only
 printables as text on every protocol — the router and the registry
 agree, and the user config parser rejects them too), (c) non-grammar
 key names (the runtime parser can never produce them — `f13`,
-arbitrary strings — round-17 finding), and (d) the legacy
+arbitrary strings — round-17 finding), (d) the legacy
 C0 collisions — the registry shares the config parser's legacy inventory
 (`isLegacyCollisionKeyId`), so `ctrl+i`/`ctrl+h`/`ctrl+_`/`ctrl+-`/
 `ctrl+[`/`ctrl+j`/`ctrl+m` registrations are rejected too (on a legacy
 terminal the raw byte is Tab/Backspace/0x1f/Esc/Enter — the router's
 normalized plugin lookup could never match it; the old "a plugin may
-claim Ctrl+J" exception is gone, round-13/16 findings). The owner-aware
+claim Ctrl+J" exception is gone, round-13/16 findings), and (e) FORK
+EDITOR-owned keys (round-19 finding): Tab, arrows, Home/End,
+PageUp/PageDown, Backspace/Delete, word-moves, kill/yank/undo,
+Shift+Enter — the InputRouter's editorAccepts probe claims the editor's
+whole binding set on every keystroke, so such a registration would be
+an advertised-but-dead rule that even disabled a colliding leader; the
+registry shares the single `EDITOR_OWNED_KEY_IDS` inventory (the
+submit pre-submit set derives from it). The owner-aware
 dispatcher NEVER routes a plugin-owner winner into the
 AppActionDispatcher: only 'host' winners execute Host-private actions,
 'editor' winners go to the fork editor, and 'plugin' winners continue to
@@ -384,7 +391,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2494 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2496 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -298,6 +298,21 @@ README/CHANGELOG language flip) and re-reviewed:
     leader-prefix collision (`hostActiveKeys`) all exclude PLUGIN rules
     — a plugin binding is additive and never a Host action.
   Final round: accepted, no findings.
+- PR review second pass (1 P1 + 1 P2 + 1 P3, then 1 more P2 — all
+  fixed):
+  - the read-only AND continuable viewers' Esc exit is a FIXED lifecycle
+    key, INDEPENDENT of the user-configurable app.agent.interrupt (a
+    remap to Ctrl+X must not break the viewer close); `app.agent.
+    interrupt` joined VIEWER_BLOCKED_PARENT_ACTIONS so a remapped
+    interrupt is inert inside a viewer;
+  - a leader-PREFIX collision clears `effectiveLeaderBindings`, so
+    keyHint / keysLabelFor / snapshot never advertise a dead leader
+    sequence (the "UI always shows the EFFECTIVE keys" contract);
+  - RESERVED_HOST_KEYS comments clarified: it is ONLY the Stable v1
+    plugin-registration guard, never the runtime reservation authority
+    (input-router header, keybinding-registry, definitions);
+  - the consumed viewer-close Esc disarms the main-session double-Esc
+    window (no stale cancel/rewind after closing a viewer).
 
 Final gates after the PR review rounds: 2429 bundle tests (incl. the
 focus-viewport-policy suite), 985 fork tests, 11 docs tests, typecheck

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -1,0 +1,147 @@
+# Keybinding architecture
+
+The user-orchestrable keybinding design (implementation plan:
+`temp/20260825/dsh-pi-tui-keybinding-customization-implementation-plan-2026-08-24.md`).
+This doc records the decisions and the contracts that must not be broken;
+the code is the reference for the line-by-line behavior.
+
+## The pipeline
+
+```text
+Physical Key
+    ↓
+Semantic Action ID
+    ↓
+Context-aware resolver
+    ↓
+Host handler
+```
+
+The plan's core claim: the Host app layer used to treat physical keys as
+its architecture interface (`matchesKey(data, 'ctrl+o')` scattered across
+`tui-app.ts`). The migration replaces that with a stable action inventory
+(`app.*`), a context-aware effective keymap, and a semantic dispatcher —
+so a future user override only touches the keymap, never a business
+handler.
+
+## The modules (`src/keybindings/`)
+
+| Module | Role |
+|---|---|
+| `types.ts` | The contract types: `AppKeybindingId`, `KeybindingScope`, `AppKeybindingDefinition`, `KeybindingContext`, `EffectiveBindingRule`, `KeybindingResolution`, `KeymapSnapshot`, `KeybindingConflict`, `LeaderConfig`/`LeaderBinding` |
+| `definitions.ts` | The SINGLE action table (`APP_KEYBINDINGS`): default keys, description, category, scope, configurable flag. Every default key MUST match the pre-migration behavior (M0 gate) |
+| `context.ts` | `deriveKeybindingContext`: the resolver's context, built in ONE place per surface. `editorEmpty` is a LAZY getter — the live editor is only read when a rule predicate needs it (the input path must not add a draft read per keystroke) |
+| `effective-keymap.ts` | The rule compiler + resolver: builtin (100) / composition (100) / user (200) / plugin (10) priorities; conflict detection; `includeScopes` (the HOST keymap resolves the non-capturing scopes only) |
+| `conflicts.ts` | The conflict model: same key + overlapping scope + same priority. Capturing scopes (question/approval/overlay/search/viewer/tasks) are mutually exclusive surfaces — they never conflict with non-capturing scopes or each other |
+| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, plain-printable-to-host-action and terminal-unreliable (Ctrl+J/M) diagnostics; fail-soft |
+| `manager.ts` | The stateful facade: user config, safe mode, plugin rules, leader machine, diagnostics, snapshot |
+| `action-dispatcher.ts` | The semantic action → host method router (`AppActionHost`). The dispatcher NEVER re-implements business state |
+| `leader.ts` | The M6 leader state machine: pending prefix, timeout, ambiguous prefix, cancel, paste/typing isolation |
+| `hints.ts` | `formatKeyId` / `formatKeyList` — the ONE place that turns a KeyId into the human label the UI renders |
+| `component-keymap.ts` | The read-only focused-component keymap (QuestionFlow, TaskBrowserPanel) |
+
+## The input ladder (what must not be broken)
+
+The `InputRouter` (input-router.ts) keeps its protocol/capture/focus
+precedence — the keymap is consulted ONLY when the ladder allows
+keybinding resolution. The plan is explicit: **do not delete the
+InputRouter**. The host ladder in `handleInputCore` is:
+
+```text
+terminal protocol replies / press-filtering
+  ↓
+active question / editor-seat capturing flow
+  ↓
+active approval
+  ↓
+read-only viewer guard
+  ↓
+active overlay (search owns its keys)
+  ↓
+leader sequence machine (M6, only when a leader key is configured)
+  ↓
+host semantic action resolution (the effective keymap)
+  ↓
+focused editor / pi-tui editor action
+  ↓
+non-capturing plugin keybindings
+```
+
+## Key decisions
+
+1. **Enter stays with the fork editor.** `app.input.submit` is
+   `hostResolved: false`: the builtin Enter rule is NOT compiled into the
+   host keymap, because the fork editor's submit path owns paste-burst
+   suppression and the backslash-newline workaround. A user-bound
+   alternate key for the action still compiles and routes through
+   `submitDraft` (which mirrors the Enter path exactly).
+2. **The viewer guard is action-based.** `viewerParentLockedKey` resolves
+   the key through the effective keymap and blocks
+   `VIEWER_BLOCKED_PARENT_ACTIONS` — a user remap of a parent action stays
+   blocked automatically. The guard never maintains a physical key list.
+3. **The Esc path stays a host method.** `app.agent.interrupt` resolves to
+   `handleEscapeKey` (autocomplete/replacement-editor pass-through,
+   single/double-Esc, rewind) — a user remap moves the WHOLE path to the
+   new key. Same for `app.exit.request` → `handleExitKey` (Ctrl+C keeps
+   its clear-then-exit chord; every other bound key exits immediately).
+4. **Conflicts are deactivated, never last-write-wins.** A conflict
+   (same key + overlapping scope + same priority) disables BOTH rules with
+   a diagnostic; every other rule keeps working (fail-soft).
+5. **Safe mode** (`DSH_PI_TUI_SAFE_KEYBINDINGS=1`) ignores user overrides
+   and keeps the builtin defaults; plugin keybindings still load.
+6. **The leader is opt-in.** No leader key is configured by default, so
+   the pending-prefix machinery never changes ordinary input. A leader
+   sequence is cancelled by: timeout, Esc, a non-matching key (passed
+   through), a paste burst (passed through), or a focus transition
+   (question/approval/overlay/viewer/fullscreen).
+7. **The static gate** (`scripts/check-host-keybindings.mts`, wired into
+   `verify:prepush`) forbids NEW `matchesKey(data, 'ctrl+…'/'alt+…'/
+   'shift+…')` chords in `src/tui-app.ts`. The allowlist covers the
+   sanctioned seams: the read-only viewer guard, the Ctrl+C exit-chord
+   discriminator, the approval dialog keys, and the replacement-editor
+   Enter seams.
+
+## User configuration
+
+Settings namespace `pi-tui`, field `keybindings` (the schema deliberately
+does NOT declare the field — schemastery's `z.object` keeps unknown keys,
+and the parser owns the validation):
+
+```yaml
+pi-tui:
+  keybindings:
+    app.input.steer: ctrl+s
+    app.permission.cycle: [shift+tab, ctrl+shift+p]
+    app.history.search: ctrl+r
+    app.transcript.toggleThinking: false
+    leader: ctrl+x
+    bindings:
+      app.tasks.open: <leader>t
+```
+
+Semantics: string = one key; array = several; `false` = disable the
+action's effective binding; absent = builtin default; `<leader>X` = a
+leader sequence (requires `leader`). A plain printable key can never be
+bound to a Host action (it would swallow typing). Hot reload: the runner
+watches the settings document and rebuilds the keymap without a restart.
+
+## Diagnostics
+
+`/keybindings` shows the effective table (action, keys, scope, source)
+grouped by category; `/keybindings conflicts` lists only conflicts;
+`/keybindings reload` re-reads the settings document; `/keybindings
+reset` clears the user overrides THROUGH the settings service (never a
+direct settings.yaml write). `/help` and the footer hints render through
+`keyHint`/`keysFor` — a user remap updates every hint automatically.
+
+## Out of scope (first version)
+
+- No VS Code-style `when` expressions (scope is the static contract).
+- No arbitrary JS callback bindings.
+- No raw terminal bytes to plugins; no plugin preemption of the protocol
+  stage; no breaking extension API change (the plugin registry keeps its
+  key-level reservation; a plugin binding a protected action to a NEW key
+  is additive and allowed).
+- The model-menu / history-panel / output-viewer focused components keep
+  their component-local keys (the plan's M5 covers QuestionFlow and
+  TaskBrowserPanel; the others follow the same pattern later).

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -219,6 +219,12 @@ README/CHANGELOG language flip) and re-reviewed:
   corrected to `dsh-pi-tui`; the fixed overlay-key precedence is
   documented and the parser warns on a collision; `/keybindings reset`
   honors the async write outcome.
+- Round 8 (needs-fixes): the read-only viewer fold pass-through and the
+  search-overlay ownership resolve the EFFECTIVE keymap (a remap of
+  `app.transcript.toggleExpand` / `app.transcript.search` stays
+  authoritative — the router consults `matchesEffective`); leader-only
+  actions appear in the `/keybindings` snapshot with the `leader` flag;
+  the changelog namespace examples corrected to `dsh-pi-tui`.
 
 Final gates after the rebase: 2397 bundle tests, 985 fork tests, 11
 docs tests, typecheck (fork + bundle), `check-host-keybindings` gate,

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -199,8 +199,13 @@ typing), and `app.input.submit` can never be bound to a key the fork
 editor consumes BEFORE its submit check (tab/backspace/Ctrl+A/E/U/K/W/
 Y/C/D/Home/End/word-moves/undo/copy — the editor would consume it first,
 so the binding could never fire; rejected like Shift+Enter, other
-actions are unaffected). Hot reload: the runner watches the settings
-document and rebuilds the keymap without a restart.
+actions are unaffected). The reload seam is EXPLICIT, never automatic:
+`/keybindings reload` re-reads the settings document and rebuilds the
+keymap without a restart — there is deliberately no settings `watch`
+callback, because the config port (`TuiSettingsConfig`) is get/replace
+only and a callback could not map across the process boundary in the
+future Remote adapter (migration rule: no callbacks across the wire;
+see docs/client-server-migration.md).
 
 **Conditional affordances are ADDITIVE, never replaced.** A composition
 rule (the empty-editor `↓` task-browser affordance → `app.tasks.open`)
@@ -215,10 +220,15 @@ adds a trigger for that semantic action; `false` removes them all*.
 
 `/keybindings` shows the effective table (action, keys, scope, source)
 grouped by category; `/keybindings conflicts` lists only conflicts;
-`/keybindings reload` re-reads the settings document; `/keybindings
-reset` clears the user overrides THROUGH the settings service (never a
-direct settings.yaml write). `/help` and the footer hints render through
-`keyHint`/`keysFor` — a user remap updates every hint automatically.
+`/keybindings reload` re-reads the settings document (fail-soft: a
+throwing read keeps the last-known-good keymap and reports an error);
+`/keybindings reset` clears the user overrides THROUGH the settings
+service (never a direct settings.yaml write) AND rebuilds the running
+keymap from the cleared document — the reset takes effect immediately,
+no follow-up reload needed (the reload seam is explicit since the
+automatic settings watch was removed). `/help` and the footer hints
+render through `keyHint`/`keysFor` — a user remap updates every hint
+automatically.
 
 ## Out of scope (first version)
 

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -67,6 +67,14 @@ focused editor / pi-tui editor action
 non-capturing plugin keybindings
 ```
 
+**Fixed overlay-key precedence.** While a capturing overlay is open its
+NON-CONFIGURABLE keys (search close/next/previous, question/tasks flow
+keys) win by precedence — a configurable action (e.g. the search toggle)
+remapped to one of those keys is ECLIPSED inside the overlay (the
+binding still works outside it). The config parser warns on such a
+collision (`FIXED_OVERLAY_KEYS`); the overlay never resolves the
+configurable action first (plan §3.3).
+
 ## Key decisions
 
 1. **Enter stays with the fork editor.** `app.input.submit` is
@@ -188,6 +196,30 @@ accepted at round 4 with no open findings.
   (ambiguity-filtered) leader bindings.
 - Round 4 (accepted, none).
 
-Final gates: 1996 bundle tests, 985 fork tests, 11 docs tests,
-typecheck (fork + bundle), `check-host-keybindings` gate, `git diff
---check` — all green.
+The branch was then REBASED onto the current main (M1 migration ports,
+shell-editor-mode, thinking-disclosure unify, focus-v2, the
+README/CHANGELOG language flip) and re-reviewed:
+- Round 5 (needs-fixes): per-key rule ids (a conflict on ONE key of a
+  multi-key action now deactivates only that key); printable-leader keys
+  rejected.
+- Round 6 (needs-fixes): the monotonic keymap revision joins the
+  transcript cache identity (a remap refreshes already-rendered fold
+  hints; onInvalidate rebuilds messages); the leader machine propagates
+  the dispatch result (a declined action falls through, not consumed);
+  the configurable search toggle matches EFFECTIVE keys while the fixed
+  overlay keys keep their defaults; `space` is printable (rejected as
+  leader/direct binding); the settings namespace docs corrected to
+  `dsh-pi-tui` (not `pi-tui`); `/keybindings reset` notifies success
+  only after the write resolves; hot reload keeps last-known-good;
+  definitions.ts joins the gate scan (its `defaultKeys` are the source
+  of truth, its description strings must stay key-neutral); the
+  config-port documents `keybindings` as raw pass-through extension
+  data.
+- Round 7 (needs-fixes, 3 P2): the config.ts header example namespace
+  corrected to `dsh-pi-tui`; the fixed overlay-key precedence is
+  documented and the parser warns on a collision; `/keybindings reset`
+  honors the async write outcome.
+
+Final gates after the rebase: 2397 bundle tests, 985 fork tests, 11
+docs tests, typecheck (fork + bundle), `check-host-keybindings` gate,
+`git diff --check` — all green.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -33,7 +33,7 @@ handler.
 | `context.ts` | `deriveKeybindingContext`: the resolver's context, built in ONE place per surface. `editorEmpty` is a LAZY getter — the live editor is only read when a rule predicate needs it (the input path must not add a draft read per keystroke) |
 | `effective-keymap.ts` | The rule compiler + resolver: builtin (100) / composition (100) / user (200) / plugin (10) priorities; conflict detection; `includeScopes` (the HOST keymap resolves the non-capturing scopes only) |
 | `conflicts.ts` | The conflict model: same key + overlapping scope + same priority. Capturing scopes (question/approval/overlay/search/viewer/tasks) are mutually exclusive surfaces — they never conflict with non-capturing scopes or each other |
-| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, plain-printable-to-host-action and the SHARED terminal-ambiguous key inventory (TERMINAL_AMBIGUOUS_KEY_IDS: Ctrl+[ / Ctrl+J/M / Ctrl+I/H / Ctrl+_/- / Ctrl+Backspace) diagnostics; fail-soft |
+| `config.ts` | The user settings parser: string / array / `false` / `<leader>X`; unknown action, invalid key, the RUNTIME-BINDABLE gate (modified F-keys / modified Escape can never be matched), plain-printable-to-host-action (text-producing), the SHARED terminal-ambiguous key inventory (TERMINAL_AMBIGUOUS_KEY_IDS: Ctrl+[ / Ctrl+J/M / Ctrl+I/H / Ctrl+_/- / Ctrl+Backspace) and the editor-owned submit pre-submit set; all fail-soft |
 | `manager.ts` | The stateful facade: user config, safe mode, plugin rules, leader machine, diagnostics, snapshot |
 | `action-dispatcher.ts` | The semantic action → host method router (`AppActionHost`). The dispatcher NEVER re-implements business state |
 | `leader.ts` | The M6 leader state machine: pending prefix, timeout, ambiguous prefix, cancel, paste/typing isolation |
@@ -395,7 +395,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2499 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2502 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -343,9 +343,15 @@ submit never fires on Enter or LF (LF is a newline).
 registry REJECTS at registration: (a) any action string outside the
 public `TuiAction` set (the runtime whitelist `TUI_ACTIONS` — a
 JS/`as any` plugin can never register `app.exit.request` and reach the
-Host dispatcher), and (b) plain printable keys (the spacebar and bare
-letters never reach the plugin stage — the router keeps them with the
-editor's text entry; modified chords stay bindable), and (c) the legacy
+Host dispatcher), (b) TEXT-PRODUCING keys — bare letters, digits,
+symbols and the spacebar, WITH OR WITHOUT Shift (round-17 finding:
+Shift+A is the raw `A` byte on legacy terminals and `a`+shift on Kitty,
+so the old shift-means-chord guard let a plugin steal typing on some
+terminals; the shared `isTextProducingKeyId` policy treats shift-only
+printables as text on every protocol — the router and the registry
+agree, and the user config parser rejects them too), (c) non-grammar
+key names (the runtime parser can never produce them — `f13`,
+arbitrary strings — round-17 finding), and (d) the legacy
 C0 collisions — the registry shares the config parser's legacy inventory
 (`isLegacyCollisionKeyId`), so `ctrl+i`/`ctrl+h`/`ctrl+_`/`ctrl+-`/
 `ctrl+[`/`ctrl+j`/`ctrl+m` registrations are rejected too (on a legacy
@@ -378,7 +384,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2491 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2494 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -240,7 +240,13 @@ README/CHANGELOG language flip) and re-reviewed:
   '—' for them); duplicate `<leader>X` entries of the SAME action are
   deduped before ambiguity detection (only cross-action same-key pairs
   are ambiguous).
+- Round 12 (accepted, none) — after the SECOND rebase onto main
+  (76c8c96, the focus-viewport policy): the reviewer swept all 39
+  changed files, verified the keybinding feature coexists with the
+  focus viewport-anchoring logic in src/tui-app.ts, re-checked every
+  prior-round fix survived both rebases, and accepted with no findings.
 
-Final gates after the rebase: 2405 bundle tests, 985 fork tests, 11
-docs tests, typecheck (fork + bundle), `check-host-keybindings` gate,
-`git diff --check` — all green.
+Final gates after the second rebase: 2413 bundle tests (incl. the
+focus-viewport-policy suite), 985 fork tests, 11 docs tests, typecheck
+(fork + bundle), `check-host-keybindings` gate, `git diff --check` —
+all green.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -226,9 +226,13 @@ throwing read keeps the last-known-good keymap and reports an error);
 service (never a direct settings.yaml write) AND rebuilds the running
 keymap from the cleared document — the reset takes effect immediately,
 no follow-up reload needed (the reload seam is explicit since the
-automatic settings watch was removed). `/help` and the footer hints
-render through `keyHint`/`keysFor` — a user remap updates every hint
-automatically.
+automatic settings watch was removed). The reset is ONE transaction:
+read → construct the cleared doc → persist → apply the SAME local
+projection (no post-write re-read of the Host document — a Remote
+adapter's reset is write + local projection, never GET → PUT → GET; a
+post-write read that failed would fork the disk reset from the runtime).
+`/help` and the footer hints render through `keyHint`/`keysFor` — a user
+remap updates every hint automatically.
 
 ## Out of scope (first version)
 

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -226,8 +226,9 @@ direct settings.yaml write). `/help` and the footer hints render through
 - No arbitrary JS callback bindings.
 - No raw terminal bytes to plugins; no plugin preemption of the protocol
   stage; no breaking extension API change (the plugin registry keeps its
-  key-level reservation; a plugin binding a protected action to a NEW key
-  is additive and allowed).
+  key-level reservation AND the runtime ACTION whitelist — a Stable
+  plugin registers only the public `TuiAction` set; the Host-private
+  `app.*` actions are never plugin-bindable, round-12 finding).
 - The model-menu / history-panel / output-viewer focused components keep
   their component-local keys (the plan's M5 covers QuestionFlow and
   TaskBrowserPanel; the others follow the same pattern later).
@@ -320,10 +321,14 @@ plugin NormalizedKey shape at register/storage/lookup (including the
 reserved-key check, which runs AFTER canonicalization so `esc`/`return`
 registrations are rejected as the reserved `escape`/`enter`).
 
-**Legacy terminal collisions are rejected everywhere.** `ctrl+[` (Esc)
-and `ctrl+j`/`ctrl+m` (Enter) are rejected as direct bindings, leader
-prefixes and leader completions — a binding indistinguishable from a
-lifecycle key on legacy terminals is unsupported, never a warning.
+**Legacy terminal collisions are rejected everywhere.** `ctrl+[` (Esc),
+`ctrl+j`/`ctrl+m` (Enter), `ctrl+i` (the Tab byte — `matchesKey('\t',
+'ctrl+i')` is true, so a Host binding fires on Tab presses on legacy
+terminals), `ctrl+h` (the Backspace byte) and `ctrl+_` (the same 0x1f
+byte the fork's rawCtrlChar maps Ctrl+- to) are rejected as direct
+bindings, leader prefixes and leader completions — a binding
+indistinguishable from a fixed key on legacy terminals is unsupported,
+never a warning.
 
 **Dynamic plugin lifecycle + edge hardening.** Plugin keybinding rules
 resync on every registry register/dispose (subscribe), plugin rule ids
@@ -332,6 +337,21 @@ the manager's leaderTimeoutMs is applied, and stop() cancels a pending
 leader + clears the interrupt double-action window. The host editor
 submits ONLY through the synced `tui.input.submit` binding — a disabled
 submit never fires on Enter or LF (LF is a newline).
+
+**The Stable plugin boundary is capability-enforced (round 12).** The
+registry REJECTS at registration: (a) any action string outside the
+public `TuiAction` set (the runtime whitelist `TUI_ACTIONS` — a
+JS/`as any` plugin can never register `app.exit.request` and reach the
+Host dispatcher), and (b) plain printable keys (the spacebar and bare
+letters never reach the plugin stage — the router keeps them with the
+editor's text entry; modified chords stay bindable). The owner-aware
+dispatcher NEVER routes a plugin-owner winner into the
+AppActionDispatcher: only 'host' winners execute Host-private actions,
+'editor' winners go to the fork editor, and 'plugin' winners continue to
+the Stable plugin remainder (`onExtensionAction`). A leader prefix that
+equals a LIVE plugin key disables the leader machine with a diagnostic
+(the leader feeds before the plugin stage — never a silent swallow;
+same fail-soft as a host-key collision).
 
 **Owner-aware winner selection (round 9).** All owners (host/editor/
 plugin) compete in the resolver on equal footing; the resolution carries
@@ -351,7 +371,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2482 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2490 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The final
 convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -114,7 +114,9 @@ configurable action first (plan §3.3).
    `hostResolves` is winner-based — an editor-owned winner is never
    host-reserved, so the key reaches the fork editor. User remaps/`false`
    sync into the fork editor's binding, conflict and shadow apply,
-   fail-soft (a dead override restores the builtin Enter unless `false`)
+   fail-soft (a CONFLICTED direct submit override restores the builtin
+   Enter — convergence §4.5; a DEAD leader-only override stays inert,
+   never a fabricated restore; explicit `false` removes everything)
    is evaluated on the EFFECTIVE rules — never the raw config, and a
    leader sequence NEVER clears the direct keys (`submit:
    ['ctrl+z', '<leader>s']` keeps BOTH triggers; only a truly leader-only
@@ -207,6 +209,30 @@ only and a callback could not map across the process boundary in the
 future Remote adapter (migration rule: no callbacks across the wire;
 see docs/client-server-migration.md).
 
+**The UNIFIED override contract (review round 37).** One rule for every
+action, enforced by the parser AND the effective keymap together:
+
+```text
+absent             -> builtin default keys
+direct user keys   -> REPLACE the builtin
+leader-only        -> REPLACE the builtin (the leader is the only trigger)
+direct + leader    -> both USER triggers, builtin removed
+false              -> remove every trigger (builtin included)
+composition        -> additive affordance (never removed by a remap)
+```
+
+A leader-only declaration is recorded as an EMPTY-ARRAY marker in the
+parsed user bindings, so the effective keymap sees a real user
+declaration and suppresses the builtin (including the editor-owned
+builtin for submit — `resolve(Enter)` is undefined and
+`matches(Enter, submit)` is false for a leader-only submit; the unified
+model has ONE effective truth). The conflict fail-soft is the only
+exception: a DIRECT submit override that CONFLICTS away (all user rules
+deactivated) restores the builtin Enter — the documented convergence
+§4.5 rule, never a fabricated fallback for a working override. A dead
+leader (shadowed/ambiguous) leaves a leader-only action inert — the
+diagnostic explains why; no silent builtin restoration.
+
 **Conditional affordances are ADDITIVE, never replaced.** A composition
 rule (the empty-editor `↓` task-browser affordance → `app.tasks.open`)
 stays live alongside a user binding of the same action: binding
@@ -214,7 +240,8 @@ stays live alongside a user binding of the same action: binding
 editor + active tasks) still opens the browser. Only `false` disables
 the affordance along with every other key of the action. The README
 uses "override" loosely; the effective semantics are: *a user binding
-adds a trigger for that semantic action; `false` removes them all*.
+replaces the action's builtin default keys and adds its triggers;
+`false` removes them all*.
 
 ## Diagnostics
 
@@ -409,7 +436,7 @@ The read model is ONE projection: `keysFor`/`keyHint`/
 working submit remap never leaves the replaced Enter advertised), and a
 CONDITIONAL top claim never permanently hides its context fallback.
 
-Final gates: 2527 bundle tests, 985 fork tests, 11 docs tests,
+Final gates: 2536 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
-styles, either casing), `git diff --check` — all green. The final
-convergence review round was accepted with no findings.
+styles, either casing), `git diff --check` — all green. The latest
+external convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -278,6 +278,14 @@ semantic core. The fixed viewer close stays independent.
 `configurable: false` + `availability: 'reserved'` — never bindable
 no-ops.
 
-Final gates: 2452 bundle tests, 985 fork tests, 11 docs tests,
+**Remapped interrupt is semantic.** Only the physical Escape key runs
+the editor Escape seams; a remapped interrupt key goes straight to the
+semantic core AND keeps its own consecutive-press idle semantics (its
+first press does not disarm its own double-action window). Shift+Enter
+can never be bound to submit (the fork editor's fixed newline key —
+parser-rejected, aliases included).
+
+Final gates: 2455 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
-styles, either casing), `git diff --check` — all green.
+styles, either casing), `git diff --check` — all green. The final
+convergence review round was accepted with no findings.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -146,6 +146,28 @@ direct settings.yaml write). `/help` and the footer hints render through
   their component-local keys (the plan's M5 covers QuestionFlow and
   TaskBrowserPanel; the others follow the same pattern later).
 
+## Comment and copy convention (review follow-up)
+
+Host code must not hard-code physical keys in a way that can drift from
+the user's live bindings:
+
+- **The single source of truth for DEFAULT keys is `definitions.ts`**
+  (plus the `RESERVED_HOST_KEYS` inventory in keybinding-registry.ts).
+  `src/tui-app.ts` and `src/index.ts` carry a header note pointing here.
+- **User-facing strings derive key labels from the keymap**
+  (`keyHint()` / `keysFor()` — e.g. the guard notices and the `/settings`
+  row descriptions). A remap updates the copy automatically; a disabled
+  action shows a neutral fallback.
+- **Comments** may name a key only when the SEMANTICS are key-specific
+  (the Ctrl+C clear-then-exit chord, the double-Esc window, the
+  read-only viewer's fixed Esc/Ctrl+O policy, the search overlay's fixed
+  keys). Every other mention is shorthand for the default binding and
+  must not be relied on as the live binding.
+- **The static gate** also rejects hard-coded chord labels in
+  user-facing string literals (`src/index.ts`, `src/commands.ts`,
+  `src/tui-app.ts`), with a documented allowlist for fork editor-level
+  keys (Ctrl+Home/End).
+
 ## Review chain (2026-08-25, openai-codex / gpt-5.6-luna)
 
 Four review rounds on `feat/keybinding-customization`; the reviewer

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -230,7 +230,11 @@ README/CHANGELOG language flip) and re-reviewed:
   (`['ctrl+z', '<leader>h']`) render BOTH in the snapshot (`keys` +
   `leaderKeys`) and in `keyHint` (`Ctrl+Z / Leader H`) — the leader
   sequence used to vanish behind the direct key.
+- Round 10 (needs-fixes): `/help` renders through the manager's new
+  `keysLabelFor()` — ALL direct keys and ALL leader sequences of an
+  action, one shared effective-label source (a mixed action no longer
+  shows only its direct keys).
 
-Final gates after the rebase: 2402 bundle tests, 985 fork tests, 11
+Final gates after the rebase: 2403 bundle tests, 985 fork tests, 11
 docs tests, typecheck (fork + bundle), `check-host-keybindings` gate,
 `git diff --check` — all green.

--- a/package.json
+++ b/package.json
@@ -177,9 +177,10 @@
     "pack:release": "rm -f xmoon76-dsh-pi-tui-*.tgz && pnpm pack --pack-destination .",
     "release:notes": "node scripts/release-notes.mjs",
     "smoke:pack": "node scripts/tarball-smoke.mjs",
-    "verify:prepush": "pnpm typecheck:fork && pnpm test:fork && pnpm test:docs && node scripts/naming-gate.mjs && pnpm gate:boundary && pnpm audit --prod --audit-level high && pnpm pack:release",
-    "verify:prepush:nofork": "pnpm test:docs && node scripts/naming-gate.mjs && pnpm gate:boundary && pnpm audit --prod --audit-level high && pnpm pack:release",
+    "verify:prepush": "pnpm typecheck:fork && pnpm test:fork && pnpm test:docs && node scripts/naming-gate.mjs && pnpm gate:boundary && pnpm gate:keybindings && pnpm audit --prod --audit-level high && pnpm pack:release",
+    "verify:prepush:nofork": "pnpm test:docs && node scripts/naming-gate.mjs && pnpm gate:boundary && pnpm gate:keybindings && pnpm audit --prod --audit-level high && pnpm pack:release",
     "prepare": "husky",
-    "gate:boundary": "node scripts/client-boundary-gate.mjs"
+    "gate:boundary": "node scripts/client-boundary-gate.mjs",
+    "gate:keybindings": "node --import tsx/esm scripts/check-host-keybindings.mts"
   }
 }

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -72,6 +72,10 @@ const ALLOWLIST = [
   "} else if (matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {",
   // The approval dialog's own keys (a capturing overlay component).
   "else if (matchesKey(data, 'ctrl+c')) this.settleApproval(pending, 'cancelled')",
+  // The effective-submit mirror (PR review): the host-owned seams exclude
+  // Shift+Enter (the fork editor's newline) from the submit-key check —
+  // an editor-level key, not a Host action.
+  "if (matchesKey(data, 'shift+enter')) return false",
 ]
 
 /** The sanctioned hard-coded key labels in user-facing strings: fork
@@ -85,6 +89,11 @@ const STRING_ALLOWLIST = [
   // that owns y/n/Esc/Ctrl+C while it is up — never resolved by the
   // keymap).
   '[esc/ctrl+c] cancel',
+  // The armed Ctrl+C exit-chord hint: the clear-then-exit chord is
+  // Ctrl+C-SPECIFIC (a second Ctrl+C exits; another exit key exits
+  // immediately), so the copy names Ctrl+C literally — the semantics are
+  // key-specific, the sanctioned convention (PR review finding).
+  'Press Ctrl+C again to exit',
 ]
 
 let failures = 0

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -1,0 +1,67 @@
+/**
+ * The host-keybinding static gate (plan §22): Host BUSINESS code must not
+ * reintroduce physical shortcuts. The gate scans the host input path for
+ * `matchesKey(data, 'ctrl+…' / 'alt+…' / 'shift+…')` chord checks and
+ * fails on any NEW one.
+ *
+ * Allowlist (focused-component / protocol seams — the plan's sanctioned
+ * exceptions):
+ * - the read-only subagent viewer guard (Esc + Ctrl+O pass through);
+ * - the Ctrl+C exit-chord discriminator (the chord is Ctrl+C-specific);
+ * - the approval dialog's own keys (a capturing overlay component).
+ *
+ * The vendored fork's editor, the InputRouter's precedence checks, the
+ * focused components (question/tasks — now routed through the component
+ * keymap) and the leader machine are NOT host business shortcuts.
+ *
+ * Usage: `node scripts/check-host-keybindings.mjs` (built by tsdown) or
+ * `node --import tsx/esm scripts/check-host-keybindings.mts`.
+ * @module @xmoon76/dsh-pi-tui/check-host-keybindings
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** The scanned host business files. */
+const SCANNED_FILES = ['src/tui-app.ts']
+
+/** The chord pattern: a matchesKey call with a ctrl/alt/shift modifier. */
+const CHORD_PATTERN = /matchesKey\(\s*data\s*,\s*'(?:ctrl|alt|shift)\+/
+
+/** The sanctioned seams (matched by trimmed line content). */
+const ALLOWLIST = [
+  // The read-only viewer guard: only Esc (exit) and Ctrl+O (fold) pass.
+  "if (!matchesKey(data, 'escape') && !matchesKey(data, 'ctrl+o')) {",
+  // The exit-chord discriminator: Ctrl+C keeps the clear-then-exit chord.
+  "if (matchesKey(data, 'ctrl+c')) {",
+  // The replacement-editor Enter seam (P1-10): a plugin editor receives
+  // editor-routed input; Enter is forwarded to the hidden host editor and
+  // Shift+Enter stays with the plugin (its own multiline editing).
+  "&& matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {",
+  // The replacement-editor DECLINED-event retry (Enter submits through the
+  // normal host path after the plugin editor handed the event back).
+  "if (matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {",
+  // The continuable viewer's Enter submit (the CHILD is the target).
+  "} else if (matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {",
+  // The approval dialog's own keys (a capturing overlay component).
+  "else if (matchesKey(data, 'ctrl+c')) this.settleApproval(pending, 'cancelled')",
+]
+
+let failures = 0
+for (const file of SCANNED_FILES) {
+  const path = join(process.cwd(), file)
+  const lines = readFileSync(path, 'utf8').split('\n')
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!
+    if (!CHORD_PATTERN.test(line)) continue
+    if (ALLOWLIST.includes(line.trim())) continue
+    failures += 1
+    console.error(`check-host-keybindings: ${file}:${index + 1}: physical host shortcut — route through the keymap instead:\n  ${line.trim()}`)
+  }
+}
+
+if (failures > 0) {
+  console.error(`check-host-keybindings: ${failures} physical host shortcut(s) found (see docs/keybinding-architecture.md)`)
+  process.exit(1)
+}
+console.log('check-host-keybindings: ok')

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -52,8 +52,10 @@ const CHORD_PATTERN = /matchesKey\(\s*data\s*,\s*'(?:ctrl|alt|shift)\+/
 
 /** A chord label inside a quoted string literal (user-facing text).
  * Matches BOTH casing styles ('Ctrl+O' and 'ctrl+o' — the fold hints
- * used the lowercase form and slipped past the gate once). */
-const STRING_CHORD_PATTERN = /'(?:[^'\\]|\\.)*?(?:(?:Ctrl|Alt|Shift)|(?:ctrl|alt|shift))\+/
+ * used the lowercase form and slipped past the gate once) and ALL THREE
+ * quote styles (single, double, backtick — convergence §14: a remap lies
+ * whichever quoting the string uses). */
+const STRING_CHORD_PATTERN = /(?:'[^'\\]*|"[^"\\]*|`[^`\\]*)(?:(?:Ctrl|Alt|Shift)|(?:ctrl|alt|shift))\+/
 
 /** The sanctioned seams (matched by trimmed line content). */
 const ALLOWLIST = [

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -95,12 +95,14 @@ for (const file of SCANNED_STRING_FILES) {
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]!
     // Skip comment-only lines (comments are covered by the convention in
-    // docs/keybinding-architecture.md, not by this mechanical check) and
-    // matchesKey CALLS (key-matching code, not user-facing copy).
+    // docs/keybinding-architecture.md, not by this mechanical check).
     const trimmed = line.trim()
     if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue
-    if (line.includes('matchesKey(')) continue
-    if (!STRING_CHORD_PATTERN.test(line)) continue
+    // Strip matchesKey CALLS (key-matching code, not user-facing copy) — a
+    // hard-coded chord string elsewhere on the SAME line must still be
+    // caught (a whole-line skip could hide it).
+    const stripped = line.replace(/matchesKey\(\s*data\s*,\s*'[^']*'\)/g, '')
+    if (!STRING_CHORD_PATTERN.test(stripped)) continue
     if (STRING_ALLOWLIST.some(label => line.includes(label))) continue
     failures += 1
     console.error(`check-host-keybindings: ${file}:${index + 1}: hard-coded key label in a user-facing string — use keyHint()/keysFor() instead:\n  ${trimmed}`)

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -32,7 +32,7 @@ const SCANNED_FILES = ['src/tui-app.ts']
 
 /** The user-facing string files (hard-coded chord labels must not
  * resurface in anything the user sees). */
-const SCANNED_STRING_FILES = ['src/index.ts', 'src/commands.ts', 'src/tui-app.ts']
+const SCANNED_STRING_FILES = ['src/index.ts', 'src/commands.ts', 'src/tui-app.ts', 'src/local-shell-card.ts']
 
 /** The chord pattern: a matchesKey call with a ctrl/alt/shift modifier. */
 const CHORD_PATTERN = /matchesKey\(\s*data\s*,\s*'(?:ctrl|alt|shift)\+/

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -37,8 +37,10 @@ const SCANNED_STRING_FILES = ['src/index.ts', 'src/commands.ts', 'src/tui-app.ts
 /** The chord pattern: a matchesKey call with a ctrl/alt/shift modifier. */
 const CHORD_PATTERN = /matchesKey\(\s*data\s*,\s*'(?:ctrl|alt|shift)\+/
 
-/** A chord label inside a quoted string literal (user-facing text). */
-const STRING_CHORD_PATTERN = /'(?:[^'\\]|\\.)*?(?:Ctrl|Alt|Shift)\+/
+/** A chord label inside a quoted string literal (user-facing text).
+ * Matches BOTH casing styles ('Ctrl+O' and 'ctrl+o' — the fold hints
+ * used the lowercase form and slipped past the gate once). */
+const STRING_CHORD_PATTERN = /'(?:[^'\\]|\\.)*?(?:(?:Ctrl|Alt|Shift)|(?:ctrl|alt|shift))\+/
 
 /** The sanctioned seams (matched by trimmed line content). */
 const ALLOWLIST = [
@@ -60,11 +62,16 @@ const ALLOWLIST = [
 ]
 
 /** The sanctioned hard-coded key labels in user-facing strings: fork
- * editor-level keys that do not follow the Host keymap. */
+ * editor-level keys and capturing-overlay fixed keys that do not follow
+ * the Host keymap. */
 const STRING_ALLOWLIST = [
   // The Home/End settings row describes the fork EDITOR's Ctrl+Home/End —
   // an editor-level key, not a Host action (does not follow the keymap).
   'Ctrl+Home/End',
+  // The approval dialog's own fixed keys (a capturing overlay component
+  // that owns y/n/Esc/Ctrl+C while it is up — never resolved by the
+  // keymap).
+  '[esc/ctrl+c] cancel',
 ]
 
 let failures = 0
@@ -88,9 +95,11 @@ for (const file of SCANNED_STRING_FILES) {
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index]!
     // Skip comment-only lines (comments are covered by the convention in
-    // docs/keybinding-architecture.md, not by this mechanical check).
+    // docs/keybinding-architecture.md, not by this mechanical check) and
+    // matchesKey CALLS (key-matching code, not user-facing copy).
     const trimmed = line.trim()
     if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue
+    if (line.includes('matchesKey(')) continue
     if (!STRING_CHORD_PATTERN.test(line)) continue
     if (STRING_ALLOWLIST.some(label => line.includes(label))) continue
     failures += 1

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -2,13 +2,18 @@
  * The host-keybinding static gate (plan §22): Host BUSINESS code must not
  * reintroduce physical shortcuts. The gate scans the host input path for
  * `matchesKey(data, 'ctrl+…' / 'alt+…' / 'shift+…')` chord checks and
- * fails on any NEW one.
+ * fails on any NEW one; it also scans USER-FACING string literals for
+ * hard-coded chord labels (a remap would make the string lie — key labels
+ * must come from the keymap's keyHint/keysFor).
  *
  * Allowlist (focused-component / protocol seams — the plan's sanctioned
  * exceptions):
  * - the read-only subagent viewer guard (Esc + Ctrl+O pass through);
  * - the Ctrl+C exit-chord discriminator (the chord is Ctrl+C-specific);
- * - the approval dialog's own keys (a capturing overlay component).
+ * - the approval dialog's own keys (a capturing overlay component);
+ * - the replacement-editor Enter seams (a plugin editor owns Shift+Enter);
+ * - `Ctrl+Home/End` in the Home/End settings row (fork editor-level keys,
+ *   not Host actions — they do not follow the keymap).
  *
  * The vendored fork's editor, the InputRouter's precedence checks, the
  * focused components (question/tasks — now routed through the component
@@ -25,8 +30,15 @@ import { join } from 'node:path'
 /** The scanned host business files. */
 const SCANNED_FILES = ['src/tui-app.ts']
 
+/** The user-facing string files (hard-coded chord labels must not
+ * resurface in anything the user sees). */
+const SCANNED_STRING_FILES = ['src/index.ts', 'src/commands.ts', 'src/tui-app.ts']
+
 /** The chord pattern: a matchesKey call with a ctrl/alt/shift modifier. */
 const CHORD_PATTERN = /matchesKey\(\s*data\s*,\s*'(?:ctrl|alt|shift)\+/
+
+/** A chord label inside a quoted string literal (user-facing text). */
+const STRING_CHORD_PATTERN = /'(?:[^'\\]|\\.)*?(?:Ctrl|Alt|Shift)\+/
 
 /** The sanctioned seams (matched by trimmed line content). */
 const ALLOWLIST = [
@@ -47,6 +59,14 @@ const ALLOWLIST = [
   "else if (matchesKey(data, 'ctrl+c')) this.settleApproval(pending, 'cancelled')",
 ]
 
+/** The sanctioned hard-coded key labels in user-facing strings: fork
+ * editor-level keys that do not follow the Host keymap. */
+const STRING_ALLOWLIST = [
+  // The Home/End settings row describes the fork EDITOR's Ctrl+Home/End —
+  // an editor-level key, not a Host action (does not follow the keymap).
+  'Ctrl+Home/End',
+]
+
 let failures = 0
 for (const file of SCANNED_FILES) {
   const path = join(process.cwd(), file)
@@ -57,6 +77,24 @@ for (const file of SCANNED_FILES) {
     if (ALLOWLIST.includes(line.trim())) continue
     failures += 1
     console.error(`check-host-keybindings: ${file}:${index + 1}: physical host shortcut — route through the keymap instead:\n  ${line.trim()}`)
+  }
+}
+
+// User-facing string literals: a hard-coded chord label lies as soon as
+// the user remaps it (the label must come from keyHint/keysFor).
+for (const file of SCANNED_STRING_FILES) {
+  const path = join(process.cwd(), file)
+  const lines = readFileSync(path, 'utf8').split('\n')
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!
+    // Skip comment-only lines (comments are covered by the convention in
+    // docs/keybinding-architecture.md, not by this mechanical check).
+    const trimmed = line.trim()
+    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue
+    if (!STRING_CHORD_PATTERN.test(line)) continue
+    if (STRING_ALLOWLIST.some(label => line.includes(label))) continue
+    failures += 1
+    console.error(`check-host-keybindings: ${file}:${index + 1}: hard-coded key label in a user-facing string — use keyHint()/keysFor() instead:\n  ${trimmed}`)
   }
 }
 

--- a/scripts/check-host-keybindings.mts
+++ b/scripts/check-host-keybindings.mts
@@ -32,7 +32,20 @@ const SCANNED_FILES = ['src/tui-app.ts']
 
 /** The user-facing string files (hard-coded chord labels must not
  * resurface in anything the user sees). */
-const SCANNED_STRING_FILES = ['src/index.ts', 'src/commands.ts', 'src/tui-app.ts', 'src/local-shell-card.ts']
+const SCANNED_STRING_FILES = [
+  'src/index.ts',
+  'src/commands.ts',
+  'src/tui-app.ts',
+  'src/local-shell-card.ts',
+  // The action TABLE's descriptions are USER-FACING (they render in
+  // /keybindings and /help) — a hard-coded chord label there lies after a
+  // remap, exactly like any other user-facing string (review finding).
+  // The `defaultKeys` arrays are the machine-readable source of truth and
+  // are EXCLUDED by the line-based check below (the pattern only fires on
+  // lines whose quoted string contains a chord label OUTSIDE a
+  // matchesKey/defaultKeys context).
+  'src/keybindings/definitions.ts',
+]
 
 /** The chord pattern: a matchesKey call with a ctrl/alt/shift modifier. */
 const CHORD_PATTERN = /matchesKey\(\s*data\s*,\s*'(?:ctrl|alt|shift)\+/
@@ -98,6 +111,11 @@ for (const file of SCANNED_STRING_FILES) {
     // docs/keybinding-architecture.md, not by this mechanical check).
     const trimmed = line.trim()
     if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue
+    // The keybinding table's `defaultKeys` arrays are the machine-readable
+    // source of truth (not user-facing copy) — a hard-coded chord there
+    // is the DEFINITION, not a lie. Only the table's `description`
+    // strings are user-facing and must stay key-neutral.
+    if (trimmed.startsWith('defaultKeys:')) continue
     // Strip matchesKey CALLS (key-matching code, not user-facing copy) — a
     // hard-coded chord string elsewhere on the SAME line must still be
     // caught (a whole-line skip could hide it).

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,10 @@ import { SettingsList, type SettingItem } from '@xmoon76/pi-tui'
 import { mergeDraft } from './steer.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
 import { iconStyleOf } from './icons.ts'
+import { parseUserKeybindings } from './keybindings/config.ts'
+import { APP_KEYBINDINGS } from './keybindings/definitions.ts'
+import { formatKeyId, formatKeyList } from './keybindings/hints.ts'
+import type { AppKeybindingId } from './keybindings/types.ts'
 import type { TuiApp } from './tui-app.ts'
 import type { PickerCategory, PickerItem } from './tui-app.ts'
 import type { Diag } from './diag.ts'
@@ -204,11 +208,13 @@ export function presetDisplayText(preset: {
 }
 
 /** The TUI settings document surface (theme/footer/fullscreen/busyEnter/
- * localShellSandbox/homeEndKeys). The old `history` field moved to
- * $DSH_HOME/user-history/*.jsonl and is deliberately NOT part of the
+ * localShellSandbox/homeEndKeys/focusMode). The old `history` field moved
+ * to $DSH_HOME/user-history/*.jsonl and is deliberately NOT part of the
  * document anymore. The type now lives on the config port (M1.9); the
- * re-export keeps the public commands-surface name stable for tests. */
-export type { TuiSettingsLike } from './runtime/config-port.ts'
+ * re-export keeps the public commands-surface name stable for tests. The
+ * user keybinding overrides (`keybindings`, an unknown-key pass-through
+ * in the config port's document schema — see index.ts) ride along. */
+export type { TuiSettingsLike, TuiSettingsDoc } from './runtime/config-port.ts'
 import type { TuiSettingsLike } from './runtime/config-port.ts'
 
 
@@ -2857,16 +2863,26 @@ export function registerTuiCommands(
     name: 'help',
     description: 'Show keybindings and available commands',
     handler: () => {
-      const rows: SettingItem[] = [        { id: 'k-enter', label: 'Enter', description: 'Submit (steers the running turn while busy when Enter while busy is Steer; skill commands steer too, UI commands run locally)', currentValue: '' },
-        { id: 'k-queue', label: 'Ctrl+Enter', description: 'Queue the draft while the agent is busy (the opposite of Enter while busy)', currentValue: '' },
-        { id: 'k-exit', label: 'Ctrl+C / Ctrl+D', description: 'Quit the TUI (flushes the session)', currentValue: '' },
-        { id: 'k-cancel', label: 'Esc', description: 'Cancel the active turn / tool / shell command (one Esc while the agent is busy; double-Esc while idle — with an empty editor it opens the rewind picker)', currentValue: '' },
-        { id: 'k-fold', label: 'Ctrl+O', description: 'Expand/collapse recent tool and system output; in regular Focus it reveals the recent Thoughts; in fullscreen Focus it bulk-expands the recent Thoughts or collapses them all (per-card detail stays mouse-owned). Thinking detail is Alt+T', currentValue: '' },
-        { id: 'k-todo', label: 'Ctrl+T', description: 'Toggle the todo panel', currentValue: '' },
-        { id: 'k-think', label: 'Alt+T', description: 'Collapse/expand thinking blocks (detail level — blocks stay visible)', currentValue: '' },
-        { id: 'k-steer', label: 'Ctrl+S', description: 'Steer the running turn with the draft', currentValue: '' },
-        { id: 'k-editor', label: 'Ctrl+G', description: 'Edit the draft in $VISUAL/$EDITOR', currentValue: '' },
-        { id: 'k-search', label: 'Ctrl+F', description: 'Search the transcript (Enter/Shift+Enter jump, Esc closes)', currentValue: '' },
+      // M4: the key labels come from the EFFECTIVE keymap (plan §18) — a
+      // user remap updates /help automatically; the UI never hard-codes a
+      // physical shortcut.
+      const keybindings = app.keybindingsManager()
+      const keysLabel = (action: AppKeybindingId): string => {
+        const keys = keybindings.keysFor(action)
+        if (keys.length > 0) return formatKeyList(keys)
+        const hint = keybindings.keyHint(action)
+        return hint === '' ? '—' : hint
+      }
+      const rows: SettingItem[] = [        { id: 'k-enter', label: keysLabel('app.input.submit'), description: 'Submit (steers the running turn while busy when Enter while busy is Steer; skill commands steer too, UI commands run locally)', currentValue: '' },
+        { id: 'k-queue', label: keysLabel('app.input.queue'), description: 'Queue the draft while the agent is busy (the opposite of Enter while busy)', currentValue: '' },
+        { id: 'k-exit', label: keysLabel('app.exit.request'), description: 'Quit the TUI (flushes the session)', currentValue: '' },
+        { id: 'k-cancel', label: keysLabel('app.agent.interrupt'), description: 'Cancel the active turn / tool / shell command (one Esc while the agent is busy; double-Esc while idle — with an empty editor it opens the rewind picker)', currentValue: '' },
+        { id: 'k-fold', label: keysLabel('app.transcript.toggleExpand'), description: 'Expand/collapse recent tool and system output; in regular Focus it reveals the recent Thoughts; in fullscreen Focus it bulk-expands the recent Thoughts or collapses them all (per-card detail stays mouse-owned). Thinking detail is Alt+T', currentValue: '' },
+        { id: 'k-todo', label: keysLabel('app.todo.toggle'), description: 'Toggle the todo panel', currentValue: '' },
+        { id: 'k-think', label: keysLabel('app.transcript.toggleThinking'), description: 'Collapse/expand thinking blocks (detail level — blocks stay visible)', currentValue: '' },
+        { id: 'k-steer', label: keysLabel('app.input.steer'), description: 'Steer the running turn with the draft', currentValue: '' },
+        { id: 'k-editor', label: keysLabel('app.editor.external'), description: 'Edit the draft in $VISUAL/$EDITOR', currentValue: '' },
+        { id: 'k-search', label: keysLabel('app.transcript.search'), description: 'Search the transcript (Enter/Shift+Enter jump, Esc closes)', currentValue: '' },
         { id: 'k-tab', label: 'Tab', description: 'Autocomplete slash commands and file paths', currentValue: '' },
         { id: 'k-hist', label: '↑/↓', description: 'Recall input history on an empty line', currentValue: '' },
         { id: 'k-bang', label: '! cmd', description: 'Run a shell command and submit the command and its output to the session; !! runs locally without recording', currentValue: '' },
@@ -2878,6 +2894,84 @@ export function registerTuiCommands(
           currentValue: '',
         })),
       ]
+      app.openSettings(rows, () => {}, () => {})
+      return { kind: 'success' }
+    },
+  })
+
+  // M4: the keybinding diagnostics command (plan §19). The panel is
+  // read-only (no key recorder in the first version); reload re-reads the
+  // settings document, reset clears the user overrides THROUGH the
+  // settings service (never a direct settings.yaml write).
+  commands.register({
+    name: 'keybindings',
+    description: 'Show effective keybindings (conflicts / reload / reset)',
+    input: { hint: '[conflicts|reload|reset]' },
+    handler: (invocation) => {
+      const verb = invocation.rawInput.trim().split(/\s+/)[0]?.toLowerCase() ?? ''
+      const keybindings = app.keybindingsManager()
+      if (verb === 'conflicts') {
+        const conflicts = keybindings.snapshot().conflicts
+        if (conflicts.length === 0) {
+          app.notify('No keybinding conflicts.', 'info')
+          return { kind: 'success', text: 'No keybinding conflicts.' }
+        }
+        const rows: SettingItem[] = conflicts.flatMap(conflict => [{
+          id: `conflict-${conflict.key}`,
+          label: color.warning(formatKeyId(conflict.key)),
+          description: conflict.actions
+            .map(entry => `${entry.action} (${entry.scope}, ${entry.source})`)
+            .join('  vs  '),
+          currentValue: 'conflict',
+        }])
+        app.openSettings(rows, () => {}, () => {})
+        return { kind: 'success' }
+      }
+      if (verb === 'reload') {
+        // Re-validate the settings document and rebuild the keymap
+        // (fail-soft: bad entries are diagnostics, never a crash).
+        const parsed = parseUserKeybindings(runner.tuiSettings?.get().keybindings)
+        for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
+        keybindings.setUserConfiguration(parsed)
+        app.notify('Keybindings reloaded.', 'info')
+        return { kind: 'success', text: 'Keybindings reloaded.' }
+      }
+      if (verb === 'reset') {
+        const settings = runner.tuiSettings
+        if (settings === undefined) return { kind: 'error', text: 'settings service unavailable' }
+        const doc = { ...settings.get() } as Record<string, unknown>
+        delete doc.keybindings
+        detach('keybindings reset', () => settings.replace(doc), { notify: true })
+        app.notify('Keybindings reset to defaults.', 'info')
+        return { kind: 'success', text: 'Keybindings reset to defaults.' }
+      }
+      // The full effective table, grouped by category (plan §19).
+      const snapshot = keybindings.snapshot()
+      const categories = new Map<string, SettingItem[]>()
+      for (const binding of snapshot.bindings) {
+        const definition = APP_KEYBINDINGS[binding.action as AppKeybindingId]
+        const category = definition?.category ?? 'Other'
+        const list = categories.get(category) ?? []
+        list.push({
+          id: `kb-${binding.action}`,
+          label: binding.keys.length === 0 ? '—' : binding.keys.map(formatKeyId).join(' / '),
+          description: `${binding.action} — ${definition?.description ?? ''} (${binding.scope}, ${binding.source})`,
+          currentValue: '',
+        })
+        categories.set(category, list)
+      }
+      const rows: SettingItem[] = []
+      for (const [category, list] of categories) {
+        rows.push({ id: `sep-${category}`, label: color.border(`── ${category} ──`), currentValue: '' })
+        rows.push(...list)
+      }
+      const diagnostics = keybindings.diagnosticsList()
+      if (diagnostics.length > 0) {
+        rows.push({ id: 'sep-diag', label: color.border('── diagnostics ──'), currentValue: '' })
+        for (const message of diagnostics) {
+          rows.push({ id: `diag-${rows.length}`, label: color.warning('⚠'), description: message, currentValue: '' })
+        }
+      }
       app.openSettings(rows, () => {}, () => {})
       return { kind: 'success' }
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2939,6 +2939,13 @@ export function registerTuiCommands(
         return { kind: 'success' }
       }
       if (verb === 'reload') {
+        const settings = runner.tuiSettings
+        // The reload seam needs a settings document (review round 35:
+        // without the backend, "reading the defaults" would be a lie —
+        // mirror /keybindings reset's explicit refusal so a degraded /
+        // Remote backend cannot misrepresent an absent settings service
+        // as a successful defaults read).
+        if (settings === undefined) return { kind: 'error', text: 'settings service unavailable' }
         // Re-validate the settings document and rebuild the keymap
         // (fail-soft: bad entries are diagnostics, never a crash). The
         // settings read itself is guarded too — a transient `get()`
@@ -2947,7 +2954,7 @@ export function registerTuiCommands(
         // (review round 28: reload is now the ONLY reload seam, so its
         // fail-soft contract must match the startup application).
         try {
-          const parsed = parseUserKeybindings(runner.tuiSettings?.get().keybindings)
+          const parsed = parseUserKeybindings(settings.get().keybindings)
           for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
           keybindings.setUserConfiguration(parsed)
         } catch (error: unknown) {
@@ -2972,14 +2979,23 @@ export function registerTuiCommands(
             // Await the persistence write: the command result reflects the
             // ACTUAL outcome (a failed write must not report success — review
             // finding). The handler may return a Promise<CommandResult>.
+            // NOTE (review round 35): after a successful write there is
+            // deliberately NO second `settings.get()`. The reset doc is
+            // already the canonical projection (the `keybindings` field was
+            // deleted above), so the runtime is rebuilt from THAT local
+            // state — `parseUserKeybindings(doc.keybindings)` — never from
+            // a second Host read. A post-write read could fail (leaving the
+            // disk reset but the runtime claiming "reset failed"), and a
+            // Remote adapter must not be a GET → PUT → GET round trip:
+            // reset is write + local projection.
             await settings.replace(doc as unknown as import('./runtime/config-port.ts').TuiSettingsDoc)
             // Apply the cleared configuration NOW: with the automatic
             // settings watch removed (review round 28 — the reload seam is
             // explicit), a reset that only persisted would leave the
             // RUNNING keymap with the old overrides until a manual
             // /keybindings reload. The reset is a full reset: persist AND
-            // rebuild from the (now keybindings-less) document.
-            const parsed = parseUserKeybindings(settings.get().keybindings)
+            // rebuild from the cleared document.
+            const parsed = parseUserKeybindings(doc.keybindings)
             for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
             keybindings.setUserConfiguration(parsed)
             app.notify('Keybindings reset to defaults.', 'info')

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2975,7 +2975,7 @@ export function registerTuiCommands(
         const list = categories.get(category) ?? []
         list.push({
           id: `kb-${binding.action}`,
-          label: binding.keys.length === 0 ? '—' : binding.keys.map(key => binding.leader === true ? formatLeaderSequence(key as never) : formatKeyId(key)).join(' / '),
+          label: [ ...binding.keys.map(key => formatKeyId(key)), ...(binding.leaderKeys ?? []).map(key => formatLeaderSequence(key)) ].join(' / ') || '—',
           description: `${binding.action} — ${definition?.description ?? ''} (${binding.scope}, ${binding.source})`,
           currentValue: '',
         })

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,7 +29,7 @@ import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
 import { iconStyleOf } from './icons.ts'
 import { parseUserKeybindings } from './keybindings/config.ts'
 import { APP_KEYBINDINGS } from './keybindings/definitions.ts'
-import { formatKeyId, formatKeyList, formatLeaderSequence } from './keybindings/hints.ts'
+import { formatKeyId, formatLeaderSequence } from './keybindings/hints.ts'
 import type { AppKeybindingId } from './keybindings/types.ts'
 import type { TuiApp } from './tui-app.ts'
 import type { PickerCategory, PickerItem } from './tui-app.ts'
@@ -2875,10 +2875,12 @@ export function registerTuiCommands(
       // physical shortcut.
       const keybindings = app.keybindingsManager()
       const keysLabel = (action: AppKeybindingId): string => {
-        const keys = keybindings.keysFor(action)
-        if (keys.length > 0) return formatKeyList(keys)
-        const hint = keybindings.keyHint(action)
-        return hint === '' ? '—' : hint
+        // The full effective label: ALL direct keys AND ALL leader
+        // sequences (a mixed `['ctrl+z', '<leader>h']` shows
+        // `Ctrl+Z / Leader H`; a disabled action advertises nothing) —
+        // review finding: keysFor() alone dropped the leader bindings.
+        const label = keybindings.keysLabelFor(action)
+        return label === '' ? '—' : label
       }
       const rows: SettingItem[] = [        { id: 'k-enter', label: keysLabel('app.input.submit'), description: 'Submit (steers the running turn while busy when Enter while busy is Steer; skill commands steer too, UI commands run locally)', currentValue: '' },
         { id: 'k-queue', label: keysLabel('app.input.queue'), description: 'Queue the draft while the agent is busy (the opposite of Enter while busy)', currentValue: '' },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1245,7 +1245,7 @@ export function registerTuiCommands(
           },
           {
             id: 'busy-enter',
-            label: 'Enter while busy',
+            label: 'Submit while busy',
             description: `Steer injects the draft into the running turn; ${keyHint('app.input.queue')} uses the other behavior`,
             currentValue: tuiSettings?.get().busyEnter ?? 'queue',
             values: ['queue', 'steer'],
@@ -2882,10 +2882,10 @@ export function registerTuiCommands(
         const label = keybindings.keysLabelFor(action)
         return label === '' ? '—' : label
       }
-      const rows: SettingItem[] = [        { id: 'k-enter', label: keysLabel('app.input.submit'), description: 'Submit (steers the running turn while busy when Enter while busy is Steer; skill commands steer too, UI commands run locally)', currentValue: '' },
-        { id: 'k-queue', label: keysLabel('app.input.queue'), description: 'Queue the draft while the agent is busy (the opposite of Enter while busy)', currentValue: '' },
+      const rows: SettingItem[] = [        { id: 'k-enter', label: keysLabel('app.input.submit'), description: 'Submit the draft; while the agent is busy, delivery follows the "Submit while busy" preference (skill commands steer too, UI commands run locally)', currentValue: '' },
+        { id: 'k-queue', label: keysLabel('app.input.queue'), description: 'Queue the draft while the agent is busy (the opposite of "Submit while busy")', currentValue: '' },
         { id: 'k-exit', label: keysLabel('app.exit.request'), description: 'Quit the TUI (flushes the session)', currentValue: '' },
-        { id: 'k-cancel', label: keysLabel('app.agent.interrupt'), description: 'Cancel the active turn / tool / shell command (one Esc while the agent is busy; double-Esc while idle — with an empty editor it opens the rewind picker)', currentValue: '' },
+        { id: 'k-cancel', label: keysLabel('app.agent.interrupt'), description: 'Cancel the active turn / tool / shell command (one interrupt while the agent is busy; press the interrupt action twice while idle — with an empty editor it opens the rewind picker)', currentValue: '' },
         { id: 'k-fold', label: keysLabel('app.transcript.toggleExpand'), description: `Expand/collapse recent tool and system output; in regular Focus it reveals the recent Thoughts; in fullscreen Focus it bulk-expands the recent Thoughts or collapses them all (per-card detail stays mouse-owned). Thinking detail is ${keysLabel('app.transcript.toggleThinking')}`, currentValue: '' },
         { id: 'k-todo', label: keysLabel('app.todo.toggle'), description: 'Toggle the todo panel', currentValue: '' },
         { id: 'k-think', label: keysLabel('app.transcript.toggleThinking'), description: 'Collapse/expand thinking blocks (detail level — blocks stay visible)', currentValue: '' },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -945,6 +945,13 @@ export function registerTuiCommands(
   // TUI commands cannot be registered at all — the caller surfaces this.
   if (commands === undefined) throw new Error('commands service unavailable')
 
+  /** The EFFECTIVE key label for user-facing descriptions (plan §18): a
+   * remap updates every row; a disabled action shows a neutral dash. */
+  const keyHint = (id: AppKeybindingId): string => {
+    const hint = app.keybindingsManager().keyHint(id)
+    return hint === '' ? '—' : hint
+  }
+
   // Fire-and-forget with the runner's diag: cancellations debug-only,
   // recoverable (persistence) failures notify + warn, everything else
   // warns — never a bare `void somePromise()` (AGENTS.md hard rule). The
@@ -1193,7 +1200,7 @@ export function registerTuiCommands(
           ...permissionNames.length > 0 ? [{
             id: 'default-permission',
             label: 'Default permission',
-            description: 'Preset new sessions start with (persisted; Shift+Tab cycles this session)',
+            description: `Preset new sessions start with (persisted; ${keyHint('app.permission.cycle')} cycles this session)`,  // keysLabel? no — keyHint
             currentValue: defaultPermission ?? permissionNames[0] ?? '',
             values: permissionNames,
           }] : [],
@@ -1239,7 +1246,7 @@ export function registerTuiCommands(
           {
             id: 'busy-enter',
             label: 'Enter while busy',
-            description: 'Steer injects the draft into the running turn; Ctrl+Enter uses the other behavior',
+            description: `Steer injects the draft into the running turn; ${keyHint('app.input.queue')} uses the other behavior`,
             currentValue: tuiSettings?.get().busyEnter ?? 'queue',
             values: ['queue', 'steer'],
           },
@@ -2882,7 +2889,9 @@ export function registerTuiCommands(
         { id: 'k-think', label: keysLabel('app.transcript.toggleThinking'), description: 'Collapse/expand thinking blocks (detail level — blocks stay visible)', currentValue: '' },
         { id: 'k-steer', label: keysLabel('app.input.steer'), description: 'Steer the running turn with the draft', currentValue: '' },
         { id: 'k-editor', label: keysLabel('app.editor.external'), description: 'Edit the draft in $VISUAL/$EDITOR', currentValue: '' },
-        { id: 'k-search', label: keysLabel('app.transcript.search'), description: 'Search the transcript (Enter/Shift+Enter jump, Esc closes)', currentValue: '' },
+
+        { id: 'k-search', label: keysLabel('app.transcript.search'), description: `Search the transcript (${keysLabel('app.transcript.search.next')}/${keysLabel('app.transcript.search.previous')} jump, ${keysLabel('app.transcript.search.close')} closes)`, currentValue: '' },
+
         { id: 'k-tab', label: 'Tab', description: 'Autocomplete slash commands and file paths', currentValue: '' },
         { id: 'k-hist', label: '↑/↓', description: 'Recall input history on an empty line', currentValue: '' },
         { id: 'k-bang', label: '! cmd', description: 'Run a shell command and submit the command and its output to the session; !! runs locally without recording', currentValue: '' },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,7 +29,7 @@ import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
 import { iconStyleOf } from './icons.ts'
 import { parseUserKeybindings } from './keybindings/config.ts'
 import { APP_KEYBINDINGS } from './keybindings/definitions.ts'
-import { formatKeyId, formatKeyList } from './keybindings/hints.ts'
+import { formatKeyId, formatKeyList, formatLeaderSequence } from './keybindings/hints.ts'
 import type { AppKeybindingId } from './keybindings/types.ts'
 import type { TuiApp } from './tui-app.ts'
 import type { PickerCategory, PickerItem } from './tui-app.ts'
@@ -2975,7 +2975,7 @@ export function registerTuiCommands(
         const list = categories.get(category) ?? []
         list.push({
           id: `kb-${binding.action}`,
-          label: binding.keys.length === 0 ? '—' : binding.keys.map(formatKeyId).join(' / '),
+          label: binding.keys.length === 0 ? '—' : binding.keys.map(key => binding.leader === true ? formatLeaderSequence(key as never) : formatKeyId(key)).join(' / '),
           description: `${binding.action} — ${definition?.description ?? ''} (${binding.scope}, ${binding.source})`,
           currentValue: '',
         })

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2940,24 +2940,48 @@ export function registerTuiCommands(
       }
       if (verb === 'reload') {
         // Re-validate the settings document and rebuild the keymap
-        // (fail-soft: bad entries are diagnostics, never a crash).
-        const parsed = parseUserKeybindings(runner.tuiSettings?.get().keybindings)
-        for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
-        keybindings.setUserConfiguration(parsed)
+        // (fail-soft: bad entries are diagnostics, never a crash). The
+        // settings read itself is guarded too — a transient `get()`
+        // failure must NOT throw out of the handler: the keymap keeps its
+        // last-known-good configuration and the command reports the error
+        // (review round 28: reload is now the ONLY reload seam, so its
+        // fail-soft contract must match the startup application).
+        try {
+          const parsed = parseUserKeybindings(runner.tuiSettings?.get().keybindings)
+          for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
+          keybindings.setUserConfiguration(parsed)
+        } catch (error: unknown) {
+          const message = safeErrorMessage(error)
+          runner.diag.warn('keybindings', { error: message, message: 'keybindings reload failed — keeping the last-known-good configuration' })
+          app.notify(`keybindings reload failed: ${message}`, 'error')
+          return { kind: 'error', text: `keybindings reload failed: ${message}` }
+        }
         app.notify('Keybindings reloaded.', 'info')
         return { kind: 'success', text: 'Keybindings reloaded.' }
       }
       if (verb === 'reset') {
         const settings = runner.tuiSettings
         if (settings === undefined) return { kind: 'error', text: 'settings service unavailable' }
-        const doc = { ...settings.get() } as Record<string, unknown>
-        delete doc.keybindings
-        // Await the persistence write: the command result reflects the
-        // ACTUAL outcome (a failed write must not report success — review
-        // finding). The handler may return a Promise<CommandResult>.
+        // The whole reset is guarded — INCLUDING the initial read (review
+        // round 30): a throwing first `get()` must not escape the handler;
+        // it reports an error and the running keymap stays untouched.
         return (async (): Promise<CommandResult> => {
           try {
+            const doc = { ...settings.get() } as Record<string, unknown>
+            delete doc.keybindings
+            // Await the persistence write: the command result reflects the
+            // ACTUAL outcome (a failed write must not report success — review
+            // finding). The handler may return a Promise<CommandResult>.
             await settings.replace(doc as unknown as import('./runtime/config-port.ts').TuiSettingsDoc)
+            // Apply the cleared configuration NOW: with the automatic
+            // settings watch removed (review round 28 — the reload seam is
+            // explicit), a reset that only persisted would leave the
+            // RUNNING keymap with the old overrides until a manual
+            // /keybindings reload. The reset is a full reset: persist AND
+            // rebuild from the (now keybindings-less) document.
+            const parsed = parseUserKeybindings(settings.get().keybindings)
+            for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
+            keybindings.setUserConfiguration(parsed)
             app.notify('Keybindings reset to defaults.', 'info')
             return { kind: 'success', text: 'Keybindings reset to defaults.' }
           } catch (error: unknown) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2950,21 +2950,21 @@ export function registerTuiCommands(
         if (settings === undefined) return { kind: 'error', text: 'settings service unavailable' }
         const doc = { ...settings.get() } as Record<string, unknown>
         delete doc.keybindings
-        // Owned persistence: the success notify fires only after the
-        // write RESOLVES (a false "reset to defaults" on a failed write
-        // would lie — review finding). runOwned records the failure
-        // diagnostics and onError notifies.
-        runOwned('keybindings reset', () => settings.replace(doc as unknown as import('./runtime/config-port.ts').TuiSettingsDoc), {
-          diag: runner.diag,
-          sessionId: () => runner.liveAgent?.session.id,
-          onResult: () => {
+        // Await the persistence write: the command result reflects the
+        // ACTUAL outcome (a failed write must not report success — review
+        // finding). The handler may return a Promise<CommandResult>.
+        return (async (): Promise<CommandResult> => {
+          try {
+            await settings.replace(doc as unknown as import('./runtime/config-port.ts').TuiSettingsDoc)
             app.notify('Keybindings reset to defaults.', 'info')
-          },
-          onError: (error: unknown) => {
-            app.notify(`keybindings reset failed: ${safeErrorMessage(error)}`, 'error')
-          },
-        })
-        return { kind: 'success', text: 'Keybindings reset to defaults.' }
+            return { kind: 'success', text: 'Keybindings reset to defaults.' }
+          } catch (error: unknown) {
+            const message = safeErrorMessage(error)
+            runner.diag.warn('keybindings', { error: message })
+            app.notify(`keybindings reset failed: ${message}`, 'error')
+            return { kind: 'error', text: `keybindings reset failed: ${message}` }
+          }
+        })()
       }
       // The full effective table, grouped by category (plan §19).
       const snapshot = keybindings.snapshot()

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2950,8 +2950,20 @@ export function registerTuiCommands(
         if (settings === undefined) return { kind: 'error', text: 'settings service unavailable' }
         const doc = { ...settings.get() } as Record<string, unknown>
         delete doc.keybindings
-        detach('keybindings reset', () => settings.replace(doc as unknown as import('./runtime/config-port.ts').TuiSettingsDoc), { notify: true })
-        app.notify('Keybindings reset to defaults.', 'info')
+        // Owned persistence: the success notify fires only after the
+        // write RESOLVES (a false "reset to defaults" on a failed write
+        // would lie — review finding). runOwned records the failure
+        // diagnostics and onError notifies.
+        runOwned('keybindings reset', () => settings.replace(doc as unknown as import('./runtime/config-port.ts').TuiSettingsDoc), {
+          diag: runner.diag,
+          sessionId: () => runner.liveAgent?.session.id,
+          onResult: () => {
+            app.notify('Keybindings reset to defaults.', 'info')
+          },
+          onError: (error: unknown) => {
+            app.notify(`keybindings reset failed: ${safeErrorMessage(error)}`, 'error')
+          },
+        })
         return { kind: 'success', text: 'Keybindings reset to defaults.' }
       }
       // The full effective table, grouped by category (plan §19).

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2884,7 +2884,7 @@ export function registerTuiCommands(
         { id: 'k-queue', label: keysLabel('app.input.queue'), description: 'Queue the draft while the agent is busy (the opposite of Enter while busy)', currentValue: '' },
         { id: 'k-exit', label: keysLabel('app.exit.request'), description: 'Quit the TUI (flushes the session)', currentValue: '' },
         { id: 'k-cancel', label: keysLabel('app.agent.interrupt'), description: 'Cancel the active turn / tool / shell command (one Esc while the agent is busy; double-Esc while idle — with an empty editor it opens the rewind picker)', currentValue: '' },
-        { id: 'k-fold', label: keysLabel('app.transcript.toggleExpand'), description: 'Expand/collapse recent tool and system output; in regular Focus it reveals the recent Thoughts; in fullscreen Focus it bulk-expands the recent Thoughts or collapses them all (per-card detail stays mouse-owned). Thinking detail is Alt+T', currentValue: '' },
+        { id: 'k-fold', label: keysLabel('app.transcript.toggleExpand'), description: `Expand/collapse recent tool and system output; in regular Focus it reveals the recent Thoughts; in fullscreen Focus it bulk-expands the recent Thoughts or collapses them all (per-card detail stays mouse-owned). Thinking detail is ${keysLabel('app.transcript.toggleThinking')}`, currentValue: '' },
         { id: 'k-todo', label: keysLabel('app.todo.toggle'), description: 'Toggle the todo panel', currentValue: '' },
         { id: 'k-think', label: keysLabel('app.transcript.toggleThinking'), description: 'Collapse/expand thinking blocks (detail level — blocks stay visible)', currentValue: '' },
         { id: 'k-steer', label: keysLabel('app.input.steer'), description: 'Steer the running turn with the draft', currentValue: '' },
@@ -2950,7 +2950,7 @@ export function registerTuiCommands(
         if (settings === undefined) return { kind: 'error', text: 'settings service unavailable' }
         const doc = { ...settings.get() } as Record<string, unknown>
         delete doc.keybindings
-        detach('keybindings reset', () => settings.replace(doc), { notify: true })
+        detach('keybindings reset', () => settings.replace(doc as unknown as import('./runtime/config-port.ts').TuiSettingsDoc), { notify: true })
         app.notify('Keybindings reset to defaults.', 'info')
         return { kind: 'success', text: 'Keybindings reset to defaults.' }
       }

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -577,7 +577,11 @@ export type TuiAction =
   | 'toggle-fullscreen'
   | 'cycle-permission'
 
-/** One keybinding contribution (M5 metadata only; routing in M6). */
+/** One keybinding contribution (M5): a normalized key + one of the
+ * PUBLIC semantic actions. The registry validates and canonicalizes it
+ * (action whitelist, reserved keys, plain printables, legacy C0
+ * collisions); the records feed the LIVE InputRouter lookups and the
+ * runner's effective-keymap plugin rules (M6). */
 export interface TuiKeybindingContribution {
   readonly id: string
   readonly key: NormalizedKey

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -579,7 +579,7 @@ export type TuiAction =
 
 /** One keybinding contribution (M5): a normalized key + one of the
  * PUBLIC semantic actions. The registry validates and canonicalizes it
- * (action whitelist, reserved keys, text-producing keys, legacy C0
+ * (action whitelist, reserved keys, text-producing keys, editor-owned keys, legacy C0
  * collisions); the records feed the LIVE InputRouter lookups and the
  * runner's effective-keymap plugin rules (M6). */
 export interface TuiKeybindingContribution {

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -579,7 +579,7 @@ export type TuiAction =
 
 /** One keybinding contribution (M5): a normalized key + one of the
  * PUBLIC semantic actions. The registry validates and canonicalizes it
- * (action whitelist, reserved keys, plain printables, legacy C0
+ * (action whitelist, reserved keys, text-producing keys, legacy C0
  * collisions); the records feed the LIVE InputRouter lookups and the
  * runner's effective-keymap plugin rules (M6). */
 export interface TuiKeybindingContribution {

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -243,10 +243,13 @@ export interface PiTuiExtensionService {
    */
   registerSetting(contribution: TuiSettingContribution): TuiSettingHandle
   /**
-   * Register a keybinding (M5, metadata only): normalized key → semantic
-   * action. Routing is Host-owned (the InputRouter lands in M6); until
-   * then the binding is recorded and reported. Reserved host keys are
-   * rejected. Owned by the calling fiber.
+   * Register a keybinding (M5): normalized key → public semantic action.
+   * The registry validates the contribution (public TuiAction whitelist,
+   * reserved keys, plain printables, legacy C0 collisions) and its
+   * records feed the LIVE InputRouter lookups + the runner's
+   * effective-keymap plugin rules (M6); routing precedence stays
+   * Host-owned. Rejections throw loudly; the binding is owned by the
+   * calling fiber.
    * @param contribution - the binding contribution.
    */
   registerKeybinding(contribution: TuiKeybindingContribution): TuiKeybindingHandle
@@ -938,9 +941,11 @@ export class PiTuiExtensionServiceImpl extends Service implements PiTuiExtension
   }
 
   /**
-   * Register a keybinding (M5, metadata only — routing lands in M6).
-   * Fiber-bound; owner unload removes the binding. Reserved host keys are
-   * rejected.
+   * Register a keybinding (M5): normalized key → public semantic action.
+   * Fiber-bound; owner unload removes the binding. The registry rejects
+   * loudly: non-public actions, reserved host keys, plain printables and
+   * legacy C0 collisions. The records feed the live InputRouter lookups
+   * and the runner's effective-keymap plugin rules (M6).
    */
   registerKeybinding(contribution: TuiKeybindingContribution): TuiKeybindingHandle {
     const caller = this.ctx

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -245,7 +245,7 @@ export interface PiTuiExtensionService {
   /**
    * Register a keybinding (M5): normalized key → public semantic action.
    * The registry validates the contribution (public TuiAction whitelist,
-   * reserved keys, text-producing keys, legacy C0 collisions) and its
+   * reserved keys, text-producing keys, editor-owned keys, legacy C0 collisions) and its
    * records feed the LIVE InputRouter lookups + the runner's
    * effective-keymap plugin rules (M6); routing precedence stays
    * Host-owned. Rejections throw loudly; the binding is owned by the
@@ -943,7 +943,7 @@ export class PiTuiExtensionServiceImpl extends Service implements PiTuiExtension
   /**
    * Register a keybinding (M5): normalized key → public semantic action.
    * Fiber-bound; owner unload removes the binding. The registry rejects
-   * loudly: non-public actions, reserved host keys, text-producing keys and
+   * loudly: non-public actions, reserved host keys, text-producing keys, editor-owned keys and
    * legacy C0 collisions. The records feed the live InputRouter lookups
    * and the runner's effective-keymap plugin rules (M6).
    */

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -245,7 +245,7 @@ export interface PiTuiExtensionService {
   /**
    * Register a keybinding (M5): normalized key → public semantic action.
    * The registry validates the contribution (public TuiAction whitelist,
-   * reserved keys, plain printables, legacy C0 collisions) and its
+   * reserved keys, text-producing keys, legacy C0 collisions) and its
    * records feed the LIVE InputRouter lookups + the runner's
    * effective-keymap plugin rules (M6); routing precedence stays
    * Host-owned. Rejections throw loudly; the binding is owned by the
@@ -943,7 +943,7 @@ export class PiTuiExtensionServiceImpl extends Service implements PiTuiExtension
   /**
    * Register a keybinding (M5): normalized key → public semantic action.
    * Fiber-bound; owner unload removes the binding. The registry rejects
-   * loudly: non-public actions, reserved host keys, plain printables and
+   * loudly: non-public actions, reserved host keys, text-producing keys and
    * legacy C0 collisions. The records feed the live InputRouter lookups
    * and the runner's effective-keymap plugin rules (M6).
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,14 @@
  * a persistent `TranscriptFolder` folds appended events incrementally and a
  * coalesced repaint flushes the windowed transcript (older turns collapse
  * into a summary), so long sessions never re-scan the whole log per event.
+ *
+ * KEYS ARE NOT HARD-CODED HERE: host shortcuts are semantic actions (app.*)
+ * resolved through the user-orchestrable keymap; the single source of truth
+ * for default keys is src/keybindings/definitions.ts and the effective map
+ * is inspectable at runtime with `/keybindings`. User-FACING strings derive
+ * key labels through the keymap's keyHint() (e.g. the guard notices); key
+ * names in comments are shorthand for the default binding and must never be
+ * relied on as the live binding.
  * @module @xmoon76/dsh-pi-tui
  */
 
@@ -78,6 +86,7 @@ import { formatStats, StatsFolder } from './stats.ts'
 import { color, loadCustomTheme, resolveCustomTheme, type ColorPalette, type CustomThemeFile } from './theme.ts'
 import { startProcessTui, type CompactionPhase, type QueueItem, type TuiApp } from './tui-app.ts'
 import { parseUserKeybindings } from './keybindings/config.ts'
+import type { AppKeybindingId } from './keybindings/types.ts'
 import { normalizedKeyToKeyId } from './keybindings/manager.ts'
 import { Text } from '@xmoon76/pi-tui'
 import { SurfaceHost } from './extension/internal/surface-host.ts'
@@ -860,14 +869,16 @@ const DANGER_PATTERNS: readonly RegExp[] = [
   /\bcurl\b[^\n|]*\|\s*(ba)?sh\b/,
 ]
 
-/** Divergence-guard notices (user-facing, English like the rest of the TUI). */
-const GUARD_BLOCKED_NOTIFY = (action: GuardAction): string =>
-  `This session may be open in another dsh process (TUI/web); send blocked. Press ${action === 'submit' ? 'Enter' : 'Ctrl+S'} again to force (may corrupt the session log)`
-const GUARD_TAIL_MISMATCH_NOTIFY = (action: GuardAction): string =>
-  `This session file was rewritten by another process (same event count, different content); send blocked. Press ${action === 'submit' ? 'Enter' : 'Ctrl+S'} again to force (may corrupt the session log)`
+/** Divergence-guard notices (user-facing, English like the rest of the TUI).
+ * The key labels are the EFFECTIVE keymap hints (defaults: Enter for
+ * submit, Ctrl+S for steer) — a user remap updates the notice. */
+const GUARD_BLOCKED_NOTIFY = (action: GuardAction, submitKey: string, steerKey: string): string =>
+  `This session may be open in another dsh process (TUI/web); send blocked. Press ${action === 'submit' ? submitKey : steerKey} again to force (may corrupt the session log)`
+const GUARD_TAIL_MISMATCH_NOTIFY = (action: GuardAction, submitKey: string, steerKey: string): string =>
+  `This session file was rewritten by another process (same event count, different content); send blocked. Press ${action === 'submit' ? submitKey : steerKey} again to force (may corrupt the session log)`
 const GUARD_FORCED_NOTIFY = 'Forced send — the session may be written by another process; the log may be damaged'
-const GUARD_REMOVED_NOTIFY = (action: GuardAction): string =>
-  `This session's log was removed externally — it can no longer be persisted. Press ${action === 'submit' ? 'Enter' : 'Ctrl+S'} again to continue without persistence (restart to recover)`
+const GUARD_REMOVED_NOTIFY = (action: GuardAction, submitKey: string, steerKey: string): string =>
+  `This session's log was removed externally — it can no longer be persisted. Press ${action === 'submit' ? submitKey : steerKey} again to continue without persistence (restart to recover)`
 
 /** Hard cap for the /exit session flush: a hung provider must not trap the
  * user; after this the TUI exits and warns that the tail may be lost. */
@@ -2400,7 +2411,7 @@ export function apply(ctx: Context, config: Config): void {
       extensionHost = undefined
       diag.dispose()
     }
-    // The ONE exit orchestration, shared by every exit entry (Ctrl+C, Ctrl+D,
+    // The ONE exit orchestration, shared by every exit entry (the exit keys,
     // /exit, /quit): flush with a hard timeout → record → idempotent cleanup
     // → warn on a failed/timed-out flush → resume hint → process exit. A
     // later request while one is in flight is a no-op (createExitController
@@ -3144,10 +3155,10 @@ export function apply(ctx: Context, config: Config): void {
           app.setEditorText(merged)
           app.notify(merged === text
             ? (verdict.reason === 'removed'
-              ? GUARD_REMOVED_NOTIFY('submit')
+              ? GUARD_REMOVED_NOTIFY('submit', keyHint('app.input.submit'), keyHint('app.input.steer'))
               : verdict.reason === 'tail-mismatch'
-                ? GUARD_TAIL_MISMATCH_NOTIFY('submit')
-                : GUARD_BLOCKED_NOTIFY('submit'))
+                ? GUARD_TAIL_MISMATCH_NOTIFY('submit', keyHint('app.input.submit'), keyHint('app.input.steer'))
+                : GUARD_BLOCKED_NOTIFY('submit', keyHint('app.input.submit'), keyHint('app.input.steer')))
             : 'the draft changed while sending — review it before submitting again (the earlier text was preserved below)', 'error')
           return
         }
@@ -3524,10 +3535,10 @@ export function apply(ctx: Context, config: Config): void {
           fenceNotice: () => 'a session transition is in progress — try again in a moment',
           createDraft: () => prepared,
           blockedNotice: (reason) => reason === 'removed'
-            ? GUARD_REMOVED_NOTIFY('save')
+            ? GUARD_REMOVED_NOTIFY('save', keyHint('app.input.submit'), keyHint('app.input.steer'))
             : reason === 'tail-mismatch'
-              ? GUARD_TAIL_MISMATCH_NOTIFY('save')
-              : GUARD_BLOCKED_NOTIFY('save'),
+              ? GUARD_TAIL_MISMATCH_NOTIFY('save', keyHint('app.input.submit'), keyHint('app.input.steer'))
+              : GUARD_BLOCKED_NOTIFY('save', keyHint('app.input.submit'), keyHint('app.input.steer')),
           forcedNotice: () => GUARD_FORCED_NOTIFY,
           staleNotice: () => 'the queue or session changed while sending — try again',
           mergedNotice: () => 'the draft changed while sending — review it before submitting again (the earlier text was preserved below)',
@@ -4318,6 +4329,13 @@ export function apply(ctx: Context, config: Config): void {
     // overrides, and the plugin contributions — all fail-soft (a bad entry
     // is a diagnostic, never a startup failure; plan §16/§17).
     const keybindings = app.keybindingsManager()
+    /** The EFFECTIVE key label for user-facing notices (guard messages):
+     * a remap updates the notice; a disabled action falls back to a
+     * neutral phrase instead of a stale default. */
+    const keyHint = (id: AppKeybindingId): string => {
+      const hint = keybindings.keyHint(id)
+      return hint === '' ? 'the action key' : hint
+    }
     if (process.env.DSH_PI_TUI_SAFE_KEYBINDINGS === '1') {
       keybindings.setSafeMode(true)
       diag.info('keybindings', { safeMode: true })

--- a/src/index.ts
+++ b/src/index.ts
@@ -2404,6 +2404,9 @@ export function apply(ctx: Context, config: Config): void {
       // M3: stop the keybinding settings watch (the manager dies with the
       // app; the watch must not outlive the surface).
       stopKeybindingWatch?.()
+      // M2: unsubscribe the plugin keybinding sync (the registry outlives
+      // the surface — a stale listener must not resync into a dead app).
+      stopPluginKeybindingSync?.()
       // Detach the extension service's surface bridge (its capability set
       // and state listeners die with the surface). The surfaceId lease
       // makes a stale detach a no-op (P1).
@@ -4374,6 +4377,12 @@ export function apply(ctx: Context, config: Config): void {
       })))
     }
     syncPluginKeybindings()
+    // M2 DYNAMIC LIFECYCLE (convergence finding): plugin bindings
+    // registered AFTER mount — or unloaded — must resync the effective
+    // keymap (the initial snapshot is not enough). Subscribe to the
+    // registry's change notifications so every register/dispose
+    // re-syncs; the subscription is disposed with the runner teardown.
+    const stopPluginKeybindingSync = extensionService?.keybindings?.subscribe(() => syncPluginKeybindings())
     /**
      * One follow-up send settled (plan §10/§11/§12):
      * - ACCEPTED: the child inbox owns the message — never restore the
@@ -4664,7 +4673,6 @@ export function apply(ctx: Context, config: Config): void {
         },
       )
     }
-    // Fullscreen is a persisted preference like the theme and the footer
     // (new installs default to 'on' — alt screen by default): boot applies
     // it FIRST so the alt screen owns the terminal input handler before any
     // theme query below targets "the active screen" — a query sent while the

--- a/src/index.ts
+++ b/src/index.ts
@@ -4341,13 +4341,23 @@ export function apply(ctx: Context, config: Config): void {
       diag.info('keybindings', { safeMode: true })
     }
     const applyUserKeybindings = (): void => {
-      const parsed = parseUserKeybindings(tuiSettings?.get().keybindings)
-      for (const message of parsed.diagnostics) diag.warn('keybindings', { message })
-      keybindings.setUserConfiguration(parsed)
+      // Fail-soft hot reload (review finding): a transient settings read
+      // error must never abort the watcher or leave the keymap in a
+      // partial state — the previous (last-known-good) configuration
+      // stays active, and the failure is a diagnostic.
+      try {
+        const parsed = parseUserKeybindings(tuiSettings?.get().keybindings)
+        for (const message of parsed.diagnostics) diag.warn('keybindings', { message })
+        keybindings.setUserConfiguration(parsed)
+      } catch (error: unknown) {
+        diag.warn('keybindings', { error: String(error), message: 'keybindings reload aborted — keeping the last-known-good configuration' })
+      }
     }
     applyUserKeybindings()
     // M3: hot reload — a settings change re-validates and rebuilds the
-    // keymap without a restart (plan §12/§16).
+    // keymap without a restart (plan §12/§16). The settings watcher
+    // contains listener failures; the try/catch above keeps the keymap's
+    // last-known-good state on any read/parse error.
     const stopKeybindingWatch = tuiSettings?.watch(() => applyUserKeybindings())
     // M2: the plugin contributions compile into the effective keymap at
     // the LOWEST priority (a Host action always wins). The runner syncs

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,8 @@ import { focusModeOf, installFocusPrompt, type FocusState } from './focus.ts'
 import { formatStats, StatsFolder } from './stats.ts'
 import { color, loadCustomTheme, resolveCustomTheme, type ColorPalette, type CustomThemeFile } from './theme.ts'
 import { startProcessTui, type CompactionPhase, type QueueItem, type TuiApp } from './tui-app.ts'
+import { parseUserKeybindings } from './keybindings/config.ts'
+import { normalizedKeyToKeyId } from './keybindings/manager.ts'
 import { Text } from '@xmoon76/pi-tui'
 import { SurfaceHost } from './extension/internal/surface-host.ts'
 import { PI_TUI_EXTENSIONS_SERVICE, type PiTuiExtensionService } from './extensions.ts'
@@ -234,7 +236,7 @@ export const SESSIONLESS_COMMANDS = new Set([
  * body — there is no command-execution wire for skills.
  */
 export const LOCAL_COMMANDS = new Set([
-  'copy', 'exit', 'export', 'focus', 'fork', 'help', 'image', 'kill', 'login', 'logout',
+  'copy', 'exit', 'export', 'focus', 'fork', 'help', 'image', 'keybindings', 'kill', 'login', 'logout',
   'model', 'new', 'preset', 'quit', 'reload', 'rename', 'resume', 'rewind',
   'search', 'sessions', 'settings', 'skill', 'status', 'subagents', 'tasks',
   'title', 'yolo',
@@ -1418,6 +1420,12 @@ export function apply(ctx: Context, config: Config): void {
         // structural icon palette (see src/icons.ts). A persisted invalid
         // value fails safe to emoji at consumption.
         iconStyle: z.string(),
+        // NOTE: the user keybinding overrides (`keybindings`) are NOT in
+        // the schema — schemastery's z.object keeps unknown keys in the
+        // resolved doc (see the `history` migration note below), and the
+        // keybindings parser (src/keybindings/config.ts) owns the
+        // validation fail-soft. Adding a schema field here would break
+        // the z<T> inference of the whole register call (probed).
       }),
       // `history` used to live here (a per-cwd map in the settings
       // document). It moved to $DSH_HOME/user-history/*.jsonl (see
@@ -2382,6 +2390,9 @@ export function apply(ctx: Context, config: Config): void {
       }
       shellTempFiles.clear()
       app?.dispose()
+      // M3: stop the keybinding settings watch (the manager dies with the
+      // app; the watch must not outlive the surface).
+      stopKeybindingWatch?.()
       // Detach the extension service's surface bridge (its capability set
       // and state listeners die with the surface). The surfaceId lease
       // makes a stale detach a no-op (P1).
@@ -4302,6 +4313,39 @@ export function apply(ctx: Context, config: Config): void {
       unstableInputsRevision: () => extensionService?._unstableInputsRevision() ?? 0,
       unstableFailSafeRelease: () => extensionService?._unstableEmergencyRelease(),
     })
+    // M3: the user-orchestrable keybinding manager (the app built it with
+    // the builtin defaults). Apply safe mode, the persisted user
+    // overrides, and the plugin contributions — all fail-soft (a bad entry
+    // is a diagnostic, never a startup failure; plan §16/§17).
+    const keybindings = app.keybindingsManager()
+    if (process.env.DSH_PI_TUI_SAFE_KEYBINDINGS === '1') {
+      keybindings.setSafeMode(true)
+      diag.info('keybindings', { safeMode: true })
+    }
+    const applyUserKeybindings = (): void => {
+      const parsed = parseUserKeybindings(tuiSettings?.get().keybindings)
+      for (const message of parsed.diagnostics) diag.warn('keybindings', { message })
+      keybindings.setUserConfiguration(parsed)
+    }
+    applyUserKeybindings()
+    // M3: hot reload — a settings change re-validates and rebuilds the
+    // keymap without a restart (plan §12/§16).
+    const stopKeybindingWatch = tuiSettings?.watch(() => applyUserKeybindings())
+    // M2: the plugin contributions compile into the effective keymap at
+    // the LOWEST priority (a Host action always wins). The runner syncs
+    // the registry snapshot on every invalidation (the manager skips
+    // unchanged rules, so the rebuild is cheap).
+    const syncPluginKeybindings = (): void => {
+      const registry = extensionService?.keybindings
+      if (registry === undefined) return
+      const snapshot = registry.snapshot()
+      keybindings.setPluginRules(snapshot.bindings.map(binding => ({
+        id: binding.id,
+        action: binding.action,
+        key: normalizedKeyToKeyId(binding.key),
+      })))
+    }
+    syncPluginKeybindings()
     /**
      * One follow-up send settled (plan §10/§11/§12):
      * - ACCEPTED: the child inbox owns the message — never restore the
@@ -4582,7 +4626,14 @@ export function apply(ctx: Context, config: Config): void {
         // The attachment lease (P1): a stale detachSurface from an older
         // generation must not tear down THIS surface's bridge.
         attached.surfaceId,
-        (force) => app.requestRender(force),
+        (force) => {
+          // M2: registry invalidations (including plugin keybinding
+          // register/unload) flush through the batcher into this callback
+          // — sync the plugin rules into the effective keymap (a no-op
+          // when unchanged), then repaint.
+          syncPluginKeybindings()
+          app.requestRender(force)
+        },
       )
     }
     // Fullscreen is a persisted preference like the theme and the footer

--- a/src/index.ts
+++ b/src/index.ts
@@ -2368,6 +2368,19 @@ export function apply(ctx: Context, config: Config): void {
     // 0600 temp files holding FULL local-shell output (for truncated runs);
     // removed at TUI exit (default), never on their own.
     const shellTempFiles = new Set<string>()
+    // M2: the plugin keybinding-sync unsubscribe slot. Hoisted here BEFORE
+    // cleanup (TDZ guard, review finding): cleanup is already registered
+    // into the effect below, so a throwing subscription registration at
+    // startup must never turn the teardown into a second ReferenceError
+    // that masks the original failure and skips the extension detach /
+    // diag dispose.
+    let stopPluginKeybindingSync: (() => void) | undefined
+    // The catalog refresh coordinator: the ONE post-mount refresh owner
+    // (first session, switches, /preset, /reload). Declared here (before
+    // cleanup) for the same TDZ guard — cleanup disposes it, and a
+    // mid-startup HMR unload must never reference it while it is still in
+    // the temporal dead zone; it is assigned during command registration.
+    let catalogCoordinator: CatalogRefreshCoordinator | undefined
     // Idempotent teardown: abort lifecycle loads, stop the TUI, close diag.
     // Shared by /exit, the effect cleanup, and the startup-failure path.
     let cleanedUp = false
@@ -2401,12 +2414,10 @@ export function apply(ctx: Context, config: Config): void {
       }
       shellTempFiles.clear()
       app?.dispose()
-      // M3: stop the keybinding settings watch (the manager dies with the
-      // app; the watch must not outlive the surface).
-      stopKeybindingWatch?.()
       // M2: unsubscribe the plugin keybinding sync (the registry outlives
       // the surface — a stale listener must not resync into a dead app).
       stopPluginKeybindingSync?.()
+      stopPluginKeybindingSync = undefined
       // Detach the extension service's surface bridge (its capability set
       // and state listeners die with the surface). The surfaceId lease
       // makes a stale detach a no-op (P1).
@@ -4344,24 +4355,29 @@ export function apply(ctx: Context, config: Config): void {
       diag.info('keybindings', { safeMode: true })
     }
     const applyUserKeybindings = (): void => {
-      // Fail-soft hot reload (review finding): a transient settings read
-      // error must never abort the watcher or leave the keymap in a
-      // partial state — the previous (last-known-good) configuration
-      // stays active, and the failure is a diagnostic.
+      // Fail-soft reload (review finding): a transient settings read
+      // error must never abort the startup application or leave the
+      // keymap in a partial state — the previous (last-known-good)
+      // configuration stays active, and the failure is a diagnostic.
       try {
         const parsed = parseUserKeybindings(tuiSettings?.get().keybindings)
         for (const message of parsed.diagnostics) diag.warn('keybindings', { message })
         keybindings.setUserConfiguration(parsed)
       } catch (error: unknown) {
-        diag.warn('keybindings', { error: String(error), message: 'keybindings reload aborted — keeping the last-known-good configuration' })
+        diag.warn('keybindings', { error: String(error), message: 'keybindings startup apply failed — keeping the last-known-good configuration' })
       }
     }
     applyUserKeybindings()
-    // M3: hot reload — a settings change re-validates and rebuilds the
-    // keymap without a restart (plan §12/§16). The settings watcher
-    // contains listener failures; the try/catch above keeps the keymap's
+    // M3: the user keybindings reload seam is EXPLICIT — `/keybindings
+    // reload` re-reads the settings document and re-validates/rebuilds the
+    // keymap (plan §12/§16). There is deliberately NO automatic settings
+    // watch here: a `watch(callback)` would be a Direct-only dependency —
+    // the TuiSettingsConfig port is get/replace only, a future Remote
+    // adapter cannot map a callback across the process boundary, and the
+    // migration rule forbids callbacks across the wire (see
+    // docs/client-server-migration.md). A settings edit takes effect after
+    // `/keybindings reload`; the fail-soft parser above keeps the keymap's
     // last-known-good state on any read/parse error.
-    const stopKeybindingWatch = tuiSettings?.watch(() => applyUserKeybindings())
     // M2: the plugin contributions compile into the effective keymap at
     // the LOWEST priority (a Host action always wins). The runner syncs
     // the registry snapshot on every invalidation (the manager skips
@@ -4382,7 +4398,8 @@ export function apply(ctx: Context, config: Config): void {
     // keymap (the initial snapshot is not enough). Subscribe to the
     // registry's change notifications so every register/dispose
     // re-syncs; the subscription is disposed with the runner teardown.
-    const stopPluginKeybindingSync = extensionService?.keybindings?.subscribe(() => syncPluginKeybindings())
+    // The unsubscribe slot was hoisted before cleanup (TDZ guard).
+    stopPluginKeybindingSync = extensionService?.keybindings?.subscribe(() => syncPluginKeybindings())
     /**
      * One follow-up send settled (plan §10/§11/§12):
      * - ACCEPTED: the child inbox owns the message — never restore the
@@ -5218,9 +5235,9 @@ export function apply(ctx: Context, config: Config): void {
     let wasAdvertisedClaim: ((name: string) => boolean) | undefined
     /** The catalog refresh coordinator: the ONE post-mount refresh owner
      * (first session, switches, /preset, /reload). Built inside
-     * registerCommands once the surface hooks exist. */
+     * registerCommands once the surface hooks exist. (Declared before
+     * cleanup — see the hoisted slot above.) */
     let catalogRefreshRequest: ((request: CatalogRefreshRequest) => Promise<CatalogRefreshOutcome>) | undefined
-    let catalogCoordinator: CatalogRefreshCoordinator | undefined
     /** `skills/change` coalescing: bursts of invalidation notifications cost
      * at most two reads, and the follow-up re-read observes the CURRENT
      * ownership (live agent vs standing preset). */

--- a/src/input-router.ts
+++ b/src/input-router.ts
@@ -48,8 +48,11 @@
  *   sequences; there is deliberately NO `onTerminalInput(raw)` seam;
  * - terminal protocol replies (Kitty press/repeat/release filtering) are
  *   handled BEFORE plugins — a plugin can never see them;
- * - reserved Host lifecycle keys (the M5 RESERVED_HOST_KEYS inventory)
- *   are handled before plugin bindings and cannot be preempted;
+ * - host lifecycle keys are handled before plugin bindings and cannot be
+ *   preempted — the reservation is ACTION-DRIVEN via
+ *   {@link InputRouterContext.hostResolves} (a key is reserved only while
+ *   an ACTIVE host action binds it; the static RESERVED_HOST_KEYS list is
+ *   only the plugin REGISTRATION guard, never a runtime reservation);
  * - a plugin binding is consulted ONLY when nothing earlier consumed the
  *   input AND the editor did not consume it (non-capturing, last in the
  *   ladder);

--- a/src/input-router.ts
+++ b/src/input-router.ts
@@ -277,9 +277,12 @@ function keyIdToNormalized(keyId: string): NormalizedKey {
 }
 
 /** Whether a normalized key is a plain printable (a plugin binding for a
- * printable key would swallow typing — the editor's text input wins). */
+ * printable key would swallow typing — the editor's text input wins).
+ * The `space` key name (the spacebar) is printable too: a plugin binding
+ * on it would swallow every typed space (convergence finding). */
 function isPrintableKey(key: NormalizedKey): boolean {
   if (key.ctrl || key.alt || key.super) return false
   if (key.shift) return false
+  if (key.key === 'space') return true
   return key.key.length === 1 && key.key.charCodeAt(0) >= 32 && key.key.charCodeAt(0) <= 126
 }

--- a/src/input-router.ts
+++ b/src/input-router.ts
@@ -101,6 +101,11 @@ export interface InputRouterContext {
    * (PR review finding — the runtime reservation is action-driven, never
    * a static physical-key list). */
   readonly hostResolves?: (data: string) => boolean
+  /** The HOST dispatcher already DECLINED this exact input (e.g.
+   * pasteMedia without a handler returned false). The reservation must
+   * be SKIPPED — the key must reach the editor/plugin remainder, never
+   * be re-reserved by the same host action (convergence §6/§4.9). */
+  readonly hostDeclined?: boolean
   /** Whether a replacement editor must receive an editor-routed key before
    * plugin bindings are considered. TuiApp flips this off only after the
    * replacement editor explicitly declines the key. */
@@ -226,7 +231,7 @@ export class InputRouter {
     // (RESERVED_HOST_KEYS) keeps the Stable v1 compatibility rejection;
     // the RUNTIME swallowing here is purely action-driven.
     const normalized = this.normalize(data)
-    if (normalized !== undefined && ctx.hostResolves?.(data) === true) {
+    if (!ctx.hostDeclined && normalized !== undefined && ctx.hostResolves?.(data) === true) {
       return { kind: 'consumed' }
     }
     // A replacement editor is probed by TuiApp before this final plugin

--- a/src/input-router.ts
+++ b/src/input-router.ts
@@ -85,11 +85,23 @@ export interface InputRouterContext {
    * probe (default: the plugin binding wins, matching pre-P1-06
    * behavior for surfaces without a seat editor). */
   readonly editorAccepts?: (data: string) => boolean
+  /** Whether one raw input matches the EFFECTIVE keys of a semantic
+   * action (the app supplies this from its keymap — review finding: the
+   * router's hard-coded physical keys for the read-only viewer fold
+   * pass-through and the search overlay must follow a user remap). */
+  readonly matchesEffective?: (action: string, data: string) => boolean
   /** Whether a replacement editor must receive an editor-routed key before
    * plugin bindings are considered. TuiApp flips this off only after the
    * replacement editor explicitly declines the key. */
   readonly editorReplacement?: boolean
 }
+
+/** The semantic actions the router's physical-key seams consult the
+ * EFFECTIVE keymap for (review finding). The ids are the user-orchestrable
+ * action strings (src/keybindings/definitions.ts); the router keeps them
+ * as plain constants so it never imports the keybindings module. */
+const TUI_ACTION_FOLD = 'app.transcript.toggleExpand'
+const TUI_ACTION_SEARCH = 'app.transcript.search'
 
 /** The outcome of one input event. */
 export type InputRouteResult =
@@ -166,13 +178,19 @@ export class InputRouter {
     // An INTERACTIVE (continuable) viewer keeps the editor live — the
     // router's editor routes below become `viewer-editor` (the host has
     // already consumed Enter and the parent-owned chords).
-    if (ctx.viewerInputMode === 'readonly' && !matchesKey(data, 'escape') && !matchesKey(data, 'ctrl+o')) {
+    if (ctx.viewerInputMode === 'readonly'
+      && !matchesKey(data, 'escape')
+      && !(ctx.matchesEffective?.(TUI_ACTION_FOLD, data) ?? matchesKey(data, 'ctrl+o'))) {
       return { kind: 'consumed' }
     }
-    // The transcript-search overlay owns its keys.
+    // The transcript-search overlay owns its keys. The toggle follows the
+    // EFFECTIVE key (a remap of the configurable app.transcript.search
+    // still closes/owns the overlay); the fixed close/next/previous stay
+    // physical (non-configurable overlay contracts).
     if (ctx.searchActive) {
       if (matchesKey(data, 'escape') || matchesKey(data, 'enter')
-        || matchesKey(data, 'shift+enter') || matchesKey(data, 'ctrl+f')) {
+        || matchesKey(data, 'shift+enter')
+        || (ctx.matchesEffective?.(TUI_ACTION_SEARCH, data) ?? matchesKey(data, 'ctrl+f'))) {
         return { kind: 'consumed' }
       }
       return { kind: 'editor' }

--- a/src/input-router.ts
+++ b/src/input-router.ts
@@ -90,6 +90,14 @@ export interface InputRouterContext {
    * router's hard-coded physical keys for the read-only viewer fold
    * pass-through and the search overlay must follow a user remap). */
   readonly matchesEffective?: (action: string, data: string) => boolean
+  /** Whether the HOST keymap currently binds one raw input to an ACTIVE
+   * host action (the app supplies this from its effective keymap). The
+   * router reserves a key for the host ONLY when a host action is live
+   * for it — a remapped-away old key (e.g. Ctrl+V after pasteMedia moved
+   * to Ctrl+P) is NOT reserved and falls through to the editor/plugin
+   * (PR review finding — the runtime reservation is action-driven, never
+   * a static physical-key list). */
+  readonly hostResolves?: (data: string) => boolean
   /** Whether a replacement editor must receive an editor-routed key before
    * plugin bindings are considered. TuiApp flips this off only after the
    * replacement editor explicitly declines the key. */
@@ -128,17 +136,12 @@ export type InputRouteResult =
  * surface state — it only decides.
  */
 export class InputRouter {
-  /**
-   * The reserved lifecycle keys handled BEFORE plugins (the same
-   * inventory the M5 KeybindingRegistry rejects — plan §11.3). Routing
-   * for these stays in TuiApp's host paths; the router just needs to
-   * know they exist so a plugin binding for them is never consulted.
-   */
-  private readonly reservedKeys: readonly NormalizedKey[]
-
-  constructor(reservedKeys: readonly NormalizedKey[]) {
-    this.reservedKeys = reservedKeys
-  }
+  /** The keybinding registry rejection of reserved host keys stays with
+   * the REGISTRY (RESERVED_HOST_KEYS — Stable v1 plugin compatibility
+   * guard). The ROUTER's runtime reservation is ACTION-driven via
+   * {@link InputRouterContext.hostResolves} — never a static physical-key
+   * list (PR review finding). */
+  constructor() {}
 
   /**
    * Normalize raw terminal input into the public {@link NormalizedKey}
@@ -173,14 +176,19 @@ export class InputRouter {
     // Capturing flows own everything.
     if (ctx.questionActive) return { kind: 'consumed' }
     if (ctx.approvalActive) return { kind: 'consumed' }
-    // Read-only (one-shot) viewer: only Esc + Ctrl+O pass through (host
-    // paths); the router treats everything else as consumed while locked.
+    // Read-only (one-shot) viewer: ONLY Esc and the fold key pass through
+    // — to the HOST paths (viewer-exit, fold-toggle). The router reports
+    // them consumed (never a plugin binding, never the editor); every
+    // other key is consumed while locked. The fold key resolves the
+    // EFFECTIVE keymap (a remap stays authoritative — review finding).
     // An INTERACTIVE (continuable) viewer keeps the editor live — the
     // router's editor routes below become `viewer-editor` (the host has
     // already consumed Enter and the parent-owned chords).
-    if (ctx.viewerInputMode === 'readonly'
-      && !matchesKey(data, 'escape')
-      && !(ctx.matchesEffective?.(TUI_ACTION_FOLD, data) ?? matchesKey(data, 'ctrl+o'))) {
+    if (ctx.viewerInputMode === 'readonly') {
+      if (matchesKey(data, 'escape')) return { kind: 'consumed' }
+      if (ctx.matchesEffective?.(TUI_ACTION_FOLD, data) ?? matchesKey(data, 'ctrl+o')) {
+        return { kind: 'consumed' }
+      }
       return { kind: 'consumed' }
     }
     // The transcript-search overlay owns its keys. The toggle follows the
@@ -205,8 +213,17 @@ export class InputRouter {
     // set so a plugin can never claim them — but the ROUTING itself stays
     // in TuiApp (its host paths hold the state). The router only reports
     // which reserved key this is (if any), so TuiApp runs its path.
+    //
+    // EFFECTIVE-ACTION BASED (PR review finding): the reservation follows
+    // the LIVE keymap, never a static physical-key list. A key that NO
+    // host action currently binds (e.g. Ctrl+V after app.clipboard.
+    // pasteMedia was remapped to Ctrl+P) is NOT reserved — it falls
+    // through to the editor/plugin instead of being swallowed by a stale
+    // physical reservation. The plugin-registration guard
+    // (RESERVED_HOST_KEYS) keeps the Stable v1 compatibility rejection;
+    // the RUNTIME swallowing here is purely action-driven.
     const normalized = this.normalize(data)
-    if (normalized !== undefined && this.isReserved(normalized)) {
+    if (normalized !== undefined && ctx.hostResolves?.(data) === true) {
       return { kind: 'consumed' }
     }
     // A replacement editor is probed by TuiApp before this final plugin
@@ -235,12 +252,6 @@ export class InputRouter {
     return ctx.viewerInputMode === 'continuable' ? { kind: 'viewer-editor' } : { kind: 'editor' }
   }
 
-  /** Whether a normalized key is reserved by the host lifecycle. */
-  private isReserved(key: NormalizedKey): boolean {
-    return this.reservedKeys.some(reserved =>
-      reserved.key === key.key && reserved.ctrl === key.ctrl && reserved.alt === key.alt
-        && reserved.shift === key.shift && reserved.super === key.super)
-  }
 }
 
 /** Convert a fork key-id string (`ctrl+shift+f`, `up`, `alt+up`) into the

--- a/src/input-router.ts
+++ b/src/input-router.ts
@@ -63,7 +63,9 @@
  */
 
 import { isKeyRelease, isKeyRepeat, matchesKey, parseKey } from '@xmoon76/pi-tui'
+import type { KeyId } from '@xmoon76/pi-tui'
 import type { NormalizedKey, TuiAction } from './extension/public-types.ts'
+import { isTextProducingKeyId } from './keybindings/key-identity.ts'
 
 /** The live surface context the router reads (provided by TuiApp). */
 export interface InputRouterContext {
@@ -230,7 +232,8 @@ export class InputRouter {
     // physical reservation. The plugin-registration guard
     // (RESERVED_HOST_KEYS) keeps the Stable v1 compatibility rejection;
     // the RUNTIME swallowing here is purely action-driven.
-    const normalized = this.normalize(data)
+    const parsed = parseKey(data)
+    const normalized = parsed === undefined ? undefined : keyIdToNormalized(parsed)
     if (!ctx.hostDeclined && normalized !== undefined && ctx.hostResolves?.(data) === true) {
       return { kind: 'consumed' }
     }
@@ -239,10 +242,14 @@ export class InputRouter {
     // the key, then retry plugin resolution only when the editor declined.
     if (ctx.editorReplacement) return this.viewerEditor(ctx)
     // Non-capturing plugin keybindings are consulted last for the host
-    // editor. Printable keys always stay with normal text entry, and an
-    // editor-owned binding (navigation, deletion, completion) keeps priority
-    // over a plugin action.
-    if (normalized !== undefined && !isPrintableKey(normalized)) {
+    // editor. TEXT-PRODUCING keys always stay with normal text entry
+    // (round-17 finding: the guard used to treat ANY shift as a chord, so
+    // Shift+A reached the plugin stage on Kitty while typing 'A' on
+    // legacy — the shared isTextProducingKeyId policy treats shift-only
+    // printables as text on EVERY protocol), and an editor-owned binding
+    // (navigation, deletion, completion) keeps priority over a plugin
+    // action.
+    if (normalized !== undefined && parsed !== undefined && !isTextProducingKeyId(parsed as KeyId)) {
       const action = pluginActionFor(normalized)
       if (action !== undefined) {
         if (ctx.editorAccepts?.(data) === true) return this.viewerEditor(ctx)
@@ -274,15 +281,4 @@ function keyIdToNormalized(keyId: string): NormalizedKey {
     shift: parts.includes('shift'),
     super: parts.includes('super'),
   }
-}
-
-/** Whether a normalized key is a plain printable (a plugin binding for a
- * printable key would swallow typing — the editor's text input wins).
- * The `space` key name (the spacebar) is printable too: a plugin binding
- * on it would swallow every typed space (convergence finding). */
-function isPrintableKey(key: NormalizedKey): boolean {
-  if (key.ctrl || key.alt || key.super) return false
-  if (key.shift) return false
-  if (key.key === 'space') return true
-  return key.key.length === 1 && key.key.charCodeAt(0) >= 32 && key.key.charCodeAt(0) <= 126
 }

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -40,7 +40,7 @@
 
 import { describeKey, type NormalizedKey, type TuiAction, type TuiKeybindingContribution, type TuiKeybindingHandle, type TuiKeybindingRegistrySnapshot } from './extension/public-types.ts'
 import type { KeyId } from '@xmoon76/pi-tui'
-import { canonicalizeKeyId, isEditorOwnedKeyId, isTextProducingKeyId, isValidKeyId } from './keybindings/key-identity.ts'
+import { canonicalizeKeyId, isEditorOwnedKeyId, isRuntimeBindableKeyId, isTextProducingKeyId, isValidKeyId } from './keybindings/key-identity.ts'
 import { isTerminalAmbiguousKeyId } from './keybindings/config.ts'
 import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
 
@@ -243,6 +243,15 @@ export class KeybindingRegistry {
     if (!isValidKeyId(canonicalKeyId)) {
       throw new Error(
         `keybinding key "${describeKey(canonicalKey)}" is not a valid key name (the host grammar cannot produce it)`,
+      )
+    }
+    // RUNTIME-BINDABLE GATE (round-22 finding): the fork matcher can
+    // never match a modified F-key or modified Escape (keys.ts:
+    // `modifier !== 0` → false), so the registration would be an
+    // advertised rule that can never fire on any terminal protocol.
+    if (!isRuntimeBindableKeyId(canonicalKeyId)) {
+      throw new Error(
+        `keybinding for "${describeKey(canonicalKey)}" can never be matched by the runtime (modified F-keys and Escape are unsupported)`,
       )
     }
     // TEXT-PRODUCING REJECTION (review findings): the router keeps text-

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -45,18 +45,20 @@ interface BindingRecord {
 }
 
 /**
- * The keys the HOST reserves for its own lifecycle: a plugin can never
- * claim them (plan §11.3 — reserved lifecycle key cannot be preempted).
- * This inventory is the SINGLE authoritative list, kept in sync with the
- * host's `matchesKey` lifecycle checks in tui-app.ts (Ctrl+C/D exit,
- * Ctrl+S steer-all, Ctrl+F transcript search, Ctrl+Shift+F search, Ctrl+O
- * expand, Ctrl+T todo panel, Ctrl+G external editor, Ctrl+R input-history
- * search, Ctrl+V clipboard image intake, Ctrl+Enter queue,
- * Enter submit, Esc cancel, Shift+Tab permission cycle, Alt+Up dequeue,
- * Alt+T thinking detail toggle). Every
- * reserved binding here must match a host `matchesKey(data, ...)` call;
- * when a new host lifecycle key lands, extend THIS list in the same
- * commit.
+ * The keys a PLUGIN can never claim (plan §11.3 — the Stable v1 plugin
+ * registration compatibility guard). This inventory is NOT the runtime
+ * source of truth: the InputRouter's runtime reservation is ACTION-driven
+ * (hostResolves — a key is reserved only while an ACTIVE host action
+ * binds it), and the user-orchestrable keymap (src/keybindings/
+ * definitions.ts) owns the effective keys. This list exists ONLY to
+ * reject plugin registrations on the host's DEFAULT lifecycle keys
+ * (Ctrl+C/D exit, Ctrl+S steer-all, Ctrl+F search, Ctrl+O expand, Ctrl+T
+ * todo, Ctrl+G external editor, Ctrl+R history search, Ctrl+V clipboard,
+ * Ctrl+Enter queue, Enter submit, Esc cancel, Shift+Tab permission,
+ * Alt+Up dequeue, Alt+T thinking, Alt+K dismiss). When a NEW default
+ * host lifecycle key lands, extend THIS list in the same commit so
+ * plugins cannot claim it; the runtime reservation needs no change (it
+ * follows the keymap).
  */
 export const RESERVED_HOST_KEYS: readonly NormalizedKey[] = [
   { key: 'c', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+C exit

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -29,6 +29,8 @@
  */
 
 import { describeKey, type NormalizedKey, type TuiAction, type TuiKeybindingContribution, type TuiKeybindingHandle, type TuiKeybindingRegistrySnapshot } from './extension/public-types.ts'
+import type { KeyId } from '@xmoon76/pi-tui'
+import { canonicalizeKeyId } from './keybindings/key-identity.ts'
 import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
 
 export { PROTECTED_HOST_ACTIONS }
@@ -95,6 +97,31 @@ function keyEquals(left: NormalizedKey, right: NormalizedKey): boolean {
     && left.shift === right.shift && left.super === right.super
 }
 
+/** Canonicalize a NORMALIZED key (the plugin public shape): collapse
+ * base-key aliases (esc→escape, return→enter) and order modifiers
+ * ctrl→shift→alt→super, so a plugin registering `esc` or `return` is
+ * found by the runtime's `escape`/`enter` lookups and duplicate
+ * detection sees one identity (convergence finding). The public
+ * NormalizedKey contract is unchanged. */
+function canonicalNormalizedKey(key: NormalizedKey): NormalizedKey {
+  const parts: string[] = []
+  if (key.ctrl) parts.push('ctrl')
+  if (key.shift) parts.push('shift')
+  if (key.alt) parts.push('alt')
+  if (key.super) parts.push('super')
+  parts.push(key.key)
+  const canonicalKeyId = canonicalizeKeyId(parts.join('+') as KeyId)
+  const canonicalParts = canonicalKeyId.split('+')
+  const base = canonicalParts[canonicalParts.length - 1]!
+  return {
+    key: base,
+    ctrl: canonicalParts.includes('ctrl'),
+    shift: canonicalParts.includes('shift'),
+    alt: canonicalParts.includes('alt'),
+    super: canonicalParts.includes('super'),
+  }
+}
+
 /**
  * The keybinding registry (metadata only until the InputRouter lands in
  * M6). One instance backs the runner; the extension service exposes
@@ -143,15 +170,16 @@ export class KeybindingRegistry {
         `keybinding for "${describeKey(contribution.key)}" is reserved by the host and cannot be claimed by a plugin`,
       )
     }
+    const canonicalKey = canonicalNormalizedKey(contribution.key)
     for (const record of this.records.values()) {
       if (record.disposed) continue
-      if (keyEquals(record.key, contribution.key)) {
-        throw new Error(`duplicate keybinding for "${describeKey(contribution.key)}" (owner "${record.owner}")`)
+      if (keyEquals(record.key, canonicalKey)) {
+        throw new Error(`duplicate keybinding for "${describeKey(canonicalKey)}" (owner "${record.owner}")`)
       }
     }
     this.records.set(contribution.id, {
       id: contribution.id,
-      key: contribution.key,
+      key: canonicalKey,
       action: contribution.action,
       description: contribution.description,
       owner,
@@ -184,18 +212,20 @@ export class KeybindingRegistry {
 
   /** The action bound to one normalized key, or undefined. */
   actionFor(key: NormalizedKey): TuiAction | undefined {
+    const canonical = canonicalNormalizedKey(key)
     for (const record of this.records.values()) {
       if (record.disposed) continue
-      if (keyEquals(record.key, key)) return record.action
+      if (keyEquals(record.key, canonical)) return record.action
     }
     return undefined
   }
 
   /** The contribution id bound to one normalized key, or undefined. */
   idFor(key: NormalizedKey): string | undefined {
+    const canonical = canonicalNormalizedKey(key)
     for (const record of this.records.values()) {
       if (record.disposed) continue
-      if (keyEquals(record.key, key)) return record.id
+      if (keyEquals(record.key, canonical)) return record.id
     }
     return undefined
   }

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -16,10 +16,22 @@
  *   registry REJECTS a reserved key loudly);
  * - unload removes the bindings (fiber-bound);
  * - duplicates are an explicit conflict error.
+ *
+ * Protected actions (plan §10): {@link PROTECTED_HOST_ACTIONS} is the
+ * action-level abstraction of the host's safety-critical set
+ * (app.exit.request / app.agent.interrupt / app.input.submit). The
+ * registry keeps the KEY-level reservation (RESERVED_HOST_KEYS) as the
+ * compatibility guard; a plugin binding a protected action to a NEW key
+ * is ADDITIVE (the host's own handler still executes — the runner routes
+ * the semantic action through the host paths), so it is allowed. The
+ * protected set is what the USER-config surface and the viewer guard use.
  * @module @xmoon76/dsh-pi-tui/keybinding-registry
  */
 
 import { describeKey, type NormalizedKey, type TuiAction, type TuiKeybindingContribution, type TuiKeybindingHandle, type TuiKeybindingRegistrySnapshot } from './extension/public-types.ts'
+import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
+
+export { PROTECTED_HOST_ACTIONS }
 
 
 /** Internal registration record. */

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -19,7 +19,7 @@
  * - reserved Host lifecycle keys cannot be claimed by a plugin (the
  *   registry REJECTS a reserved key loudly), and TEXT-PRODUCING keys
  *   (letters/digits/symbols/space — shift-only printables included,
- *   round-17 finding) and FORK EDITOR-owned keys (tab/arrows/home/end/
+ *   round-17 finding) and FORK EDITOR-owned keys (tab/arrows/Home/End/
  *   backspace/kill-yank/undo — round-19 finding) are rejected too (they
  *   never reach the plugin stage);
  * - unload removes the bindings (fiber-bound);
@@ -277,7 +277,7 @@ export class KeybindingRegistry {
     }
     // FORK EDITOR-OWNED REJECTION (round-19 finding): the InputRouter's
     // editorAccepts probe claims the fork editor's whole binding set for
-    // the focused editor on EVERY keystroke (tab, arrows, home/end, page
+    // the focused editor on EVERY keystroke (tab, arrows, Home/End, page
     // keys, backspace/delete, word moves, kill/yank/undo, newline — the
     // shared EDITOR_OWNED_KEY_IDS inventory), so a plugin registration
     // on one of these could never fire — yet it used to enter the

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -17,9 +17,10 @@
  *   Host-private `app.*` action and reach the Host dispatcher, round-12
  *   finding) — the host executes;
  * - reserved Host lifecycle keys cannot be claimed by a plugin (the
- *   registry REJECTS a reserved key loudly), and plain printable keys
- *   (letters, the spacebar) are rejected too (they never reach the
- *   plugin stage — round-12 finding);
+ *   registry REJECTS a reserved key loudly), and TEXT-PRODUCING keys
+ *   (letters/digits/symbols/space — shift-only printables included,
+ *   round-17 finding) are rejected too (they never reach the plugin
+ *   stage);
  * - unload removes the bindings (fiber-bound);
  * - duplicates are an explicit conflict error.
  *
@@ -38,7 +39,7 @@
 
 import { describeKey, type NormalizedKey, type TuiAction, type TuiKeybindingContribution, type TuiKeybindingHandle, type TuiKeybindingRegistrySnapshot } from './extension/public-types.ts'
 import type { KeyId } from '@xmoon76/pi-tui'
-import { canonicalizeKeyId } from './keybindings/key-identity.ts'
+import { canonicalizeKeyId, isTextProducingKeyId, isValidKeyId } from './keybindings/key-identity.ts'
 import { isLegacyCollisionKeyId } from './keybindings/config.ts'
 import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
 
@@ -64,16 +65,13 @@ export const TUI_ACTIONS: ReadonlySet<TuiAction> = new Set<TuiAction>([
   'cycle-permission',
 ])
 
-/** Whether a NORMALIZED key is a plain printable (a plugin binding for a
- * printable key would swallow typing — the router keeps printable keys
- * with the editor's text entry, so the binding could never fire; the
- * registration must be rejected, never advertised as an effective rule —
- * review finding). The `space` key name (the spacebar) is printable too.
- * Mirrors the InputRouter's isPrintableKey — both guards must agree. */
+/** Whether a NORMALIZED key is a plain printable — kept for callers of
+ * the registry module; the registration guard itself uses the SHARED
+ * {@link isTextProducingKeyId} policy (which also covers shift-only
+ * printables — Shift+A is text on every protocol, round-17 finding).
+ * Mirrors the InputRouter's text-producing guard: both must agree. */
 export function isPlainPrintableNormalizedKey(key: NormalizedKey): boolean {
-  if (key.ctrl || key.alt || key.shift || key.super) return false
-  if (key.key === 'space') return true
-  return key.key.length === 1 && key.key.charCodeAt(0) >= 32 && key.key.charCodeAt(0) <= 126
+  return isTextProducingKeyId(canonicalNormalizedKeyId(key))
 }
 
 
@@ -235,15 +233,28 @@ export class KeybindingRegistry {
     // `return` is bound to the reserved `escape`/`enter` and must be
     // rejected, not accepted under an alias spelling.
     const canonicalKey = canonicalNormalizedKey(contribution.key)
-    // PLAIN PRINTABLE REJECTION (review finding): the router keeps plain
-    // printable keys (and the spacebar) with the editor's text entry, so
-    // a plugin binding on one can never fire. Accepting it would
-    // advertise an "effective rule" that never executes — rejected here,
-    // mirroring the config parser's Host-side rule. Modified chords
-    // (ctrl+space) stay bindable — they really reach the plugin stage.
-    if (isPlainPrintableNormalizedKey(canonicalKey)) {
+    const canonicalKeyId = canonicalNormalizedKeyId(canonicalKey)
+    // KEY-ID GRAMMAR (round-17 finding): the runtime's only identity
+    // source is parseKey, which can never produce a non-grammar key name
+    // ('definitely-not-a-key', 'f13', ...) — a registration on one would
+    // be an advertised rule that can never fire. The registry shares the
+    // config parser's grammar policy.
+    if (!isValidKeyId(canonicalKeyId)) {
       throw new Error(
-        `keybinding for "${describeKey(canonicalKey)}" is a plain printable key and cannot be bound by a plugin (it would never reach the plugin stage)`,
+        `keybinding key "${describeKey(canonicalKey)}" is not a valid key name (the host grammar cannot produce it)`,
+      )
+    }
+    // TEXT-PRODUCING REJECTION (review findings): the router keeps text-
+    // producing keys with the editor's text entry — bare letters, digits,
+    // symbols and the spacebar, WITH OR WITHOUT Shift (Shift+A is the raw
+    // 'A' byte on legacy terminals and 'a'+shift on Kitty — either way it
+    // produces text, round-17 finding). Accepting such a registration
+    // would advertise an "effective rule" that never executes (or steals
+    // typing on some terminals). Named keys (shift+tab, shift+left, f-keys,
+    // ...) are NOT text-producing and stay bindable.
+    if (isTextProducingKeyId(canonicalKeyId)) {
+      throw new Error(
+        `keybinding for "${describeKey(canonicalKey)}" is a text-producing key and cannot be bound by a plugin (it would steal the user's text input)`,
       )
     }
     // LEGACY C0 COLLISION REJECTION (round-13 finding): the registry
@@ -253,7 +264,7 @@ export class KeybindingRegistry {
     // such a registration (matchesKey accepts the raw byte), but the
     // router's plugin stage normalizes \t to `tab` and could never match
     // it — an advertised plugin rule that can never fire.
-    if (isLegacyCollisionKeyId(canonicalNormalizedKeyId(canonicalKey))) {
+    if (isLegacyCollisionKeyId(canonicalKeyId)) {
       throw new Error(
         `keybinding for "${describeKey(canonicalKey)}" collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ and Ctrl+- are one key) and cannot be claimed by a plugin`,
       )

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -165,12 +165,16 @@ export class KeybindingRegistry {
       throw new Error(`duplicate keybinding id "${contribution.id}"`)
     }
     if (contribution.key.key === '') throw new Error('keybinding key must not be empty')
-    if (isReservedHostKey(contribution.key)) {
+    // CANONICALIZE FIRST (convergence finding): the reserved-key check
+    // must see the canonical identity — a plugin registering `esc` or
+    // `return` is bound to the reserved `escape`/`enter` and must be
+    // rejected, not accepted under an alias spelling.
+    const canonicalKey = canonicalNormalizedKey(contribution.key)
+    if (isReservedHostKey(canonicalKey)) {
       throw new Error(
-        `keybinding for "${describeKey(contribution.key)}" is reserved by the host and cannot be claimed by a plugin`,
+        `keybinding for "${describeKey(canonicalKey)}" is reserved by the host and cannot be claimed by a plugin`,
       )
     }
-    const canonicalKey = canonicalNormalizedKey(contribution.key)
     for (const record of this.records.values()) {
       if (record.disposed) continue
       if (keyEquals(record.key, canonicalKey)) {

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -1,10 +1,11 @@
 /**
- * The keybinding registry (M5, plan §10 item 5): plugin keybinding
- * METADATA only — the actual routing is Host-owned (the InputRouter, M6).
- * A plugin declares a normalized key + a semantic ACTION; the host maps
- * actions to its own execution paths. The registry stores the declared
- * bindings; the InputRouter (M6) resolves them against the fixed
- * precedence ladder.
+ * The keybinding registry (M5, plan §10 item 5): the Stable plugin
+ * keybinding REGISTRATION boundary — a plugin declares a normalized key
+ * + a public semantic ACTION; the registry validates, canonicalizes and
+ * stores it, and the live InputRouter (M6) resolves raw input against
+ * it (`actionFor`). The routing precedence itself stays Host-owned (the
+ * InputRouter ladder), and the runner syncs the registry snapshot into
+ * the effective keymap (plugin rules, lowest priority).
  *
  * Contract (plan §11):
  * - keys are NORMALIZED (the host's key identity — never raw escape
@@ -38,6 +39,7 @@
 import { describeKey, type NormalizedKey, type TuiAction, type TuiKeybindingContribution, type TuiKeybindingHandle, type TuiKeybindingRegistrySnapshot } from './extension/public-types.ts'
 import type { KeyId } from '@xmoon76/pi-tui'
 import { canonicalizeKeyId } from './keybindings/key-identity.ts'
+import { isLegacyCollisionKeyId } from './keybindings/config.ts'
 import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
 
 export { PROTECTED_HOST_ACTIONS }
@@ -112,10 +114,13 @@ export const RESERVED_HOST_KEYS: readonly NormalizedKey[] = [
   { key: 'g', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+G external editor
   { key: 'r', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+R input-history search
   { key: 'v', ctrl: true, alt: false, shift: false, super: false },     // Ctrl+V clipboard image intake
-  // Ctrl+J is deliberately NOT reserved/bound: legacy terminals send it
-  // as LF, which the editor treats as Enter, so the chord was unreliable
-  // in practice — the task browser is reached via ↓ (empty editor) and
-  // `/tasks` instead, and a plugin may bind Ctrl+J itself.
+  // Ctrl+J is deliberately NOT reserved: legacy terminals send it as LF,
+  // which the editor treats as Enter, so the chord was unreliable in
+  // practice — the task browser is reached via ↓ (empty editor) and
+  // `/tasks` instead. The LEGACY-COLLISION policy (shared with the config
+  // parser — isLegacyCollisionKeyId) rejects a plugin registration on it
+  // anyway: on a legacy terminal the byte IS Enter, so the binding could
+  // never fire through the router's normalized lookup (round-13 finding).
   { key: 'enter', ctrl: true, alt: false, shift: false, super: false }, // Ctrl+Enter queue
   { key: 'enter', ctrl: false, alt: false, shift: false, super: false }, // Enter submit
   { key: 'escape', ctrl: false, alt: false, shift: false, super: false }, // Esc cancel
@@ -136,6 +141,20 @@ function keyEquals(left: NormalizedKey, right: NormalizedKey): boolean {
     && left.shift === right.shift && left.super === right.super
 }
 
+/** The CANONICAL KeyId of one normalized key (modifiers in the fixed
+ * ctrl→shift→alt→super order, base aliases collapsed). The single
+ * identity used by duplicate detection, the reserved/printable/legacy
+ * policy checks and the runtime lookups. */
+function canonicalNormalizedKeyId(key: NormalizedKey): KeyId {
+  const parts: string[] = []
+  if (key.ctrl) parts.push('ctrl')
+  if (key.shift) parts.push('shift')
+  if (key.alt) parts.push('alt')
+  if (key.super) parts.push('super')
+  parts.push(key.key)
+  return canonicalizeKeyId(parts.join('+') as KeyId)
+}
+
 /** Canonicalize a NORMALIZED key (the plugin public shape): collapse
  * base-key aliases (esc→escape, return→enter) and order modifiers
  * ctrl→shift→alt→super, so a plugin registering `esc` or `return` is
@@ -143,13 +162,7 @@ function keyEquals(left: NormalizedKey, right: NormalizedKey): boolean {
  * detection sees one identity (convergence finding). The public
  * NormalizedKey contract is unchanged. */
 function canonicalNormalizedKey(key: NormalizedKey): NormalizedKey {
-  const parts: string[] = []
-  if (key.ctrl) parts.push('ctrl')
-  if (key.shift) parts.push('shift')
-  if (key.alt) parts.push('alt')
-  if (key.super) parts.push('super')
-  parts.push(key.key)
-  const canonicalKeyId = canonicalizeKeyId(parts.join('+') as KeyId)
+  const canonicalKeyId = canonicalNormalizedKeyId(key)
   const canonicalParts = canonicalKeyId.split('+')
   const base = canonicalParts[canonicalParts.length - 1]!
   return {
@@ -162,9 +175,11 @@ function canonicalNormalizedKey(key: NormalizedKey): NormalizedKey {
 }
 
 /**
- * The keybinding registry (metadata only until the InputRouter lands in
- * M6). One instance backs the runner; the extension service exposes
- * registration; the InputRouter consults {@link actionFor}.
+ * The keybinding registry: the Stable registration boundary (M5) whose
+ * records feed the LIVE InputRouter lookups and the runner's effective-
+ * keymap plugin rules (M6). One instance backs the runner; the extension
+ * service exposes registration; the InputRouter consults
+ * {@link actionFor}.
  */
 export class KeybindingRegistry {
   private readonly records = new Map<string, BindingRecord>()
@@ -229,6 +244,18 @@ export class KeybindingRegistry {
     if (isPlainPrintableNormalizedKey(canonicalKey)) {
       throw new Error(
         `keybinding for "${describeKey(canonicalKey)}" is a plain printable key and cannot be bound by a plugin (it would never reach the plugin stage)`,
+      )
+    }
+    // LEGACY C0 COLLISION REJECTION (round-13 finding): the registry
+    // shares the config parser's legacy inventory — on a legacy terminal
+    // ctrl+i IS the Tab byte, ctrl+h the Backspace byte and ctrl+_ the
+    // 0x1f byte shared with ctrl+-. The EffectiveKeymap would resolve
+    // such a registration (matchesKey accepts the raw byte), but the
+    // router's plugin stage normalizes \t to `tab` and could never match
+    // it — an advertised plugin rule that can never fire.
+    if (isLegacyCollisionKeyId(canonicalNormalizedKeyId(canonicalKey))) {
+      throw new Error(
+        `keybinding for "${describeKey(canonicalKey)}" collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ and Ctrl+- are one key) and cannot be claimed by a plugin`,
       )
     }
     if (isReservedHostKey(canonicalKey)) {

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -19,8 +19,9 @@
  * - reserved Host lifecycle keys cannot be claimed by a plugin (the
  *   registry REJECTS a reserved key loudly), and TEXT-PRODUCING keys
  *   (letters/digits/symbols/space — shift-only printables included,
- *   round-17 finding) are rejected too (they never reach the plugin
- *   stage);
+ *   round-17 finding) and FORK EDITOR-owned keys (tab/arrows/home/end/
+ *   backspace/kill-yank/undo — round-19 finding) are rejected too (they
+ *   never reach the plugin stage);
  * - unload removes the bindings (fiber-bound);
  * - duplicates are an explicit conflict error.
  *
@@ -39,7 +40,7 @@
 
 import { describeKey, type NormalizedKey, type TuiAction, type TuiKeybindingContribution, type TuiKeybindingHandle, type TuiKeybindingRegistrySnapshot } from './extension/public-types.ts'
 import type { KeyId } from '@xmoon76/pi-tui'
-import { canonicalizeKeyId, isTextProducingKeyId, isValidKeyId } from './keybindings/key-identity.ts'
+import { canonicalizeKeyId, isEditorOwnedKeyId, isTextProducingKeyId, isValidKeyId } from './keybindings/key-identity.ts'
 import { isLegacyCollisionKeyId } from './keybindings/config.ts'
 import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
 
@@ -272,6 +273,19 @@ export class KeybindingRegistry {
     if (isReservedHostKey(canonicalKey)) {
       throw new Error(
         `keybinding for "${describeKey(canonicalKey)}" is reserved by the host and cannot be claimed by a plugin`,
+      )
+    }
+    // FORK EDITOR-OWNED REJECTION (round-19 finding): the InputRouter's
+    // editorAccepts probe claims the fork editor's whole binding set for
+    // the focused editor on EVERY keystroke (tab, arrows, home/end, page
+    // keys, backspace/delete, word moves, kill/yank/undo, newline — the
+    // shared EDITOR_OWNED_KEY_IDS inventory), so a plugin registration
+    // on one of these could never fire — yet it used to enter the
+    // effective keymap, appear in /keybindings and even disable a
+    // colliding leader. Rejected at the registration boundary.
+    if (isEditorOwnedKeyId(canonicalKeyId)) {
+      throw new Error(
+        `keybinding for "${describeKey(canonicalKey)}" is an editor-owned key and cannot be bound by a plugin (the focused editor consumes it first)`,
       )
     }
     for (const record of this.records.values()) {

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -9,11 +9,16 @@
  * Contract (plan §11):
  * - keys are NORMALIZED (the host's key identity — never raw escape
  *   sequences; a plugin can never interpret terminal bytes);
- * - actions are SEMANTIC (the plan's action list: submit-draft,
- *   queue-draft, steer-draft, cancel-activity, open-search,
- *   toggle-fullscreen, cycle-permission, ...) — the host executes;
+ * - actions are SEMANTIC and WHITELISTED (the public `TuiAction` set —
+ *   submit-draft, queue-draft, steer-draft, cancel-activity, open-search,
+ *   toggle-fullscreen, cycle-permission — enforced at RUNTIME by
+ *   {@link TUI_ACTIONS}: a JS/`as any` plugin can never register a
+ *   Host-private `app.*` action and reach the Host dispatcher, round-12
+ *   finding) — the host executes;
  * - reserved Host lifecycle keys cannot be claimed by a plugin (the
- *   registry REJECTS a reserved key loudly);
+ *   registry REJECTS a reserved key loudly), and plain printable keys
+ *   (letters, the spacebar) are rejected too (they never reach the
+ *   plugin stage — round-12 finding);
  * - unload removes the bindings (fiber-bound);
  * - duplicates are an explicit conflict error.
  *
@@ -21,10 +26,12 @@
  * action-level abstraction of the host's safety-critical set
  * (app.exit.request / app.agent.interrupt / app.input.submit). The
  * registry keeps the KEY-level reservation (RESERVED_HOST_KEYS) as the
- * compatibility guard; a plugin binding a protected action to a NEW key
- * is ADDITIVE (the host's own handler still executes — the runner routes
- * the semantic action through the host paths), so it is allowed. The
- * protected set is what the USER-config surface and the viewer guard use.
+ * compatibility guard. The ACTION whitelist is the other half of the
+ * boundary: the protected `app.*` actions are HOST-PRIVATE and are never
+ * plugin-bindable — a plugin may only trigger the public semantic
+ * actions, which the runner routes through the host's own execution
+ * paths (round-12 finding). The protected set is what the USER-config
+ * surface and the viewer guard use.
  * @module @xmoon76/dsh-pi-tui/keybinding-registry
  */
 
@@ -34,6 +41,38 @@ import { canonicalizeKeyId } from './keybindings/key-identity.ts'
 import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
 
 export { PROTECTED_HOST_ACTIONS }
+
+/** The PUBLIC semantic actions a Stable plugin may trigger (the
+ * `TuiAction` union — the extension API's capability boundary). The
+ * runner's `onExtensionAction` switch executes exactly these; the HOST
+ * `app.*` actions are private to the Host and are NEVER reachable from a
+ * plugin-registered action string (review finding: the registry had no
+ * runtime action whitelist, so a JS/`as any` plugin could register
+ * `app.exit.request` and the plugin-owned winner would then enter the
+ * Host dispatcher — the AppActionDispatcher must never execute a
+ * plugin-supplied string). Kept in sync with `TuiAction` in
+ * extension/public-types.ts. */
+export const TUI_ACTIONS: ReadonlySet<TuiAction> = new Set<TuiAction>([
+  'submit-draft',
+  'queue-draft',
+  'steer-draft',
+  'cancel-activity',
+  'open-search',
+  'toggle-fullscreen',
+  'cycle-permission',
+])
+
+/** Whether a NORMALIZED key is a plain printable (a plugin binding for a
+ * printable key would swallow typing — the router keeps printable keys
+ * with the editor's text entry, so the binding could never fire; the
+ * registration must be rejected, never advertised as an effective rule —
+ * review finding). The `space` key name (the spacebar) is printable too.
+ * Mirrors the InputRouter's isPrintableKey — both guards must agree. */
+export function isPlainPrintableNormalizedKey(key: NormalizedKey): boolean {
+  if (key.ctrl || key.alt || key.shift || key.super) return false
+  if (key.key === 'space') return true
+  return key.key.length === 1 && key.key.charCodeAt(0) >= 32 && key.key.charCodeAt(0) <= 126
+}
 
 
 /** Internal registration record. */
@@ -165,11 +204,33 @@ export class KeybindingRegistry {
       throw new Error(`duplicate keybinding id "${contribution.id}"`)
     }
     if (contribution.key.key === '') throw new Error('keybinding key must not be empty')
+    // THE ACTION WHITELIST (review finding): only the PUBLIC TuiAction set
+    // may be registered. A Host-private `app.*` action string would be
+    // routed to the Host dispatcher by the plugin-owned winner — a Stable
+    // plugin must never trigger a Host-private semantic action. The
+    // TuiAction TYPE enforces this at compile time; this is the RUNTIME
+    // enforcement for JS plugins / `as any` callers.
+    if (!TUI_ACTIONS.has(contribution.action)) {
+      throw new Error(
+        `keybinding action "${contribution.action}" is not a public TuiAction (a Stable plugin may only trigger the public semantic actions)`,
+      )
+    }
     // CANONICALIZE FIRST (convergence finding): the reserved-key check
     // must see the canonical identity — a plugin registering `esc` or
     // `return` is bound to the reserved `escape`/`enter` and must be
     // rejected, not accepted under an alias spelling.
     const canonicalKey = canonicalNormalizedKey(contribution.key)
+    // PLAIN PRINTABLE REJECTION (review finding): the router keeps plain
+    // printable keys (and the spacebar) with the editor's text entry, so
+    // a plugin binding on one can never fire. Accepting it would
+    // advertise an "effective rule" that never executes — rejected here,
+    // mirroring the config parser's Host-side rule. Modified chords
+    // (ctrl+space) stay bindable — they really reach the plugin stage.
+    if (isPlainPrintableNormalizedKey(canonicalKey)) {
+      throw new Error(
+        `keybinding for "${describeKey(canonicalKey)}" is a plain printable key and cannot be bound by a plugin (it would never reach the plugin stage)`,
+      )
+    }
     if (isReservedHostKey(canonicalKey)) {
       throw new Error(
         `keybinding for "${describeKey(canonicalKey)}" is reserved by the host and cannot be claimed by a plugin`,

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -41,7 +41,7 @@
 import { describeKey, type NormalizedKey, type TuiAction, type TuiKeybindingContribution, type TuiKeybindingHandle, type TuiKeybindingRegistrySnapshot } from './extension/public-types.ts'
 import type { KeyId } from '@xmoon76/pi-tui'
 import { canonicalizeKeyId, isEditorOwnedKeyId, isTextProducingKeyId, isValidKeyId } from './keybindings/key-identity.ts'
-import { isLegacyCollisionKeyId } from './keybindings/config.ts'
+import { isTerminalAmbiguousKeyId } from './keybindings/config.ts'
 import { PROTECTED_HOST_ACTIONS } from './keybindings/definitions.ts'
 
 export { PROTECTED_HOST_ACTIONS }
@@ -117,7 +117,7 @@ export const RESERVED_HOST_KEYS: readonly NormalizedKey[] = [
   // which the editor treats as Enter, so the chord was unreliable in
   // practice — the task browser is reached via ↓ (empty editor) and
   // `/tasks` instead. The LEGACY-COLLISION policy (shared with the config
-  // parser — isLegacyCollisionKeyId) rejects a plugin registration on it
+  // parser — isTerminalAmbiguousKeyId) rejects a plugin registration on it
   // anyway: on a legacy terminal the byte IS Enter, so the binding could
   // never fire through the router's normalized lookup (round-13 finding).
   { key: 'enter', ctrl: true, alt: false, shift: false, super: false }, // Ctrl+Enter queue
@@ -265,9 +265,9 @@ export class KeybindingRegistry {
     // such a registration (matchesKey accepts the raw byte), but the
     // router's plugin stage normalizes \t to `tab` and could never match
     // it — an advertised plugin rule that can never fire.
-    if (isLegacyCollisionKeyId(canonicalKeyId)) {
+    if (isTerminalAmbiguousKeyId(canonicalKeyId)) {
       throw new Error(
-        `keybinding for "${describeKey(canonicalKey)}" collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ and Ctrl+- are one key) and cannot be claimed by a plugin`,
+        `keybinding for "${describeKey(canonicalKey)}" collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ and Ctrl+- are one key; Ctrl+Backspace is Backspace on legacy, Ctrl+Backspace on Windows Terminal) and cannot be claimed by a plugin`,
       )
     }
     if (isReservedHostKey(canonicalKey)) {

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -245,13 +245,14 @@ export class KeybindingRegistry {
         `keybinding key "${describeKey(canonicalKey)}" is not a valid key name (the host grammar cannot produce it)`,
       )
     }
-    // RUNTIME-BINDABLE GATE (round-22 finding): the fork matcher can
-    // never match a modified F-key or modified Escape (keys.ts:
-    // `modifier !== 0` → false), so the registration would be an
+    // RUNTIME-BINDABLE GATE (round-22/24 finding): the fork matcher can
+    // never match certain modifier combinations (F-keys/Escape take no
+    // modifiers — keys.ts `modifier !== 0` → false; Clear takes only
+    // Shift/Ctrl — no CSI-u fallback), so the registration would be an
     // advertised rule that can never fire on any terminal protocol.
     if (!isRuntimeBindableKeyId(canonicalKeyId)) {
       throw new Error(
-        `keybinding for "${describeKey(canonicalKey)}" can never be matched by the runtime (modified F-keys and Escape are unsupported)`,
+        `keybinding for "${describeKey(canonicalKey)}" can never be matched by the runtime (F-keys and Escape take no modifiers; Clear takes only Shift/Ctrl)`,
       )
     }
     // TEXT-PRODUCING REJECTION (review findings): the router keeps text-

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -104,9 +104,27 @@ export class KeybindingRegistry {
   private readonly records = new Map<string, BindingRecord>()
   private revision = 0
   private readonly onInvalidate: () => void
+  /** Change listeners: invoked on EVERY register/dispose/disposeOwner
+   * AFTER the repaint invalidation — consumers (the runner's
+   * HostKeybindingManager sync) resync the effective keymap so plugin
+   * bindings registered after mount fire and unloaded ones stop
+   * (convergence finding: the initial snapshot sync is not enough). */
+  private readonly listeners = new Set<() => void>()
 
   constructor(onInvalidate: () => void = () => {}) {
     this.onInvalidate = onInvalidate
+  }
+
+  /** Subscribe to keybinding set changes (register/dispose/unload). The
+   * listener is called after every mutation; returns an unsubscribe. */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => { this.listeners.delete(listener) }
+  }
+
+  private notifyChanged(): void {
+    this.onInvalidate()
+    for (const listener of this.listeners) listener()
   }
 
   /**
@@ -140,7 +158,7 @@ export class KeybindingRegistry {
       disposed: false,
     })
     this.revision += 1
-    this.onInvalidate()
+    this.notifyChanged()
     return {
       id: contribution.id,
       dispose: () => this.dispose(contribution.id),
@@ -154,7 +172,7 @@ export class KeybindingRegistry {
     record.disposed = true
     this.records.delete(id)
     this.revision += 1
-    this.onInvalidate()
+    this.notifyChanged()
   }
 
   /** Dispose every binding owned by one fiber (owner unload). */

--- a/src/keybindings/action-dispatcher.ts
+++ b/src/keybindings/action-dispatcher.ts
@@ -1,0 +1,149 @@
+/**
+ * The AppActionDispatcher (plan §9): the semantic routing layer between a
+ * resolved action and the Host's business methods.
+ *
+ * ```text
+ * resolver 决定“是什么意思”
+ * dispatcher 决定“怎么执行”
+ * ```
+ *
+ * The dispatcher NEVER re-implements business state — it calls the Host
+ * methods (submitDraft, steerDraft, …) which already own the guards. A
+ * host method returns `true` when it consumed the key, `false` when the
+ * key must fall through (e.g. pasteMedia without a clipboard handler).
+ * @module @xmoon76/dsh-pi-tui/keybindings/action-dispatcher
+ */
+
+import type { KeyId } from '@xmoon76/pi-tui'
+import type { AppKeybindingId } from './types.ts'
+
+/** The Host business surface the dispatcher routes to. Every method
+ * returns whether the key was consumed (false lets the input fall through
+ * to the editor/plugin stages). */
+export interface AppActionHost {
+  /** Submit the draft (forceQueue = the Ctrl+Enter parity). */
+  submitDraft(forceQueue?: boolean): boolean
+  /** Steer the running agent with the draft. */
+  steerDraft(): boolean
+  /** Pull queued input back into the editor. */
+  dequeueDraft(): boolean
+  /** Interrupt the current activity (the Esc path). */
+  interruptActivity(): boolean
+  /** Request TUI exit (the Ctrl+C chord / Ctrl+D path). */
+  requestExit(key: KeyId): boolean
+  /** Open the transcript search overlay. */
+  openTranscriptSearch(): boolean
+  /** Close the transcript search overlay. */
+  closeTranscriptSearch(): boolean
+  /** Jump to the next search match. */
+  searchNext(): boolean
+  /** Jump to the previous search match. */
+  searchPrevious(): boolean
+  /** Toggle the transcript/tool expansion master switch. */
+  toggleTranscriptExpand(): boolean
+  /** Toggle thinking visibility. */
+  toggleThinking(): boolean
+  /** Toggle fullscreen mode. */
+  toggleFullscreen(): boolean
+  /** Toggle the todo panel. */
+  toggleTodo(): boolean
+  /** Cycle the permission preset. */
+  cyclePermission(): boolean
+  /** Open the external editor with the current draft. */
+  openExternalEditor(): boolean
+  /** Paste media from the clipboard (false = no handler, fall through). */
+  pasteMedia(): boolean
+  /** Open the task browser. */
+  openTasks(): boolean
+  /** Open the input-history search panel. */
+  openHistorySearch(): boolean
+  /** Dismiss settled local shell cards. */
+  dismissSettledShell(): boolean
+}
+
+/** The semantic action → Host method router. */
+export class AppActionDispatcher {
+  private readonly host: AppActionHost
+
+  constructor(host: AppActionHost) {
+    this.host = host
+  }
+
+  /** Dispatch one resolved action. Returns whether the key was consumed.
+   * @param action - the resolved semantic action.
+   * @param key - the physical key that resolved (the exit path needs it:
+   *   Ctrl+C uses the clear-then-exit chord, every other key exits
+   *   immediately). */
+  dispatch(action: AppKeybindingId, key?: KeyId): boolean {
+    switch (action) {
+      case 'app.input.submit':
+        return this.host.submitDraft(false)
+      case 'app.input.queue':
+        return this.host.submitDraft(true)
+      case 'app.input.steer':
+        return this.host.steerDraft()
+      case 'app.input.dequeue':
+        return this.host.dequeueDraft()
+      case 'app.agent.interrupt':
+        return this.host.interruptActivity()
+      case 'app.exit.request':
+        return this.host.requestExit(key ?? 'enter')
+      case 'app.transcript.search':
+        return this.host.openTranscriptSearch()
+      case 'app.transcript.search.next':
+        return this.host.searchNext()
+      case 'app.transcript.search.previous':
+        return this.host.searchPrevious()
+      case 'app.transcript.search.close':
+        return this.host.closeTranscriptSearch()
+      case 'app.transcript.toggleExpand':
+        return this.host.toggleTranscriptExpand()
+      case 'app.transcript.toggleThinking':
+        return this.host.toggleThinking()
+      case 'app.transcript.toggleFullscreen':
+        return this.host.toggleFullscreen()
+      case 'app.todo.toggle':
+        return this.host.toggleTodo()
+      case 'app.permission.cycle':
+        return this.host.cyclePermission()
+      case 'app.editor.external':
+        return this.host.openExternalEditor()
+      case 'app.clipboard.pasteMedia':
+        return this.host.pasteMedia()
+      case 'app.tasks.open':
+        return this.host.openTasks()
+      case 'app.history.search':
+        return this.host.openHistorySearch()
+      case 'app.shell.dismissSettled':
+        return this.host.dismissSettledShell()
+      // Reserved session/model actions have no host wiring yet (plan §3.2):
+      // resolving one is a no-op (the key is consumed — the user bound it
+      // deliberately, and a silent fall-through would be surprising).
+      case 'app.session.open':
+      case 'app.session.new':
+      case 'app.session.resume':
+      case 'app.model.open':
+        return true
+      // Focused-component actions never reach the HOST dispatcher (their
+      // components own them); a stray resolution is a no-op.
+      case 'question.confirm':
+      case 'question.cancel':
+      case 'question.previous':
+      case 'question.next':
+      case 'question.cursorUp':
+      case 'question.cursorDown':
+      case 'question.pageUp':
+      case 'question.pageDown':
+      case 'question.toggleExpand':
+      case 'tasks.confirm':
+      case 'tasks.cancel':
+      case 'tasks.cursorUp':
+      case 'tasks.cursorDown':
+      case 'tasks.pageUp':
+      case 'tasks.pageDown':
+      case 'tasks.cycleType':
+      case 'tasks.interrupt':
+        return true
+    }
+  }
+}

--- a/src/keybindings/action-dispatcher.ts
+++ b/src/keybindings/action-dispatcher.ts
@@ -3,8 +3,8 @@
  * resolved action and the Host's business methods.
  *
  * ```text
- * resolver 决定“是什么意思”
- * dispatcher 决定“怎么执行”
+ * the resolver decides what the input MEANS
+ * the dispatcher decides how it EXECUTES
  * ```
  *
  * The dispatcher NEVER re-implements business state — it calls the Host

--- a/src/keybindings/component-keymap.ts
+++ b/src/keybindings/component-keymap.ts
@@ -1,0 +1,41 @@
+/**
+ * The focused-component keymap (plan §3.3/§5 M5): a tiny read-only keymap
+ * for components that own their input while focused (QuestionFlow,
+ * TaskBrowserPanel). The component actions are non-configurable in the
+ * first version, so the effective keys ARE the definition defaults — the
+ * component never hard-codes a physical key, and a future M4 opening of
+ * component actions only needs to swap this class for the full manager.
+ *
+ * Component-local printable keys (h/j/k/l/e/i/digits) stay component
+ * logic — they only exist while the component owns the seat (plan §14).
+ * @module @xmoon76/dsh-pi-tui/keybindings/component-keymap
+ */
+
+import { matchesKey, type KeyId } from '@xmoon76/pi-tui'
+import { APP_KEYBINDINGS } from './definitions.ts'
+import { formatKeyId } from './hints.ts'
+import type { AppKeybindingId } from './types.ts'
+
+/** The read-only component keymap. */
+export class ComponentKeymap {
+  /** Whether the raw event matches one component action's default keys. */
+  matches(data: string, action: AppKeybindingId): boolean {
+    const definition = APP_KEYBINDINGS[action]
+    if (definition === undefined) return false
+    return definition.defaultKeys.some(key => matchesKey(data, key))
+  }
+
+  /** The default keys of one component action. */
+  keysFor(action: AppKeybindingId): KeyId[] {
+    return [...(APP_KEYBINDINGS[action]?.defaultKeys ?? [])]
+  }
+
+  /** The human hint for one component action. */
+  keyHint(action: AppKeybindingId): string {
+    const keys = this.keysFor(action)
+    return keys.length === 0 ? '' : keys.map(formatKeyId).join(' / ')
+  }
+}
+
+/** The shared instance (the component keymaps are stateless). */
+export const componentKeymap = new ComponentKeymap()

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -28,7 +28,7 @@
  */
 
 import type { KeyId } from '@xmoon76/pi-tui'
-import { canonicalizeKeyId } from './key-identity.ts'
+import { canonicalizeKeyId, isTextProducingKeyId, isValidKeyId } from './key-identity.ts'
 import { APP_KEYBINDINGS, NON_CONFIGURABLE_ACTIONS } from './definitions.ts'
 import type { AppKeybindingId, LeaderBinding, LeaderConfig, UserKeybindingValue, UserKeybindingsConfig } from './types.ts'
 
@@ -39,21 +39,10 @@ const BINDINGS_KEY = 'bindings'
 /** The leader sequence marker (`<leader>t`). */
 export const LEADER_PREFIX = '<leader>'
 
-/** The base keys the fork's KeyId grammar accepts (keys.ts). */
-const BASE_KEYS = new Set([
-  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-  '`', '-', '=', '[', ']', '\\', ';', "'", ',', '.', '/', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '|', '~', '{', '}', ':', '<', '>', '?',
-  'escape', 'esc', 'enter', 'return', 'tab', 'space', 'backspace', 'delete', 'insert', 'clear',
-  'home', 'end', 'pageUp', 'pageDown', 'up', 'down', 'left', 'right',
-  'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12',
-])
-
-const MODIFIERS = new Set(['ctrl', 'shift', 'alt', 'super'])
-
-/** Case-insensitive view of the base-key grammar: `pageUp` and `pageup`
- * are the SAME physical key (the canonical identity is lowercase). */
-const BASE_KEYS_LOWER = new Set([...BASE_KEYS].map(key => key.toLowerCase()))
+/** The fork's KeyId grammar (moved to key-identity.ts — the SHARED
+ * policy of the config parser and the plugin registry; re-exported here
+ * for callers of the parser module). */
+export { isValidKeyId }
 
 /** The FORK EDITOR's UNCONDITIONAL pre-submit keys (packages/pi-tui
  * TUI_KEYBINDINGS + components/editor.ts handleInput): the editor
@@ -89,31 +78,12 @@ const EDITOR_PRE_SUBMIT_KEYS = new Set([
 ].map(key => canonicalizeKeyId(key as KeyId)),
 )
 
-/** Whether a string is a valid KeyId (the fork's grammar). */
-export function isValidKeyId(value: string): value is KeyId {
-  if (value === '') return false
-  const parts = value.split('+')
-  if (parts.length === 0) return false
-  const base = parts[parts.length - 1]!
-  // Named keys are CASE-INSENSITIVE at parse time: the fork grammar
-  // spells pageUp/pageDown with camelCase, but the canonical identity is
-  // lowercase (pageup) — accept either spelling (convergence: one
-  // physical key has one canonical identity).
-  if (!BASE_KEYS.has(base) && !BASE_KEYS_LOWER.has(base.toLowerCase())) return false
-  for (let index = 0; index < parts.length - 1; index += 1) {
-    if (!MODIFIERS.has(parts[index]!)) return false
-  }
-  // No duplicate modifiers.
-  return new Set(parts.slice(0, -1)).size === parts.length - 1
-}
-
-/** Whether a key is a plain printable (plan §14: a direct user binding of
- * a plain printable to a Host action would swallow typing). Unmodified
- * single characters (32–126) AND the `space` key name (the fork alias for
- * the spacebar, which types char 32 — a bare `space` binding would swallow
- * every space the user types) are printable; everything with a modifier,
- * a named editing key (enter/tab/escape/arrows/f-keys) or a multi-char
- * sequence is not. */
+/** Whether a key is a PLAIN (unmodified) printable — the strict subset of
+ * {@link isTextProducingKeyId} with no modifier at all (plan §14). The
+ * parser rejects the BROADER text-producing set (shift-only printables
+ * included — round-17 finding: Shift+A is the raw 'A' byte on legacy
+ * terminals, so a Host binding on it would steal typing); this helper is
+ * kept for the exact "no modifier" classification. */
 export function isPlainPrintableKey(key: KeyId): boolean {
   if (key.includes('+')) return false
   if (key === 'space') return true
@@ -211,8 +181,8 @@ export function parseUserKeybindings(
   if (leaderValue !== undefined) {
     if (typeof leaderValue === 'string' && isValidKeyId(leaderValue)) {
       const canonicalLeader = canonicalizeKeyId(leaderValue as KeyId)
-      if (isPlainPrintableKey(canonicalLeader)) {
-        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a plain printable leader would swallow typing — ignored`)
+      if (isTextProducingKeyId(canonicalLeader)) {
+        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a text-producing leader would swallow typing — ignored`)
       } else if (LEGACY_COLLISION_KEY_IDS.has(canonicalLeader)) {
         // Legacy terminal collisions are REJECTED for the leader prefix too
         // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
@@ -314,8 +284,8 @@ export function parseUserKeybindings(
       // never bypass the printable guard or the collision sets — the raw
       // spelling is only used in the diagnostic text.
       const canonicalEntry = canonicalizeKeyId(entry as KeyId)
-      if (isPlainPrintableKey(canonicalEntry)) {
-        diagnostics.push(`keybindings: "${actionId}" cannot bind the plain printable key "${entry}" to a Host action — ignored`)
+      if (isTextProducingKeyId(canonicalEntry)) {
+        diagnostics.push(`keybindings: "${actionId}" cannot bind the text-producing key "${entry}" to a Host action — ignored`)
         continue
       }
       // Shift+Enter is the fork editor's FIXED newline key (tui.input

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -64,9 +64,15 @@ export function isValidKeyId(value: string): value is KeyId {
 }
 
 /** Whether a key is a plain printable (plan §14: a direct user binding of
- * a plain printable to a Host action would swallow typing). */
+ * a plain printable to a Host action would swallow typing). Unmodified
+ * single characters (32–126) AND the `space` key name (the fork alias for
+ * the spacebar, which types char 32 — a bare `space` binding would swallow
+ * every space the user types) are printable; everything with a modifier,
+ * a named editing key (enter/tab/escape/arrows/f-keys) or a multi-char
+ * sequence is not. */
 export function isPlainPrintableKey(key: KeyId): boolean {
   if (key.includes('+')) return false
+  if (key === 'space') return true
   return key.length === 1 && key.charCodeAt(0) >= 32 && key.charCodeAt(0) <= 126
 }
 

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -105,10 +105,13 @@ export function parseUserKeybindings(
   }
   const doc = raw as Record<string, unknown>
 
-  // The leader key itself.
+  // The leader key itself. A plain PRINTABLE leader key is rejected: the
+  // machine consumes it while idle (arming the pending state), so a
+  // printable leader would swallow typing — same rule as a direct
+  // printable binding (review finding).
   const leaderValue = doc[LEADER_KEY]
   if (leaderValue !== undefined) {
-    if (typeof leaderValue === 'string' && isValidKeyId(leaderValue)) {
+    if (typeof leaderValue === 'string' && isValidKeyId(leaderValue) && !isPlainPrintableKey(leaderValue)) {
       leader = { key: leaderValue, timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
     } else {
       diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — ignored`)

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -28,7 +28,7 @@
  */
 
 import type { KeyId } from '@xmoon76/pi-tui'
-import { canonicalizeKeyId, EDITOR_OWNED_KEY_IDS, EDITOR_POST_SUBMIT_KEYS, isTextProducingKeyId, isValidKeyId } from './key-identity.ts'
+import { canonicalizeKeyId, EDITOR_OWNED_KEY_IDS, EDITOR_POST_SUBMIT_KEYS, isRuntimeBindableKeyId, isTextProducingKeyId, isValidKeyId } from './key-identity.ts'
 import { APP_KEYBINDINGS, NON_CONFIGURABLE_ACTIONS } from './definitions.ts'
 import type { AppKeybindingId, LeaderBinding, LeaderConfig, UserKeybindingValue, UserKeybindingsConfig } from './types.ts'
 
@@ -168,7 +168,9 @@ export function parseUserKeybindings(
   if (leaderValue !== undefined) {
     if (typeof leaderValue === 'string' && isValidKeyId(leaderValue)) {
       const canonicalLeader = canonicalizeKeyId(leaderValue as KeyId)
-      if (isTextProducingKeyId(canonicalLeader)) {
+      if (!isRuntimeBindableKeyId(canonicalLeader)) {
+        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — the runtime can never match a modified F-key or Escape — ignored`)
+      } else if (isTextProducingKeyId(canonicalLeader)) {
         diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a text-producing leader would swallow typing — ignored`)
       } else if (TERMINAL_AMBIGUOUS_KEY_IDS.has(canonicalLeader)) {
         // Legacy terminal collisions are REJECTED for the leader prefix too
@@ -251,6 +253,12 @@ export function parseUserKeybindings(
           diagnostics.push(`keybindings: "${actionId}" binds a "<leader>escape" sequence — Esc is the leader cancel key and cannot be a completion — ignored`)
           continue
         }
+        // The runtime-bindable gate (round-22 finding): a completion on a
+        // modified F-key or modified Escape can never be matched.
+        if (!isRuntimeBindableKeyId(canonicalCompleting)) {
+          diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — the runtime can never match a modified F-key or Escape — ignored`)
+          continue
+        }
         // Legacy terminal collisions are REJECTED for completions too
         // (convergence finding): a completion on ctrl+[ / ctrl+j / ctrl+m
         // would swallow the lifecycle Esc/Enter on legacy terminals.
@@ -271,6 +279,15 @@ export function parseUserKeybindings(
       // never bypass the printable guard or the collision sets — the raw
       // spelling is only used in the diagnostic text.
       const canonicalEntry = canonicalizeKeyId(entry as KeyId)
+      // RUNTIME-BINDABLE GATE (round-22 finding): the fork matcher can
+      // never match a modified F-key or modified Escape (keys.ts:
+      // `modifier !== 0` → false), so accepting them would advertise a
+      // key that can never fire. Separates "valid grammar" from
+      // "runtime-bindable" — the plugin registry shares the gate.
+      if (!isRuntimeBindableKeyId(canonicalEntry)) {
+        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — the runtime can never match a modified F-key or Escape — ignored`)
+        continue
+      }
       if (isTextProducingKeyId(canonicalEntry)) {
         diagnostics.push(`keybindings: "${actionId}" cannot bind the text-producing key "${entry}" to a Host action — ignored`)
         continue

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -217,6 +217,17 @@ export function parseUserKeybindings(
         diagnostics.push(`keybindings: "${actionId}" cannot bind the plain printable key "${entry}" to a Host action — ignored`)
         continue
       }
+      // Shift+Enter is the fork editor's FIXED newline key (tui.input
+      // .newLine): binding it to app.input.submit would be advertised by
+      // the read model but could never fire as a submit (the editor
+      // treats it as newline; the host submit seam excludes it). Rejected
+      // with a diagnostic — a binding that can never work must not be
+      // accepted (convergence §3 finding).
+      const canonicalEntry0 = canonicalizeKeyId(entry as KeyId)
+      if (actionId === 'app.input.submit' && canonicalEntry0 === 'shift+enter') {
+        diagnostics.push('keybindings: "app.input.submit" cannot bind Shift+Enter — it is the editor newline key — ignored')
+        continue
+      }
       const canonicalEntry = canonicalizeKeyId(entry as KeyId)
       if (TERMINAL_UNRELIABLE_KEYS.has(canonicalEntry)) {
         diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which legacy terminals report as Enter — the binding may not fire there`)

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -169,7 +169,7 @@ export function parseUserKeybindings(
     if (typeof leaderValue === 'string' && isValidKeyId(leaderValue)) {
       const canonicalLeader = canonicalizeKeyId(leaderValue as KeyId)
       if (!isRuntimeBindableKeyId(canonicalLeader)) {
-        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — the runtime can never match a modified F-key or Escape — ignored`)
+        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — the runtime can never match this modifier combination (F-keys and Escape take no modifiers; Clear takes only Shift/Ctrl) — ignored`)
       } else if (isTextProducingKeyId(canonicalLeader)) {
         diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a text-producing leader would swallow typing — ignored`)
       } else if (TERMINAL_AMBIGUOUS_KEY_IDS.has(canonicalLeader)) {
@@ -253,10 +253,11 @@ export function parseUserKeybindings(
           diagnostics.push(`keybindings: "${actionId}" binds a "<leader>escape" sequence — Esc is the leader cancel key and cannot be a completion — ignored`)
           continue
         }
-        // The runtime-bindable gate (round-22 finding): a completion on a
-        // modified F-key or modified Escape can never be matched.
+        // The runtime-bindable gate (round-22/24 finding): a completion
+        // whose modifier combination the fork matcher can never match
+        // (F-keys/Escape take no modifiers; Clear takes only Shift/Ctrl).
         if (!isRuntimeBindableKeyId(canonicalCompleting)) {
-          diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — the runtime can never match a modified F-key or Escape — ignored`)
+          diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — the runtime can never match this modifier combination (F-keys and Escape take no modifiers; Clear takes only Shift/Ctrl) — ignored`)
           continue
         }
         // Legacy terminal collisions are REJECTED for completions too
@@ -279,13 +280,15 @@ export function parseUserKeybindings(
       // never bypass the printable guard or the collision sets — the raw
       // spelling is only used in the diagnostic text.
       const canonicalEntry = canonicalizeKeyId(entry as KeyId)
-      // RUNTIME-BINDABLE GATE (round-22 finding): the fork matcher can
-      // never match a modified F-key or modified Escape (keys.ts:
-      // `modifier !== 0` → false), so accepting them would advertise a
-      // key that can never fire. Separates "valid grammar" from
-      // "runtime-bindable" — the plugin registry shares the gate.
+      // RUNTIME-BINDABLE GATE (round-22/24 finding): the fork matcher
+      // can never match certain modifier combinations (F-keys/Escape
+      // take no modifiers — keys.ts `modifier !== 0` → false; Clear
+      // takes only Shift/Ctrl — no CSI-u fallback), so accepting them
+      // would advertise a key that can never fire. Separates "valid
+      // grammar" from "runtime-bindable" — the plugin registry shares
+      // the gate.
       if (!isRuntimeBindableKeyId(canonicalEntry)) {
-        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — the runtime can never match a modified F-key or Escape — ignored`)
+        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — the runtime can never match this modifier combination (F-keys and Escape take no modifiers; Clear takes only Shift/Ctrl) — ignored`)
         continue
       }
       if (isTextProducingKeyId(canonicalEntry)) {

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -73,7 +73,7 @@ export function isPlainPrintableKey(key: KeyId): boolean {
   return key.length === 1 && key.charCodeAt(0) >= 32 && key.charCodeAt(0) <= 126
 }
 
-/** LEGACY TERMINAL COLLISIONS — REJECTED, never warned (convergence §4.5
+/** TERMINAL-AMBIGUOUS KEYS — REJECTED, never warned (convergence §4.5
  * finding + round-12 finding): on legacy/non-Kitty terminals these keys
  * are INDISTINGUISHABLE from fixed keys, so a binding on them would
  * silently steal the other key (or never fire):
@@ -92,7 +92,11 @@ export function isPlainPrintableKey(key: KeyId): boolean {
  *   (round-16 finding: ctrl+- used to bypass the inventory while its
  *   twin ctrl+_ was rejected);
  * - `ctrl+-` is the fork editor's undo key, and on legacy terminals its
- *   byte IS the 0x1f above — indistinguishable from ctrl+_.
+ *   byte IS the 0x1f above — indistinguishable from ctrl+_;
+ * - `ctrl+backspace` is TERMINAL-AMBIGUOUS: the fork's matchesRawBackspace
+ *   reads raw 0x08 as Ctrl+Backspace on Windows Terminal (WT_SESSION) but
+ *   as plain Backspace on legacy terminals/tmux — a binding on it fires
+ *   on some terminals and can never fire on others (round-20 finding).
  * A binding that depends on the terminal protocol to be distinguishable
  * from a fixed key is unsupported: rejected with a diagnostic.
  *
@@ -101,14 +105,14 @@ export function isPlainPrintableKey(key: KeyId): boolean {
  * SAME canonical key ids — a plugin registration on ctrl+i would
  * otherwise resolve in the EffectiveKeymap but never match the router's
  * normalized plugin lookup (\t normalizes to `tab`, not `ctrl+i`). */
-export const LEGACY_COLLISION_KEY_IDS: ReadonlySet<string> = new Set(
-  ['ctrl+[', 'ctrl+j', 'ctrl+m', 'ctrl+i', 'ctrl+h', 'ctrl+_', 'ctrl+-'].map(key => canonicalizeKeyId(key as KeyId)),
+export const TERMINAL_AMBIGUOUS_KEY_IDS: ReadonlySet<string> = new Set(
+  ['ctrl+[', 'ctrl+j', 'ctrl+m', 'ctrl+i', 'ctrl+h', 'ctrl+_', 'ctrl+-', 'ctrl+backspace'].map(key => canonicalizeKeyId(key as KeyId)),
 )
 
-/** Whether one CANONICAL key id is a legacy-terminal collision (the
- * shared policy of the config parser and the plugin registry). */
-export function isLegacyCollisionKeyId(key: KeyId): boolean {
-  return LEGACY_COLLISION_KEY_IDS.has(canonicalizeKeyId(key))
+/** Whether one canonical key id is a terminal-ambiguous key (the shared
+ * policy of the config parser and the plugin registry). */
+export function isTerminalAmbiguousKeyId(key: KeyId): boolean {
+  return TERMINAL_AMBIGUOUS_KEY_IDS.has(canonicalizeKeyId(key))
 }
 
 /** The NON-CONFIGURABLE overlay/component default keys (plan §3.3 fixed
@@ -166,7 +170,7 @@ export function parseUserKeybindings(
       const canonicalLeader = canonicalizeKeyId(leaderValue as KeyId)
       if (isTextProducingKeyId(canonicalLeader)) {
         diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a text-producing leader would swallow typing — ignored`)
-      } else if (LEGACY_COLLISION_KEY_IDS.has(canonicalLeader)) {
+      } else if (TERMINAL_AMBIGUOUS_KEY_IDS.has(canonicalLeader)) {
         // Legacy terminal collisions are REJECTED for the leader prefix too
         // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
         // swallow the lifecycle Esc/Enter on legacy terminals.
@@ -250,7 +254,7 @@ export function parseUserKeybindings(
         // Legacy terminal collisions are REJECTED for completions too
         // (convergence finding): a completion on ctrl+[ / ctrl+j / ctrl+m
         // would swallow the lifecycle Esc/Enter on legacy terminals.
-        if (LEGACY_COLLISION_KEY_IDS.has(canonicalCompleting)) {
+        if (TERMINAL_AMBIGUOUS_KEY_IDS.has(canonicalCompleting)) {
           diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — it collides with a fixed key on legacy terminals — ignored`)
           continue
         }
@@ -284,8 +288,8 @@ export function parseUserKeybindings(
       // Legacy terminal collisions are REJECTED (convergence §4.5 +
       // round-12 finding): a binding indistinguishable from a fixed key
       // on legacy terminals is unsupported, never a warning.
-      if (LEGACY_COLLISION_KEY_IDS.has(canonicalEntry)) {
-        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ and Ctrl+- are one key) — ignored`)
+      if (TERMINAL_AMBIGUOUS_KEY_IDS.has(canonicalEntry)) {
+        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ and Ctrl+- are one key; Ctrl+Backspace is Backspace on legacy, Ctrl+Backspace on Windows Terminal) — ignored`)
         continue
       }
       // The fork editor CONSUMES its own editing bindings BEFORE the

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -149,7 +149,15 @@ export function parseUserKeybindings(
   const leaderValue = doc[LEADER_KEY]
   if (leaderValue !== undefined) {
     if (typeof leaderValue === 'string' && isValidKeyId(leaderValue) && !isPlainPrintableKey(leaderValue)) {
-      leader = { key: canonicalizeKeyId(leaderValue as KeyId), timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
+      const canonicalLeader = canonicalizeKeyId(leaderValue as KeyId)
+      // Legacy terminal collisions are REJECTED for the leader prefix too
+      // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
+      // swallow the lifecycle Esc/Enter on legacy terminals.
+      if (LEGACY_COLLISION_KEYS.has(canonicalLeader)) {
+        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — it collides with a lifecycle key on legacy terminals — ignored`)
+      } else {
+        leader = { key: canonicalLeader, timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
+      }
     } else {
       diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — ignored`)
     }
@@ -221,6 +229,13 @@ export function parseUserKeybindings(
         const canonicalCompleting = canonicalizeKeyId(completing as KeyId)
         if (canonicalCompleting === 'escape') {
           diagnostics.push(`keybindings: "${actionId}" binds a "<leader>escape" sequence — Esc is the leader cancel key and cannot be a completion — ignored`)
+          continue
+        }
+        // Legacy terminal collisions are REJECTED for completions too
+        // (convergence finding): a completion on ctrl+[ / ctrl+j / ctrl+m
+        // would swallow the lifecycle Esc/Enter on legacy terminals.
+        if (LEGACY_COLLISION_KEYS.has(canonicalCompleting)) {
+          diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — it collides with a lifecycle key on legacy terminals — ignored`)
           continue
         }
         leaderBindings.push({ action, key: canonicalCompleting })

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -51,13 +51,21 @@ const BASE_KEYS = new Set([
 
 const MODIFIERS = new Set(['ctrl', 'shift', 'alt', 'super'])
 
+/** Case-insensitive view of the base-key grammar: `pageUp` and `pageup`
+ * are the SAME physical key (the canonical identity is lowercase). */
+const BASE_KEYS_LOWER = new Set([...BASE_KEYS].map(key => key.toLowerCase()))
+
 /** Whether a string is a valid KeyId (the fork's grammar). */
 export function isValidKeyId(value: string): value is KeyId {
   if (value === '') return false
   const parts = value.split('+')
   if (parts.length === 0) return false
   const base = parts[parts.length - 1]!
-  if (!BASE_KEYS.has(base)) return false
+  // Named keys are CASE-INSENSITIVE at parse time: the fork grammar
+  // spells pageUp/pageDown with camelCase, but the canonical identity is
+  // lowercase (pageup) — accept either spelling (convergence: one
+  // physical key has one canonical identity).
+  if (!BASE_KEYS.has(base) && !BASE_KEYS_LOWER.has(base.toLowerCase())) return false
   for (let index = 0; index < parts.length - 1; index += 1) {
     if (!MODIFIERS.has(parts[index]!)) return false
   }

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -115,21 +115,33 @@ export function parseUserKeybindings(
     }
   }
 
-  // The nested `bindings` map merges with the top-level action entries.
+  // The nested `bindings` map merges with the top-level action entries. A
+  // duplicate action declaration (top level AND nested, or twice) is a
+  // diagnostic — never a silent last-write-wins (plan §15/§16): the FIRST
+  // declaration wins, the later one is ignored.
   const entries: [string, unknown][] = []
+  const seen = new Set<string>()
+  const pushEntry = (actionId: string, value: unknown): void => {
+    if (seen.has(actionId)) {
+      diagnostics.push(`keybindings: action "${actionId}" declared more than once — the later entry is ignored`)
+      return
+    }
+    seen.add(actionId)
+    entries.push([actionId, value])
+  }
   for (const [key, value] of Object.entries(doc)) {
     if (key === LEADER_KEY) continue
     if (key === BINDINGS_KEY) {
       if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
         for (const [nestedKey, nestedValue] of Object.entries(value as Record<string, unknown>)) {
-          entries.push([nestedKey, nestedValue])
+          pushEntry(nestedKey, nestedValue)
         }
       } else {
         diagnostics.push('keybindings: "bindings" must be an object — ignored')
       }
       continue
     }
-    entries.push([key, value])
+    pushEntry(key, value)
   }
 
   for (const [actionId, value] of entries) {

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -78,10 +78,19 @@ export function isPlainPrintableKey(key: KeyId): boolean {
   return key.length === 1 && key.charCodeAt(0) >= 32 && key.charCodeAt(0) <= 126
 }
 
-/** Terminal-unreliable combinations (plan §13 item 5): legacy terminals
- * send Ctrl+J as LF (Enter) and Ctrl+M as CR (Enter), so binding them is
- * a silent no-op on those terminals. Warned, not rejected. */
-const TERMINAL_UNRELIABLE_KEYS = new Set(['ctrl+j', 'ctrl+m'].map(key => canonicalizeKeyId(key as KeyId)))
+/** LEGACY TERMINAL COLLISIONS — REJECTED, never warned (convergence §4.5
+ * finding): on legacy/non-Kitty terminals these keys are INDISTINGUISHABLE
+ * from fixed lifecycle keys, so a binding on them would silently steal the
+ * lifecycle key (or never fire):
+ * - `ctrl+[` is the legacy ESC sequence (0x1b) — binding it would steal
+ *   the interrupt/viewer-close key on legacy terminals;
+ * - `ctrl+j` / `ctrl+m` are LF/CR (Enter) — binding them would steal
+ *   submit/queue on legacy terminals.
+ * A binding that depends on the terminal protocol to be distinguishable
+ * from a lifecycle key is unsupported: rejected with a diagnostic. */
+const LEGACY_COLLISION_KEYS = new Set(
+  ['ctrl+[', 'ctrl+j', 'ctrl+m'].map(key => canonicalizeKeyId(key as KeyId)),
+)
 
 /** The NON-CONFIGURABLE overlay/component default keys (plan §3.3 fixed
  * overlay contracts: search close/next/previous, question/tasks flows).
@@ -229,8 +238,12 @@ export function parseUserKeybindings(
         continue
       }
       const canonicalEntry = canonicalizeKeyId(entry as KeyId)
-      if (TERMINAL_UNRELIABLE_KEYS.has(canonicalEntry)) {
-        diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which legacy terminals report as Enter — the binding may not fire there`)
+      // Legacy terminal collisions are REJECTED (convergence §4.5): a
+      // binding indistinguishable from a lifecycle key on legacy
+      // terminals is unsupported, never a warning.
+      if (LEGACY_COLLISION_KEYS.has(canonicalEntry)) {
+        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a lifecycle key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter) — ignored`)
+        continue
       }
       // Fixed overlay-key precedence (review finding): a configurable
       // action bound to a non-configurable overlay's key is eclipsed

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -55,6 +55,40 @@ const MODIFIERS = new Set(['ctrl', 'shift', 'alt', 'super'])
  * are the SAME physical key (the canonical identity is lowercase). */
 const BASE_KEYS_LOWER = new Set([...BASE_KEYS].map(key => key.toLowerCase()))
 
+/** The FORK EDITOR's UNCONDITIONAL pre-submit keys (packages/pi-tui
+ * TUI_KEYBINDINGS + components/editor.ts handleInput): the editor
+ * dispatches these bindings BEFORE its submit check (copy, undo, tab,
+ * deletion, kill-ring, line/word cursor moves, newline), so a submit
+ * remap onto one of them would be advertised by the read model but could
+ * never fire — the editor consumes the key earlier (e.g. `submit: tab`
+ * stays autocomplete). Same unsupported-key policy as the Shift+Enter
+ * newline rejection (review finding): a binding that can never work is
+ * rejected, never advertised. The list is the fork's DEFAULT keys only —
+ * the autocomplete-gated select.* keys (up/down/enter/escape/pageUp/
+ * pageDown while the dropdown is open) are NOT included: enter is the
+ * default submit itself and the others still reach the submit check when
+ * the dropdown is closed. Consumer-side validation only — the fork stays
+ * pristine. */
+const EDITOR_PRE_SUBMIT_KEYS = new Set([
+  'ctrl+c', // tui.input.copy
+  'ctrl+-', // tui.editor.undo
+  'tab', // tui.input.tab
+  'ctrl+k', // tui.editor.deleteToLineEnd
+  'ctrl+u', // tui.editor.deleteToLineStart
+  'ctrl+w', 'alt+backspace', // tui.editor.deleteWordBackward
+  'alt+d', 'alt+delete', // tui.editor.deleteWordForward
+  'backspace', 'shift+backspace', // tui.editor.deleteCharBackward
+  'delete', 'shift+delete', 'ctrl+d', // tui.editor.deleteCharForward
+  'ctrl+y', // tui.editor.yank
+  'alt+y', // tui.editor.yankPop
+  'home', 'ctrl+home', 'ctrl+a', // tui.editor.cursorLineStart
+  'end', 'ctrl+end', 'ctrl+e', // tui.editor.cursorLineEnd
+  'alt+left', 'ctrl+left', 'alt+b', // tui.editor.cursorWordLeft
+  'alt+right', 'ctrl+right', 'alt+f', // tui.editor.cursorWordRight
+  'shift+enter', 'ctrl+j', // tui.input.newLine (also covered by dedicated checks)
+].map(key => canonicalizeKeyId(key as KeyId)),
+)
+
 /** Whether a string is a valid KeyId (the fork's grammar). */
 export function isValidKeyId(value: string): value is KeyId {
   if (value === '') return false
@@ -145,15 +179,20 @@ export function parseUserKeybindings(
   // The leader key itself. A plain PRINTABLE leader key is rejected: the
   // machine consumes it while idle (arming the pending state), so a
   // printable leader would swallow typing — same rule as a direct
-  // printable binding (review finding).
+  // printable binding (review finding). The check runs on the CANONICAL
+  // key: an uppercase `SPACE`/`Space` spelling is still the printable
+  // spacebar (the whole pipeline is grammar → canonicalize → policy →
+  // store, review finding).
   const leaderValue = doc[LEADER_KEY]
   if (leaderValue !== undefined) {
-    if (typeof leaderValue === 'string' && isValidKeyId(leaderValue) && !isPlainPrintableKey(leaderValue)) {
+    if (typeof leaderValue === 'string' && isValidKeyId(leaderValue)) {
       const canonicalLeader = canonicalizeKeyId(leaderValue as KeyId)
-      // Legacy terminal collisions are REJECTED for the leader prefix too
-      // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
-      // swallow the lifecycle Esc/Enter on legacy terminals.
-      if (LEGACY_COLLISION_KEYS.has(canonicalLeader)) {
+      if (isPlainPrintableKey(canonicalLeader)) {
+        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a plain printable leader would swallow typing — ignored`)
+      } else if (LEGACY_COLLISION_KEYS.has(canonicalLeader)) {
+        // Legacy terminal collisions are REJECTED for the leader prefix too
+        // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
+        // swallow the lifecycle Esc/Enter on legacy terminals.
         diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — it collides with a lifecycle key on legacy terminals — ignored`)
       } else {
         leader = { key: canonicalLeader, timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
@@ -245,7 +284,13 @@ export function parseUserKeybindings(
         diagnostics.push(`keybindings: "${actionId}" has an invalid key "${entry}" — ignored`)
         continue
       }
-      if (isPlainPrintableKey(entry)) {
+      // The policy pipeline is grammar → CANONICALIZE → policy → store
+      // (review finding): every check below runs on the canonical identity,
+      // so an uppercase spelling (`SPACE`, `ctrl+A`, `CTRL+RETURN`) can
+      // never bypass the printable guard or the collision sets — the raw
+      // spelling is only used in the diagnostic text.
+      const canonicalEntry = canonicalizeKeyId(entry as KeyId)
+      if (isPlainPrintableKey(canonicalEntry)) {
         diagnostics.push(`keybindings: "${actionId}" cannot bind the plain printable key "${entry}" to a Host action — ignored`)
         continue
       }
@@ -255,17 +300,25 @@ export function parseUserKeybindings(
       // treats it as newline; the host submit seam excludes it). Rejected
       // with a diagnostic — a binding that can never work must not be
       // accepted (convergence §3 finding).
-      const canonicalEntry0 = canonicalizeKeyId(entry as KeyId)
-      if (actionId === 'app.input.submit' && canonicalEntry0 === 'shift+enter') {
+      if (actionId === 'app.input.submit' && canonicalEntry === 'shift+enter') {
         diagnostics.push('keybindings: "app.input.submit" cannot bind Shift+Enter — it is the editor newline key — ignored')
         continue
       }
-      const canonicalEntry = canonicalizeKeyId(entry as KeyId)
       // Legacy terminal collisions are REJECTED (convergence §4.5): a
       // binding indistinguishable from a lifecycle key on legacy
       // terminals is unsupported, never a warning.
       if (LEGACY_COLLISION_KEYS.has(canonicalEntry)) {
         diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a lifecycle key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter) — ignored`)
+        continue
+      }
+      // The fork editor CONSUMES its own editing bindings BEFORE the
+      // submit check, so an app.input.submit remap onto one of them could
+      // never fire (review finding: `submit: tab` stayed autocomplete).
+      // Rejected like Shift+Enter — never advertised as a submit key. The
+      // other actions are NOT affected: the host ladder consumes their
+      // keys before the editor, so they really fire.
+      if (actionId === 'app.input.submit' && EDITOR_PRE_SUBMIT_KEYS.has(canonicalEntry)) {
+        diagnostics.push(`keybindings: "app.input.submit" cannot bind "${entry}" — the editor consumes it before submit — ignored`)
         continue
       }
       // Fixed overlay-key precedence (review finding): a configurable

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -149,6 +149,13 @@ export function parseUserKeybindings(
   const diagnostics: string[] = []
   const bindings: UserKeybindingsConfig = {}
   const leaderBindings: LeaderBinding[] = []
+  // Actions whose ONLY declaration is a leader sequence (no direct keys).
+  // The empty-array marker is written ONLY after the leader prefix is
+  // confirmed valid (review round 39 finding): a missing/invalid leader
+  // makes the sequences inert (fail-soft) and the action must fall back
+  // to its builtin default — a marker left behind would suppress the
+  // builtin for a config that was diagnosed and ignored.
+  const leaderOnlyActions = new Set<AppKeybindingId>()
   let leader: LeaderConfig | undefined
 
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
@@ -336,14 +343,12 @@ export function parseUserKeybindings(
       bindings[action] = keys.length === 1 ? keys[0]! : keys
     } else if (leaderBindings.some(binding => binding.action === action)) {
       // A LEADER-ONLY declaration (no direct keys, only `<leader>X`
-      // sequences): record an EMPTY-ARRAY marker so the effective keymap
-      // sees a USER DECLARATION and REPLACES the builtin default for this
-      // action (review round 37 — the unified override contract: absent =
-      // builtin, direct = replace, leader-only = replace, direct+leader =
-      // both user triggers with the builtin removed, false = remove all).
-      // The empty array compiles no direct rules but suppresses the
-      // builtin; the leader sequences live in `leaderBindings`.
-      bindings[action] = []
+      // sequences): record the action — the empty-array marker is
+      // written AFTER the leader prefix is confirmed valid (review
+      // round 39 finding: the marker used to be written here, before
+      // the leader check, so a missing/invalid leader — diagnosed and
+      // ignored — still suppressed the builtin default).
+      leaderOnlyActions.add(action)
     }
   }
 
@@ -351,6 +356,18 @@ export function parseUserKeybindings(
   if (leaderBindings.length > 0 && leader === undefined) {
     diagnostics.push('keybindings: leader sequences configured but no "leader" key — the sequences are ignored')
     return { bindings, leader, leaderBindings: [], diagnostics }
+  }
+  // The leader prefix is confirmed valid: write the empty-array markers
+  // for the leader-only declarations (review round 37 — the unified
+  // override contract: absent = builtin, direct = replace, leader-only =
+  // replace, direct+leader = both user triggers with the builtin removed,
+  // false = remove all). The empty array compiles no direct rules but
+  // suppresses the builtin; the leader sequences live in `leaderBindings`.
+  // Written only NOW so a missing/invalid leader (fail-soft: the
+  // sequences are ignored) leaves the action on its builtin default
+  // (review round 39 finding).
+  for (const action of leaderOnlyActions) {
+    bindings[action] = []
   }
   return { bindings, leader, leaderBindings, diagnostics }
 }

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -28,7 +28,7 @@
  */
 
 import type { KeyId } from '@xmoon76/pi-tui'
-import { canonicalizeKeyId, isTextProducingKeyId, isValidKeyId } from './key-identity.ts'
+import { canonicalizeKeyId, EDITOR_OWNED_KEY_IDS, EDITOR_POST_SUBMIT_KEYS, isTextProducingKeyId, isValidKeyId } from './key-identity.ts'
 import { APP_KEYBINDINGS, NON_CONFIGURABLE_ACTIONS } from './definitions.ts'
 import type { AppKeybindingId, LeaderBinding, LeaderConfig, UserKeybindingValue, UserKeybindingsConfig } from './types.ts'
 
@@ -44,38 +44,21 @@ export const LEADER_PREFIX = '<leader>'
  * for callers of the parser module). */
 export { isValidKeyId }
 
-/** The FORK EDITOR's UNCONDITIONAL pre-submit keys (packages/pi-tui
- * TUI_KEYBINDINGS + components/editor.ts handleInput): the editor
- * dispatches these bindings BEFORE its submit check (copy, undo, tab,
- * deletion, kill-ring, line/word cursor moves, newline), so a submit
- * remap onto one of them would be advertised by the read model but could
- * never fire — the editor consumes the key earlier (e.g. `submit: tab`
- * stays autocomplete). Same unsupported-key policy as the Shift+Enter
- * newline rejection (review finding): a binding that can never work is
- * rejected, never advertised. The list is the fork's DEFAULT keys only —
- * the autocomplete-gated select.* keys (up/down/enter/escape/pageUp/
- * pageDown while the dropdown is open) are NOT included: enter is the
- * default submit itself and the others still reach the submit check when
- * the dropdown is closed. Consumer-side validation only — the fork stays
- * pristine. */
-const EDITOR_PRE_SUBMIT_KEYS = new Set([
-  'ctrl+c', // tui.input.copy
-  'ctrl+-', // tui.editor.undo
-  'tab', // tui.input.tab
-  'ctrl+k', // tui.editor.deleteToLineEnd
-  'ctrl+u', // tui.editor.deleteToLineStart
-  'ctrl+w', 'alt+backspace', // tui.editor.deleteWordBackward
-  'alt+d', 'alt+delete', // tui.editor.deleteWordForward
-  'backspace', 'shift+backspace', // tui.editor.deleteCharBackward
-  'delete', 'shift+delete', 'ctrl+d', // tui.editor.deleteCharForward
-  'ctrl+y', // tui.editor.yank
-  'alt+y', // tui.editor.yankPop
-  'home', 'ctrl+home', 'ctrl+a', // tui.editor.cursorLineStart
-  'end', 'ctrl+end', 'ctrl+e', // tui.editor.cursorLineEnd
-  'alt+left', 'ctrl+left', 'alt+b', // tui.editor.cursorWordLeft
-  'alt+right', 'ctrl+right', 'alt+f', // tui.editor.cursorWordRight
-  'shift+enter', 'ctrl+j', // tui.input.newLine (also covered by dedicated checks)
-].map(key => canonicalizeKeyId(key as KeyId)),
+/** The FORK EDITOR's UNCONDITIONAL PRE-SUBMIT keys — DERIVED from the
+ * shared {@link EDITOR_OWNED_KEY_IDS} inventory minus the POST-SUBMIT
+ * keys (packages/pi-tui components/editor.ts handleInput dispatch
+ * order): the editor dispatches these bindings BEFORE its submit check
+ * (copy, undo, tab, deletion, kill-ring, line/word cursor moves,
+ * newline), so a submit remap onto one of them would be advertised by
+ * the read model but could never fire — the editor consumes the key
+ * earlier (e.g. `submit: tab` stays autocomplete). Same unsupported-key
+ * policy as the Shift+Enter newline rejection (review finding): a
+ * binding that can never work is rejected, never advertised. The
+ * POST-SUBMIT keys (arrows, page keys, jump chords, enter, escape) DO
+ * reach the submit check and stay bindable for submit. Consumer-side
+ * validation only — the fork stays pristine. */
+const EDITOR_PRE_SUBMIT_KEYS = new Set(
+  [...EDITOR_OWNED_KEY_IDS].filter(key => !EDITOR_POST_SUBMIT_KEYS.has(key)),
 )
 
 /** Whether a key is a PLAIN (unmodified) printable — the strict subset of

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -1,0 +1,194 @@
+/**
+ * User keybinding config parsing and validation (plan §12/§13/§14/§16).
+ *
+ * Settings shape (namespace `pi-tui`, field `keybindings`):
+ *
+ * ```yaml
+ * pi-tui:
+ *   keybindings:
+ *     app.input.steer: ctrl+s
+ *     app.permission.cycle: [shift+tab, ctrl+shift+p]
+ *     app.history.search: ctrl+r
+ *     app.transcript.toggleThinking: false
+ *     leader: ctrl+x
+ *     bindings:
+ *       app.tasks.open: <leader>t
+ * ```
+ *
+ * Semantics (plan §12):
+ * - string: a single key (or a `<leader>X` sequence, M6);
+ * - array: multiple keys;
+ * - `false`: disable the action's effective binding;
+ * - absent: the builtin default.
+ *
+ * Fail-soft (plan §16): a malformed entry is a diagnostic + ignore; it
+ * never disables the whole map and never prevents the TUI from starting.
+ * @module @xmoon76/dsh-pi-tui/keybindings/config
+ */
+
+import type { KeyId } from '@xmoon76/pi-tui'
+import { APP_KEYBINDINGS, NON_CONFIGURABLE_ACTIONS } from './definitions.ts'
+import type { AppKeybindingId, LeaderBinding, LeaderConfig, UserKeybindingValue, UserKeybindingsConfig } from './types.ts'
+
+/** The special keys of the keybindings settings object. */
+const LEADER_KEY = 'leader'
+const BINDINGS_KEY = 'bindings'
+
+/** The leader sequence marker (`<leader>t`). */
+export const LEADER_PREFIX = '<leader>'
+
+/** The base keys the fork's KeyId grammar accepts (keys.ts). */
+const BASE_KEYS = new Set([
+  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+  '`', '-', '=', '[', ']', '\\', ';', "'", ',', '.', '/', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '|', '~', '{', '}', ':', '<', '>', '?',
+  'escape', 'esc', 'enter', 'return', 'tab', 'space', 'backspace', 'delete', 'insert', 'clear',
+  'home', 'end', 'pageUp', 'pageDown', 'up', 'down', 'left', 'right',
+  'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12',
+])
+
+const MODIFIERS = new Set(['ctrl', 'shift', 'alt', 'super'])
+
+/** Whether a string is a valid KeyId (the fork's grammar). */
+export function isValidKeyId(value: string): value is KeyId {
+  if (value === '') return false
+  const parts = value.split('+')
+  if (parts.length === 0) return false
+  const base = parts[parts.length - 1]!
+  if (!BASE_KEYS.has(base)) return false
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    if (!MODIFIERS.has(parts[index]!)) return false
+  }
+  // No duplicate modifiers.
+  return new Set(parts.slice(0, -1)).size === parts.length - 1
+}
+
+/** Whether a key is a plain printable (plan §14: a direct user binding of
+ * a plain printable to a Host action would swallow typing). */
+export function isPlainPrintableKey(key: KeyId): boolean {
+  if (key.includes('+')) return false
+  return key.length === 1 && key.charCodeAt(0) >= 32 && key.charCodeAt(0) <= 126
+}
+
+/** Terminal-unreliable combinations (plan §13 item 5): legacy terminals
+ * send Ctrl+J as LF (Enter) and Ctrl+M as CR (Enter), so binding them is
+ * a silent no-op on those terminals. Warned, not rejected. */
+const TERMINAL_UNRELIABLE_KEYS = new Set(['ctrl+j', 'ctrl+m'])
+
+/** The parsed, validated user configuration. */
+export interface ParsedUserKeybindings {
+  /** The direct action → keys map (leader sequences removed). */
+  readonly bindings: UserKeybindingsConfig
+  /** The leader configuration (undefined when unset). */
+  readonly leader: LeaderConfig | undefined
+  /** The leader-sequence bindings (`<leader>X`). */
+  readonly leaderBindings: readonly LeaderBinding[]
+  /** Fail-soft diagnostics (warnings, never fatal). */
+  readonly diagnostics: readonly string[]
+}
+
+/** Parse and validate the raw `keybindings` settings value. Unknown
+ * actions, invalid keys and malformed entries are diagnostics + ignored
+ * (plan §16). */
+export function parseUserKeybindings(
+  raw: unknown,
+  options: { leaderTimeoutMs?: number } = {},
+): ParsedUserKeybindings {
+  const diagnostics: string[] = []
+  const bindings: UserKeybindingsConfig = {}
+  const leaderBindings: LeaderBinding[] = []
+  let leader: LeaderConfig | undefined
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    if (raw !== undefined) diagnostics.push('keybindings: expected an object, ignored')
+    return { bindings, leader, leaderBindings, diagnostics }
+  }
+  const doc = raw as Record<string, unknown>
+
+  // The leader key itself.
+  const leaderValue = doc[LEADER_KEY]
+  if (leaderValue !== undefined) {
+    if (typeof leaderValue === 'string' && isValidKeyId(leaderValue)) {
+      leader = { key: leaderValue, timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
+    } else {
+      diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — ignored`)
+    }
+  }
+
+  // The nested `bindings` map merges with the top-level action entries.
+  const entries: [string, unknown][] = []
+  for (const [key, value] of Object.entries(doc)) {
+    if (key === LEADER_KEY) continue
+    if (key === BINDINGS_KEY) {
+      if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        for (const [nestedKey, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+          entries.push([nestedKey, nestedValue])
+        }
+      } else {
+        diagnostics.push('keybindings: "bindings" must be an object — ignored')
+      }
+      continue
+    }
+    entries.push([key, value])
+  }
+
+  for (const [actionId, value] of entries) {
+    if (!(actionId in APP_KEYBINDINGS)) {
+      diagnostics.push(`keybindings: unknown action "${actionId}" — ignored`)
+      continue
+    }
+    const action = actionId as AppKeybindingId
+    if (NON_CONFIGURABLE_ACTIONS.has(action)) {
+      diagnostics.push(`keybindings: action "${actionId}" is not user-configurable in this version — ignored`)
+      continue
+    }
+    if (value === false) {
+      bindings[action] = false
+      continue
+    }
+    const values = Array.isArray(value) ? value : [value]
+    const keys: KeyId[] = []
+    for (const entry of values) {
+      if (typeof entry !== 'string') {
+        diagnostics.push(`keybindings: "${actionId}" entry "${String(entry)}" is not a key string — ignored`)
+        continue
+      }
+      if (entry.startsWith(LEADER_PREFIX)) {
+        const completing = entry.slice(LEADER_PREFIX.length)
+        if (completing === '') {
+          diagnostics.push(`keybindings: "${actionId}" has a bare "<leader>" sequence — a completing key is required — ignored`)
+          continue
+        }
+        if (!isValidKeyId(completing)) {
+          diagnostics.push(`keybindings: "${actionId}" has an invalid leader sequence "${entry}" — ignored`)
+          continue
+        }
+        leaderBindings.push({ action, key: completing })
+        continue
+      }
+      if (!isValidKeyId(entry)) {
+        diagnostics.push(`keybindings: "${actionId}" has an invalid key "${entry}" — ignored`)
+        continue
+      }
+      if (isPlainPrintableKey(entry)) {
+        diagnostics.push(`keybindings: "${actionId}" cannot bind the plain printable key "${entry}" to a Host action — ignored`)
+        continue
+      }
+      if (TERMINAL_UNRELIABLE_KEYS.has(entry)) {
+        diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which legacy terminals report as Enter — the binding may not fire there`)
+      }
+      keys.push(entry)
+    }
+    if (keys.length > 0) bindings[action] = keys.length === 1 ? keys[0]! : keys
+  }
+
+  // A leader sequence without a leader key is inert: warn once.
+  if (leaderBindings.length > 0 && leader === undefined) {
+    diagnostics.push('keybindings: leader sequences configured but no "leader" key — the sequences are ignored')
+    return { bindings, leader, leaderBindings: [], diagnostics }
+  }
+  return { bindings, leader, leaderBindings, diagnostics }
+}
+
+/** The default leader timeout (plan §6 M6: pending prefix expiry). */
+export const DEFAULT_LEADER_TIMEOUT_MS = 1500

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -28,6 +28,7 @@
  */
 
 import type { KeyId } from '@xmoon76/pi-tui'
+import { canonicalizeKeyId } from './key-identity.ts'
 import { APP_KEYBINDINGS, NON_CONFIGURABLE_ACTIONS } from './definitions.ts'
 import type { AppKeybindingId, LeaderBinding, LeaderConfig, UserKeybindingValue, UserKeybindingsConfig } from './types.ts'
 
@@ -80,7 +81,7 @@ export function isPlainPrintableKey(key: KeyId): boolean {
 /** Terminal-unreliable combinations (plan §13 item 5): legacy terminals
  * send Ctrl+J as LF (Enter) and Ctrl+M as CR (Enter), so binding them is
  * a silent no-op on those terminals. Warned, not rejected. */
-const TERMINAL_UNRELIABLE_KEYS = new Set(['ctrl+j', 'ctrl+m'])
+const TERMINAL_UNRELIABLE_KEYS = new Set(['ctrl+j', 'ctrl+m'].map(key => canonicalizeKeyId(key as KeyId)))
 
 /** The NON-CONFIGURABLE overlay/component default keys (plan §3.3 fixed
  * overlay contracts: search close/next/previous, question/tasks flows).
@@ -90,7 +91,8 @@ const TERMINAL_UNRELIABLE_KEYS = new Set(['ctrl+j', 'ctrl+m'])
 const FIXED_OVERLAY_KEYS = new Set(
   Object.values(APP_KEYBINDINGS)
     .filter(definition => !definition.configurable)
-    .flatMap(definition => definition.defaultKeys),
+    .flatMap(definition => definition.defaultKeys)
+    .map(canonicalizeKeyId),
 )
 
 /** The parsed, validated user configuration. */
@@ -130,7 +132,7 @@ export function parseUserKeybindings(
   const leaderValue = doc[LEADER_KEY]
   if (leaderValue !== undefined) {
     if (typeof leaderValue === 'string' && isValidKeyId(leaderValue) && !isPlainPrintableKey(leaderValue)) {
-      leader = { key: leaderValue, timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
+      leader = { key: canonicalizeKeyId(leaderValue as KeyId), timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
     } else {
       diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — ignored`)
     }
@@ -196,7 +198,15 @@ export function parseUserKeybindings(
           diagnostics.push(`keybindings: "${actionId}" has an invalid leader sequence "${entry}" — ignored`)
           continue
         }
-        leaderBindings.push({ action, key: completing })
+        // Esc (aliases included) is the leader's pending-CANCEL fixed
+        // contract — a completion on it could never fire (convergence
+        // contract §4.6a). Rejected at the parser.
+        const canonicalCompleting = canonicalizeKeyId(completing as KeyId)
+        if (canonicalCompleting === 'escape') {
+          diagnostics.push(`keybindings: "${actionId}" binds a "<leader>escape" sequence — Esc is the leader cancel key and cannot be a completion — ignored`)
+          continue
+        }
+        leaderBindings.push({ action, key: canonicalCompleting })
         continue
       }
       if (!isValidKeyId(entry)) {
@@ -207,7 +217,8 @@ export function parseUserKeybindings(
         diagnostics.push(`keybindings: "${actionId}" cannot bind the plain printable key "${entry}" to a Host action — ignored`)
         continue
       }
-      if (TERMINAL_UNRELIABLE_KEYS.has(entry)) {
+      const canonicalEntry = canonicalizeKeyId(entry as KeyId)
+      if (TERMINAL_UNRELIABLE_KEYS.has(canonicalEntry)) {
         diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which legacy terminals report as Enter — the binding may not fire there`)
       }
       // Fixed overlay-key precedence (review finding): a configurable
@@ -215,10 +226,10 @@ export function parseUserKeybindings(
       // while that overlay is open (e.g. the search toggle remapped to
       // Enter collides with search.next). The binding still works
       // outside the overlay; warned, never silently dropped.
-      if (FIXED_OVERLAY_KEYS.has(entry)) {
+      if (FIXED_OVERLAY_KEYS.has(canonicalEntry)) {
         diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which a non-configurable overlay owns while it is open — the overlay wins there`)
       }
-      keys.push(entry)
+      keys.push(canonicalEntry)
     }
     if (keys.length > 0) bindings[action] = keys.length === 1 ? keys[0]! : keys
   }

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -121,17 +121,25 @@ export function isPlainPrintableKey(key: KeyId): boolean {
 }
 
 /** LEGACY TERMINAL COLLISIONS — REJECTED, never warned (convergence §4.5
- * finding): on legacy/non-Kitty terminals these keys are INDISTINGUISHABLE
- * from fixed lifecycle keys, so a binding on them would silently steal the
- * lifecycle key (or never fire):
+ * finding + round-12 finding): on legacy/non-Kitty terminals these keys
+ * are INDISTINGUISHABLE from fixed keys, so a binding on them would
+ * silently steal the other key (or never fire):
  * - `ctrl+[` is the legacy ESC sequence (0x1b) — binding it would steal
  *   the interrupt/viewer-close key on legacy terminals;
  * - `ctrl+j` / `ctrl+m` are LF/CR (Enter) — binding them would steal
- *   submit/queue on legacy terminals.
+ *   submit/queue on legacy terminals;
+ * - `ctrl+i` is the TAB byte (0x09 — the fork's rawCtrlChar maps Ctrl+I
+ *   to 9, and matchesKey('\t','ctrl+i') is TRUE, so a Host binding on
+ *   ctrl+i fires on Tab presses on legacy terminals — stealing the
+ *   editor's tab completion);
+ * - `ctrl+h` is the BACKSPACE byte (0x08) — same class as ctrl+i;
+ * - `ctrl+_` is the 0x1f byte — the fork maps Ctrl+- to the SAME 0x1f
+ *   (rawCtrlChar('-') = 31, the same physical US key as _), so ctrl+_ and
+ *   ctrl+- are one physical legacy byte.
  * A binding that depends on the terminal protocol to be distinguishable
- * from a lifecycle key is unsupported: rejected with a diagnostic. */
+ * from a fixed key is unsupported: rejected with a diagnostic. */
 const LEGACY_COLLISION_KEYS = new Set(
-  ['ctrl+[', 'ctrl+j', 'ctrl+m'].map(key => canonicalizeKeyId(key as KeyId)),
+  ['ctrl+[', 'ctrl+j', 'ctrl+m', 'ctrl+i', 'ctrl+h', 'ctrl+_'].map(key => canonicalizeKeyId(key as KeyId)),
 )
 
 /** The NON-CONFIGURABLE overlay/component default keys (plan §3.3 fixed
@@ -193,7 +201,7 @@ export function parseUserKeybindings(
         // Legacy terminal collisions are REJECTED for the leader prefix too
         // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
         // swallow the lifecycle Esc/Enter on legacy terminals.
-        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — it collides with a lifecycle key on legacy terminals — ignored`)
+        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — it collides with a fixed key on legacy terminals — ignored`)
       } else {
         leader = { key: canonicalLeader, timeoutMs: options.leaderTimeoutMs ?? DEFAULT_LEADER_TIMEOUT_MS }
       }
@@ -274,7 +282,7 @@ export function parseUserKeybindings(
         // (convergence finding): a completion on ctrl+[ / ctrl+j / ctrl+m
         // would swallow the lifecycle Esc/Enter on legacy terminals.
         if (LEGACY_COLLISION_KEYS.has(canonicalCompleting)) {
-          diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — it collides with a lifecycle key on legacy terminals — ignored`)
+          diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — it collides with a fixed key on legacy terminals — ignored`)
           continue
         }
         leaderBindings.push({ action, key: canonicalCompleting })
@@ -304,11 +312,11 @@ export function parseUserKeybindings(
         diagnostics.push('keybindings: "app.input.submit" cannot bind Shift+Enter — it is the editor newline key — ignored')
         continue
       }
-      // Legacy terminal collisions are REJECTED (convergence §4.5): a
-      // binding indistinguishable from a lifecycle key on legacy
-      // terminals is unsupported, never a warning.
+      // Legacy terminal collisions are REJECTED (convergence §4.5 +
+      // round-12 finding): a binding indistinguishable from a fixed key
+      // on legacy terminals is unsupported, never a warning.
       if (LEGACY_COLLISION_KEYS.has(canonicalEntry)) {
-        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a lifecycle key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter) — ignored`)
+        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ is Ctrl+-) — ignored`)
         continue
       }
       // The fork editor CONSUMES its own editing bindings BEFORE the

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -332,7 +332,19 @@ export function parseUserKeybindings(
       }
       keys.push(canonicalEntry)
     }
-    if (keys.length > 0) bindings[action] = keys.length === 1 ? keys[0]! : keys
+    if (keys.length > 0) {
+      bindings[action] = keys.length === 1 ? keys[0]! : keys
+    } else if (leaderBindings.some(binding => binding.action === action)) {
+      // A LEADER-ONLY declaration (no direct keys, only `<leader>X`
+      // sequences): record an EMPTY-ARRAY marker so the effective keymap
+      // sees a USER DECLARATION and REPLACES the builtin default for this
+      // action (review round 37 — the unified override contract: absent =
+      // builtin, direct = replace, leader-only = replace, direct+leader =
+      // both user triggers with the builtin removed, false = remove all).
+      // The empty array compiles no direct rules but suppresses the
+      // builtin; the leader sequences live in `leaderBindings`.
+      bindings[action] = []
+    }
   }
 
   // A leader sequence without a leader key is inert: warn once.

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -1,10 +1,11 @@
 /**
  * User keybinding config parsing and validation (plan §12/§13/§14/§16).
  *
- * Settings shape (namespace `pi-tui`, field `keybindings`):
+ * Settings shape (namespace `dsh-pi-tui` — the TUI's own settings
+ * section, NOT the `pi-tui` profile name — field `keybindings`):
  *
  * ```yaml
- * pi-tui:
+ * dsh-pi-tui:
  *   keybindings:
  *     app.input.steer: ctrl+s
  *     app.permission.cycle: [shift+tab, ctrl+shift+p]
@@ -80,6 +81,17 @@ export function isPlainPrintableKey(key: KeyId): boolean {
  * send Ctrl+J as LF (Enter) and Ctrl+M as CR (Enter), so binding them is
  * a silent no-op on those terminals. Warned, not rejected. */
 const TERMINAL_UNRELIABLE_KEYS = new Set(['ctrl+j', 'ctrl+m'])
+
+/** The NON-CONFIGURABLE overlay/component default keys (plan §3.3 fixed
+ * overlay contracts: search close/next/previous, question/tasks flows).
+ * A configurable action bound to one of these keys is ECLIPSED while the
+ * overlay is open — the fixed key wins by precedence. Warned, not
+ * rejected (the binding still works outside the overlay). */
+const FIXED_OVERLAY_KEYS = new Set(
+  Object.values(APP_KEYBINDINGS)
+    .filter(definition => !definition.configurable)
+    .flatMap(definition => definition.defaultKeys),
+)
 
 /** The parsed, validated user configuration. */
 export interface ParsedUserKeybindings {
@@ -197,6 +209,14 @@ export function parseUserKeybindings(
       }
       if (TERMINAL_UNRELIABLE_KEYS.has(entry)) {
         diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which legacy terminals report as Enter — the binding may not fire there`)
+      }
+      // Fixed overlay-key precedence (review finding): a configurable
+      // action bound to a non-configurable overlay's key is eclipsed
+      // while that overlay is open (e.g. the search toggle remapped to
+      // Enter collides with search.next). The binding still works
+      // outside the overlay; warned, never silently dropped.
+      if (FIXED_OVERLAY_KEYS.has(entry)) {
+        diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which a non-configurable overlay owns while it is open — the overlay wins there`)
       }
       keys.push(entry)
     }

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -135,12 +135,28 @@ export function isPlainPrintableKey(key: KeyId): boolean {
  * - `ctrl+h` is the BACKSPACE byte (0x08) — same class as ctrl+i;
  * - `ctrl+_` is the 0x1f byte — the fork maps Ctrl+- to the SAME 0x1f
  *   (rawCtrlChar('-') = 31, the same physical US key as _), so ctrl+_ and
- *   ctrl+- are one physical legacy byte.
+ *   ctrl+- are ONE physical legacy byte — BOTH spellings are rejected
+ *   (round-16 finding: ctrl+- used to bypass the inventory while its
+ *   twin ctrl+_ was rejected);
+ * - `ctrl+-` is the fork editor's undo key, and on legacy terminals its
+ *   byte IS the 0x1f above — indistinguishable from ctrl+_.
  * A binding that depends on the terminal protocol to be distinguishable
- * from a fixed key is unsupported: rejected with a diagnostic. */
-const LEGACY_COLLISION_KEYS = new Set(
-  ['ctrl+[', 'ctrl+j', 'ctrl+m', 'ctrl+i', 'ctrl+h', 'ctrl+_'].map(key => canonicalizeKeyId(key as KeyId)),
+ * from a fixed key is unsupported: rejected with a diagnostic.
+ *
+ * The inventory is SHARED (round-13 finding): the config parser AND the
+ * Stable plugin registry (KeybindingRegistry.register) must reject the
+ * SAME canonical key ids — a plugin registration on ctrl+i would
+ * otherwise resolve in the EffectiveKeymap but never match the router's
+ * normalized plugin lookup (\t normalizes to `tab`, not `ctrl+i`). */
+export const LEGACY_COLLISION_KEY_IDS: ReadonlySet<string> = new Set(
+  ['ctrl+[', 'ctrl+j', 'ctrl+m', 'ctrl+i', 'ctrl+h', 'ctrl+_', 'ctrl+-'].map(key => canonicalizeKeyId(key as KeyId)),
 )
+
+/** Whether one CANONICAL key id is a legacy-terminal collision (the
+ * shared policy of the config parser and the plugin registry). */
+export function isLegacyCollisionKeyId(key: KeyId): boolean {
+  return LEGACY_COLLISION_KEY_IDS.has(canonicalizeKeyId(key))
+}
 
 /** The NON-CONFIGURABLE overlay/component default keys (plan §3.3 fixed
  * overlay contracts: search close/next/previous, question/tasks flows).
@@ -197,7 +213,7 @@ export function parseUserKeybindings(
       const canonicalLeader = canonicalizeKeyId(leaderValue as KeyId)
       if (isPlainPrintableKey(canonicalLeader)) {
         diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a plain printable leader would swallow typing — ignored`)
-      } else if (LEGACY_COLLISION_KEYS.has(canonicalLeader)) {
+      } else if (LEGACY_COLLISION_KEY_IDS.has(canonicalLeader)) {
         // Legacy terminal collisions are REJECTED for the leader prefix too
         // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
         // swallow the lifecycle Esc/Enter on legacy terminals.
@@ -281,7 +297,7 @@ export function parseUserKeybindings(
         // Legacy terminal collisions are REJECTED for completions too
         // (convergence finding): a completion on ctrl+[ / ctrl+j / ctrl+m
         // would swallow the lifecycle Esc/Enter on legacy terminals.
-        if (LEGACY_COLLISION_KEYS.has(canonicalCompleting)) {
+        if (LEGACY_COLLISION_KEY_IDS.has(canonicalCompleting)) {
           diagnostics.push(`keybindings: "${actionId}" binds a "<leader>${completing}" sequence — it collides with a fixed key on legacy terminals — ignored`)
           continue
         }
@@ -315,8 +331,8 @@ export function parseUserKeybindings(
       // Legacy terminal collisions are REJECTED (convergence §4.5 +
       // round-12 finding): a binding indistinguishable from a fixed key
       // on legacy terminals is unsupported, never a warning.
-      if (LEGACY_COLLISION_KEYS.has(canonicalEntry)) {
-        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ is Ctrl+-) — ignored`)
+      if (LEGACY_COLLISION_KEY_IDS.has(canonicalEntry)) {
+        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — it collides with a fixed key on legacy terminals (Ctrl+[ is Esc; Ctrl+J/M is Enter; Ctrl+I/H are Tab/Backspace; Ctrl+_ and Ctrl+- are one key) — ignored`)
         continue
       }
       // The fork editor CONSUMES its own editing bindings BEFORE the

--- a/src/keybindings/conflicts.ts
+++ b/src/keybindings/conflicts.ts
@@ -1,0 +1,106 @@
+/**
+ * The conflict model (plan §15): a conflict is
+ *
+ * ```text
+ * same key
+ * AND overlapping scope
+ * AND same effective priority
+ * ```
+ *
+ * — never a bare "declared twice" check. Examples:
+ *
+ * ```text
+ * Esc + question → question.cancel        legal (different keymaps)
+ * Esc + agent-running → app.agent.interrupt
+ *
+ * Ctrl+R + editor → app.history.search   conflict (same keymap, same scope)
+ * Ctrl+R + editor → app.session.rename
+ * ```
+ *
+ * Conflicting rules are DEACTIVATED (fail-soft, plan §16): neither fires,
+ * the diagnostic lists both, and every other rule keeps working. There is
+ * deliberately NO silent last-write-wins.
+ * @module @xmoon76/dsh-pi-tui/keybindings/conflicts
+ */
+
+import type { EffectiveBindingRule, KeybindingConflict, KeybindingScope } from './types.ts'
+import type { KeyId } from '@xmoon76/pi-tui'
+
+/** The scopes that are mutually exclusive capturing surfaces: when one is
+ * active the others are not (they live in different keymaps anyway — the
+ * host keymap never mixes them with app.* rules). */
+const CAPTURING_SCOPES: ReadonlySet<KeybindingScope> = new Set([
+  'question',
+  'approval',
+  'overlay',
+  'search',
+  'viewer',
+  'tasks',
+])
+
+/** Whether two scopes can be active at the same time (plan §15). The
+ * capturing scopes (question/approval/overlay/search/viewer/tasks) are
+ * mutually exclusive surfaces: while one is active the host ladder never
+ * resolves (the InputRouter's precedence owns the key first), so a
+ * capturing-scope rule NEVER conflicts with a non-capturing rule or with a
+ * DIFFERENT capturing scope. The non-capturing scopes
+ * (global/editor/agent-running) all overlap with each other. */
+export function scopesOverlap(left: KeybindingScope, right: KeybindingScope): boolean {
+  if (left === right) return true
+  const leftCapturing = CAPTURING_SCOPES.has(left)
+  const rightCapturing = CAPTURING_SCOPES.has(right)
+  if (leftCapturing || rightCapturing) return false
+  return true
+}
+
+/** Detect conflicts among a set of rules. Returns the conflicting rules
+ * (to be deactivated) and the conflict records (for diagnostics). */
+export function detectConflicts(rules: readonly EffectiveBindingRule[]): {
+  readonly conflicts: readonly KeybindingConflict[]
+  readonly deactivated: ReadonlySet<string>
+} {
+  const byKey = new Map<KeyId, EffectiveBindingRule[]>()
+  for (const rule of rules) {
+    const list = byKey.get(rule.key) ?? []
+    list.push(rule)
+    byKey.set(rule.key, list)
+  }
+  const conflicts: KeybindingConflict[] = []
+  const deactivated = new Set<string>()
+  for (const [key, keyRules] of byKey) {
+    if (keyRules.length < 2) continue
+    // Group by priority; only same-priority rules can conflict.
+    const byPriority = new Map<number, EffectiveBindingRule[]>()
+    for (const rule of keyRules) {
+      const list = byPriority.get(rule.priority) ?? []
+      list.push(rule)
+      byPriority.set(rule.priority, list)
+    }
+    for (const [priority, priorityRules] of byPriority) {
+      if (priorityRules.length < 2) continue
+      // Find the maximal set of pairwise-overlapping scopes. Simple
+      // approach: every rule whose scope overlaps with at least one other
+      // rule's scope in this group joins the conflict.
+      const involved = new Set<EffectiveBindingRule>()
+      for (let i = 0; i < priorityRules.length; i += 1) {
+        for (let j = i + 1; j < priorityRules.length; j += 1) {
+          const left = priorityRules[i]!
+          const right = priorityRules[j]!
+          if (scopesOverlap(left.scope, right.scope)) {
+            involved.add(left)
+            involved.add(right)
+          }
+        }
+      }
+      if (involved.size === 0) continue
+      for (const rule of involved) deactivated.add(rule.id)
+      conflicts.push({
+        key,
+        actions: [...involved]
+          .sort((a, b) => a.action.localeCompare(b.action))
+          .map(rule => ({ action: rule.action, scope: rule.scope, source: rule.source, ruleId: rule.id })),
+      })
+    }
+  }
+  return { conflicts, deactivated }
+}

--- a/src/keybindings/context.ts
+++ b/src/keybindings/context.ts
@@ -1,0 +1,51 @@
+/**
+ * The context contract of the keybinding resolver (plan §6). The type
+ * itself lives in types.ts; this module adds the pure derivation helper so
+ * components and tests build a context from a narrow state view without
+ * reaching into TuiApp.
+ * @module @xmoon76/dsh-pi-tui/keybindings/context
+ */
+
+import type { KeybindingContext } from './types.ts'
+
+/** A partial state view sufficient to derive a {@link KeybindingContext}. */
+export interface KeybindingContextState {
+  readonly questionActive?: boolean
+  readonly approvalActive?: boolean
+  readonly viewerMode?: 'none' | 'readonly' | 'continuable'
+  readonly searchActive?: boolean
+  readonly overlayActive?: boolean
+  readonly agentRunning?: boolean
+  /** A boolean, or a LAZY thunk (the resolver only evaluates it when a
+   * rule predicate needs it — the live editor must not be read on every
+   * keystroke). */
+  readonly editorEmpty?: boolean | (() => boolean)
+  readonly autocompleteActive?: boolean
+  readonly tasksActive?: boolean
+  readonly focusedSeat?: 'editor' | 'overlay' | 'editor-panel' | 'none'
+}
+
+/** Derive a complete context from a partial state view (defaults: the
+ * idle main-editor state). TuiApp's `keybindingContext()` and the focused
+ * components both use this, so the resolver never reads live fields
+ * directly. */
+export function deriveKeybindingContext(state: KeybindingContextState = {}): KeybindingContext {
+  const editorEmpty = state.editorEmpty ?? true
+  return {
+    focusedSeat: state.focusedSeat ?? 'editor',
+    questionActive: state.questionActive ?? false,
+    approvalActive: state.approvalActive ?? false,
+    viewerMode: state.viewerMode ?? 'none',
+    searchActive: state.searchActive ?? false,
+    overlayActive: state.overlayActive ?? false,
+    agentRunning: state.agentRunning ?? false,
+    // LAZY: reading the live editor on every keystroke would add a draft
+    // read to the input path (the input-router test asserts exactly one
+    // read per printable key). The getter defers to the thunk.
+    get editorEmpty() {
+      return typeof editorEmpty === 'function' ? editorEmpty() : editorEmpty
+    },
+    autocompleteActive: state.autocompleteActive ?? false,
+    tasksActive: state.tasksActive ?? false,
+  }
+}

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -3,7 +3,10 @@
  * Every default key here MUST match the pre-migration behavior — M0's
  * gate is "no production behavior change" (plan §20 M0). When a new host
  * shortcut lands, extend THIS table in the same commit (and the
- * RESERVED_HOST_KEYS inventory in keybinding-registry.ts).
+ * RESERVED_HOST_KEYS plugin-registration guard in keybinding-registry.ts
+ * if plugins must not claim the new default — that list is NOT the
+ * runtime authority; the effective keymap and the action-driven
+ * hostResolves reservation are).
  *
  * Scope semantics (plan §4): the static context contract used for conflict
  * detection and diagnostics. The resolver additionally honors per-rule
@@ -405,6 +408,11 @@ export const VIEWER_BLOCKED_PARENT_ACTIONS: ReadonlySet<AppKeybindingId> = new S
   'app.transcript.toggleThinking',
   'app.clipboard.pasteMedia',
   'app.tasks.open',
+  // Interrupting the PARENT agent from inside a subagent viewer would
+  // cancel the very session the child is part of — meaningless and
+  // destructive. The viewer's OWN exit is the fixed Esc lifecycle key,
+  // independent of the user-configurable interrupt (PR review finding).
+  'app.agent.interrupt',
 ])
 
 /** The actions whose keys are Host-owned overlay contracts for the first

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -1,0 +1,412 @@
+/**
+ * The single source of truth for the HOST action definitions (plan §5).
+ * Every default key here MUST match the pre-migration behavior — M0's
+ * gate is "no production behavior change" (plan §20 M0). When a new host
+ * shortcut lands, extend THIS table in the same commit (and the
+ * RESERVED_HOST_KEYS inventory in keybinding-registry.ts).
+ *
+ * Scope semantics (plan §4): the static context contract used for conflict
+ * detection and diagnostics. The resolver additionally honors per-rule
+ * predicates (e.g. the empty-editor ↓ affordance).
+ * @module @xmoon76/dsh-pi-tui/keybindings/definitions
+ */
+
+import type { AppKeybindingDefinition, AppKeybindingId } from './types.ts'
+
+/**
+ * The full action table. `configurable: false` marks actions whose keys
+ * are Host-owned overlay/component contracts for the first version (the
+ * plan's phased opening: M3 opens Host global actions, focused component
+ * actions open later — plan §3.3). They are still routed through the
+ * keymap so the UI never hard-codes their keys.
+ */
+export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> = {
+  // ── Input / Agent ──────────────────────────────────────────────────────
+  'app.input.submit': {
+    id: 'app.input.submit',
+    defaultKeys: ['enter'],
+    description: 'Submit input',
+    category: 'Input',
+    scope: 'editor',
+    configurable: true,
+    // Enter stays with the FORK editor's submit path (paste-burst and
+    // backslash-newline semantics live there — plan §8 resolver priority
+    // 5). The host ladder never consumes Enter; a user-bound alternate
+    // key for this action routes through submitDraft.
+    hostResolved: false,
+  },
+  'app.input.queue': {
+    id: 'app.input.queue',
+    defaultKeys: ['ctrl+enter'],
+    description: 'Queue input (the busy-Enter opposite chord)',
+    category: 'Input',
+    scope: 'editor',
+    configurable: true,
+  },
+  'app.input.steer': {
+    id: 'app.input.steer',
+    defaultKeys: ['ctrl+s'],
+    description: 'Steer the running agent with the draft',
+    category: 'Input',
+    scope: 'agent-running',
+    configurable: true,
+  },
+  'app.input.dequeue': {
+    id: 'app.input.dequeue',
+    defaultKeys: ['alt+up'],
+    description: 'Recall queued input into the editor',
+    category: 'Input',
+    scope: 'editor',
+    configurable: true,
+  },
+  'app.agent.interrupt': {
+    id: 'app.agent.interrupt',
+    defaultKeys: ['escape'],
+    description: 'Interrupt the current activity (single Esc while busy; double-Esc while idle)',
+    category: 'Agent',
+    scope: 'agent-running',
+    configurable: true,
+  },
+  'app.exit.request': {
+    id: 'app.exit.request',
+    defaultKeys: ['ctrl+c', 'ctrl+d'],
+    description: 'Quit the TUI (Ctrl+C clears the draft first; a second press exits)',
+    category: 'Agent',
+    scope: 'global',
+    configurable: true,
+  },
+
+  // ── Transcript ─────────────────────────────────────────────────────────
+  'app.transcript.search': {
+    id: 'app.transcript.search',
+    defaultKeys: ['ctrl+f', 'ctrl+shift+f'],
+    description: 'Search the transcript',
+    category: 'Transcript',
+    scope: 'global',
+    configurable: true,
+  },
+  'app.transcript.search.next': {
+    id: 'app.transcript.search.next',
+    defaultKeys: ['enter'],
+    description: 'Jump to the next search match',
+    category: 'Transcript',
+    scope: 'search',
+    configurable: false,
+  },
+  'app.transcript.search.previous': {
+    id: 'app.transcript.search.previous',
+    defaultKeys: ['shift+enter'],
+    description: 'Jump to the previous search match',
+    category: 'Transcript',
+    scope: 'search',
+    configurable: false,
+  },
+  'app.transcript.search.close': {
+    id: 'app.transcript.search.close',
+    defaultKeys: ['escape'],
+    description: 'Close transcript search',
+    category: 'Transcript',
+    scope: 'search',
+    configurable: false,
+  },
+  'app.transcript.toggleExpand': {
+    id: 'app.transcript.toggleExpand',
+    defaultKeys: ['ctrl+o'],
+    description: 'Expand/collapse recent tool output and thinking',
+    category: 'Transcript',
+    scope: 'global',
+    configurable: true,
+  },
+  'app.transcript.toggleThinking': {
+    id: 'app.transcript.toggleThinking',
+    defaultKeys: ['alt+t'],
+    description: 'Hide/show thinking blocks',
+    category: 'Transcript',
+    scope: 'global',
+    configurable: true,
+  },
+  'app.transcript.toggleFullscreen': {
+    id: 'app.transcript.toggleFullscreen',
+    // No default key in the current TUI (fullscreen is a settings/plugin
+    // surface); registered so the user may bind it (plan §3.2).
+    defaultKeys: [],
+    description: 'Toggle fullscreen mode',
+    category: 'Transcript',
+    scope: 'global',
+    configurable: true,
+  },
+
+  // ── Editor / Clipboard ───────────────────────────────────────────────
+  'app.editor.external': {
+    id: 'app.editor.external',
+    defaultKeys: ['ctrl+g'],
+    description: 'Edit the draft in $VISUAL/$EDITOR',
+    category: 'Editor',
+    scope: 'editor',
+    configurable: true,
+  },
+  'app.clipboard.pasteMedia': {
+    id: 'app.clipboard.pasteMedia',
+    defaultKeys: ['ctrl+v'],
+    description: 'Paste media from the clipboard',
+    category: 'Editor',
+    scope: 'editor',
+    configurable: true,
+  },
+
+  // ── Permissions / Panels ───────────────────────────────────────────────
+  'app.permission.cycle': {
+    id: 'app.permission.cycle',
+    defaultKeys: ['shift+tab'],
+    description: 'Cycle the permission preset',
+    category: 'Permission',
+    scope: 'editor',
+    configurable: true,
+  },
+  'app.todo.toggle': {
+    id: 'app.todo.toggle',
+    defaultKeys: ['ctrl+t'],
+    description: 'Toggle the todo panel',
+    category: 'Panels',
+    scope: 'global',
+    configurable: true,
+  },
+  'app.tasks.open': {
+    id: 'app.tasks.open',
+    // The main path is the CONDITIONAL affordance (↓ + empty editor +
+    // active tasks — plan §5); no plain default key. Never reintroduce
+    // Ctrl+J (legacy terminals send it as LF — plan §5 note).
+    defaultKeys: [],
+    description: 'Open the task browser',
+    category: 'Panels',
+    scope: 'editor',
+    configurable: true,
+  },
+  'app.history.search': {
+    id: 'app.history.search',
+    defaultKeys: ['ctrl+r'],
+    description: 'Search input history',
+    category: 'Editor',
+    scope: 'editor',
+    configurable: true,
+  },
+  'app.shell.dismissSettled': {
+    id: 'app.shell.dismissSettled',
+    defaultKeys: ['alt+k'],
+    description: 'Dismiss settled local shell cards',
+    category: 'Panels',
+    scope: 'global',
+    configurable: true,
+  },
+
+  // ── Session / Model (reserved for later unification — plan §3.2) ──────
+  'app.session.open': {
+    id: 'app.session.open',
+    defaultKeys: [],
+    description: 'Open a session',
+    category: 'Session',
+    scope: 'global',
+    configurable: true,
+  },
+  'app.session.new': {
+    id: 'app.session.new',
+    defaultKeys: [],
+    description: 'Start a new session',
+    category: 'Session',
+    scope: 'global',
+    configurable: true,
+  },
+  'app.session.resume': {
+    id: 'app.session.resume',
+    defaultKeys: [],
+    description: 'Resume a session',
+    category: 'Session',
+    scope: 'global',
+    configurable: true,
+  },
+  'app.model.open': {
+    id: 'app.model.open',
+    defaultKeys: [],
+    description: 'Open the model picker',
+    category: 'Session',
+    scope: 'global',
+    configurable: true,
+  },
+
+  // ── Focused component: user-questions flow (plan §3.3) ────────────────
+  'question.confirm': {
+    id: 'question.confirm',
+    defaultKeys: ['enter'],
+    description: 'Confirm the current question',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.cancel': {
+    id: 'question.cancel',
+    defaultKeys: ['escape'],
+    description: 'Cancel the question flow',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.previous': {
+    id: 'question.previous',
+    defaultKeys: ['left'],
+    description: 'Go to the previous question',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.next': {
+    id: 'question.next',
+    defaultKeys: ['right'],
+    description: 'Go to the next question',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.cursorUp': {
+    id: 'question.cursorUp',
+    defaultKeys: ['up'],
+    description: 'Move the selection up',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.cursorDown': {
+    id: 'question.cursorDown',
+    defaultKeys: ['down'],
+    description: 'Move the selection down',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.pageUp': {
+    id: 'question.pageUp',
+    defaultKeys: ['pageUp'],
+    description: 'Scroll the question body up',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.pageDown': {
+    id: 'question.pageDown',
+    defaultKeys: ['pageDown'],
+    description: 'Scroll the question body down',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+  'question.toggleExpand': {
+    id: 'question.toggleExpand',
+    defaultKeys: ['e'],
+    description: 'Expand/collapse the question frame',
+    category: 'Question',
+    scope: 'question',
+    configurable: false,
+  },
+
+  // ── Focused component: task browser (plan §3.3) ────────────────────────
+  'tasks.confirm': {
+    id: 'tasks.confirm',
+    defaultKeys: ['enter'],
+    description: 'Confirm the selected task',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+  'tasks.cancel': {
+    id: 'tasks.cancel',
+    defaultKeys: ['escape'],
+    description: 'Close the task browser',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+  'tasks.cursorUp': {
+    id: 'tasks.cursorUp',
+    defaultKeys: ['up'],
+    description: 'Move the selection up',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+  'tasks.cursorDown': {
+    id: 'tasks.cursorDown',
+    defaultKeys: ['down'],
+    description: 'Move the selection down',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+  'tasks.pageUp': {
+    id: 'tasks.pageUp',
+    defaultKeys: ['pageUp'],
+    description: 'Page the task list up',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+  'tasks.pageDown': {
+    id: 'tasks.pageDown',
+    defaultKeys: ['pageDown'],
+    description: 'Page the task list down',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+  'tasks.cycleType': {
+    id: 'tasks.cycleType',
+    defaultKeys: ['tab'],
+    description: 'Cycle the task type filter',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+  'tasks.interrupt': {
+    id: 'tasks.interrupt',
+    defaultKeys: ['i'],
+    description: 'Interrupt the selected task',
+    category: 'Tasks',
+    scope: 'tasks',
+    configurable: false,
+  },
+}
+
+/** The actions a plugin may never override or preempt (plan §10): the
+ * Host safety-critical set. Users MAY rebind these (that is the point of
+ * the feature); plugins may not claim their keys or handlers. */
+export const PROTECTED_HOST_ACTIONS: ReadonlySet<AppKeybindingId> = new Set([
+  'app.exit.request',
+  'app.agent.interrupt',
+  'app.input.submit',
+])
+
+/** The parent-session actions the continuable subagent viewer blocks
+ * (plan §1.2 / M1): inside the viewer the CHILD is the only input target,
+ * so any key that resolves to one of these actions is inert there. This is
+ * the ACTION-based replacement of the old physical-key blacklist — a user
+ * remap automatically stays blocked. */
+export const VIEWER_BLOCKED_PARENT_ACTIONS: ReadonlySet<AppKeybindingId> = new Set([
+  'app.input.steer',
+  'app.input.queue',
+  'app.input.dequeue',
+  'app.permission.cycle',
+  'app.transcript.search',
+  'app.exit.request',
+  'app.editor.external',
+  'app.todo.toggle',
+  'app.transcript.toggleThinking',
+  'app.clipboard.pasteMedia',
+  'app.tasks.open',
+])
+
+/** The actions whose keys are Host-owned overlay contracts for the first
+ * version (configurable: false). Kept as a set for the config validator
+ * and the /keybindings diagnostics. */
+export const NON_CONFIGURABLE_ACTIONS: ReadonlySet<AppKeybindingId> = new Set(
+  Object.values(APP_KEYBINDINGS)
+    .filter(definition => !definition.configurable)
+    .map(definition => definition.id),
+)

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -29,10 +29,12 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
     category: 'Input',
     scope: 'editor',
     configurable: true,
-    // Enter stays with the FORK editor's submit path (paste-burst and
-    // backslash-newline semantics live there — plan §8 resolver priority
-    // 5). The host ladder never consumes Enter; a user-bound alternate
-    // key for this action routes through submitDraft.
+    // The submit key stays with the FORK editor's submit path (paste-burst
+    // and backslash-newline semantics live there — plan §8 resolver
+    // priority 5); the host ladder NEVER consumes it. A user remap /
+    // `false` is synced into the fork editor's `tui.input.submit` binding
+    // by the runner (onEditorSubmitSync), so Enter REALLY moves / gets
+    // disabled — not just the hints (PR review finding).
     hostResolved: false,
   },
   'app.input.queue': {

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -70,7 +70,10 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
   'app.exit.request': {
     id: 'app.exit.request',
     defaultKeys: ['ctrl+c', 'ctrl+d'],
-    description: 'Quit the TUI (Ctrl+C clears the draft first; a second press exits)',
+    // Key-neutral on purpose: the description shows in /keybindings and
+    // must not hard-code a physical chord (a remap must not make it a
+    // lie — see the copy-convention in docs/keybinding-architecture.md).
+    description: 'Quit the TUI (the default chord clears the draft first; a second press exits)',
     category: 'Agent',
     scope: 'global',
     configurable: true,

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -67,7 +67,11 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
   'app.agent.interrupt': {
     id: 'app.agent.interrupt',
     defaultKeys: ['escape'],
-    description: 'Interrupt the current activity (single Esc while busy; double-Esc while idle)',
+    // Action-neutral on purpose: the description shows in /keybindings
+    // and must not hard-code the physical Escape chord — the action is
+    // user-configurable, so a remap must not make the copy a lie
+    // (convergence §14 copy convention).
+    description: 'Interrupt the current activity (once while busy; twice while idle)',
     category: 'Agent',
     scope: 'agent-running',
     configurable: true,
@@ -207,38 +211,47 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
     configurable: true,
   },
 
-  // ── Session / Model (reserved for later unification — plan §3.2) ──────
+  // ── Session / Model (RESERVED for later unification — plan §3.2) ──────
+  // These are NOT implemented in this version: the dispatcher has no
+  // host behavior for them. `configurable: false` + `availability:
+  // 'reserved'` means the parser rejects any user binding with a
+  // diagnostic — they are never bindable no-op keys (convergence §7: a
+  // user-configurable action must actually DO something).
   'app.session.open': {
     id: 'app.session.open',
     defaultKeys: [],
-    description: 'Open a session',
+    description: 'Open a session (reserved — not implemented in this version)',
     category: 'Session',
     scope: 'global',
-    configurable: true,
+    configurable: false,
+    availability: 'reserved',
   },
   'app.session.new': {
     id: 'app.session.new',
     defaultKeys: [],
-    description: 'Start a new session',
+    description: 'Start a new session (reserved — not implemented in this version)',
     category: 'Session',
     scope: 'global',
-    configurable: true,
+    configurable: false,
+    availability: 'reserved',
   },
   'app.session.resume': {
     id: 'app.session.resume',
     defaultKeys: [],
-    description: 'Resume a session',
+    description: 'Resume a session (reserved — not implemented in this version)',
     category: 'Session',
     scope: 'global',
-    configurable: true,
+    configurable: false,
+    availability: 'reserved',
   },
   'app.model.open': {
     id: 'app.model.open',
     defaultKeys: [],
-    description: 'Open the model picker',
+    description: 'Open the model picker (reserved — not implemented in this version)',
     category: 'Session',
     scope: 'global',
-    configurable: true,
+    configurable: false,
+    availability: 'reserved',
   },
 
   // ── Focused component: user-questions flow (plan §3.3) ────────────────

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -147,8 +147,9 @@ export class EffectiveKeymap {
       }
       if (userValue !== undefined) {
         // 2. User overrides replace the builtin keys for this action.
-        // (`false` was handled above, so this is a key or key list.) A
-        // conditional action's user rules inherit its predicate.
+        // (`false` was handled above, so this is a key, key list, or the
+        // LEADER-ONLY EMPTY-ARRAY marker.) A conditional action's user
+        // rules inherit its predicate.
         const predicate = predicateByAction.get(definition.id)
         const keys = Array.isArray(userValue) ? userValue : [userValue]
         for (const key of keys) {
@@ -156,14 +157,20 @@ export class EffectiveKeymap {
           if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
         }
         // For an EDITOR-OWNED action (submit) the BUILTIN also compiles as
-        // an owner=editor rule: the user override (priority 200) shadows it
-        // when effective, but if the override CONFLICTS away (e.g.
-        // submit=ctrl+x vs history=ctrl+x), the builtin Enter survives the
-        // shadow as the fail-soft (convergence §4.5 — no fabricated
-        // fallback: the builtin was always a declared rule, it just gets
-        // shadowed by a WORKING override). Explicit `false` was handled
-        // above and skips this entirely.
-        if (definition.hostResolved === false) {
+        // an owner=editor rule: a NON-EMPTY user override (priority 200)
+        // shadows it when effective, but if the override CONFLICTS away
+        // (e.g. submit=ctrl+x vs history=ctrl+x), the builtin Enter
+        // survives the shadow as the fail-soft (convergence §4.5 — no
+        // fabricated fallback: the builtin was always a declared rule, it
+        // just gets shadowed by a WORKING override). The LEADER-ONLY
+        // marker (an EMPTY user array) is a full replacement declaration
+        // and does NOT compile the builtin fallback either — the leader
+        // sequence is the only trigger (review round 37: the unified
+        // override contract — a leader-only submit must not keep the
+        // builtin Enter declared in the unified model, so resolve(Enter)
+        // returns undefined and matches(Enter, submit) is false). Explicit
+        // `false` was handled above and skips this entirely.
+        if (definition.hostResolved === false && keys.length > 0) {
           for (const key of definition.defaultKeys) {
             const rule = this.rule(definition, key, 'builtin', PRIORITY.builtin)
             if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
@@ -228,8 +235,33 @@ export class EffectiveKeymap {
       if (!isDuplicate(pluginRule.action, pluginRule.key)) rules.push(pluginRule)
     }
     // 5. Conflict detection: deactivate conflicting rules, report them.
-    const { conflicts, deactivated } = detectConflicts(rules)
+    const { conflicts, deactivated: conflicted } = detectConflicts(rules)
+    // The deactivation set is mutated below (the editor-owned fail-soft
+    // deactivation), so copy the conflict result.
+    const deactivated = new Set(conflicted)
     this.conflicts = conflicts
+    // 5b. EDITOR-OWNED FAIL-SOFT deactivation (review round 37 — the
+    // unified override contract): for an editor-owned action (submit), a
+    // WORKING user direct override must remove the builtin default from
+    // the RUNTIME resolver too — not just from the read model. The
+    // builtin Enter rule compiles as a fail-soft (convergence §4.5) so a
+    // CONFLICTED override restores it, but when a user-owned editor rule
+    // of the same action is LIVE (not deactivated), the builtin default
+    // is removed from the resolution set: resolve(Enter) is undefined and
+    // matches(Enter, submit) is false — one effective truth everywhere.
+    // (A conflicted-away override has no live user editor rule, so the
+    // builtin survives — the documented conflict fail-soft.)
+    const userEditorLive = new Set<string>()
+    for (const rule of rules) {
+      if (deactivated.has(rule.id)) continue
+      if (rule.owner === 'editor' && rule.source === 'user') userEditorLive.add(rule.action)
+    }
+    for (const rule of rules) {
+      if (rule.owner === 'editor' && rule.source === 'builtin'
+        && userEditorLive.has(rule.action)) {
+        deactivated.add(rule.id)
+      }
+    }
     // 6. PRIORITY SHADOW (plan §6.2, convergence §4.3): for each key, the
     // highest-priority tier that still has a live (non-deactivated) rule
     // is the TOP TRIGGER; every LOWER-priority rule on the same key with
@@ -370,15 +402,18 @@ export class EffectiveKeymap {
     return false
   }
 
-  /** The read-model projection of ONE action: its visible rules with a
-   * working user override REPLACING the editor-owned builtin default of
-   * the same action (a user remap of submit moves the key — the builtin
-   * Enter is not advertised alongside, convergence §4.5). HOST-owned
-   * builtins stay ADDITIVE (the documented additive affordance: a user
-   * key joins the action's default keys). This is the SINGLE projection
-   * behind keysFor/editorKeysFor/hostKeysFor/snapshot — one fact
-   * everywhere (review finding: the snapshot used to iterate the raw
-   * visible set and re-advertised a replaced builtin). */
+  /** The read-model projection of ONE action: its visible rules. A
+   * working user override already REPLACED the builtin at compile time
+   * (the user-declaration branch skips the builtin compilation — unified
+   * override contract, review round 37), and any unconditionally shadowed
+   * rule was removed by the priority-shadow step, so this set is the
+   * effective truth. The editor-owned builtin of submit is additionally
+   * filtered here for safety (convergence §4.5: a working user remap
+   * never advertises the replaced Enter alongside), though the step-5b
+   * deactivation already removes it from the resolution set. This is the
+   * SINGLE projection behind keysFor/editorKeysFor/hostKeysFor/snapshot —
+   * one fact everywhere (review finding: the snapshot used to iterate the
+   * raw visible set and re-advertised a replaced builtin). */
   private visibleRulesFor(action: string): EffectiveBindingRule[] {
     const rules = this.visibleRules.filter(rule => rule.action === action)
     if (!rules.some(rule => rule.source === 'user')) return rules

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -242,6 +242,15 @@ export class EffectiveKeymap {
     return [...keys]
   }
 
+  /** Every ACTIVE key across all rules (conflict detection: the leader
+   * prefix must not collide with an active direct key — PR review
+   * finding). */
+  activeKeys(): KeyId[] {
+    const keys = new Set<KeyId>()
+    for (const rule of this.activeRules) keys.add(rule.key)
+    return [...keys]
+  }
+
   /** The primary (first) effective key of one action, or undefined. */
   primaryKeyFor(action: string): KeyId | undefined {
     const keys = this.keysFor(action)

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -204,8 +204,15 @@ export class EffectiveKeymap {
     }
     // 4. Plugin contributions (lowest priority; never beats a Host rule).
     for (const plugin of this.pluginRules) {
+      // The rule id is NAMESPACED (convergence finding): the public
+      // contribution id is arbitrary and could equal a HOST rule id
+      // (e.g. `app.input.steer@builtin:ctrl+s`); deactivation is by id,
+      // so a plugin-id collision would deactivate the HOST rule too. The
+      // `plugin:` prefix is impossible for a host rule (host ids are
+      // `${action}@${source}:${key}`) and preserves the public id for
+      // diagnostics.
       const pluginRule = {
-        id: plugin.id,
+        id: `plugin:${plugin.id}`,
         action: plugin.action,
         key: canonicalizeKeyId(plugin.key),
         source: 'plugin' as const,

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -244,10 +244,54 @@ export class EffectiveKeymap {
 
   /** Every ACTIVE key across all rules (conflict detection: the leader
    * prefix must not collide with an active direct key — PR review
-   * finding). */
+   * finding). NOTE: this includes PLUGIN rules — use
+   * {@link hostActiveKeys} for the host-owned reservation/conflict
+   * checks (PR review finding: plugin rules must never be treated as
+   * Host actions). */
   activeKeys(): KeyId[] {
     const keys = new Set<KeyId>()
     for (const rule of this.activeRules) keys.add(rule.key)
+    return [...keys]
+  }
+
+  /** Every ACTIVE key of the HOST-owned sources only (builtin / user /
+   * composition — PLUGIN rules excluded). The runtime reservation and
+   * the leader-prefix collision check must consider only these: a
+   * plugin binding is NOT a Host action, so it neither reserves a key
+   * in the router nor collides with the leader prefix (PR review
+   * finding). */
+  hostActiveKeys(): KeyId[] {
+    const keys = new Set<KeyId>()
+    for (const rule of this.activeRules) {
+      if (rule.source === 'plugin') continue
+      keys.add(rule.key)
+    }
+    return [...keys]
+  }
+
+  /** Whether the raw input resolves to a HOST-owned action (plugin rules
+   * excluded). The input router's runtime reservation uses this: a key
+   * only a PLUGIN binds is NOT host-reserved and must reach the plugin
+   * dispatch stage (PR review finding). */
+  hostResolves(data: string, context: KeybindingContext): boolean {
+    for (const rule of this.activeRules) {
+      if (rule.source === 'plugin') continue
+      if (!matchesKey(data, rule.key)) continue
+      if (rule.predicate !== undefined && !rule.predicate(context)) continue
+      return true
+    }
+    return false
+  }
+
+  /** The effective keys of one action from the HOST sources ONLY
+   * (plugin rules excluded — a plugin binding is additive, never a
+   * replacement of the host's key; PR review finding). */
+  hostKeysFor(action: string): KeyId[] {
+    const keys = new Set<KeyId>()
+    for (const rule of this.activeRules) {
+      if (rule.source === 'plugin') continue
+      if (rule.action === action) keys.add(rule.key)
+    }
     return [...keys]
   }
 

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -18,7 +18,8 @@
  */
 
 import { matchesKey, type KeyId } from '@xmoon76/pi-tui'
-import { detectConflicts } from './conflicts.ts'
+import { detectConflicts, scopesOverlap } from './conflicts.ts'
+import { canonicalizeKeyId } from './key-identity.ts'
 import { formatKeyId } from './hints.ts'
 import type {
   AppKeybindingDefinition,
@@ -104,6 +105,14 @@ export class EffectiveKeymap {
   rebuild(): void {
     const rules: EffectiveBindingRule[] = []
     const diagnostics: string[] = []
+    // Same-action + same-canonical-key declarations DEDUPE (plan §6.1):
+    // `['ctrl+s', 'ctrl+s']` (or alias spellings of one key) is ONE
+    // trigger, never a self-conflict. Tracked by action+canonicalKey; the
+    // FIRST declaration (highest source priority among identical ones)
+    // wins. This runs before conflict detection so a duplicated key never
+    // deactivates itself.
+    const isDuplicate = (action: string, key: KeyId): boolean =>
+      rules.some(rule => rule.action === action && rule.key === key)
     // The conditional predicate of one action (the composition rules):
     // a USER override of a conditional action must keep the SAME
     // predicate — e.g. a remap of app.tasks.open must not open the task
@@ -129,13 +138,15 @@ export class EffectiveKeymap {
         const predicate = predicateByAction.get(definition.id)
         const keys = Array.isArray(userValue) ? userValue : [userValue]
         for (const key of keys) {
-          rules.push({ ...this.rule(definition, key, 'user', PRIORITY.user), ...predicate === undefined ? {} : { predicate } })
+          const rule = { ...this.rule(definition, key, 'user', PRIORITY.user), ...predicate === undefined ? {} : { predicate } }
+          if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
         }
         continue
       }
       if (definition.hostResolved === false) continue
       for (const key of definition.defaultKeys) {
-        rules.push(this.rule(definition, key, 'builtin', PRIORITY.builtin))
+        const rule = this.rule(definition, key, 'builtin', PRIORITY.builtin)
+        if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
       }
     }
     // 3. Composition (conditional affordance) rules. Skipped when the user
@@ -145,31 +156,62 @@ export class EffectiveKeymap {
       if (definition === undefined) continue
       if (this.includeScopes !== undefined && !this.includeScopes.has(definition.scope)) continue
       if (!this.safeMode && this.userBindings[composition.action] === false) continue
-      rules.push({
-        id: `${composition.action}@composition`,
+      const compositionRule = {
+        id: `${composition.action}@composition:${canonicalizeKeyId(composition.key)}`,
         action: composition.action,
-        key: composition.key,
-        source: 'composition',
+        key: canonicalizeKeyId(composition.key),
+        source: 'composition' as const,
         scope: definition.scope,
         priority: PRIORITY.composition,
         predicate: composition.predicate,
-      })
+      }
+      if (!isDuplicate(compositionRule.action, compositionRule.key)) rules.push(compositionRule)
     }
     // 4. Plugin contributions (lowest priority; never beats a Host rule).
     for (const plugin of this.pluginRules) {
-      rules.push({
+      const pluginRule = {
         id: plugin.id,
         action: plugin.action,
-        key: plugin.key,
-        source: 'plugin',
-        scope: 'global',
+        key: canonicalizeKeyId(plugin.key),
+        source: 'plugin' as const,
+        scope: 'global' as const,
         priority: PRIORITY.plugin,
-      })
+      }
+      if (!isDuplicate(pluginRule.action, pluginRule.key)) rules.push(pluginRule)
     }
     // 5. Conflict detection: deactivate conflicting rules, report them.
     const { conflicts, deactivated } = detectConflicts(rules)
     this.conflicts = conflicts
-    this.activeRules = rules.filter(rule => !deactivated.has(rule.id))
+    // 6. PRIORITY SHADOW (plan §6.2, convergence §4.3): for each key, the
+    // highest-priority tier that still has a live (non-deactivated) rule
+    // wins; every LOWER-priority rule on the same key with an OVERLAPPING
+    // scope is SHADOWED — it must never appear in resolve/keysFor/keyHint/
+    // snapshot, because the runtime can never fire it. (The higher tier
+    // may itself be fully conflict-deactivated; then the next tier
+    // survives — plan §6.3 — provided its rules were DECLARED, never a
+    // fabricated builtin fallback.)
+    const shadowed = new Set<string>()
+    {
+      const byKey = new Map<KeyId, EffectiveBindingRule[]>()
+      for (const rule of rules) {
+        if (deactivated.has(rule.id)) continue
+        const list = byKey.get(rule.key) ?? []
+        list.push(rule)
+        byKey.set(rule.key, list)
+      }
+      for (const keyRules of byKey.values()) {
+        if (keyRules.length < 2) continue
+        const maxPriority = Math.max(...keyRules.map(rule => rule.priority))
+        for (const rule of keyRules) {
+          if (rule.priority >= maxPriority) continue
+          // Only shadow when the scopes actually overlap with a winner.
+          const winnerOverlaps = keyRules.some(winner =>
+            winner.priority === maxPriority && scopesOverlap(rule.scope, winner.scope))
+          if (winnerOverlaps) shadowed.add(rule.id)
+        }
+      }
+    }
+    this.activeRules = rules.filter(rule => !deactivated.has(rule.id) && !shadowed.has(rule.id))
     for (const conflict of conflicts) {
       const names = conflict.actions.map(entry => `${entry.ruleId} (${entry.scope}, ${entry.source})`).join(' vs ')
       diagnostics.push(`keybinding conflict on ${formatKeyId(conflict.key)}: ${names} — neither binding was activated`)
@@ -189,10 +231,15 @@ export class EffectiveKeymap {
     // (review finding: a shared `${action}@${source}` id chained the
     // deactivation across every key of the action, and the resolve
     // tie-break could not tell the rules apart either).
+    // The key is CANONICALIZED at compile time: every spelling of one
+    // physical key (esc/escape, ctrl+shift+p / shift+ctrl+p) becomes the
+    // SAME rule key, so conflict detection, dedupe, the leader collision
+    // and the read model all share one identity (convergence contract).
+    const canonical = canonicalizeKeyId(key)
     return {
-      id: `${definition.id}@${source}:${key}`,
+      id: `${definition.id}@${source}:${canonical}`,
       action: definition.id,
-      key,
+      key: canonical,
       source,
       scope: definition.scope,
       priority,
@@ -293,6 +340,23 @@ export class EffectiveKeymap {
       if (rule.action === action) keys.add(rule.key)
     }
     return [...keys]
+  }
+
+  /** Whether one action can fire in the CURRENT context (convergence
+   * §4.7/§8.3): the action has at least one effective rule whose
+   * predicate passes. Used by the leader machine before dispatching a
+   * completion — a leader sequence is another TRIGGER of the same
+   * semantic action and must obey the action's context predicate (e.g.
+   * the empty-editor ↓ tasks affordance), never a predicate bypass.
+   * Actions with no effective rules cannot activate. */
+  canActivate(action: string, context: KeybindingContext): boolean {
+    let sawRule = false
+    for (const rule of this.activeRules) {
+      if (rule.action !== action) continue
+      sawRule = true
+      if (rule.predicate === undefined || rule.predicate(context)) return true
+    }
+    return sawRule ? false : false
   }
 
   /** The primary (first) effective key of one action, or undefined. */

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -1,0 +1,265 @@
+/**
+ * The EffectiveKeymap (plan §7/§8/§2 M2): compiles Host defaults + user
+ * overrides + plugin contributions into a unified read model of RULES, and
+ * resolves raw input against the live context.
+ *
+ * The InputRouter (input-router.ts) keeps its protocol/capture/focus
+ * precedence — the keymap is consulted ONLY when the ladder allows
+ * keybinding resolution (plan §8: "不要把 InputRouter 删除").
+ *
+ * Priorities (plan §8 / §15):
+ * - plugin: 10 (a plugin binding never beats a Host action);
+ * - builtin / composition: 100;
+ * - user: 200 (a user override beats the builtin default).
+ *
+ * Conflicts (same key + overlapping scope + same priority) are deactivated
+ * with a diagnostic — never silent last-write-wins (plan §15/§16).
+ * @module @xmoon76/dsh-pi-tui/keybindings/effective-keymap
+ */
+
+import { matchesKey, type KeyId } from '@xmoon76/pi-tui'
+import { detectConflicts } from './conflicts.ts'
+import { formatKeyId } from './hints.ts'
+import type {
+  AppKeybindingDefinition,
+  AppKeybindingId,
+  EffectiveBindingRule,
+  KeybindingContext,
+  KeybindingResolution,
+  KeybindingScope,
+  KeybindingSource,
+  KeymapSnapshot,
+  UserKeybindingsConfig,
+} from './types.ts'
+
+/** The priority ladder of the effective keymap. */
+export const PRIORITY = {
+  plugin: 10,
+  builtin: 100,
+  composition: 100,
+  user: 200,
+} as const
+
+/** One plugin keybinding contribution compiled into the keymap. */
+export interface PluginKeybindingRule {
+  readonly id: string
+  readonly action: string
+  readonly key: KeyId
+}
+
+/** The conditional affordance rules synthesized by the host (plan §5):
+ * `↓` + empty editor + active tasks → app.tasks.open. */
+export interface CompositionRule {
+  readonly action: AppKeybindingId
+  readonly key: KeyId
+  readonly predicate: (context: KeybindingContext) => boolean
+}
+
+export interface EffectiveKeymapOptions {
+  readonly definitions: Readonly<Record<string, AppKeybindingDefinition>>
+  /** User overrides (M3); `false` disables the action's keys entirely. */
+  readonly userBindings?: UserKeybindingsConfig
+  /** Plugin contributions (source 'plugin', lowest priority). */
+  readonly pluginRules?: readonly PluginKeybindingRule[]
+  /** Conditional affordance rules (source 'composition'). */
+  readonly compositionRules?: readonly CompositionRule[]
+  /** Safe mode: ignore user overrides (plan §17). */
+  readonly safeMode?: boolean
+  /** Diagnostic sink (fail-soft reporting, plan §16). */
+  readonly onDiagnostic?: (message: string) => void
+  /** When set, only definitions whose scope is in this set compile rules.
+   * The HOST keymap includes the non-capturing scopes only — the
+   * focused-component actions (the question and tasks families) and the
+   * search overlay keys live in their own contexts and must never resolve
+   * in the host ladder (plan §3.3). */
+  readonly includeScopes?: ReadonlySet<KeybindingScope>
+}
+
+/** The compiled, conflict-checked rule set. */
+export class EffectiveKeymap {
+  private readonly definitions: Readonly<Record<string, AppKeybindingDefinition>>
+  private readonly userBindings: UserKeybindingsConfig
+  private readonly pluginRules: readonly PluginKeybindingRule[]
+  private readonly compositionRules: readonly CompositionRule[]
+  private readonly safeMode: boolean
+  private readonly onDiagnostic: (message: string) => void
+  private readonly includeScopes: ReadonlySet<KeybindingScope> | undefined
+
+  private revision = 0
+  private activeRules: EffectiveBindingRule[] = []
+  private conflicts: ReturnType<typeof detectConflicts>['conflicts'] = []
+
+  constructor(options: EffectiveKeymapOptions) {
+    this.definitions = options.definitions
+    this.userBindings = options.userBindings ?? {}
+    this.pluginRules = options.pluginRules ?? []
+    this.compositionRules = options.compositionRules ?? []
+    this.safeMode = options.safeMode ?? false
+    this.onDiagnostic = options.onDiagnostic ?? (() => {})
+    this.includeScopes = options.includeScopes
+    this.rebuild()
+  }
+
+  /** Recompile the rule set (after a user/plugin/safe-mode change). */
+  rebuild(): void {
+    const rules: EffectiveBindingRule[] = []
+    const diagnostics: string[] = []
+    // 1. Builtin defaults (skipped for actions the user disabled, for
+    // actions outside the keymap's scope set, and for actions whose
+    // default key belongs to a focused component — hostResolved: false).
+    for (const definition of Object.values(this.definitions)) {
+      if (this.includeScopes !== undefined && !this.includeScopes.has(definition.scope)) continue
+      const userValue = this.safeMode ? undefined : this.userBindings[definition.id as AppKeybindingId]
+      if (userValue === false) {
+        diagnostics.push(`keybinding "${definition.id}" disabled by user config`)
+        continue
+      }
+      if (userValue !== undefined) {
+        // 2. User overrides replace the builtin keys for this action.
+        // (`false` was handled above, so this is a key or key list.)
+        const keys = Array.isArray(userValue) ? userValue : [userValue]
+        for (const key of keys) {
+          rules.push(this.rule(definition, key, 'user', PRIORITY.user))
+        }
+        continue
+      }
+      if (definition.hostResolved === false) continue
+      for (const key of definition.defaultKeys) {
+        rules.push(this.rule(definition, key, 'builtin', PRIORITY.builtin))
+      }
+    }
+    // 3. Composition (conditional affordance) rules.
+    for (const composition of this.compositionRules) {
+      const definition = this.definitions[composition.action]
+      if (definition === undefined) continue
+      if (this.includeScopes !== undefined && !this.includeScopes.has(definition.scope)) continue
+      rules.push({
+        id: `${composition.action}@composition`,
+        action: composition.action,
+        key: composition.key,
+        source: 'composition',
+        scope: definition.scope,
+        priority: PRIORITY.composition,
+        predicate: composition.predicate,
+      })
+    }
+    // 4. Plugin contributions (lowest priority; never beats a Host rule).
+    for (const plugin of this.pluginRules) {
+      rules.push({
+        id: plugin.id,
+        action: plugin.action,
+        key: plugin.key,
+        source: 'plugin',
+        scope: 'global',
+        priority: PRIORITY.plugin,
+      })
+    }
+    // 5. Conflict detection: deactivate conflicting rules, report them.
+    const { conflicts, deactivated } = detectConflicts(rules)
+    this.conflicts = conflicts
+    this.activeRules = rules.filter(rule => !deactivated.has(rule.id))
+    for (const conflict of conflicts) {
+      const names = conflict.actions.map(entry => `${entry.ruleId} (${entry.scope}, ${entry.source})`).join(' vs ')
+      diagnostics.push(`keybinding conflict on ${formatKeyId(conflict.key)}: ${names} — neither binding was activated`)
+    }    for (const message of diagnostics) this.onDiagnostic(message)
+    this.revision += 1
+  }
+
+  private rule(
+    definition: AppKeybindingDefinition,
+    key: KeyId,
+    source: KeybindingSource,
+    priority: number,
+  ): EffectiveBindingRule {
+    return {
+      id: `${definition.id}@${source}`,
+      action: definition.id,
+      key,
+      source,
+      scope: definition.scope,
+      priority,
+    }
+  }
+
+  /** Resolve one raw input event against the live context. Predicates are
+   * evaluated ONLY for keys that match (a lazy context field like
+   * `editorEmpty` must not be read on every keystroke). */
+  resolve(data: string, context: KeybindingContext): KeybindingResolution | undefined {
+    let best: EffectiveBindingRule | undefined
+    for (const rule of this.activeRules) {
+      if (!matchesKey(data, rule.key)) continue
+      if (rule.predicate !== undefined && !rule.predicate(context)) continue
+      if (best === undefined
+        || rule.priority > best.priority
+        || (rule.priority === best.priority && rule.id < best.id)) {
+        best = rule
+      }
+    }
+    if (best === undefined) return undefined
+    return { action: best.action, key: best.key, source: best.source, ruleId: best.id }
+  }
+
+  /** The action one raw event resolves to (context-aware), or undefined. */
+  actionFor(data: string, context: KeybindingContext): string | undefined {
+    return this.resolve(data, context)?.action
+  }
+
+  /** Whether the raw event matches ANY effective key of one action
+   * (context predicates are NOT applied — use {@link resolve} when the
+   * rule is conditional). */
+  matches(data: string, action: string): boolean {
+    for (const rule of this.activeRules) {
+      if (rule.action !== action) continue
+      if (matchesKey(data, rule.key)) return true
+    }
+    return false
+  }
+
+  /** The effective keys of one action (all sources). */
+  keysFor(action: string): KeyId[] {
+    const keys = new Set<KeyId>()
+    for (const rule of this.activeRules) {
+      if (rule.action === action) keys.add(rule.key)
+    }
+    return [...keys]
+  }
+
+  /** The primary (first) effective key of one action, or undefined. */
+  primaryKeyFor(action: string): KeyId | undefined {
+    const keys = this.keysFor(action)
+    return keys[0]
+  }
+
+  /** The human hint for one action's primary key (plan §18). */
+  keyHint(action: string): string {
+    const key = this.primaryKeyFor(action)
+    return key === undefined ? '' : formatKeyId(key)
+  }
+
+  /** The current conflicts (diagnostics). */
+  conflictsList(): ReturnType<typeof detectConflicts>['conflicts'] {
+    return this.conflicts
+  }
+
+  /** The immutable read model (plan §2 M2). */
+  snapshot(): KeymapSnapshot {
+    const byAction = new Map<string, { keys: KeyId[]; scope: string; source: KeybindingSource }>()
+    for (const rule of this.activeRules) {
+      const entry = byAction.get(rule.action) ?? { keys: [], scope: rule.scope, source: rule.source }
+      entry.keys.push(rule.key)
+      byAction.set(rule.action, entry)
+    }
+    return {
+      revision: this.revision,
+      bindings: [...byAction.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([action, entry]) => ({
+          action,
+          keys: entry.keys,
+          scope: entry.scope as AppKeybindingDefinition['scope'],
+          source: entry.source,
+        })),
+      conflicts: this.conflicts,
+    }
+  }
+}

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -449,6 +449,23 @@ export class EffectiveKeymap {
     return [...keys]
   }
 
+  /** Every ACTIVE key of the PLUGIN-owned rules (owner=plugin — the
+   * Stable plugin bindings). The leader-prefix collision check considers
+   * these too (round-12 finding): the leader machine feeds BEFORE the
+   * plugin stage, so a leader key equal to a live plugin key would
+   * silently swallow the plugin binding while the read model still
+   * advertised it — the leader must be disabled instead. Visible rules
+   * only: a deactivated (conflicted) or unconditionally shadowed plugin
+   * key is not a live binding. */
+  pluginActiveKeys(): KeyId[] {
+    const keys = new Set<KeyId>()
+    for (const rule of this.visibleRules) {
+      if (rule.owner !== 'plugin') continue
+      keys.add(rule.key)
+    }
+    return [...keys]
+  }
+
   /** Whether one action can fire in the CURRENT context (convergence
    * §4.7/§8.3): the action has at least one effective rule whose
    * predicate passes. Used by the leader machine before dispatching a

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -30,6 +30,7 @@ import type {
   KeybindingScope,
   KeybindingSource,
   KeymapSnapshot,
+  RuleOwner,
   UserKeybindingsConfig,
 } from './types.ts'
 
@@ -87,7 +88,15 @@ export class EffectiveKeymap {
   private readonly includeScopes: ReadonlySet<KeybindingScope> | undefined
 
   private revision = 0
+  /** The full resolution set: every non-deactivated rule (shadowed rules
+   * stay — the resolver picks the highest-priority predicate-passing
+   * candidate, so a conditional top trigger with a false predicate lets a
+   * shadowed lower rule fire in context). */
   private activeRules: EffectiveBindingRule[] = []
+  /** The READ-MODEL set: top triggers only (shadowed rules excluded) —
+   * keysFor/keyHint/snapshot/hostActiveKeys/hostKeysFor/editorKeysFor
+   * report these (convergence §4.3). */
+  private topTriggerRules: EffectiveBindingRule[] = []
   private conflicts: ReturnType<typeof detectConflicts>['conflicts'] = []
 
   constructor(options: EffectiveKeymapOptions) {
@@ -141,9 +150,34 @@ export class EffectiveKeymap {
           const rule = { ...this.rule(definition, key, 'user', PRIORITY.user), ...predicate === undefined ? {} : { predicate } }
           if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
         }
+        // For an EDITOR-OWNED action (submit) the BUILTIN also compiles as
+        // an owner=editor rule: the user override (priority 200) shadows it
+        // when effective, but if the override CONFLICTS away (e.g.
+        // submit=ctrl+x vs history=ctrl+x), the builtin Enter survives the
+        // shadow as the fail-soft (convergence §4.5 — no fabricated
+        // fallback: the builtin was always a declared rule, it just gets
+        // shadowed by a WORKING override). Explicit `false` was handled
+        // above and skips this entirely.
+        if (definition.hostResolved === false) {
+          for (const key of definition.defaultKeys) {
+            const rule = this.rule(definition, key, 'builtin', PRIORITY.builtin)
+            if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
+          }
+        }
         continue
       }
-      if (definition.hostResolved === false) continue
+      if (definition.hostResolved === false) {
+        // The editor-owned defaults (submit's Enter) DO compile — as
+        // owner=editor rules — so the unified model sees them
+        // (conflict/shadow/read-model); the Host resolver excludes them
+        // (convergence §3 finding: submit participates in the model, the
+        // fork editor executes it).
+        for (const key of definition.defaultKeys) {
+          const rule = this.rule(definition, key, 'builtin', PRIORITY.builtin)
+          if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
+        }
+        continue
+      }
       for (const key of definition.defaultKeys) {
         const rule = this.rule(definition, key, 'builtin', PRIORITY.builtin)
         if (!isDuplicate(rule.action, rule.key)) rules.push(rule)
@@ -163,6 +197,7 @@ export class EffectiveKeymap {
         source: 'composition' as const,
         scope: definition.scope,
         priority: PRIORITY.composition,
+        owner: 'host' as const,
         predicate: composition.predicate,
       }
       if (!isDuplicate(compositionRule.action, compositionRule.key)) rules.push(compositionRule)
@@ -176,6 +211,7 @@ export class EffectiveKeymap {
         source: 'plugin' as const,
         scope: 'global' as const,
         priority: PRIORITY.plugin,
+        owner: 'plugin' as const,
       }
       if (!isDuplicate(pluginRule.action, pluginRule.key)) rules.push(pluginRule)
     }
@@ -184,12 +220,17 @@ export class EffectiveKeymap {
     this.conflicts = conflicts
     // 6. PRIORITY SHADOW (plan §6.2, convergence §4.3): for each key, the
     // highest-priority tier that still has a live (non-deactivated) rule
-    // wins; every LOWER-priority rule on the same key with an OVERLAPPING
-    // scope is SHADOWED — it must never appear in resolve/keysFor/keyHint/
-    // snapshot, because the runtime can never fire it. (The higher tier
-    // may itself be fully conflict-deactivated; then the next tier
-    // survives — plan §6.3 — provided its rules were DECLARED, never a
-    // fabricated builtin fallback.)
+    // is the TOP TRIGGER; every LOWER-priority rule on the same key with
+    // an OVERLAPPING scope is SHADOWED for the READ MODEL. Shadowed rules
+    // STAY in the resolution set, because shadowing is CONTEXT-AWARE: a
+    // conditional high-priority rule whose predicate is FALSE in a given
+    // context must NOT block the lower rule from firing (convergence §4.3
+    // finding — the resolver picks the highest-priority predicate-passing
+    // candidate). Read-model APIs (keysFor/keyHint/snapshot/
+    // hostActiveKeys/hostKeysFor/editorKeysFor) report the TOP TRIGGER
+    // only. (The higher tier may itself be fully conflict-deactivated;
+    // then the next tier is the top — plan §6.3 — provided its rules were
+    // DECLARED, never a fabricated builtin fallback.)
     const shadowed = new Set<string>()
     {
       const byKey = new Map<KeyId, EffectiveBindingRule[]>()
@@ -211,7 +252,12 @@ export class EffectiveKeymap {
         }
       }
     }
-    this.activeRules = rules.filter(rule => !deactivated.has(rule.id) && !shadowed.has(rule.id))
+    // Resolution set: every non-deactivated rule (shadowed rules stay —
+    // the resolver's predicate-aware priority pick may need them as
+    // context fallbacks).
+    this.activeRules = rules.filter(rule => !deactivated.has(rule.id))
+    // Read-model set: top triggers only (shadowed rules excluded).
+    this.topTriggerRules = rules.filter(rule => !deactivated.has(rule.id) && !shadowed.has(rule.id))
     for (const conflict of conflicts) {
       const names = conflict.actions.map(entry => `${entry.ruleId} (${entry.scope}, ${entry.source})`).join(' vs ')
       diagnostics.push(`keybinding conflict on ${formatKeyId(conflict.key)}: ${names} — neither binding was activated`)
@@ -235,7 +281,12 @@ export class EffectiveKeymap {
     // physical key (esc/escape, ctrl+shift+p / shift+ctrl+p) becomes the
     // SAME rule key, so conflict detection, dedupe, the leader collision
     // and the read model all share one identity (convergence contract).
+    // OWNER: a hostResolved:false definition's keys are EXECUTED BY THE
+    // FORK EDITOR (the unified model's editor-owned tier — submit) — they
+    // never resolve in the Host ladder, but they participate in
+    // conflict/shadow/read-model (convergence §3 finding).
     const canonical = canonicalizeKeyId(key)
+    const owner: RuleOwner = definition.hostResolved === false ? 'editor' : 'host'
     return {
       id: `${definition.id}@${source}:${canonical}`,
       action: definition.id,
@@ -243,6 +294,7 @@ export class EffectiveKeymap {
       source,
       scope: definition.scope,
       priority,
+      owner,
     }
   }
 
@@ -252,6 +304,12 @@ export class EffectiveKeymap {
   resolve(data: string, context: KeybindingContext): KeybindingResolution | undefined {
     let best: EffectiveBindingRule | undefined
     for (const rule of this.activeRules) {
+      // Editor-owned rules (submit's Enter) never resolve in the HOST
+      // ladder — the fork editor executes them (convergence §3).
+      // PLUGIN rules DO resolve here at priority 10 (they always lose to
+      // a host rule); the caller's dispatcher falls through to the plugin
+      // stage when the resolved action is a plugin action.
+      if (rule.owner === 'editor') continue
       if (!matchesKey(data, rule.key)) continue
       if (rule.predicate !== undefined && !rule.predicate(context)) continue
       if (best === undefined
@@ -273,18 +331,27 @@ export class EffectiveKeymap {
    * (context predicates are NOT applied — use {@link resolve} when the
    * rule is conditional). */
   matches(data: string, action: string): boolean {
-    for (const rule of this.activeRules) {
+    for (const rule of this.topTriggerRules) {
       if (rule.action !== action) continue
       if (matchesKey(data, rule.key)) return true
     }
     return false
   }
 
-  /** The effective keys of one action (all sources). */
+  /** The effective keys of one action (all sources, top triggers only —
+   * a shadowed lower rule is never advertised, convergence §4.3). For an
+   * EDITOR-OWNED action with a working user override, the builtin default
+   * is replaced (not advertised alongside). */
   keysFor(action: string): KeyId[] {
     const keys = new Set<KeyId>()
-    for (const rule of this.activeRules) {
-      if (rule.action === action) keys.add(rule.key)
+    let sawUser = false
+    for (const rule of this.topTriggerRules) {
+      if (rule.action === action && rule.source === 'user') sawUser = true
+    }
+    for (const rule of this.topTriggerRules) {
+      if (rule.action !== action) continue
+      if (sawUser && rule.owner === 'editor' && rule.source !== 'user') continue
+      keys.add(rule.key)
     }
     return [...keys]
   }
@@ -309,8 +376,8 @@ export class EffectiveKeymap {
    * finding). */
   hostActiveKeys(): KeyId[] {
     const keys = new Set<KeyId>()
-    for (const rule of this.activeRules) {
-      if (rule.source === 'plugin') continue
+    for (const rule of this.topTriggerRules) {
+      if (rule.owner !== 'host') continue
       keys.add(rule.key)
     }
     return [...keys]
@@ -322,7 +389,7 @@ export class EffectiveKeymap {
    * dispatch stage (PR review finding). */
   hostResolves(data: string, context: KeybindingContext): boolean {
     for (const rule of this.activeRules) {
-      if (rule.source === 'plugin') continue
+      if (rule.owner !== 'host') continue
       if (!matchesKey(data, rule.key)) continue
       if (rule.predicate !== undefined && !rule.predicate(context)) continue
       return true
@@ -335,8 +402,8 @@ export class EffectiveKeymap {
    * replacement of the host's key; PR review finding). */
   hostKeysFor(action: string): KeyId[] {
     const keys = new Set<KeyId>()
-    for (const rule of this.activeRules) {
-      if (rule.source === 'plugin') continue
+    for (const rule of this.topTriggerRules) {
+      if (rule.owner !== 'host') continue
       if (rule.action === action) keys.add(rule.key)
     }
     return [...keys]
@@ -350,13 +417,57 @@ export class EffectiveKeymap {
    * the empty-editor ↓ tasks affordance), never a predicate bypass.
    * Actions with no effective rules cannot activate. */
   canActivate(action: string, context: KeybindingContext): boolean {
-    let sawRule = false
+    // ACTION AVAILABILITY (convergence §4.7 finding): whether the
+    // semantic action MAY fire in the current context — INDEPENDENT of
+    // whether a direct trigger currently survives. A leader-only action
+    // (no direct rules — e.g. app.transcript.toggleFullscreen) is still
+    // available; a direct key that got shadowed/conflicted does NOT make
+    // the action unavailable to its OTHER triggers (leader sequences).
+    //
+    // The availability is the action's context PREDICATE set (the
+    // composition affordances like the empty-editor ↓ tasks rule):
+    // every applicable predicate must be satisfiable. An action with NO
+    // predicates is always available (the caller already checked
+    // disabled/reserved).
+    const definition = this.definitions[action]
+    if (definition === undefined) return false
+    const predicates = this.compositionRules
+      .filter(composition => composition.action === action)
+      .map(composition => composition.predicate)
+    // Any unconditional effective rule makes the action available too
+    // (a user direct binding with no predicate).
     for (const rule of this.activeRules) {
       if (rule.action !== action) continue
-      sawRule = true
-      if (rule.predicate === undefined || rule.predicate(context)) return true
+      if (rule.predicate === undefined) return true
     }
-    return sawRule ? false : false
+    if (predicates.length === 0) return true
+    return predicates.some(predicate => predicate(context))
+  }
+
+  /** The effective EDITOR-OWNED keys of one action (owner=editor — the
+   * fork editor executes them; convergence §3). Used by
+   * `editorSubmitKeysFor` so the sync and the read model derive ONLY from
+   * effective editor rules, never the raw config. */
+  editorKeysFor(action: string): KeyId[] {
+    const keys = new Set<KeyId>()
+    let sawUser = false
+    for (const rule of this.topTriggerRules) {
+      if (rule.owner !== 'editor') continue
+      if (rule.action !== action) continue
+      if (rule.source === 'user') sawUser = true
+    }
+    for (const rule of this.topTriggerRules) {
+      if (rule.owner !== 'editor') continue
+      if (rule.action !== action) continue
+      // A WORKING user override REPLACES the builtin default for the same
+      // action (they are alternative triggers, not same-key shadowing):
+      // with an effective user rule, the builtin is not advertised — the
+      // override is the trigger. If the override CONFLICTED away (not in
+      // topTriggerRules), the builtin survives as the fail-soft.
+      if (sawUser && rule.source !== 'user') continue
+      keys.add(rule.key)
+    }
+    return [...keys]
   }
 
   /** The primary (first) effective key of one action, or undefined. */
@@ -379,7 +490,7 @@ export class EffectiveKeymap {
   /** The immutable read model (plan §2 M2). */
   snapshot(): KeymapSnapshot {
     const byAction = new Map<string, { keys: KeyId[]; scope: string; source: KeybindingSource }>()
-    for (const rule of this.activeRules) {
+    for (const rule of this.topTriggerRules) {
       const entry = byAction.get(rule.action) ?? { keys: [], scope: rule.scope, source: rule.source }
       entry.keys.push(rule.key)
       byAction.set(rule.action, entry)

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -183,8 +183,14 @@ export class EffectiveKeymap {
     source: KeybindingSource,
     priority: number,
   ): EffectiveBindingRule {
+    // The rule id is PER KEY (`${action}@${source}:${key}`): conflict
+    // deactivation is by id, so a conflict on ONE key of a multi-key
+    // action deactivates THAT key only — never the action's other keys
+    // (review finding: a shared `${action}@${source}` id chained the
+    // deactivation across every key of the action, and the resolve
+    // tie-break could not tell the rules apart either).
     return {
-      id: `${definition.id}@${source}`,
+      id: `${definition.id}@${source}:${key}`,
       action: definition.id,
       key,
       source,

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -90,13 +90,18 @@ export class EffectiveKeymap {
   private revision = 0
   /** The full resolution set: every non-deactivated rule (shadowed rules
    * stay — the resolver picks the highest-priority predicate-passing
-   * candidate, so a conditional top trigger with a false predicate lets a
-   * shadowed lower rule fire in context). */
+   * candidate across ALL owners, so a conditional top trigger with a
+   * false predicate lets a shadowed lower rule fire in context). */
   private activeRules: EffectiveBindingRule[] = []
-  /** The READ-MODEL set: top triggers only (shadowed rules excluded) —
-   * keysFor/keyHint/snapshot/hostActiveKeys/hostKeysFor/editorKeysFor
-   * report these (convergence §4.3). */
-  private topTriggerRules: EffectiveBindingRule[] = []
+  /** The READ-MODEL set: top triggers only, where "top" means an
+   * UNCONDITIONAL higher-priority rule (a conditional top trigger cannot
+   * permanently hide a lower rule — in the contexts where its predicate
+   * fails the lower rule genuinely fires, so the read model keeps
+   * advertising it; review finding). Every read API — keysFor/keyHint/
+   * snapshot/hostActiveKeys/hostKeysFor/editorKeysFor — projects from
+   * this ONE set (review finding: snapshot used to iterate the raw set
+   * and re-advertised replaced builtins). */
+  private visibleRules: EffectiveBindingRule[] = []
   private conflicts: ReturnType<typeof detectConflicts>['conflicts'] = []
 
   constructor(options: EffectiveKeymapOptions) {
@@ -233,11 +238,16 @@ export class EffectiveKeymap {
     // conditional high-priority rule whose predicate is FALSE in a given
     // context must NOT block the lower rule from firing (convergence §4.3
     // finding — the resolver picks the highest-priority predicate-passing
-    // candidate). Read-model APIs (keysFor/keyHint/snapshot/
-    // hostActiveKeys/hostKeysFor/editorKeysFor) report the TOP TRIGGER
-    // only. (The higher tier may itself be fully conflict-deactivated;
-    // then the next tier is the top — plan §6.3 — provided its rules were
-    // DECLARED, never a fabricated builtin fallback.)
+    // candidate). READ-MODEL shadowing is therefore CONDITIONAL-AWARE too
+    // (review finding): only an UNCONDITIONAL top trigger permanently
+    // hides a lower rule; a conditional top trigger (a predicate exists)
+    // advertises BOTH the conditional claim and its context fallback —
+    // otherwise the read model would hide a key that genuinely fires in
+    // half the contexts (keyHint/snapshot lied while the runtime was
+    // context-aware). (The higher tier may itself be fully
+    // conflict-deactivated; then the next tier is the top — plan §6.3 —
+    // provided its rules were DECLARED, never a fabricated builtin
+    // fallback.)
     const shadowed = new Set<string>()
     {
       const byKey = new Map<KeyId, EffectiveBindingRule[]>()
@@ -250,11 +260,14 @@ export class EffectiveKeymap {
       for (const keyRules of byKey.values()) {
         if (keyRules.length < 2) continue
         const maxPriority = Math.max(...keyRules.map(rule => rule.priority))
+        const topRules = keyRules.filter(rule => rule.priority === maxPriority)
+        // A purely conditional top tier never shadows in the read model.
+        if (!topRules.some(rule => rule.predicate === undefined)) continue
         for (const rule of keyRules) {
           if (rule.priority >= maxPriority) continue
           // Only shadow when the scopes actually overlap with a winner.
-          const winnerOverlaps = keyRules.some(winner =>
-            winner.priority === maxPriority && scopesOverlap(rule.scope, winner.scope))
+          const winnerOverlaps = topRules.some(winner =>
+            scopesOverlap(rule.scope, winner.scope))
           if (winnerOverlaps) shadowed.add(rule.id)
         }
       }
@@ -263,8 +276,9 @@ export class EffectiveKeymap {
     // the resolver's predicate-aware priority pick may need them as
     // context fallbacks).
     this.activeRules = rules.filter(rule => !deactivated.has(rule.id))
-    // Read-model set: top triggers only (shadowed rules excluded).
-    this.topTriggerRules = rules.filter(rule => !deactivated.has(rule.id) && !shadowed.has(rule.id))
+    // Read-model set: top triggers only (unconditionally shadowed rules
+    // excluded).
+    this.visibleRules = rules.filter(rule => !deactivated.has(rule.id) && !shadowed.has(rule.id))
     for (const conflict of conflicts) {
       const names = conflict.actions.map(entry => `${entry.ruleId} (${entry.scope}, ${entry.source})`).join(' vs ')
       diagnostics.push(`keybinding conflict on ${formatKeyId(conflict.key)}: ${names} — neither binding was activated`)
@@ -307,16 +321,21 @@ export class EffectiveKeymap {
 
   /** Resolve one raw input event against the live context. Predicates are
    * evaluated ONLY for keys that match (a lazy context field like
-   * `editorEmpty` must not be read on every keystroke). */
+   * `editorEmpty` must not be read on every keystroke).
+   *
+   * OWNER-AWARE WINNER SELECTION (review finding): ALL owners compete —
+   * host, editor (the fork-editor-owned submit triggers) and plugin — and
+   * the winner is the highest-priority predicate-passing rule. The
+   * resolution carries the winner's OWNER; the caller routes execution by
+   * it ('host' → the Host dispatcher, 'editor' → the fork editor via
+   * hostResolved:false, 'plugin' → the plugin remainder). The owner is
+   * NEVER a pre-filter: an editor-owned USER submit override (200) must
+   * beat a host builtin (100) on the same key (`submit: ctrl+s` really
+   * submits — the old code skipped editor rules BEFORE picking a winner,
+   * so steer won at runtime while the read model advertised submit). */
   resolve(data: string, context: KeybindingContext): KeybindingResolution | undefined {
     let best: EffectiveBindingRule | undefined
     for (const rule of this.activeRules) {
-      // Editor-owned rules (submit's Enter) never resolve in the HOST
-      // ladder — the fork editor executes them (convergence §3).
-      // PLUGIN rules DO resolve here at priority 10 (they always lose to
-      // a host rule); the caller's dispatcher falls through to the plugin
-      // stage when the resolved action is a plugin action.
-      if (rule.owner === 'editor') continue
       if (!matchesKey(data, rule.key)) continue
       if (rule.predicate !== undefined && !rule.predicate(context)) continue
       if (best === undefined
@@ -326,7 +345,13 @@ export class EffectiveKeymap {
       }
     }
     if (best === undefined) return undefined
-    return { action: best.action, key: best.key, source: best.source, ruleId: best.id }
+    return {
+      action: best.action,
+      key: best.key,
+      source: best.source,
+      ruleId: best.id,
+      owner: best.owner,
+    }
   }
 
   /** The action one raw event resolves to (context-aware), or undefined. */
@@ -338,29 +363,36 @@ export class EffectiveKeymap {
    * (context predicates are NOT applied — use {@link resolve} when the
    * rule is conditional). */
   matches(data: string, action: string): boolean {
-    for (const rule of this.topTriggerRules) {
+    for (const rule of this.visibleRules) {
       if (rule.action !== action) continue
       if (matchesKey(data, rule.key)) return true
     }
     return false
   }
 
-  /** The effective keys of one action (all sources, top triggers only —
-   * a shadowed lower rule is never advertised, convergence §4.3). For an
-   * EDITOR-OWNED action with a working user override, the builtin default
-   * is replaced (not advertised alongside). */
+  /** The read-model projection of ONE action: its visible rules with a
+   * working user override REPLACING the editor-owned builtin default of
+   * the same action (a user remap of submit moves the key — the builtin
+   * Enter is not advertised alongside, convergence §4.5). HOST-owned
+   * builtins stay ADDITIVE (the documented additive affordance: a user
+   * key joins the action's default keys). This is the SINGLE projection
+   * behind keysFor/editorKeysFor/hostKeysFor/snapshot — one fact
+   * everywhere (review finding: the snapshot used to iterate the raw
+   * visible set and re-advertised a replaced builtin). */
+  private visibleRulesFor(action: string): EffectiveBindingRule[] {
+    const rules = this.visibleRules.filter(rule => rule.action === action)
+    if (!rules.some(rule => rule.source === 'user')) return rules
+    return rules.filter(rule => !(rule.owner === 'editor' && rule.source !== 'user'))
+  }
+
+  /** The effective keys of one action (all sources, visible rules only —
+   * an unconditionally shadowed lower rule is never advertised,
+   * convergence §4.3; a conditional top claim keeps its fallback visible,
+   * review finding). For an EDITOR-OWNED action with a working user
+   * override, the builtin default is replaced (not advertised
+   * alongside). */
   keysFor(action: string): KeyId[] {
-    const keys = new Set<KeyId>()
-    let sawUser = false
-    for (const rule of this.topTriggerRules) {
-      if (rule.action === action && rule.source === 'user') sawUser = true
-    }
-    for (const rule of this.topTriggerRules) {
-      if (rule.action !== action) continue
-      if (sawUser && rule.owner === 'editor' && rule.source !== 'user') continue
-      keys.add(rule.key)
-    }
-    return [...keys]
+    return [...new Set(this.visibleRulesFor(action).map(rule => rule.key))]
   }
 
   /** Every ACTIVE key across all rules (conflict detection: the leader
@@ -376,32 +408,33 @@ export class EffectiveKeymap {
   }
 
   /** Every ACTIVE key of the HOST-owned sources only (builtin / user /
-   * composition — PLUGIN rules excluded). The runtime reservation and
-   * the leader-prefix collision check must consider only these: a
-   * plugin binding is NOT a Host action, so it neither reserves a key
-   * in the router nor collides with the leader prefix (PR review
+   * composition — PLUGIN and EDITOR rules excluded). The runtime
+   * reservation and the leader-prefix collision check must consider only
+   * these: a plugin binding is NOT a Host action, so it neither reserves
+   * a key in the router nor collides with the leader prefix; an
+   * EDITOR-owned submit key is the fork editor's (the leader collision
+   * check covers it via the editorSubmitKeysFor sync — PR review
    * finding). */
   hostActiveKeys(): KeyId[] {
     const keys = new Set<KeyId>()
-    for (const rule of this.topTriggerRules) {
+    for (const rule of this.visibleRules) {
       if (rule.owner !== 'host') continue
       keys.add(rule.key)
     }
     return [...keys]
   }
 
-  /** Whether the raw input resolves to a HOST-owned action (plugin rules
-   * excluded). The input router's runtime reservation uses this: a key
-   * only a PLUGIN binds is NOT host-reserved and must reach the plugin
-   * dispatch stage (PR review finding). */
+  /** Whether the raw input resolves to a HOST-owned action (plugin and
+   * editor rules excluded). WINNER-BASED (review finding): the winner of
+   * the unified selection decides — `submit: ctrl+s` (editor-owned
+   * winner) is NOT host-resolved, so the router lets the key reach the
+   * fork editor instead of swallowing it; the old check returned true
+   * whenever ANY host rule matched, so the remapped key was reserved
+   * while the read model promised submit. The input router's runtime
+   * reservation uses this: a key only a PLUGIN binds is NOT host-reserved
+   * and must reach the plugin dispatch stage (PR review finding). */
   hostResolves(data: string, context: KeybindingContext): boolean {
-    for (const rule of this.activeRules) {
-      if (rule.owner !== 'host') continue
-      if (!matchesKey(data, rule.key)) continue
-      if (rule.predicate !== undefined && !rule.predicate(context)) continue
-      return true
-    }
-    return false
+    return this.resolve(data, context)?.owner === 'host'
   }
 
   /** The effective keys of one action from the HOST sources ONLY
@@ -409,7 +442,7 @@ export class EffectiveKeymap {
    * replacement of the host's key; PR review finding). */
   hostKeysFor(action: string): KeyId[] {
     const keys = new Set<KeyId>()
-    for (const rule of this.topTriggerRules) {
+    for (const rule of this.visibleRules) {
       if (rule.owner !== 'host') continue
       if (rule.action === action) keys.add(rule.key)
     }
@@ -456,25 +489,19 @@ export class EffectiveKeymap {
    * `editorSubmitKeysFor` so the sync and the read model derive ONLY from
    * effective editor rules, never the raw config. */
   editorKeysFor(action: string): KeyId[] {
-    const keys = new Set<KeyId>()
-    let sawUser = false
-    for (const rule of this.topTriggerRules) {
-      if (rule.owner !== 'editor') continue
-      if (rule.action !== action) continue
-      if (rule.source === 'user') sawUser = true
-    }
-    for (const rule of this.topTriggerRules) {
-      if (rule.owner !== 'editor') continue
-      if (rule.action !== action) continue
-      // A WORKING user override REPLACES the builtin default for the same
-      // action (they are alternative triggers, not same-key shadowing):
-      // with an effective user rule, the builtin is not advertised — the
-      // override is the trigger. If the override CONFLICTED away (not in
-      // topTriggerRules), the builtin survives as the fail-soft.
-      if (sawUser && rule.source !== 'user') continue
-      keys.add(rule.key)
-    }
-    return [...keys]
+    return [...new Set(this.visibleRulesFor(action)
+      .filter(rule => rule.owner === 'editor')
+      .map(rule => rule.key))]
+  }
+
+  /** Whether a USER-owned editor rule of one action is in the visible
+   * read model (a WORKING direct override). The manager uses it to
+   * distinguish a leader-only submit override (no direct user rule — the
+   * builtin Enter must be removed) from a builtin-only default (review
+   * finding: a leader sequence must not clear the direct keys). */
+  editorHasUserRule(action: string): boolean {
+    return this.visibleRules.some(rule =>
+      rule.action === action && rule.owner === 'editor' && rule.source === 'user')
   }
 
   /** The primary (first) effective key of one action, or undefined. */
@@ -494,24 +521,26 @@ export class EffectiveKeymap {
     return this.conflicts
   }
 
-  /** The immutable read model (plan §2 M2). */
+  /** The immutable read model (plan §2 M2). Projects the SAME visible
+   * rules as keysFor/editorKeysFor/keyHint — a working user override
+   * never leaves the replaced builtin advertised (review finding: the
+   * snapshot used to iterate the raw top-trigger set, so /keybindings
+   * showed `Ctrl+X + Enter` for a working submit remap while /help was
+   * right). */
   snapshot(): KeymapSnapshot {
-    const byAction = new Map<string, { keys: KeyId[]; scope: string; source: KeybindingSource }>()
-    for (const rule of this.topTriggerRules) {
-      const entry = byAction.get(rule.action) ?? { keys: [], scope: rule.scope, source: rule.source }
-      entry.keys.push(rule.key)
-      byAction.set(rule.action, entry)
-    }
+    const actions = [...new Set(this.visibleRules.map(rule => rule.action))].sort()
+    const bindings = actions.map(action => {
+      const rules = this.visibleRulesFor(action)
+      return {
+        action,
+        keys: [...new Set(rules.map(rule => rule.key))],
+        scope: rules[0]!.scope as AppKeybindingDefinition['scope'],
+        source: rules[0]!.source,
+      }
+    })
     return {
       revision: this.revision,
-      bindings: [...byAction.entries()]
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([action, entry]) => ({
-          action,
-          keys: entry.keys,
-          scope: entry.scope as AppKeybindingDefinition['scope'],
-          source: entry.source,
-        })),
+      bindings,
       conflicts: this.conflicts,
     }
   }

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -5,7 +5,7 @@
  *
  * The InputRouter (input-router.ts) keeps its protocol/capture/focus
  * precedence — the keymap is consulted ONLY when the ladder allows
- * keybinding resolution (plan §8: "不要把 InputRouter 删除").
+ * keybinding resolution (plan §8: the InputRouter must NOT be deleted).
  *
  * Priorities (plan §8 / §15):
  * - plugin: 10 (a plugin binding never beats a Host action);
@@ -104,6 +104,14 @@ export class EffectiveKeymap {
   rebuild(): void {
     const rules: EffectiveBindingRule[] = []
     const diagnostics: string[] = []
+    // The conditional predicate of one action (the composition rules):
+    // a USER override of a conditional action must keep the SAME
+    // predicate — e.g. a remap of app.tasks.open must not open the task
+    // browser with a non-empty editor or no active tasks (plan §5).
+    const predicateByAction = new Map<string, (context: KeybindingContext) => boolean>()
+    for (const composition of this.compositionRules) {
+      predicateByAction.set(composition.action, composition.predicate)
+    }
     // 1. Builtin defaults (skipped for actions the user disabled, for
     // actions outside the keymap's scope set, and for actions whose
     // default key belongs to a focused component — hostResolved: false).
@@ -116,10 +124,12 @@ export class EffectiveKeymap {
       }
       if (userValue !== undefined) {
         // 2. User overrides replace the builtin keys for this action.
-        // (`false` was handled above, so this is a key or key list.)
+        // (`false` was handled above, so this is a key or key list.) A
+        // conditional action's user rules inherit its predicate.
+        const predicate = predicateByAction.get(definition.id)
         const keys = Array.isArray(userValue) ? userValue : [userValue]
         for (const key of keys) {
-          rules.push(this.rule(definition, key, 'user', PRIORITY.user))
+          rules.push({ ...this.rule(definition, key, 'user', PRIORITY.user), ...predicate === undefined ? {} : { predicate } })
         }
         continue
       }
@@ -128,11 +138,13 @@ export class EffectiveKeymap {
         rules.push(this.rule(definition, key, 'builtin', PRIORITY.builtin))
       }
     }
-    // 3. Composition (conditional affordance) rules.
+    // 3. Composition (conditional affordance) rules. Skipped when the user
+    // DISABLED the action (`false` disables every source of its keys).
     for (const composition of this.compositionRules) {
       const definition = this.definitions[composition.action]
       if (definition === undefined) continue
       if (this.includeScopes !== undefined && !this.includeScopes.has(definition.scope)) continue
+      if (!this.safeMode && this.userBindings[composition.action] === false) continue
       rules.push({
         id: `${composition.action}@composition`,
         action: composition.action,

--- a/src/keybindings/hints.ts
+++ b/src/keybindings/hints.ts
@@ -1,0 +1,55 @@
+/**
+ * Key hint formatting (plan §18): the ONE place that turns a KeyId into
+ * the human label the footer/help/settings render. The UI must never
+ * hard-code "Shift+Tab" again — it renders `keyHint(keymap, action)` so a
+ * user remap automatically updates every hint.
+ * @module @xmoon76/dsh-pi-tui/keybindings/hints
+ */
+
+import type { KeyId } from '@xmoon76/pi-tui'
+
+/** The display name of a bare (unmodified) key id. */
+const BASE_KEY_LABELS: Record<string, string> = {
+  enter: 'Enter',
+  escape: 'Esc',
+  tab: 'Tab',
+  space: 'Space',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  insert: 'Insert',
+  home: 'Home',
+  end: 'End',
+  pageUp: 'PageUp',
+  pageDown: 'PageDown',
+  up: 'Up',
+  down: 'Down',
+  left: 'Left',
+  right: 'Right',
+  'ctrl+[': 'Ctrl+[',
+}
+
+/** Format one KeyId as a human label (`ctrl+shift+f` → `Ctrl+Shift+F`). */
+export function formatKeyId(key: KeyId): string {
+  const parts = key.split('+')
+  const mods: string[] = []
+  let base = ''
+  for (const part of parts) {
+    if (part === 'ctrl') mods.push('Ctrl')
+    else if (part === 'alt') mods.push('Alt')
+    else if (part === 'shift') mods.push('Shift')
+    else if (part === 'super') mods.push('Super')
+    else base = part
+  }
+  const baseLabel = BASE_KEY_LABELS[base] ?? (base.length === 1 ? base.toUpperCase() : base)
+  return [...mods, baseLabel].join('+')
+}
+
+/** Format a `<leader>X` sequence label (`<leader>t` → `Leader T`). */
+export function formatLeaderSequence(completingKey: KeyId): string {
+  return `Leader ${formatKeyId(completingKey)}`
+}
+
+/** Join several key labels for one action (`Ctrl+F / Ctrl+Shift+F`). */
+export function formatKeyList(keys: readonly KeyId[]): string {
+  return keys.map(formatKeyId).join(' / ')
+}

--- a/src/keybindings/hints.ts
+++ b/src/keybindings/hints.ts
@@ -21,6 +21,12 @@ const BASE_KEY_LABELS: Record<string, string> = {
   end: 'End',
   pageUp: 'PageUp',
   pageDown: 'PageDown',
+  // The canonical form lowercases named keys (pageUp → pageup, pageDown →
+  // pagedown — convergence: the runtime parser lowercases, so the keymap
+  // identity matches it). The DISPLAY mapping must cover both spellings so
+  // hints always render PageUp/PageDown.
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
   up: 'Up',
   down: 'Down',
   left: 'Left',

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -41,7 +41,12 @@ const MODIFIER_ORDER: readonly string[] = ['ctrl', 'shift', 'alt', 'super']
  * 'return'         -> 'enter'
  * 'shift+ctrl+p'   -> 'ctrl+shift+p'
  * 'alt+ctrl+x'     -> 'ctrl+alt+x'
- * 'pageUp'         -> 'pageUp'        (named-key casing preserved)
+ * 'pageUp'         -> 'pageup'       (named keys canonicalize to
+ *                                    lowercase — the runtime parser
+ *                                    lowercases, so the canonical form
+ *                                    must match; the fork's matchesKey
+ *                                    is case-insensitive, convergence
+ *                                    finding)
  * ```
  * @param key - the raw KeyId.
  * @returns the canonical KeyId.
@@ -50,13 +55,15 @@ export function canonicalizeKeyId(key: KeyId): KeyId {
   const raw = key as string
   if (raw === '' || !raw.includes('+')) {
     const aliased = BASE_KEY_ALIASES[raw] ?? raw
-    return aliased as KeyId
+    return (aliased.length === 1 ? aliased : aliased.toLowerCase()) as KeyId
   }
   const parts = raw.split('+')
   const base = parts[parts.length - 1]!
   const modifiers = parts.slice(0, -1)
-  // Collapse the base alias first, then order the modifiers.
-  const canonicalBase = BASE_KEY_ALIASES[base] ?? base
+  // Collapse the base alias first, then order the modifiers. Named keys
+  // canonicalize to LOWERCASE so the keymap identity matches the runtime
+  // parser's lowercased normalized keys (pageUp/pageup are the same key).
+  const canonicalBase = BASE_KEY_ALIASES[base] ?? (base.length === 1 ? base : base.toLowerCase())
   const ordered = MODIFIER_ORDER.filter(modifier => modifiers.includes(modifier))
   // A modifier not in the fixed order is impossible per the fork grammar,
   // but keep it appended (defensive — never drop an unknown modifier).

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -1,0 +1,78 @@
+/**
+ * Canonical physical-key identity (the convergence contract, plan §1/§4.1):
+ * one physical key has exactly ONE canonical KeyId, so aliases and
+ * modifier order can never bypass conflict detection, leader-prefix
+ * collision or deduplication.
+ *
+ * ```text
+ * esc     -> escape
+ * return  -> enter
+ * shift+ctrl+p -> ctrl+shift+p
+ * ```
+ *
+ * Canonicalization is a pure string transform on the fork's KeyId grammar:
+ * - base-key aliases (`esc`/`escape`, `return`/`enter`) map to ONE name;
+ * - modifiers are reordered to the fixed order ctrl → shift → alt → super.
+ *
+ * The fork's grammar casing is PRESERVED for named keys (`pageUp`,
+ * `pageDown`, `Home` is NOT lower-cased — see {@link BASE_KEY_ALIASES}).
+ * @module @xmoon76/dsh-pi-tui/keybindings/key-identity
+ */
+
+import type { KeyId } from '@xmoon76/pi-tui'
+
+/** The canonical base-key alias map: the KEY is the canonical form, the
+ * value is the alias that collapses onto it. */
+const BASE_KEY_ALIASES: Readonly<Record<string, string>> = {
+  esc: 'escape',
+  return: 'enter',
+}
+
+/** The fixed modifier order every canonical KeyId carries. */
+const MODIFIER_ORDER: readonly string[] = ['ctrl', 'shift', 'alt', 'super']
+
+/**
+ * Canonicalize one KeyId: collapse base-key aliases and reorder the
+ * modifiers to the fixed order. Idempotent — canonicalizing a canonical
+ * key returns it unchanged.
+ *
+ * ```text
+ * 'esc'            -> 'escape'
+ * 'return'         -> 'enter'
+ * 'shift+ctrl+p'   -> 'ctrl+shift+p'
+ * 'alt+ctrl+x'     -> 'ctrl+alt+x'
+ * 'pageUp'         -> 'pageUp'        (named-key casing preserved)
+ * ```
+ * @param key - the raw KeyId.
+ * @returns the canonical KeyId.
+ */
+export function canonicalizeKeyId(key: KeyId): KeyId {
+  const raw = key as string
+  if (raw === '' || !raw.includes('+')) {
+    const aliased = BASE_KEY_ALIASES[raw] ?? raw
+    return aliased as KeyId
+  }
+  const parts = raw.split('+')
+  const base = parts[parts.length - 1]!
+  const modifiers = parts.slice(0, -1)
+  // Collapse the base alias first, then order the modifiers.
+  const canonicalBase = BASE_KEY_ALIASES[base] ?? base
+  const ordered = MODIFIER_ORDER.filter(modifier => modifiers.includes(modifier))
+  // A modifier not in the fixed order is impossible per the fork grammar,
+  // but keep it appended (defensive — never drop an unknown modifier).
+  const extra = modifiers.filter(modifier => !MODIFIER_ORDER.includes(modifier))
+  return [...ordered, ...extra, canonicalBase].join('+') as KeyId
+}
+
+/**
+ * The canonical IDENTITY of one physical key: a string that is EQUAL for
+ * every spelling of the same physical key (esc/escape, ctrl+shift+p /
+ * shift+ctrl+p). Built to be collision-free for the fork grammar (the
+ * canonical KeyId already is; the identity is a convenience wrapper used
+ * as a Map/Set key).
+ * @param key - the raw KeyId.
+ * @returns the canonical identity string.
+ */
+export function canonicalKeyIdentity(key: KeyId): string {
+  return canonicalizeKeyId(key)
+}

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -96,26 +96,47 @@ export function isTextProducingKeyId(key: KeyId): boolean {
   return base.length === 1 && base.charCodeAt(0) >= 32 && base.charCodeAt(0) <= 126
 }
 
+/** The fork matcher's RUNTIME MODIFIER CAPABILITY per base key (keys.ts
+ * switch — the exact answer to "does this base+modifier combination have
+ * at least one matching path?"):
+ * - `escape`: NONE — any modifier hits `modifier !== 0 → false`;
+ * - `f1`..`f12`: NONE — same hard reject;
+ * - `clear`: `shift` | `ctrl` ONLY — the case has no kitty /
+ *   modifyOtherKeys fallback and matchesLegacyModifierSequence supports
+ *   exactly shift or exactly ctrl (round-24 finding: alt+clear /
+ *   super+clear / ctrl+alt+clear / ctrl+shift+clear can never be
+ *   matched);
+ * - every OTHER base: ANY grammar-supported modifier — a CSI-u /
+ *   modifyOtherKeys fallback exists (probe-verified for insert/delete/
+ *   home/end/pageUp/pageDown/arrows/space/tab/enter/backspace and the
+ *   single-character branch). */
+const RUNTIME_MODIFIER_CAPABILITY: Readonly<Record<string, ReadonlySet<string>>> = {
+  escape: new Set(),
+  clear: new Set(['shift', 'ctrl']),
+}
+
 /** Whether a key is a runtime-bindable KeyId (round-22 finding): the
  * fork's matcher hard-rejects ANY modifier on the F-keys and Escape
- * (keys.ts: `if (modifier !== 0) return false`), so `shift+f5` /
- * `ctrl+escape` / ... are syntactically valid but can NEVER fire on any
- * terminal protocol — advertising them would be a dead binding. This
- * gate separates "syntactically valid grammar" from "the runtime can
- * actually match it"; the config parser (direct bindings, the leader key
- * and completions) and the plugin registry share it. Unmodified F-keys
- * and Escape stay bindable; every other named key has a CSI-u /
- * modifyOtherKeys path for its modified forms. */
+ * (keys.ts: `if (modifier !== 0) return false`), and `clear` only
+ * supports exactly shift or exactly ctrl — every other syntactically
+ * valid combination can NEVER fire on any terminal protocol, so
+ * advertising it would be a dead binding. This gate separates
+ * "syntactically valid grammar" from "the runtime can actually match
+ * it"; the config parser (direct bindings, the leader key and
+ * completions) and the plugin registry share it. Unmodified keys stay
+ * bindable. */
 export function isRuntimeBindableKeyId(key: KeyId): boolean {
   const canonical = canonicalizeKeyId(key)
   if (!isValidKeyId(canonical)) return false
   const parts = canonical.split('+')
   if (parts.length === 1) return true
   const base = parts[parts.length - 1]!
-  // The fork's UNMODIFIABLE bases (matchesKey: modifier !== 0 → false).
-  if (base === 'escape') return false
+  const modifiers = parts.slice(0, -1)
+  // The F-keys are unconditionally unmodifiable.
   if (/^f\d+$/.test(base)) return false
-  return true
+  const capability = RUNTIME_MODIFIER_CAPABILITY[base]
+  if (capability === undefined) return true
+  return modifiers.length === 1 && capability.has(modifiers[0]!)
 }
 
 /** The fork EDITOR's unconditionally-owned binding keys (packages/pi-tui

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -54,20 +54,29 @@ const MODIFIER_ORDER: readonly string[] = ['ctrl', 'shift', 'alt', 'super']
 export function canonicalizeKeyId(key: KeyId): KeyId {
   const raw = key as string
   if (raw === '' || !raw.includes('+')) {
-    const aliased = BASE_KEY_ALIASES[raw] ?? raw
-    return (aliased.length === 1 ? aliased : aliased.toLowerCase()) as KeyId
+    // LOWERCASE FIRST, then apply the alias map: `ESC` → `esc` →
+    // `escape`, `RETURN` → `return` → `enter` (a single-char key is
+    // untouched). Order matters — an uppercase alias must collapse onto
+    // the canonical base (convergence finding).
+    const lowered = raw.length === 1 ? raw : raw.toLowerCase()
+    const aliased = BASE_KEY_ALIASES[lowered] ?? lowered
+    return aliased as KeyId
   }
   const parts = raw.split('+')
   const base = parts[parts.length - 1]!
   const modifiers = parts.slice(0, -1)
-  // Collapse the base alias first, then order the modifiers. Named keys
-  // canonicalize to LOWERCASE so the keymap identity matches the runtime
-  // parser's lowercased normalized keys (pageUp/pageup are the same key).
-  const canonicalBase = BASE_KEY_ALIASES[base] ?? (base.length === 1 ? base : base.toLowerCase())
-  const ordered = MODIFIER_ORDER.filter(modifier => modifiers.includes(modifier))
+  // Collapse the base alias first (case-insensitive: lowercase the base
+  // BEFORE the alias lookup so `ESC` collapses to `escape`), then order
+  // the modifiers. Named keys canonicalize to LOWERCASE so the keymap
+  // identity matches the runtime parser's lowercased normalized keys
+  // (pageUp/pageup are the same key).
+  const loweredBase = base.length === 1 ? base : base.toLowerCase()
+  const canonicalBase = BASE_KEY_ALIASES[loweredBase] ?? loweredBase
+  const loweredMods = modifiers.map(m => m.toLowerCase())
+  const ordered = MODIFIER_ORDER.filter(modifier => loweredMods.includes(modifier))
   // A modifier not in the fixed order is impossible per the fork grammar,
   // but keep it appended (defensive — never drop an unknown modifier).
-  const extra = modifiers.filter(modifier => !MODIFIER_ORDER.includes(modifier))
+  const extra = loweredMods.filter(modifier => !MODIFIER_ORDER.includes(modifier))
   return [...ordered, ...extra, canonicalBase].join('+') as KeyId
 }
 

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -81,7 +81,7 @@ export function isValidKeyId(value: string): value is KeyId {
  * (matchesKey('A','shift+a') is TRUE) and the normalized 'a'+shift on
  * Kitty — either way it produces text, so a binding on it behaves
  * terminal-dependently and steals uppercase input on some terminals.
- * Named keys (shift+left, shift+enter, shift+f5, ...) are NOT
+ * Named keys (shift+left, shift+enter, ...) are NOT
  * text-producing and stay bindable. Shared by the config parser
  * (direct bindings + the leader key), the InputRouter (a text key never
  * reaches the plugin stage) and the plugin registry (registration
@@ -94,6 +94,28 @@ export function isTextProducingKeyId(key: KeyId): boolean {
   if (hasNonShiftModifier) return false
   if (base === 'space') return true
   return base.length === 1 && base.charCodeAt(0) >= 32 && base.charCodeAt(0) <= 126
+}
+
+/** Whether a key is a runtime-bindable KeyId (round-22 finding): the
+ * fork's matcher hard-rejects ANY modifier on the F-keys and Escape
+ * (keys.ts: `if (modifier !== 0) return false`), so `shift+f5` /
+ * `ctrl+escape` / ... are syntactically valid but can NEVER fire on any
+ * terminal protocol — advertising them would be a dead binding. This
+ * gate separates "syntactically valid grammar" from "the runtime can
+ * actually match it"; the config parser (direct bindings, the leader key
+ * and completions) and the plugin registry share it. Unmodified F-keys
+ * and Escape stay bindable; every other named key has a CSI-u /
+ * modifyOtherKeys path for its modified forms. */
+export function isRuntimeBindableKeyId(key: KeyId): boolean {
+  const canonical = canonicalizeKeyId(key)
+  if (!isValidKeyId(canonical)) return false
+  const parts = canonical.split('+')
+  if (parts.length === 1) return true
+  const base = parts[parts.length - 1]!
+  // The fork's UNMODIFIABLE bases (matchesKey: modifier !== 0 → false).
+  if (base === 'escape') return false
+  if (/^f\d+$/.test(base)) return false
+  return true
 }
 
 /** The fork EDITOR's unconditionally-owned binding keys (packages/pi-tui

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -81,8 +81,8 @@ export function isValidKeyId(value: string): value is KeyId {
  * (matchesKey('A','shift+a') is TRUE) and the normalized 'a'+shift on
  * Kitty — either way it produces text, so a binding on it behaves
  * terminal-dependently and steals uppercase input on some terminals.
- * Named keys (shift+tab, shift+left, shift+enter, shift+f5, ...) are
- * NOT text-producing and stay bindable. Shared by the config parser
+ * Named keys (shift+left, shift+enter, shift+f5, ...) are NOT
+ * text-producing and stay bindable. Shared by the config parser
  * (direct bindings + the leader key), the InputRouter (a text key never
  * reaches the plugin stage) and the plugin registry (registration
  * rejection). */
@@ -94,6 +94,53 @@ export function isTextProducingKeyId(key: KeyId): boolean {
   if (hasNonShiftModifier) return false
   if (base === 'space') return true
   return base.length === 1 && base.charCodeAt(0) >= 32 && base.charCodeAt(0) <= 126
+}
+
+/** The fork EDITOR's unconditionally-owned binding keys (packages/pi-tui
+ * TUI_KEYBINDINGS defaults + the editor's hardcoded shift+backspace /
+ * shift+delete): the InputRouter's editorAccepts probe claims this whole
+ * set for the focused editor on EVERY keystroke, so a Stable plugin
+ * binding on one of these keys can never fire — the editor wins by
+ * precedence and even a replacement editor's decline re-runs the probe
+ * (round-19 finding). The plugin registry rejects them at registration;
+ * the USER config parser does NOT (a Host action resolves BEFORE the
+ * editor, so tab/arrows/etc. stay bindable for user overrides). This is
+ * the single inventory — derived sets (the submit pre-submit keys) and
+ * the registry share it, never a third hard-coded copy. */
+export const EDITOR_OWNED_KEY_IDS: ReadonlySet<string> = new Set([
+  // Navigation (tui.editor.cursorUp/Down/Left/Right, cursorWordLeft/
+  // Right, cursorLineStart/End, pageUp/pageDown, jumpForward/Backward)
+  'up', 'down', 'left', 'right', 'ctrl+b', 'ctrl+f',
+  'alt+left', 'ctrl+left', 'alt+b', 'alt+right', 'ctrl+right', 'alt+f',
+  'home', 'ctrl+home', 'ctrl+a', 'end', 'ctrl+end', 'ctrl+e',
+  'pageUp', 'ctrl+pageUp', 'pageDown', 'ctrl+pageDown',
+  'ctrl+]', 'ctrl+alt+]',
+  // Editing (deleteCharBackward/Forward, deleteWordBackward/Forward,
+  // deleteToLineStart/End, yank, yankPop, undo)
+  'backspace', 'shift+backspace', 'delete', 'shift+delete', 'ctrl+d',
+  'ctrl+w', 'alt+backspace', 'alt+d', 'alt+delete',
+  'ctrl+u', 'ctrl+k', 'ctrl+y', 'alt+y', 'ctrl+-',
+  // Input / select (newLine, tab, copy, submit, select.*)
+  'shift+enter', 'ctrl+j', 'enter', 'tab', 'escape', 'ctrl+c',
+].map(key => canonicalizeKeyId(key as KeyId)))
+
+/** The editor's POST-SUBMIT keys (fork components/editor.ts handleInput
+ * dispatch order — arrows, page keys and the jump chords are checked
+ * AFTER the submit check, so a submit remap onto them WOULD fire). The
+ * app.input.submit pre-submit inventory is EDITOR_OWNED minus this set
+ * (round-9 finding: a submit remap on a PRE-submit key could never
+ * fire; a post-submit key is fine). */
+export const EDITOR_POST_SUBMIT_KEYS: ReadonlySet<string> = new Set(
+  ['up', 'down', 'left', 'right', 'ctrl+b', 'ctrl+f',
+    'pageUp', 'ctrl+pageUp', 'pageDown', 'ctrl+pageDown',
+    'ctrl+]', 'ctrl+alt+]', 'enter', 'escape']
+    .map(key => canonicalizeKeyId(key as KeyId)),
+)
+
+/** Whether one canonical key id is a fork EDITOR-owned key (the shared
+ * plugin-registration policy; see {@link EDITOR_OWNED_KEY_IDS}). */
+export function isEditorOwnedKeyId(key: KeyId): boolean {
+  return EDITOR_OWNED_KEY_IDS.has(canonicalizeKeyId(key))
 }
 
 /**

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -1,21 +1,26 @@
 /**
  * Canonical physical-key identity (the convergence contract, plan §1/§4.1):
- * one physical key has exactly ONE canonical KeyId, so aliases and
- * modifier order can never bypass conflict detection, leader-prefix
+ * one physical key has exactly ONE canonical KeyId, so aliases, modifier
+ * order and CASING can never bypass conflict detection, leader-prefix
  * collision or deduplication.
  *
  * ```text
  * esc     -> escape
  * return  -> enter
  * shift+ctrl+p -> ctrl+shift+p
+ * ctrl+A  -> ctrl+a
  * ```
  *
  * Canonicalization is a pure string transform on the fork's KeyId grammar:
  * - base-key aliases (`esc`/`escape`, `return`/`enter`) map to ONE name;
- * - modifiers are reordered to the fixed order ctrl → shift → alt → super.
- *
- * The fork's grammar casing is PRESERVED for named keys (`pageUp`,
- * `pageDown`, `Home` is NOT lower-cased — see {@link BASE_KEY_ALIASES}).
+ * - modifiers are reordered to the fixed order ctrl → shift → alt → super;
+ * - every base is LOWERCASED — including single characters (`A` → `a`,
+ *   `ctrl+A` → `ctrl+a`): the fork's runtime parser lowercases the whole
+ *   key id and its `matchesKey` is case-insensitive, so two spellings of
+ *   one physical key must collapse onto one canonical identity (review
+ *   finding: the canonicalizer used to skip single-char bases, so
+ *   `ctrl+A` and `ctrl+a` coexisted as "different" keys that the runtime
+ *   treated as the same physical key).
  * @module @xmoon76/dsh-pi-tui/keybindings/key-identity
  */
 
@@ -32,15 +37,17 @@ const BASE_KEY_ALIASES: Readonly<Record<string, string>> = {
 const MODIFIER_ORDER: readonly string[] = ['ctrl', 'shift', 'alt', 'super']
 
 /**
- * Canonicalize one KeyId: collapse base-key aliases and reorder the
- * modifiers to the fixed order. Idempotent — canonicalizing a canonical
- * key returns it unchanged.
+ * Canonicalize one KeyId: collapse base-key aliases, reorder the modifiers
+ * to the fixed order and lowercase every base. Idempotent — canonicalizing
+ * a canonical key returns it unchanged.
  *
  * ```text
  * 'esc'            -> 'escape'
  * 'return'         -> 'enter'
  * 'shift+ctrl+p'   -> 'ctrl+shift+p'
  * 'alt+ctrl+x'     -> 'ctrl+alt+x'
+ * 'A'              -> 'a'
+ * 'ctrl+A'         -> 'ctrl+a'
  * 'pageUp'         -> 'pageup'       (named keys canonicalize to
  *                                    lowercase — the runtime parser
  *                                    lowercases, so the canonical form
@@ -55,10 +62,11 @@ export function canonicalizeKeyId(key: KeyId): KeyId {
   const raw = key as string
   if (raw === '' || !raw.includes('+')) {
     // LOWERCASE FIRST, then apply the alias map: `ESC` → `esc` →
-    // `escape`, `RETURN` → `return` → `enter` (a single-char key is
-    // untouched). Order matters — an uppercase alias must collapse onto
-    // the canonical base (convergence finding).
-    const lowered = raw.length === 1 ? raw : raw.toLowerCase()
+    // `escape`, `RETURN` → `return` → `enter`, `A` → `a`. Order matters —
+    // an uppercase alias must collapse onto the canonical base
+    // (convergence finding). Single characters lowercase too (a bare
+    // letter is one physical key regardless of its spelling).
+    const lowered = raw.toLowerCase()
     const aliased = BASE_KEY_ALIASES[lowered] ?? lowered
     return aliased as KeyId
   }
@@ -69,8 +77,10 @@ export function canonicalizeKeyId(key: KeyId): KeyId {
   // BEFORE the alias lookup so `ESC` collapses to `escape`), then order
   // the modifiers. Named keys canonicalize to LOWERCASE so the keymap
   // identity matches the runtime parser's lowercased normalized keys
-  // (pageUp/pageup are the same key).
-  const loweredBase = base.length === 1 ? base : base.toLowerCase()
+  // (pageUp/pageup are the same key). Single-character bases lowercase
+  // too — `ctrl+A` and `ctrl+a` are ONE physical key (the fork's
+  // matchesKey lowercases everything).
+  const loweredBase = base.toLowerCase()
   const canonicalBase = BASE_KEY_ALIASES[loweredBase] ?? loweredBase
   const loweredMods = modifiers.map(m => m.toLowerCase())
   const ordered = MODIFIER_ORDER.filter(modifier => loweredMods.includes(modifier))

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -36,6 +36,66 @@ const BASE_KEY_ALIASES: Readonly<Record<string, string>> = {
 /** The fixed modifier order every canonical KeyId carries. */
 const MODIFIER_ORDER: readonly string[] = ['ctrl', 'shift', 'alt', 'super']
 
+/** The base keys the fork's KeyId grammar accepts (packages/pi-tui
+ * keys.ts). The single source for EVERY key-name validation: the user
+ * config parser and the Stable plugin registry share it (round-17
+ * finding — a plugin could register a key name the runtime parser can
+ * never produce, a dead binding). */
+export const KEY_ID_BASE_KEYS = new Set([
+  'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+  '`', '-', '=', '[', ']', '\\', ';', "'", ',', '.', '/', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '|', '~', '{', '}', ':', '<', '>', '?',
+  'escape', 'esc', 'enter', 'return', 'tab', 'space', 'backspace', 'delete', 'insert', 'clear',
+  'home', 'end', 'pageUp', 'pageDown', 'up', 'down', 'left', 'right',
+  'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12',
+])
+
+const KEY_ID_MODIFIERS = new Set(['ctrl', 'shift', 'alt', 'super'])
+
+/** Case-insensitive view of the base-key grammar: `pageUp` and `pageup`
+ * are the SAME physical key (the canonical identity is lowercase). */
+const BASE_KEYS_LOWER = new Set([...KEY_ID_BASE_KEYS].map(key => key.toLowerCase()))
+
+/** Whether a string is a valid KeyId (the fork's grammar) — the SHARED
+ * grammar policy of the config parser and the plugin registry. Named
+ * keys are case-insensitive at parse time (pageUp/pageup), and the
+ * modifiers must be unique. */
+export function isValidKeyId(value: string): value is KeyId {
+  if (value === '') return false
+  const parts = value.split('+')
+  if (parts.length === 0) return false
+  const base = parts[parts.length - 1]!
+  if (!BASE_KEYS_LOWER.has(base.toLowerCase())) return false
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    if (!KEY_ID_MODIFIERS.has(parts[index]!)) return false
+  }
+  // No duplicate modifiers.
+  return new Set(parts.slice(0, -1)).size === parts.length - 1
+}
+
+/** Whether a key is TEXT-PRODUCING — it types a character into the
+ * editor, so a binding on it would swallow (or steal) ordinary typing
+ * (round-17 finding): a single printable base (letters/digits/symbols,
+ * 32-126) or the spacebar, with NO ctrl/alt/super modifier. SHIFT ALONE
+ * does not change this: Shift+A is the raw 'A' byte on legacy terminals
+ * (matchesKey('A','shift+a') is TRUE) and the normalized 'a'+shift on
+ * Kitty — either way it produces text, so a binding on it behaves
+ * terminal-dependently and steals uppercase input on some terminals.
+ * Named keys (shift+tab, shift+left, shift+enter, shift+f5, ...) are
+ * NOT text-producing and stay bindable. Shared by the config parser
+ * (direct bindings + the leader key), the InputRouter (a text key never
+ * reaches the plugin stage) and the plugin registry (registration
+ * rejection). */
+export function isTextProducingKeyId(key: KeyId): boolean {
+  const canonical = canonicalizeKeyId(key)
+  const parts = canonical.split('+')
+  const base = parts[parts.length - 1]!
+  const hasNonShiftModifier = parts.slice(0, -1).some(modifier => modifier !== 'shift')
+  if (hasNonShiftModifier) return false
+  if (base === 'space') return true
+  return base.length === 1 && base.charCodeAt(0) >= 32 && base.charCodeAt(0) <= 126
+}
+
 /**
  * Canonicalize one KeyId: collapse base-key aliases, reorder the modifiers
  * to the fixed order and lowercase every base. Idempotent — canonicalizing

--- a/src/keybindings/leader.ts
+++ b/src/keybindings/leader.ts
@@ -1,0 +1,156 @@
+/**
+ * The leader / multi-key sequence state machine (plan §6 M6).
+ *
+ * When a leader key is configured (e.g. `ctrl+x`), pressing it arms a
+ * PENDING prefix state; the next single key completes a `<leader>X`
+ * binding and fires its action. The machine implements the plan's
+ * requirements:
+ *
+ * - pending prefix state (idle → pending on the leader key);
+ * - timeout (the pending state expires after {@link LeaderConfig.timeoutMs});
+ * - ambiguous prefix (two actions bound to the same completing key are a
+ *   diagnostic — neither fires);
+ * - cancel (Esc cancels the pending state and is consumed; any other
+ *   non-matching key cancels and is PASSED through for normal processing);
+ * - paste/typing isolation (a multi-char chunk / paste burst cancels the
+ *   pending state and passes through — a fast typist never loses text);
+ * - focus transition cancellation (the app calls {@link cancel} when a
+ *   question/approval/overlay/viewer opens or fullscreen toggles).
+ *
+ * The machine is pure state + timing: it never touches the terminal or
+ * the app. The app feeds raw input, reads {@link pending} for the
+ * which-key footer hint, and dispatches activated actions.
+ * @module @xmoon76/dsh-pi-tui/keybindings/leader
+ */
+
+import { isKeyRelease, isKeyRepeat, matchesKey, parseKey } from '@xmoon76/pi-tui'
+import type { LeaderBinding, LeaderConfig } from './types.ts'
+
+/** The outcome of feeding one raw input event. */
+export type LeaderFeedResult =
+  /** The leader key or a completing key was consumed. */
+  | { kind: 'consumed' }
+  /** Not leader-related; process the event normally. */
+  | { kind: 'passed' }
+  /** The pending state was cancelled by a non-matching key; the event is
+   * passed through for normal processing. */
+  | { kind: 'cancelled-pass' }
+  /** The pending state was cancelled by Esc; the event is consumed. */
+  | { kind: 'cancelled-consume' }
+  /** A leader sequence completed; the app must dispatch this action. */
+  | { kind: 'activated'; action: string }
+
+export interface LeaderMachineCallbacks {
+  /** A leader sequence completed (the app dispatches the action). */
+  readonly onActivate: (action: string) => void
+  /** The pending state changed (the app repaints the which-key hint). */
+  readonly onStateChange: () => void
+}
+
+/** The leader state machine. One instance per keymap. */
+export class LeaderStateMachine {
+  private state: 'idle' | 'pending' = 'idle'
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private readonly config: LeaderConfig
+  private readonly bindings: readonly LeaderBinding[]
+  private readonly callbacks: LeaderMachineCallbacks
+  private disposed = false
+
+  constructor(config: LeaderConfig, bindings: readonly LeaderBinding[], callbacks: LeaderMachineCallbacks) {
+    this.config = config
+    this.bindings = bindings
+    this.callbacks = callbacks
+  }
+
+  /** Whether a leader sequence is currently pending (which-key hint). */
+  get pending(): boolean {
+    return this.state === 'pending'
+  }
+
+  /** The configured leader key (undefined when the leader is disabled). */
+  get leaderKey(): LeaderConfig['key'] {
+    return this.config.key
+  }
+
+  /** The active leader bindings (which-key hint). */
+  get leaderBindings(): readonly LeaderBinding[] {
+    return this.bindings
+  }
+
+  /** Feed one raw input event. */
+  feed(data: string): LeaderFeedResult {
+    if (this.disposed) return { kind: 'passed' }
+    const leaderKey = this.config.key
+    if (leaderKey === undefined) return { kind: 'passed' }
+    if (this.state === 'idle') {
+      if (matchesKey(data, leaderKey)) {
+        this.enterPending()
+        return { kind: 'consumed' }
+      }
+      return { kind: 'passed' }
+    }
+    // Pending: protocol artifacts are ignored (a release of the leader key
+    // must not cancel the sequence it just armed).
+    if (isKeyRelease(data) || isKeyRepeat(data)) return { kind: 'consumed' }
+    // Paste/typing isolation: a multi-char chunk is not a single key —
+    // cancel the pending state and pass the text through untouched.
+    if (parseKey(data) === undefined) {
+      this.cancel()
+      return { kind: 'cancelled-pass' }
+    }
+    // Esc cancels the pending state (consumed — it must not also trigger
+    // the host's Esc handling).
+    if (matchesKey(data, 'escape')) {
+      this.cancel()
+      return { kind: 'cancelled-consume' }
+    }
+    for (const binding of this.bindings) {
+      if (matchesKey(data, binding.key)) {
+        this.cancel()
+        this.callbacks.onActivate(binding.action)
+        return { kind: 'activated', action: binding.action }
+      }
+    }
+    // A non-matching key cancels the pending state and is processed
+    // normally (vim/OpenCode behavior — the user's keystroke is never
+    // swallowed by a stale prefix).
+    this.cancel()
+    return { kind: 'cancelled-pass' }
+  }
+
+  /** Cancel any pending state (focus transitions, teardown). */
+  cancel(): void {
+    if (this.state === 'idle') return
+    this.state = 'idle'
+    this.clearTimer()
+    this.callbacks.onStateChange()
+  }
+
+  /** Dispose the machine (clears the timeout; no state-change callback —
+   * the app is tearing down). */
+  dispose(): void {
+    this.disposed = true
+    this.state = 'idle'
+    this.clearTimer()
+  }
+
+  private enterPending(): void {
+    this.state = 'pending'
+    this.clearTimer()
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      if (this.state === 'pending') {
+        this.state = 'idle'
+        this.callbacks.onStateChange()
+      }
+    }, this.config.timeoutMs)
+    this.callbacks.onStateChange()
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+  }
+}

--- a/src/keybindings/leader.ts
+++ b/src/keybindings/leader.ts
@@ -37,12 +37,17 @@ export type LeaderFeedResult =
   | { kind: 'cancelled-pass' }
   /** The pending state was cancelled by Esc; the event is consumed. */
   | { kind: 'cancelled-consume' }
-  /** A leader sequence completed; the app must dispatch this action. */
-  | { kind: 'activated'; action: string }
+  /** A leader sequence completed; the app must dispatch this action.
+   * `consumed` is the dispatch result: an action that DECLINES (e.g.
+   * pasteMedia without a clipboard handler) must fall through to the
+   * editor/plugin stages, exactly like a direct key (review finding). */
+  | { kind: 'activated'; action: string; consumed: boolean }
 
 export interface LeaderMachineCallbacks {
-  /** A leader sequence completed (the app dispatches the action). */
-  readonly onActivate: (action: string) => void
+  /** A leader sequence completed (the app dispatches the action).
+   * Returns whether the dispatch consumed the key (false → the key must
+   * fall through, mirroring the direct-key resolver contract). */
+  readonly onActivate: (action: string) => boolean
   /** The pending state changed (the app repaints the which-key hint). */
   readonly onStateChange: () => void
 }
@@ -107,8 +112,8 @@ export class LeaderStateMachine {
     for (const binding of this.bindings) {
       if (matchesKey(data, binding.key)) {
         this.cancel()
-        this.callbacks.onActivate(binding.action)
-        return { kind: 'activated', action: binding.action }
+        const consumed = this.callbacks.onActivate(binding.action)
+        return { kind: 'activated', action: binding.action, consumed }
       }
     }
     // A non-matching key cancels the pending state and is processed

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -1,0 +1,284 @@
+/**
+ * The Host keybinding manager (plan §2 M1/M2/M3/M6): the stateful facade
+ * the app and the runner use. It owns:
+ *
+ * - the effective keymap (defaults + user overrides + plugin rules);
+ * - the leader state machine (M6);
+ * - fail-soft diagnostics (plan §16);
+ * - safe mode (plan §17: ignore user overrides).
+ *
+ * The manager NEVER executes business behavior — it only resolves keys to
+ * semantic actions. Execution lives in the AppActionDispatcher.
+ * @module @xmoon76/dsh-pi-tui/keybindings/manager
+ */
+
+import type { KeyId } from '@xmoon76/pi-tui'
+import { matchesKey } from '@xmoon76/pi-tui'
+import { APP_KEYBINDINGS } from './definitions.ts'
+import { EffectiveKeymap, type CompositionRule, type PluginKeybindingRule } from './effective-keymap.ts'
+import { formatLeaderSequence, formatKeyId } from './hints.ts'
+import { LeaderStateMachine } from './leader.ts'
+import type {
+  AppKeybindingId,
+  KeybindingContext,
+  KeybindingResolution,
+  KeymapSnapshot,
+  LeaderBinding,
+  LeaderConfig,
+  UserKeybindingsConfig,
+} from './types.ts'
+
+/** The conditional affordance rules (plan §5): the empty-editor ↓ task
+ * browser. Kept as a composition rule so a user remap of app.tasks.open
+ * replaces the ACTION, while the affordance itself stays conditional. */
+const TASKS_OPEN_AFFORDANCE: CompositionRule = {
+  action: 'app.tasks.open',
+  key: 'down',
+  predicate: (context) => context.focusedSeat === 'editor' && context.editorEmpty && context.tasksActive,
+}
+
+export interface HostKeybindingManagerOptions {
+  /** Called after every rebuild (the app repaints hints/footer). */
+  readonly onInvalidate?: () => void
+  /** Called when the leader pending state changes (which-key hint). */
+  readonly onLeaderStateChange?: () => void
+  /** Called when a leader sequence completes (the app dispatches). */
+  readonly onLeaderActivate?: (action: string) => void
+  /** The leader timeout in ms (defaults to the config default). */
+  readonly leaderTimeoutMs?: number
+}
+
+/** The stateful keybinding facade. */
+export class HostKeybindingManager {
+  private readonly onInvalidate: () => void
+  private readonly onLeaderStateChange: () => void
+  private readonly onLeaderActivate: (action: string) => void
+  private readonly leaderTimeoutMs: number
+
+  private userBindings: UserKeybindingsConfig = {}
+  private leaderConfig: LeaderConfig | undefined
+  private leaderBindings: readonly LeaderBinding[] = []
+  private pluginRules: readonly PluginKeybindingRule[] = []
+  private safeMode = false
+  private diagnostics: string[] = []
+
+  private keymap: EffectiveKeymap
+  private leader: LeaderStateMachine | undefined
+  private disposed = false
+
+  constructor(options: HostKeybindingManagerOptions = {}) {
+    this.onInvalidate = options.onInvalidate ?? (() => {})
+    this.onLeaderStateChange = options.onLeaderStateChange ?? (() => {})
+    this.onLeaderActivate = options.onLeaderActivate ?? (() => {})
+    this.leaderTimeoutMs = options.leaderTimeoutMs ?? 1500
+    this.keymap = this.buildKeymap()
+  }
+
+  private buildKeymap(): EffectiveKeymap {
+    return new EffectiveKeymap({
+      definitions: APP_KEYBINDINGS,
+      userBindings: this.safeMode ? {} : this.userBindings,
+      pluginRules: this.pluginRules,
+      compositionRules: [TASKS_OPEN_AFFORDANCE],
+      safeMode: this.safeMode,
+      // The HOST keymap resolves the non-capturing scopes only: the
+      // focused-component actions (question.*/tasks.*) and the search
+      // overlay keys live in their own contexts (plan §3.3) and must never
+      // resolve in the host ladder.
+      includeScopes: new Set(['global', 'editor', 'agent-running']),
+      onDiagnostic: (message) => this.diagnostics.push(message),
+    })
+  }
+
+  private rebuild(): void {
+    if (this.disposed) return
+    this.diagnostics = []
+    // Leader bindings: a duplicate completing key is ambiguous — neither
+    // fires (plan §6 M6: ambiguous prefix is a diagnostic).
+    const byKey = new Map<KeyId, LeaderBinding[]>()
+    for (const binding of this.leaderBindings) {
+      const list = byKey.get(binding.key) ?? []
+      list.push(binding)
+      byKey.set(binding.key, list)
+    }
+    const leaderBindings: LeaderBinding[] = []
+    for (const [key, list] of byKey) {
+      if (list.length > 1) {
+        this.diagnostics.push(
+          `keybinding: ambiguous leader sequence <leader>${formatKeyId(key)} (${list.map(binding => binding.action).join(' vs ')}) — neither fires`,
+        )
+        continue
+      }
+      leaderBindings.push(list[0]!)
+    }
+    this.keymap = this.buildKeymap()
+    // Rebuild the leader machine (its bindings/config may have changed).
+    this.leader?.dispose()
+    this.leader = undefined
+    if (this.leaderConfig !== undefined) {
+      this.leader = new LeaderStateMachine(this.leaderConfig, leaderBindings, {
+        onActivate: (action) => this.onLeaderActivate(action),
+        onStateChange: () => this.onLeaderStateChange(),
+      })
+    }
+    this.onInvalidate()
+  }
+
+  // ── Configuration ──────────────────────────────────────────────────────
+
+  /** Apply the parsed user configuration (M3). */
+  setUserConfiguration(config: {
+    readonly bindings: UserKeybindingsConfig
+    readonly leader: LeaderConfig | undefined
+    readonly leaderBindings: readonly LeaderBinding[]
+  }): void {
+    this.userBindings = config.bindings
+    this.leaderConfig = config.leader
+    this.leaderBindings = config.leaderBindings
+    this.rebuild()
+  }
+
+  /** Safe mode (plan §17): ignore user overrides, keep builtin defaults.
+   * Plugin keybindings still load. */
+  setSafeMode(enabled: boolean): void {
+    if (this.safeMode === enabled) return
+    this.safeMode = enabled
+    this.rebuild()
+  }
+
+  /** Whether safe mode is active. */
+  isSafeMode(): boolean {
+    return this.safeMode
+  }
+
+  /** Replace the plugin contributions (the runner wires the keybinding
+   * registry's snapshot). A no-op when the rules are unchanged (the
+   * runner may call this on every registry invalidation). */
+  setPluginRules(rules: readonly PluginKeybindingRule[]): void {
+    if (this.pluginRules.length === rules.length
+      && this.pluginRules.every((rule, index) => {
+        const next = rules[index]!
+        return rule.id === next.id && rule.action === next.action && rule.key === next.key
+      })) {
+      return
+    }
+    this.pluginRules = rules
+    this.rebuild()
+  }
+
+  // ── Resolution ─────────────────────────────────────────────────────────
+
+  /** Resolve one raw input event against the live context. */
+  resolve(data: string, context: KeybindingContext): KeybindingResolution | undefined {
+    return this.keymap.resolve(data, context)
+  }
+
+  /** The action one raw event resolves to (context-aware), or undefined. */
+  actionFor(data: string, context: KeybindingContext): string | undefined {
+    return this.keymap.actionFor(data, context)
+  }
+
+  /** Whether the raw event matches ANY effective key of one action
+   * (context predicates NOT applied — use {@link resolve} for
+   * conditional rules). */
+  matches(data: string, action: AppKeybindingId): boolean {
+    return this.keymap.matches(data, action)
+  }
+
+  /** Whether the raw event matches the action's DEFAULT keys. Used for
+   * the non-configurable overlay/component keys (search overlay,
+   * question/tasks flows) whose effective keys are always the defaults —
+   * they never resolve in the host keymap (plan §3.3). */
+  matchesDefault(data: string, action: AppKeybindingId): boolean {
+    const definition = APP_KEYBINDINGS[action]
+    if (definition === undefined) return false
+    return definition.defaultKeys.some(key => matchesKey(data, key))
+  }
+
+  /** The effective keys of one action. */
+  keysFor(action: AppKeybindingId): KeyId[] {
+    return this.keymap.keysFor(action)
+  }
+
+  /** The primary effective key of one action, or undefined. */
+  primaryKeyFor(action: AppKeybindingId): KeyId | undefined {
+    return this.keymap.primaryKeyFor(action)
+  }
+
+  /** The human hint for one action (plan §18): the primary key, the
+   * leader sequence when the action is only leader-bound, or the default
+   * key for non-configurable overlay/component actions. */
+  keyHint(action: AppKeybindingId): string {
+    const direct = this.keymap.keyHint(action)
+    if (direct !== '') return direct
+    const leaderBinding = this.leaderBindings.find(binding => binding.action === action)
+    if (leaderBinding !== undefined) return formatLeaderSequence(leaderBinding.key)
+    const definition = APP_KEYBINDINGS[action]
+    if (definition !== undefined && definition.defaultKeys.length > 0) {
+      return formatKeyId(definition.defaultKeys[0]!)
+    }
+    return ''
+  }
+
+  /** The immutable read model (diagnostics + /keybindings). The
+   * capturing-scope actions (search overlay, question/tasks flows) are not
+   * in the host keymap; their defaults are merged in for display. */
+  snapshot(): KeymapSnapshot {
+    const snapshot = this.keymap.snapshot()
+    const present = new Set(snapshot.bindings.map(binding => binding.action))
+    const merged = [...snapshot.bindings]
+    for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
+      if (present.has(id)) continue
+      if (definition.defaultKeys.length === 0) continue
+      merged.push({
+        action: id,
+        keys: [...definition.defaultKeys],
+        scope: definition.scope,
+        source: 'builtin',
+      })
+    }
+    merged.sort((left, right) => left.action.localeCompare(right.action))
+    return { ...snapshot, bindings: merged }
+  }
+
+  /** The fail-soft diagnostics of the last rebuild. */
+  diagnosticsList(): readonly string[] {
+    return [...this.diagnostics]
+  }
+
+  /** The current keymap revision. */
+  revision(): number {
+    return this.keymap.snapshot().revision
+  }
+
+  // ── Leader (M6) ────────────────────────────────────────────────────────
+
+  /** The leader machine (undefined when no leader key is configured). */
+  leaderMachine(): LeaderStateMachine | undefined {
+    return this.leader
+  }
+
+  /** Cancel any pending leader sequence (focus transitions). */
+  cancelLeader(): void {
+    this.leader?.cancel()
+  }
+
+  /** Dispose the manager (clears the leader timer). */
+  dispose(): void {
+    this.disposed = true
+    this.leader?.dispose()
+    this.leader = undefined
+  }
+}
+
+/** Convert the public normalized key shape (the plugin registry's
+ * identity) into the fork's KeyId grammar (the keymap's identity). */
+export function normalizedKeyToKeyId(key: { readonly key: string; readonly ctrl: boolean; readonly alt: boolean; readonly shift: boolean; readonly super: boolean }): KeyId {
+  const parts: string[] = []
+  if (key.ctrl) parts.push('ctrl')
+  if (key.alt) parts.push('alt')
+  if (key.shift) parts.push('shift')
+  if (key.super) parts.push('super')
+  parts.push(key.key)
+  return parts.join('+') as KeyId
+}

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -218,9 +218,28 @@ export class HostKeybindingManager {
     return definition.defaultKeys.some(key => matchesKey(data, key))
   }
 
-  /** The effective keys of one action. */
+  /** The effective keys of one action (direct keys only — leader
+   * sequences live in {@link leaderKeysFor}). */
   keysFor(action: AppKeybindingId): KeyId[] {
     return this.keymap.keysFor(action)
+  }
+
+  /** The EFFECTIVE `<leader>X` completing keys of one action (M6),
+   * ambiguous/disabled sequences excluded. */
+  leaderKeysFor(action: AppKeybindingId): KeyId[] {
+    return this.effectiveLeaderBindings
+      .filter(binding => binding.action === action)
+      .map(binding => binding.key)
+  }
+
+  /** The full display label for one action: ALL direct keys and ALL
+   * leader sequences, each formatted (e.g. `Ctrl+Z / Leader H`); '' when
+   * the action advertises nothing (disabled, or no keys at all). */
+  keysLabelFor(action: AppKeybindingId): string {
+    if (this.isDisabled(action)) return ''
+    const direct = this.keysFor(action).map(formatKeyId)
+    const leader = this.leaderKeysFor(action).map(formatLeaderSequence)
+    return [...direct, ...leader].join(' / ')
   }
 
   /** The primary effective key of one action, or undefined. */

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -231,9 +231,15 @@ export class HostKeybindingManager {
     // a previously remapped/disabled submit must not keep Enter inert
     // under DSH_PI_TUI_SAFE_KEYBINDINGS=1; the builtin default ('enter')
     // is restored.
+    // A leader-only submit override counts ONLY when the sequence is
+    // EFFECTIVE (not raw leaderBindings): if the leader was shadowed by a
+    // prefix collision or the completing key was ambiguous (both
+    // disabled), the sequence cannot fire — fail-soft back to the
+    // builtin Enter (PR review finding: a dead leader-only submit must
+    // not disable Enter entirely).
     const hasSubmitOverride = !this.safeMode && (
       this.userBindings['app.input.submit'] !== undefined
-      || this.leaderBindings.some(binding => binding.action === 'app.input.submit'))
+      || this.effectiveLeaderBindings.some(binding => binding.action === 'app.input.submit'))
     if (hasSubmitOverride) return []
     // The builtin submit rule is hostResolved: false (the host ladder
     // never consumes it), so keysFor() is EMPTY by default — fall back to

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -215,6 +215,14 @@ export class HostKeybindingManager {
     if (this.isDisabled('app.input.submit')) return []
     const keys = this.keymap.keysFor('app.input.submit')
     if (keys.length > 0) return keys
+    // A LEADER-ONLY submit override (`app.input.submit: <leader>s`) has
+    // NO direct keys: Enter must NOT submit (only the leader sequence
+    // does) — do NOT fall back to the builtin 'enter' (PR review
+    // finding). The override lives in leaderBindings (the parser never
+    // puts `<leader>X` into the direct bindings map).
+    const hasSubmitOverride = this.userBindings['app.input.submit'] !== undefined
+      || this.leaderBindings.some(binding => binding.action === 'app.input.submit')
+    if (hasSubmitOverride) return []
     // The builtin submit rule is hostResolved: false (the host ladder
     // never consumes it), so keysFor() is EMPTY by default — fall back to
     // the definition's default ('enter'). A user remap compiles as a
@@ -234,6 +242,7 @@ export class HostKeybindingManager {
     readonly leader: LeaderConfig | undefined
     readonly leaderBindings: readonly LeaderBinding[]
   }): void {
+    if (this.disposed) return
     this.userBindings = config.bindings
     this.leaderConfig = config.leader
     this.leaderBindings = config.leaderBindings
@@ -243,6 +252,7 @@ export class HostKeybindingManager {
   /** Safe mode (plan §17): ignore user overrides, keep builtin defaults.
    * Plugin keybindings still load. */
   setSafeMode(enabled: boolean): void {
+    if (this.disposed) return
     if (this.safeMode === enabled) return
     this.safeMode = enabled
     this.rebuild()
@@ -257,6 +267,7 @@ export class HostKeybindingManager {
    * registry's snapshot). A no-op when the rules are unchanged (the
    * runner may call this on every registry invalidation). */
   setPluginRules(rules: readonly PluginKeybindingRule[]): void {
+    if (this.disposed) return
     if (this.pluginRules.length === rules.length
       && this.pluginRules.every((rule, index) => {
         const next = rules[index]!

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -58,6 +58,9 @@ export class HostKeybindingManager {
   private userBindings: UserKeybindingsConfig = {}
   private leaderConfig: LeaderConfig | undefined
   private leaderBindings: readonly LeaderBinding[] = []
+  /** The ambiguity-filtered, safe-mode-aware leader bindings (what the
+   * leader machine actually fires — hints must match, review round 3). */
+  private effectiveLeaderBindings: readonly LeaderBinding[] = []
   private pluginRules: readonly PluginKeybindingRule[] = []
   private safeMode = false
   private diagnostics: string[] = []
@@ -120,6 +123,7 @@ export class HostKeybindingManager {
       leaderBindings.push(list[0]!)
     }
     this.keymap = this.buildKeymap()
+    this.effectiveLeaderBindings = leaderBindings
     // Rebuild the leader machine (its bindings/config may have changed).
     this.leader?.dispose()
     this.leader = undefined
@@ -216,12 +220,14 @@ export class HostKeybindingManager {
   /** The human hint for one action (plan §18): the primary key, the
    * leader sequence when the action is only leader-bound, or the default
    * key for non-configurable overlay/component actions. A DISABLED action
-   * (user `false`) advertises nothing (review round 2). */
+   * (user `false`) advertises nothing (review round 2), and the hint uses
+   * the EFFECTIVE leader bindings — an ambiguous sequence that never
+   * fires is never advertised (review round 3). */
   keyHint(action: AppKeybindingId): string {
     if (this.isDisabled(action)) return ''
     const direct = this.keymap.keyHint(action)
     if (direct !== '') return direct
-    const leaderBinding = this.leaderBindings.find(binding => binding.action === action)
+    const leaderBinding = this.effectiveLeaderBindings.find(binding => binding.action === action)
     if (leaderBinding !== undefined) return formatLeaderSequence(leaderBinding.key)
     const definition = APP_KEYBINDINGS[action]
     if (definition !== undefined && definition.defaultKeys.length > 0) {

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -172,8 +172,14 @@ export class HostKeybindingManager {
     // that only collides with a DISABLED action's key is fine (no active
     // rule).
     const leaderKey = effectiveLeaderConfig?.key
+    // Collision with BOTH the host keymap's active keys AND the
+    // EDITOR-OWNED submit keys (hostResolved:false actions — the fork
+    // editor's tui.input.submit owns them; the keymap does not list them,
+    // so e.g. `leader: enter` would silently swallow Enter — PR review
+    // finding).
     const leaderCollision = leaderKey !== undefined
       ? this.keymap.activeKeys().some(key => key === leaderKey)
+        || this.editorSubmitKeysFor().some(key => key === leaderKey)
       : false
     if (leaderCollision && leaderKey !== undefined) {
       this.diagnostics.push(
@@ -215,13 +221,13 @@ export class HostKeybindingManager {
     if (this.isDisabled('app.input.submit')) return []
     const keys = this.keymap.keysFor('app.input.submit')
     if (keys.length > 0) return keys
-    // A LEADER-ONLY submit override (`app.input.submit: <leader>s`) has
-    // NO direct keys: Enter must NOT submit (only the leader sequence
-    // does) — do NOT fall back to the builtin 'enter' (PR review
-    // finding). The override lives in leaderBindings (the parser never
-    // puts `<leader>X` into the direct bindings map).
-    const hasSubmitOverride = this.userBindings['app.input.submit'] !== undefined
-      || this.leaderBindings.some(binding => binding.action === 'app.input.submit')
+    // SAFE MODE (PR review finding): the raw user overrides are IGNORED —
+    // a previously remapped/disabled submit must not keep Enter inert
+    // under DSH_PI_TUI_SAFE_KEYBINDINGS=1; the builtin default ('enter')
+    // is restored.
+    const hasSubmitOverride = !this.safeMode && (
+      this.userBindings['app.input.submit'] !== undefined
+      || this.leaderBindings.some(binding => binding.action === 'app.input.submit'))
     if (hasSubmitOverride) return []
     // The builtin submit rule is hostResolved: false (the host ladder
     // never consumes it), so keysFor() is EMPTY by default — fall back to

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -215,8 +215,10 @@ export class HostKeybindingManager {
 
   /** The human hint for one action (plan §18): the primary key, the
    * leader sequence when the action is only leader-bound, or the default
-   * key for non-configurable overlay/component actions. */
+   * key for non-configurable overlay/component actions. A DISABLED action
+   * (user `false`) advertises nothing (review round 2). */
   keyHint(action: AppKeybindingId): string {
+    if (this.isDisabled(action)) return ''
     const direct = this.keymap.keyHint(action)
     if (direct !== '') return direct
     const leaderBinding = this.leaderBindings.find(binding => binding.action === action)
@@ -228,15 +230,22 @@ export class HostKeybindingManager {
     return ''
   }
 
+  /** Whether the user disabled one action (`false`). */
+  private isDisabled(action: AppKeybindingId): boolean {
+    return !this.safeMode && this.userBindings[action] === false
+  }
+
   /** The immutable read model (diagnostics + /keybindings). The
    * capturing-scope actions (search overlay, question/tasks flows) are not
-   * in the host keymap; their defaults are merged in for display. */
+   * in the host keymap; their defaults are merged in for display. A
+   * DISABLED action is never advertised (review round 2). */
   snapshot(): KeymapSnapshot {
     const snapshot = this.keymap.snapshot()
     const present = new Set(snapshot.bindings.map(binding => binding.action))
     const merged = [...snapshot.bindings]
     for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
       if (present.has(id)) continue
+      if (this.isDisabled(id as AppKeybindingId)) continue
       if (definition.defaultKeys.length === 0) continue
       merged.push({
         action: id,

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -100,6 +100,12 @@ export class HostKeybindingManager {
     this.onEditorSubmitSync = options.onEditorSubmitSync ?? (() => {})
     this.leaderTimeoutMs = options.leaderTimeoutMs ?? 1500
     this.keymap = this.buildKeymap()
+    // Sync the BUILTIN submit keys immediately: the fork's keybindings
+    // are PROCESS-GLOBAL, so a fresh manager must restore the default
+    // `tui.input.submit` — otherwise a previous TUI instance's remap/
+    // disable leaks into this one (PR review finding: remap → stop →
+    // new default app kept the old ctrl+x/disabled submit).
+    this.onEditorSubmitSync(this.editorSubmitKeysFor())
   }
 
   private buildKeymap(): EffectiveKeymap {

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -164,11 +164,12 @@ export class HostKeybindingManager {
     }
     this.keymap = this.buildKeymap()
     this.effectiveLeaderBindings = leaderBindings
-    // Leader PREFIX collision (PR review finding): the leader key is fed
-    // BEFORE the host ladder, so a leader key that is ALSO an ACTIVE
-    // direct key of any host action would silently shadow that action
-    // (e.g. `leader: ctrl+f` swallows app.transcript.search). Fail-soft:
-    // the direct key wins, the leader machine is DISABLED, and the
+    // Leader PREFIX collision (PR review finding + round-12 finding): the
+    // leader key is fed BEFORE the host ladder AND before the plugin
+    // stage, so a leader key that is ALSO an ACTIVE direct key of any
+    // host action (e.g. `leader: ctrl+f` swallows app.transcript.search)
+    // or a LIVE plugin binding would silently shadow it. Fail-soft: the
+    // direct/plugin key wins, the leader machine is DISABLED, and the
     // collision is a diagnostic — never a silent shadow. A leader key
     // that only collides with a DISABLED action's key is fine (no active
     // rule).
@@ -177,14 +178,21 @@ export class HostKeybindingManager {
     // EDITOR-OWNED submit keys (hostResolved:false actions — the fork
     // editor's tui.input.submit owns them; the keymap does not list them,
     // so e.g. `leader: enter` would silently swallow Enter — PR review
-    // finding).
+    // finding) AND the live PLUGIN keys (the leader machine feeds before
+    // the plugin stage — round-12 finding).
+    const pluginCollision = leaderKey !== undefined
+      ? this.keymap.pluginActiveKeys().some(key => key === leaderKey)
+      : false
     const leaderCollision = leaderKey !== undefined
       ? this.keymap.hostActiveKeys().some(key => key === leaderKey)
         || this.editorSubmitKeysFor().some(key => key === leaderKey)
+        || pluginCollision
       : false
     if (leaderCollision && leaderKey !== undefined) {
       this.diagnostics.push(
-        `keybinding: leader key ${formatKeyId(leaderKey)} is also an active host key — the leader machine is disabled (the direct key wins)`,
+        pluginCollision
+          ? `keybinding: leader key ${formatKeyId(leaderKey)} is also a live plugin key — the leader machine is disabled (the plugin binding wins)`
+          : `keybinding: leader key ${formatKeyId(leaderKey)} is also an active host key — the leader machine is disabled (the direct key wins)`,
       )
       // Disable the leader machine AND its advertised bindings: the
       // direct key wins (never a silent shadow — PR review finding). The

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -185,9 +185,13 @@ export class HostKeybindingManager {
       this.diagnostics.push(
         `keybinding: leader key ${formatKeyId(leaderKey)} is also an active host key — the leader machine is disabled (the direct key wins)`,
       )
-      // Disable the leader machine: the direct key wins (never a silent
-      // shadow — PR review finding).
+      // Disable the leader machine AND its advertised bindings: the
+      // direct key wins (never a silent shadow — PR review finding). The
+      // effectiveLeaderBindings are cleared here so keyHint /
+      // keysLabelFor / snapshot never advertise a leader sequence that
+      // cannot fire (the "UI always shows the EFFECTIVE keys" contract).
       this.leaderConfigShadowed = true
+      this.effectiveLeaderBindings = []
       this.leader?.dispose()
       this.leader = undefined
     } else {

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -235,10 +235,20 @@ export class HostKeybindingManager {
    * only consumer. */
   editorSubmitKeysFor(): KeyId[] {
     if (this.isDisabled('app.input.submit')) return []
-    // A live leader-ONLY submit override (an effective sequence) removes
-    // Enter: the leader is the only trigger (checked BEFORE the editor-key
-    // fallback — the builtin Enter rule is always in the effective set).
-    if (this.effectiveLeaderBindings.some(binding => binding.action === 'app.input.submit')) return []
+    // A truly LEADER-ONLY submit (a live effective sequence AND no
+    // working direct user rule) removes Enter: the leader is the only
+    // trigger (checked BEFORE the editor-key fallback — the builtin Enter
+    // rule is always in the effective set). A leader sequence NEVER
+    // clears the DIRECT keys though (review finding): `submit:
+    // ['ctrl+z', '<leader>s']` keeps Ctrl+Z AND gains the leader —
+    // additive triggers, exactly like every other action (direct +
+    // leader = both fire). editorHasUserRule asks whether the user's
+    // direct override is EFFECTIVE (a conflicted-away override does not
+    // count).
+    if (this.effectiveLeaderBindings.some(binding => binding.action === 'app.input.submit')
+      && !this.keymap.editorHasUserRule('app.input.submit')) {
+      return []
+    }
     // The sync derives ONLY from the effective EDITOR-OWNED rules
     // (convergence §3 finding): submit's rules (builtin Enter + user
     // overrides) compile with owner=editor and participate in the unified
@@ -463,7 +473,14 @@ export class HostKeybindingManager {
     }
     const merged: MutableSnapshotBinding[] = snapshot.bindings.map(binding => ({
       action: binding.action,
-      keys: [...binding.keys],
+      // The snapshot projects the SAME per-action effective keys as
+      // keysFor/keyHint (external-review finding): the manager-level
+      // projection for app.input.submit is editorSubmitKeysFor, which a
+      // LEADER-ONLY override empties — the keymap row alone cannot see
+      // the manager-level leader state and would re-advertise the inert
+      // builtin Enter. For every other action keysFor is the keymap's own
+      // visible-rules projection, so the row is unchanged.
+      keys: [...this.keysFor(binding.action as AppKeybindingId)],
       scope: binding.scope,
       source: binding.source,
     }))

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -22,6 +22,8 @@ import type {
   AppKeybindingId,
   KeybindingContext,
   KeybindingResolution,
+  KeybindingScope,
+  KeybindingSource,
   KeymapSnapshot,
   LeaderBinding,
   LeaderConfig,
@@ -235,9 +237,16 @@ export class HostKeybindingManager {
   keyHint(action: AppKeybindingId): string {
     if (this.isDisabled(action)) return ''
     const direct = this.keymap.keyHint(action)
+    const leaderKeys = this.effectiveLeaderBindings
+      .filter(binding => binding.action === action)
+      .map(binding => formatLeaderSequence(binding.key))
+    if (direct !== '' && leaderKeys.length > 0) {
+      // Mixed direct + leader: show both (review finding — the leader
+      // sequence used to vanish behind the direct key).
+      return [direct, ...leaderKeys].join(' / ')
+    }
     if (direct !== '') return direct
-    const leaderBinding = this.effectiveLeaderBindings.find(binding => binding.action === action)
-    if (leaderBinding !== undefined) return formatLeaderSequence(leaderBinding.key)
+    if (leaderKeys.length > 0) return leaderKeys[0]!
     const definition = APP_KEYBINDINGS[action]
     if (definition !== undefined && definition.defaultKeys.length > 0) {
       return formatKeyId(definition.defaultKeys[0]!)
@@ -266,7 +275,26 @@ export class HostKeybindingManager {
       list.push(binding.key)
       leaderKeys.set(binding.action, list)
     }
-    const merged = [...snapshot.bindings]
+    type MutableSnapshotBinding = {
+      action: string
+      keys: KeyId[]
+      scope: KeybindingScope
+      source: KeybindingSource
+      leaderKeys?: KeyId[]
+    }
+    const merged: MutableSnapshotBinding[] = snapshot.bindings.map(binding => ({
+      action: binding.action,
+      keys: [...binding.keys],
+      scope: binding.scope,
+      source: binding.source,
+    }))
+    // Actions with BOTH direct and leader keys: attach the leader keys to
+    // the existing row (review finding — they were silently dropped).
+    for (const binding of merged) {
+      const leader = leaderKeys.get(binding.action)
+      if (leader === undefined) continue
+      binding.leaderKeys = leader
+    }
     for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
       if (present.has(id)) continue
       if (this.isDisabled(id as AppKeybindingId)) continue
@@ -274,10 +302,10 @@ export class HostKeybindingManager {
       if (leader !== undefined) {
         merged.push({
           action: id,
-          keys: leader,
+          keys: [],
+          leaderKeys: leader,
           scope: definition.scope,
           source: 'user',
-          leader: true,
         })
         continue
       }

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -93,10 +93,18 @@ export class HostKeybindingManager {
   private rebuild(): void {
     if (this.disposed) return
     this.diagnostics = []
+    // Safe mode (plan §17) ignores the user configuration ENTIRELY —
+    // including the leader key and its sequences (a leader sequence is a
+    // user override; safe mode must restore the builtin surface).
+    const effectiveLeaderConfig = this.safeMode ? undefined : this.leaderConfig
+    const effectiveLeaderBindings = this.safeMode
+      ? []
+      : this.leaderBindings.filter(binding => this.userBindings[binding.action] !== false)
     // Leader bindings: a duplicate completing key is ambiguous — neither
-    // fires (plan §6 M6: ambiguous prefix is a diagnostic).
+    // fires (plan §6 M6: ambiguous prefix is a diagnostic). A binding
+    // whose action the user DISABLED (false) never fires either.
     const byKey = new Map<KeyId, LeaderBinding[]>()
-    for (const binding of this.leaderBindings) {
+    for (const binding of effectiveLeaderBindings) {
       const list = byKey.get(binding.key) ?? []
       list.push(binding)
       byKey.set(binding.key, list)
@@ -115,8 +123,8 @@ export class HostKeybindingManager {
     // Rebuild the leader machine (its bindings/config may have changed).
     this.leader?.dispose()
     this.leader = undefined
-    if (this.leaderConfig !== undefined) {
-      this.leader = new LeaderStateMachine(this.leaderConfig, leaderBindings, {
+    if (effectiveLeaderConfig !== undefined) {
+      this.leader = new LeaderStateMachine(effectiveLeaderConfig, leaderBindings, {
         onActivate: (action) => this.onLeaderActivate(action),
         onStateChange: () => this.onLeaderStateChange(),
       })

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -15,6 +15,7 @@
 import type { KeyId } from '@xmoon76/pi-tui'
 import { matchesKey } from '@xmoon76/pi-tui'
 import { APP_KEYBINDINGS } from './definitions.ts'
+import { DEFAULT_LEADER_TIMEOUT_MS } from './config.ts'
 import { EffectiveKeymap, type CompositionRule, type PluginKeybindingRule } from './effective-keymap.ts'
 import { formatLeaderSequence, formatKeyId } from './hints.ts'
 import { LeaderStateMachine } from './leader.ts'
@@ -204,7 +205,14 @@ export class HostKeybindingManager {
       // the leader prefix would otherwise enter a dead pending state that
       // can never complete.
       if (effectiveLeaderConfig !== undefined && effectiveLeaderConfig.key !== undefined && leaderBindings.length > 0) {
-        this.leader = new LeaderStateMachine(effectiveLeaderConfig, leaderBindings, {
+        // The manager's leaderTimeoutMs option is the SURFACE-LEVEL
+        // override: it wins over the config-parse default (the manager
+        // owns the machine's timing; a runner/tests can tune it without
+        // touching the user config — convergence finding).
+        const machineConfig = this.leaderTimeoutMs !== DEFAULT_LEADER_TIMEOUT_MS
+          ? { ...effectiveLeaderConfig, timeoutMs: this.leaderTimeoutMs }
+          : effectiveLeaderConfig
+        this.leader = new LeaderStateMachine(machineConfig, leaderBindings, {
           onActivate: (action) => this.onLeaderActivate(action),
           onStateChange: () => this.onLeaderStateChange(),
         })

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -253,14 +253,34 @@ export class HostKeybindingManager {
   /** The immutable read model (diagnostics + /keybindings). The
    * capturing-scope actions (search overlay, question/tasks flows) are not
    * in the host keymap; their defaults are merged in for display. A
-   * DISABLED action is never advertised (review round 2). */
+   * DISABLED action is never advertised (review round 2). Leader-only
+   * actions (no default keys, only `<leader>X` bindings) are merged in
+   * with their leader sequences (review finding: they were advertised by
+   * keyHint but absent from the table). */
   snapshot(): KeymapSnapshot {
     const snapshot = this.keymap.snapshot()
     const present = new Set(snapshot.bindings.map(binding => binding.action))
+    const leaderKeys = new Map<string, KeyId[]>()
+    for (const binding of this.effectiveLeaderBindings) {
+      const list = leaderKeys.get(binding.action) ?? []
+      list.push(binding.key)
+      leaderKeys.set(binding.action, list)
+    }
     const merged = [...snapshot.bindings]
     for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
       if (present.has(id)) continue
       if (this.isDisabled(id as AppKeybindingId)) continue
+      const leader = leaderKeys.get(id)
+      if (leader !== undefined) {
+        merged.push({
+          action: id,
+          keys: leader,
+          scope: definition.scope,
+          source: 'user',
+          leader: true,
+        })
+        continue
+      }
       if (definition.defaultKeys.length === 0) continue
       merged.push({
         action: id,

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -198,8 +198,12 @@ export class HostKeybindingManager {
       this.leaderConfigShadowed = false
       this.leader?.dispose()
       this.leader = undefined
-      // Rebuild the leader machine (its bindings/config may have changed).
-      if (effectiveLeaderConfig !== undefined && effectiveLeaderConfig.key !== undefined) {
+      // Rebuild the leader machine ONLY when it has at least one
+      // EFFECTIVE completion (convergence §4.6b): with zero completions
+      // (every sequence ambiguous/disabled), the machine must not exist —
+      // the leader prefix would otherwise enter a dead pending state that
+      // can never complete.
+      if (effectiveLeaderConfig !== undefined && effectiveLeaderConfig.key !== undefined && leaderBindings.length > 0) {
         this.leader = new LeaderStateMachine(effectiveLeaderConfig, leaderBindings, {
           onActivate: (action) => this.onLeaderActivate(action),
           onStateChange: () => this.onLeaderStateChange(),
@@ -327,8 +331,11 @@ export class HostKeybindingManager {
   }
 
   /** The effective keys of one action (direct keys only — leader
-   * sequences live in {@link leaderKeysFor}). */
+   * sequences live in {@link leaderKeysFor}). For the editor-owned
+   * submit action the read model reflects the fork editor's effective
+   * trigger keys (convergence §7: one fact everywhere). */
   keysFor(action: AppKeybindingId): KeyId[] {
+    if (action === 'app.input.submit') return this.editorSubmitKeysFor()
     return this.keymap.keysFor(action)
   }
 
@@ -337,6 +344,23 @@ export class HostKeybindingManager {
    * plugin dispatch stage; PR review finding). */
   hostResolves(data: string, context: KeybindingContext): boolean {
     return this.keymap.hostResolves(data, context)
+  }
+
+  /** Whether one action can fire in the CURRENT context (leader
+   * completions check this before dispatching — a leader sequence obeys
+   * the action's context predicate, convergence §4.7). */
+  canActivate(action: AppKeybindingId, context: KeybindingContext): boolean {
+    // Editor-owned submit: the action is active whenever it has an
+    // EFFECTIVE editor trigger (the fork editor's tui.input.submit or a
+    // live leader sequence) — the host keymap has no submit rule to
+    // evaluate (hostResolved:false). A leader submit completion must
+    // activate iff submit itself is available (convergence §4.7).
+    if (action === 'app.input.submit') {
+      if (this.isDisabled(action)) return false
+      return this.editorSubmitKeysFor().length > 0
+        || this.effectiveLeaderBindings.some(binding => binding.action === action)
+    }
+    return this.keymap.canActivate(action, context)
   }
 
   /** The EFFECTIVE `<leader>X` completing keys of one action (M6),
@@ -357,12 +381,15 @@ export class HostKeybindingManager {
     if (direct.length > 0 || leader.length > 0) {
       return [...direct, ...leader].join(' / ')
     }
-    // Capturing-scope actions (search close/next/previous, question/tasks
-    // flows) are excluded from the HOST keymap, so keysFor() is empty —
-    // fall back to their defaults for display (review finding: /help
-    // showed '—' for Enter submission and the fixed overlay controls).
+    // ONLY fixed non-configurable component actions (search
+    // close/next/previous, question/tasks flows) may display their
+    // defaults — they never resolve in the HOST keymap (plan §3.3) and
+    // their keys are NOT user-configurable, so the default IS the
+    // effective key (convergence §8: no fabricated fallback for
+    // configurable actions — a conflicted/shadowed user override must
+    // not resurrect the builtin).
     const definition = APP_KEYBINDINGS[action]
-    if (definition !== undefined && definition.defaultKeys.length > 0) {
+    if (definition !== undefined && !definition.configurable && definition.defaultKeys.length > 0) {
       return definition.defaultKeys.map(formatKeyId).join(' / ')
     }
     return ''
@@ -381,7 +408,10 @@ export class HostKeybindingManager {
    * fires is never advertised (review round 3). */
   keyHint(action: AppKeybindingId): string {
     if (this.isDisabled(action)) return ''
-    const direct = this.keymap.keyHint(action)
+    // The read model is unified through keysFor (editor-owned submit
+    // included — convergence §7: one fact everywhere).
+    const directKeys = this.keysFor(action)
+    const direct = directKeys.length > 0 ? formatKeyId(directKeys[0]!) : ''
     const leaderKeys = this.effectiveLeaderBindings
       .filter(binding => binding.action === action)
       .map(binding => formatLeaderSequence(binding.key))
@@ -392,8 +422,10 @@ export class HostKeybindingManager {
     }
     if (direct !== '') return direct
     if (leaderKeys.length > 0) return leaderKeys[0]!
+    // Same no-fabrication rule as keysLabelFor: only fixed
+    // non-configurable component actions display their defaults.
     const definition = APP_KEYBINDINGS[action]
-    if (definition !== undefined && definition.defaultKeys.length > 0) {
+    if (definition !== undefined && !definition.configurable && definition.defaultKeys.length > 0) {
       return formatKeyId(definition.defaultKeys[0]!)
     }
     return ''
@@ -454,7 +486,11 @@ export class HostKeybindingManager {
         })
         continue
       }
-      if (definition.defaultKeys.length === 0) continue
+      // No fabricated builtin fallback for CONFIGURABLE actions (a
+      // conflicted/shadowed override must not resurrect the default);
+      // only fixed non-configurable component actions display defaults
+      // (their keys never resolve in the host keymap, plan §3.3).
+      if (definition.defaultKeys.length === 0 || definition.configurable) continue
       merged.push({
         action: id,
         keys: [...definition.defaultKeys],

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -48,6 +48,15 @@ export interface HostKeybindingManagerOptions {
   readonly onLeaderActivate?: (action: string) => boolean
   /** The leader timeout in ms (defaults to the config default). */
   readonly leaderTimeoutMs?: number
+  /**
+   * Called after every rebuild with the EFFECTIVE submit keys of
+   * `app.input.submit` (an empty array = the action is disabled). The
+   * app syncs them into the fork editor's `tui.input.submit` binding so
+   * a user remap/disable of submit REALLY moves/removes the editor's
+   * Enter submission (review finding — the editor path was previously
+   * physical-only and ignored user config).
+   */
+  readonly onEditorSubmitSync?: (keys: readonly KeyId[]) => void
 }
 
 /** The stateful keybinding facade. */
@@ -55,6 +64,7 @@ export class HostKeybindingManager {
   private readonly onInvalidate: () => void
   private readonly onLeaderStateChange: () => void
   private readonly onLeaderActivate: (action: string) => boolean
+  private readonly onEditorSubmitSync: (keys: readonly KeyId[]) => void
   private readonly leaderTimeoutMs: number
 
   private userBindings: UserKeybindingsConfig = {}
@@ -65,6 +75,10 @@ export class HostKeybindingManager {
   private effectiveLeaderBindings: readonly LeaderBinding[] = []
   private pluginRules: readonly PluginKeybindingRule[] = []
   private safeMode = false
+  /** True when the leader machine was DISABLED because the leader key
+   * collided with an ACTIVE host key (PR review finding — the direct key
+   * wins, never a silent shadow). */
+  private leaderConfigShadowed = false
   private diagnostics: string[] = []
 
   private keymap: EffectiveKeymap
@@ -83,6 +97,7 @@ export class HostKeybindingManager {
     this.onInvalidate = options.onInvalidate ?? (() => {})
     this.onLeaderStateChange = options.onLeaderStateChange ?? (() => {})
     this.onLeaderActivate = options.onLeaderActivate ?? (() => true)
+    this.onEditorSubmitSync = options.onEditorSubmitSync ?? (() => {})
     this.leaderTimeoutMs = options.leaderTimeoutMs ?? 1500
     this.keymap = this.buildKeymap()
   }
@@ -142,16 +157,67 @@ export class HostKeybindingManager {
     }
     this.keymap = this.buildKeymap()
     this.effectiveLeaderBindings = leaderBindings
-    // Rebuild the leader machine (its bindings/config may have changed).
-    this.leader?.dispose()
-    this.leader = undefined
-    if (effectiveLeaderConfig !== undefined) {
-      this.leader = new LeaderStateMachine(effectiveLeaderConfig, leaderBindings, {
-        onActivate: (action) => this.onLeaderActivate(action),
-        onStateChange: () => this.onLeaderStateChange(),
-      })
+    // Leader PREFIX collision (PR review finding): the leader key is fed
+    // BEFORE the host ladder, so a leader key that is ALSO an ACTIVE
+    // direct key of any host action would silently shadow that action
+    // (e.g. `leader: ctrl+f` swallows app.transcript.search). Fail-soft:
+    // the direct key wins, the leader machine is DISABLED, and the
+    // collision is a diagnostic — never a silent shadow. A leader key
+    // that only collides with a DISABLED action's key is fine (no active
+    // rule).
+    const leaderKey = effectiveLeaderConfig?.key
+    const leaderCollision = leaderKey !== undefined
+      ? this.keymap.activeKeys().some(key => key === leaderKey)
+      : false
+    if (leaderCollision && leaderKey !== undefined) {
+      this.diagnostics.push(
+        `keybinding: leader key ${formatKeyId(leaderKey)} is also an active host key — the leader machine is disabled (the direct key wins)`,
+      )
+      // Disable the leader machine: the direct key wins (never a silent
+      // shadow — PR review finding).
+      this.leaderConfigShadowed = true
+      this.leader?.dispose()
+      this.leader = undefined
+    } else {
+      this.leaderConfigShadowed = false
+      this.leader?.dispose()
+      this.leader = undefined
+      // Rebuild the leader machine (its bindings/config may have changed).
+      if (effectiveLeaderConfig !== undefined && effectiveLeaderConfig.key !== undefined) {
+        this.leader = new LeaderStateMachine(effectiveLeaderConfig, leaderBindings, {
+          onActivate: (action) => this.onLeaderActivate(action),
+          onStateChange: () => this.onLeaderStateChange(),
+        })
+      }
     }
+    // Sync the effective submit keys into the fork editor's binding
+    // (review finding): a user remap or `false` of app.input.submit must
+    // REALLY move/remove the editor's submission — the fork editor routes
+    // Enter (or the remapped key) through tui.input.submit. Empty = the
+    // action is disabled (no key submits).
+    this.onEditorSubmitSync(this.editorSubmitKeysFor())
     this.onInvalidate()
+  }
+
+  /** The effective submit keys of `app.input.submit` as the fork editor's
+   * `tui.input.submit` should carry them: the action's effective direct
+   * keys, or an EMPTY array when disabled (`false`) or safe mode dropped
+   * them. `app.input.submit` is hostResolved:false — the host ladder
+   * NEVER consumes these keys; the editor owns them, so the sync is the
+   * only consumer. */
+  editorSubmitKeysFor(): KeyId[] {
+    if (this.isDisabled('app.input.submit')) return []
+    const keys = this.keymap.keysFor('app.input.submit')
+    if (keys.length > 0) return keys
+    // The builtin submit rule is hostResolved: false (the host ladder
+    // never consumes it), so keysFor() is EMPTY by default — fall back to
+    // the definition's default ('enter'). A user remap compiles as a
+    // `user` rule and is returned above; `false` was handled above.
+    const definition = APP_KEYBINDINGS['app.input.submit']
+    if (definition !== undefined && definition.defaultKeys.length > 0) {
+      return [...definition.defaultKeys]
+    }
+    return []
   }
 
   // ── Configuration ──────────────────────────────────────────────────────

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -43,7 +43,7 @@ export interface HostKeybindingManagerOptions {
   /** Called when the leader pending state changes (which-key hint). */
   readonly onLeaderStateChange?: () => void
   /** Called when a leader sequence completes (the app dispatches). */
-  readonly onLeaderActivate?: (action: string) => void
+  readonly onLeaderActivate?: (action: string) => boolean
   /** The leader timeout in ms (defaults to the config default). */
   readonly leaderTimeoutMs?: number
 }
@@ -52,7 +52,7 @@ export interface HostKeybindingManagerOptions {
 export class HostKeybindingManager {
   private readonly onInvalidate: () => void
   private readonly onLeaderStateChange: () => void
-  private readonly onLeaderActivate: (action: string) => void
+  private readonly onLeaderActivate: (action: string) => boolean
   private readonly leaderTimeoutMs: number
 
   private userBindings: UserKeybindingsConfig = {}
@@ -66,13 +66,21 @@ export class HostKeybindingManager {
   private diagnostics: string[] = []
 
   private keymap: EffectiveKeymap
+  /**
+   * MONOTONIC rebuild counter (never restarts): the EffectiveKeymap's own
+   * revision resets to 1 on every instance (buildKeymap creates a NEW
+   * keymap per rebuild), so consumers keying caches on the keymap
+   * revision (the transcript fold-hint cache) must read THIS — a remap,
+   * safe-mode flip or plugin sync must invalidate them (review finding).
+   */
+  private revisionCounter = 0
   private leader: LeaderStateMachine | undefined
   private disposed = false
 
   constructor(options: HostKeybindingManagerOptions = {}) {
     this.onInvalidate = options.onInvalidate ?? (() => {})
     this.onLeaderStateChange = options.onLeaderStateChange ?? (() => {})
-    this.onLeaderActivate = options.onLeaderActivate ?? (() => {})
+    this.onLeaderActivate = options.onLeaderActivate ?? (() => true)
     this.leaderTimeoutMs = options.leaderTimeoutMs ?? 1500
     this.keymap = this.buildKeymap()
   }
@@ -96,6 +104,7 @@ export class HostKeybindingManager {
   private rebuild(): void {
     if (this.disposed) return
     this.diagnostics = []
+    this.revisionCounter += 1
     // Safe mode (plan §17) ignores the user configuration ENTIRELY —
     // including the leader key and its sequences (a leader sequence is a
     // user override; safe mode must restore the builtin surface).
@@ -269,9 +278,11 @@ export class HostKeybindingManager {
     return [...this.diagnostics]
   }
 
-  /** The current keymap revision. */
+  /** The current keymap revision — MONOTONIC across rebuilds (see
+   * {@link revisionCounter}); every effective-key change bumps it, so caches
+   * keyed on it (transcript fold hints) rebuild exactly when the keys do. */
   revision(): number {
-    return this.keymap.snapshot().revision
+    return this.revisionCounter
   }
 
   // ── Leader (M6) ────────────────────────────────────────────────────────

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -114,11 +114,18 @@ export class HostKeybindingManager {
     const effectiveLeaderBindings = this.safeMode
       ? []
       : this.leaderBindings.filter(binding => this.userBindings[binding.action] !== false)
-    // Leader bindings: a duplicate completing key is ambiguous — neither
-    // fires (plan §6 M6: ambiguous prefix is a diagnostic). A binding
-    // whose action the user DISABLED (false) never fires either.
+    // Leader bindings: a duplicate completing key across DIFFERENT
+    // actions is ambiguous — neither fires (plan §6 M6: ambiguous prefix
+    // is a diagnostic). Identical (action, key) pairs are DEDUPED first
+    // (e.g. `<leader>h` listed twice for ONE action is not ambiguous —
+    // review finding). A binding whose action the user DISABLED (false)
+    // never fires either.
+    const seenPairs = new Set<string>()
     const byKey = new Map<KeyId, LeaderBinding[]>()
     for (const binding of effectiveLeaderBindings) {
+      const pair = `${binding.action}\u0000${binding.key}`
+      if (seenPairs.has(pair)) continue
+      seenPairs.add(pair)
       const list = byKey.get(binding.key) ?? []
       list.push(binding)
       byKey.set(binding.key, list)
@@ -239,7 +246,18 @@ export class HostKeybindingManager {
     if (this.isDisabled(action)) return ''
     const direct = this.keysFor(action).map(formatKeyId)
     const leader = this.leaderKeysFor(action).map(formatLeaderSequence)
-    return [...direct, ...leader].join(' / ')
+    if (direct.length > 0 || leader.length > 0) {
+      return [...direct, ...leader].join(' / ')
+    }
+    // Capturing-scope actions (search close/next/previous, question/tasks
+    // flows) are excluded from the HOST keymap, so keysFor() is empty —
+    // fall back to their defaults for display (review finding: /help
+    // showed '—' for Enter submission and the fixed overlay controls).
+    const definition = APP_KEYBINDINGS[action]
+    if (definition !== undefined && definition.defaultKeys.length > 0) {
+      return definition.defaultKeys.map(formatKeyId).join(' / ')
+    }
+    return ''
   }
 
   /** The primary effective key of one action, or undefined. */

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -227,32 +227,27 @@ export class HostKeybindingManager {
    * only consumer. */
   editorSubmitKeysFor(): KeyId[] {
     if (this.isDisabled('app.input.submit')) return []
-    // HOST sources only: a PLUGIN submit binding is additive — it never
-    // replaces the builtin Enter (PR review finding).
-    const keys = this.keymap.hostKeysFor('app.input.submit')
-    if (keys.length > 0) return keys
-    // SAFE MODE (PR review finding): the raw user overrides are IGNORED —
-    // a previously remapped/disabled submit must not keep Enter inert
-    // under DSH_PI_TUI_SAFE_KEYBINDINGS=1; the builtin default ('enter')
-    // is restored.
-    // A leader-only submit override counts ONLY when the sequence is
-    // EFFECTIVE (not raw leaderBindings): if the leader was shadowed by a
-    // prefix collision or the completing key was ambiguous (both
-    // disabled), the sequence cannot fire — fail-soft back to the
-    // builtin Enter (PR review finding: a dead leader-only submit must
-    // not disable Enter entirely).
-    const hasSubmitOverride = !this.safeMode && (
-      this.userBindings['app.input.submit'] !== undefined
-      || this.effectiveLeaderBindings.some(binding => binding.action === 'app.input.submit'))
-    if (hasSubmitOverride) return []
-    // The builtin submit rule is hostResolved: false (the host ladder
-    // never consumes it), so keysFor() is EMPTY by default — fall back to
-    // the definition's default ('enter'). A user remap compiles as a
-    // `user` rule and is returned above; `false` was handled above.
-    const definition = APP_KEYBINDINGS['app.input.submit']
-    if (definition !== undefined && definition.defaultKeys.length > 0) {
-      return [...definition.defaultKeys]
-    }
+    // A live leader-ONLY submit override (an effective sequence) removes
+    // Enter: the leader is the only trigger (checked BEFORE the editor-key
+    // fallback — the builtin Enter rule is always in the effective set).
+    if (this.effectiveLeaderBindings.some(binding => binding.action === 'app.input.submit')) return []
+    // The sync derives ONLY from the effective EDITOR-OWNED rules
+    // (convergence §3 finding): submit's rules (builtin Enter + user
+    // overrides) compile with owner=editor and participate in the unified
+    // model, so a conflicted/shadowed override already vanished from the
+    // effective set — no raw-config reading here. A user remap that
+    // CONFLICTS away (e.g. submit=ctrl+x vs history=ctrl+x) therefore
+    // fails soft back to the builtin Enter; only an explicit `false`
+    // disables submission entirely.
+    const editorKeys = this.keymap.editorKeysFor('app.input.submit')
+    if (editorKeys.length > 0) return editorKeys
+    // NO definition-default fallback here (convergence §4.5 finding): the
+    // builtin Enter is ALREADY compiled as an effective editor-owned rule,
+    // so an empty editorKeysFor means the builtin was SHADOWED or
+    // CONFLICTED away — resurrecting it would both violate the read model
+    // and re-introduce a runtime/UI mismatch. (Safe mode restores the
+    // builtin because the keymap compiles it when the user overrides are
+    // ignored; an explicit `false` was handled at the top.)
     return []
   }
 
@@ -350,11 +345,10 @@ export class HostKeybindingManager {
    * completions check this before dispatching — a leader sequence obeys
    * the action's context predicate, convergence §4.7). */
   canActivate(action: AppKeybindingId, context: KeybindingContext): boolean {
-    // Editor-owned submit: the action is active whenever it has an
-    // EFFECTIVE editor trigger (the fork editor's tui.input.submit or a
-    // live leader sequence) — the host keymap has no submit rule to
-    // evaluate (hostResolved:false). A leader submit completion must
-    // activate iff submit itself is available (convergence §4.7).
+    // Editor-owned submit: active whenever it has an EFFECTIVE editor
+    // trigger (the fork editor's tui.input.submit or a live leader
+    // sequence) — a leader submit completion must activate iff submit
+    // itself is available (convergence §4.7).
     if (action === 'app.input.submit') {
       if (this.isDisabled(action)) return false
       return this.editorSubmitKeysFor().length > 0

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -178,7 +178,7 @@ export class HostKeybindingManager {
     // so e.g. `leader: enter` would silently swallow Enter — PR review
     // finding).
     const leaderCollision = leaderKey !== undefined
-      ? this.keymap.activeKeys().some(key => key === leaderKey)
+      ? this.keymap.hostActiveKeys().some(key => key === leaderKey)
         || this.editorSubmitKeysFor().some(key => key === leaderKey)
       : false
     if (leaderCollision && leaderKey !== undefined) {
@@ -219,7 +219,9 @@ export class HostKeybindingManager {
    * only consumer. */
   editorSubmitKeysFor(): KeyId[] {
     if (this.isDisabled('app.input.submit')) return []
-    const keys = this.keymap.keysFor('app.input.submit')
+    // HOST sources only: a PLUGIN submit binding is additive — it never
+    // replaces the builtin Enter (PR review finding).
+    const keys = this.keymap.hostKeysFor('app.input.submit')
     if (keys.length > 0) return keys
     // SAFE MODE (PR review finding): the raw user overrides are IGNORED —
     // a previously remapped/disabled submit must not keep Enter inert
@@ -318,6 +320,13 @@ export class HostKeybindingManager {
    * sequences live in {@link leaderKeysFor}). */
   keysFor(action: AppKeybindingId): KeyId[] {
     return this.keymap.keysFor(action)
+  }
+
+  /** Whether one raw input resolves to a HOST-owned action (PLUGIN rules
+   * excluded — a plugin binding is not a Host action and must reach the
+   * plugin dispatch stage; PR review finding). */
+  hostResolves(data: string, context: KeybindingContext): boolean {
+    return this.keymap.hostResolves(data, context)
   }
 
   /** The EFFECTIVE `<leader>X` completing keys of one action (M6),

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -214,6 +214,10 @@ export interface KeymapSnapshot {
     readonly keys: readonly KeyId[]
     readonly scope: KeybindingScope
     readonly source: KeybindingSource
+    /** True when EVERY key of this binding is a `<leader>X` sequence (the
+     * action has no direct keys — display renders them with the leader
+     * prefix). Undefined/absent = direct keys. */
+    readonly leader?: boolean
   }[]
   readonly conflicts: readonly KeybindingConflict[]
 }

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -177,6 +177,15 @@ export interface KeybindingContext {
 /** Where an effective rule came from (plan §7). */
 export type KeybindingSource = 'builtin' | 'plugin' | 'composition' | 'user'
 
+/** Who EXECUTES a rule's key (convergence §3). `editor` rules are the
+ * fork-editor-owned submit triggers: they participate in the unified
+ * model (canonical/conflict/shadow/snapshot/read-model) but are NEVER
+ * resolved by the HOST ladder — `resolve`/`hostResolves`/
+ * `hostActiveKeys`/`hostKeysFor` exclude them, and the fork editor (via
+ * `onEditorSubmitSync`) executes them, preserving paste-burst and
+ * backslash-newline semantics. */
+export type RuleOwner = 'host' | 'editor' | 'plugin'
+
 /** One compiled rule of the effective keymap (plan §7). */
 export interface EffectiveBindingRule {
   readonly id: string
@@ -185,6 +194,9 @@ export interface EffectiveBindingRule {
   readonly source: KeybindingSource
   readonly scope: KeybindingScope
   readonly priority: number
+  /** The executor: 'host' (Host ladder), 'editor' (fork editor-owned),
+   * or 'plugin' (a Stable plugin binding). */
+  readonly owner: RuleOwner
   /** Optional context predicate (e.g. the empty-editor ↓ affordance). */
   readonly predicate?: (context: KeybindingContext) => boolean
 }

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -214,10 +214,11 @@ export interface KeymapSnapshot {
     readonly keys: readonly KeyId[]
     readonly scope: KeybindingScope
     readonly source: KeybindingSource
-    /** True when EVERY key of this binding is a `<leader>X` sequence (the
-     * action has no direct keys — display renders them with the leader
-     * prefix). Undefined/absent = direct keys. */
-    readonly leader?: boolean
+    /** The `<leader>X` completing keys of this action (M6), separate
+     * from the direct `keys`: an action can have BOTH (e.g.
+     * `['ctrl+z', '<leader>t']`). Display renders them with the leader
+     * prefix. Absent = no leader bindings. */
+    readonly leaderKeys?: readonly KeyId[]
   }[]
   readonly conflicts: readonly KeybindingConflict[]
 }

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -116,6 +116,10 @@ export interface AppKeybindingDefinition {
   readonly scope: KeybindingScope
   /** Whether the user may override this action's keys (M3). */
   readonly configurable: boolean
+  /** Availability tier (convergence §7): 'implemented' (default) has
+   * real host behavior; 'reserved' is NOT implemented in this version —
+   * never user-configurable, never a bindable no-op. */
+  readonly availability?: 'implemented' | 'reserved'
   /** Whether the HOST ladder consumes this action's keys. `false` marks
    * actions whose default key belongs to a focused component (e.g. Enter
    * stays with the fork editor's submit path — paste-burst/backslash

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -132,19 +132,29 @@ export interface AppKeybindingDefinition {
 
 /**
  * The user-facing value of one action in the settings document (plan §12):
- * - a string: a single key;
- * - an array: multiple keys;
- * - `false`: disable the user binding for this action (the action keeps
- *   its builtin default unless the user ALSO disabled it — see
- *   {@link UserKeybindingsConfig} semantics in config.ts);
+ * - a string: a single key (REPLACES the action's builtin default keys);
+ * - an array: multiple keys (REPLACE the builtin defaults; a LEADER-ONLY
+ *   declaration is an EMPTY array — the parser emits it for an action
+ *   configured ONLY with `<leader>X` sequences, so the builtin default is
+ *   replaced by the leader trigger);
+ * - `false`: DISABLE the action's effective keys entirely (no builtin, no
+ *   user key, no leader sequence — every trigger is removed);
  * - a `<leader>X` string: a leader-sequence binding (M6).
+ *
+ * The unified override contract (review round 37): absent = builtin
+ * default; any user declaration (direct, leader-only, direct + leader)
+ * REPLACES the builtin default keys of that action; composition
+ * affordances stay additive (a conditional trigger like the empty-editor
+ * `↓` tasks browser is never removed by a remap — only `false` removes
+ * every trigger of an action).
  */
 export type UserKeybindingValue = KeyId | readonly KeyId[] | false
 
 /**
- * The user keybinding overrides (plan §13). `false` DISABLES the action's
- * user binding; the action then falls back to its builtin default keys
- * (the plan's fail-soft rule: a bad entry never disables the whole map).
+ * The user keybinding overrides (plan §13). Any entry is a DECLARATION
+ * whose keys REPLACE the action's builtin default keys (direct keys,
+ * leader-only empty-array marker, or both via the leader sequences);
+ * `false` REMOVES every trigger of the action (builtin included).
  */
 export type UserKeybindingsConfig = Partial<Record<AppKeybindingId, UserKeybindingValue>>
 

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -120,11 +120,13 @@ export interface AppKeybindingDefinition {
    * real host behavior; 'reserved' is NOT implemented in this version —
    * never user-configurable, never a bindable no-op. */
   readonly availability?: 'implemented' | 'reserved'
-  /** Whether the HOST ladder consumes this action's keys. `false` marks
-   * actions whose default key belongs to a focused component (e.g. Enter
-   * stays with the fork editor's submit path — paste-burst/backslash
-   * semantics); the builtin rule is then NOT compiled, but a user override
-   * still is (a custom submit key routes through submitDraft). */
+  /** Execution owner hint: whether the HOST ladder consumes this action's
+   * keys. `false` marks EDITOR-OWNED actions (submit): the builtin AND
+   * user direct bindings BOTH compile into the effective model as
+   * owner=editor rules, participate in conflict/shadow/winner selection,
+   * but execution is deferred to the fork editor (the effective keys
+   * sync into its `tui.input.submit` via onEditorSubmitSync), preserving
+   * paste-burst and backslash-newline semantics. */
   readonly hostResolved?: boolean
 }
 

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -1,0 +1,234 @@
+/**
+ * The user-orchestrable keybinding architecture (plan:
+ * temp/20260825/dsh-pi-tui-keybinding-customization-implementation-plan-2026-08-24.md).
+ *
+ * The pipeline the plan mandates:
+ *
+ * ```text
+ * Physical Key
+ *     ↓
+ * Semantic Action ID
+ *     ↓
+ * Context-aware resolver
+ *     ↓
+ * Host handler
+ * ```
+ *
+ * This module defines the CONTRACT types only: action ids, scopes,
+ * definitions, the context the resolver reads, the compiled rules, and the
+ * resolution/snapshot shapes. The runtime pieces live in
+ * definitions.ts / context.ts / effective-keymap.ts / conflicts.ts /
+ * config.ts / leader.ts / manager.ts / action-dispatcher.ts / hints.ts.
+ *
+ * Design rules (plan §2, §4, §15):
+ * - terminal protocol is NEVER configurable;
+ * - plugins never receive raw terminal bytes;
+ * - focused components own context-local keymaps;
+ * - the user configures which KEY an ACTION maps to (never the reverse);
+ * - business code stops knowing physical keys (M1);
+ * - the same key may legally map to different actions in disjoint scopes;
+ * - a conflict is: same key AND overlapping scope AND same effective
+ *   priority — never a bare "declared twice" check.
+ * @module @xmoon76/dsh-pi-tui/keybindings/types
+ */
+
+import type { KeyId } from '@xmoon76/pi-tui'
+
+/**
+ * The stable semantic action ids of the HOST surface (plan §3.2). The
+ * `app.*` family is the Host global surface; `question.*` and `tasks.*`
+ * are focused-component actions (plan §3.3) that only resolve while the
+ * corresponding component owns the seat.
+ */
+export type AppKeybindingId =
+  // Input / Agent
+  | 'app.input.submit'
+  | 'app.input.queue'
+  | 'app.input.steer'
+  | 'app.input.dequeue'
+  | 'app.agent.interrupt'
+  | 'app.exit.request'
+  // Transcript
+  | 'app.transcript.search'
+  | 'app.transcript.search.next'
+  | 'app.transcript.search.previous'
+  | 'app.transcript.search.close'
+  | 'app.transcript.toggleExpand'
+  | 'app.transcript.toggleThinking'
+  | 'app.transcript.toggleFullscreen'
+  // Editor / Clipboard
+  | 'app.editor.external'
+  | 'app.clipboard.pasteMedia'
+  // Permissions / Panels
+  | 'app.permission.cycle'
+  | 'app.todo.toggle'
+  | 'app.tasks.open'
+  | 'app.history.search'
+  // Local shell
+  | 'app.shell.dismissSettled'
+  // Session / Model (reserved for later unification; no default keys)
+  | 'app.session.open'
+  | 'app.session.new'
+  | 'app.session.resume'
+  | 'app.model.open'
+  // Focused component: the user-questions flow (plan §3.3)
+  | 'question.confirm'
+  | 'question.cancel'
+  | 'question.previous'
+  | 'question.next'
+  | 'question.cursorUp'
+  | 'question.cursorDown'
+  | 'question.pageUp'
+  | 'question.pageDown'
+  | 'question.toggleExpand'
+  // Focused component: the task browser (plan §3.3)
+  | 'tasks.confirm'
+  | 'tasks.cancel'
+  | 'tasks.cursorUp'
+  | 'tasks.cursorDown'
+  | 'tasks.pageUp'
+  | 'tasks.pageDown'
+  | 'tasks.cycleType'
+  | 'tasks.interrupt'
+
+/**
+ * The static context contract of one binding (plan §4). The first version
+ * has no user-written `when` expressions; `scope` is the internal static
+ * context contract and may later compile into a when predicate.
+ */
+export type KeybindingScope =
+  | 'global'
+  | 'editor'
+  | 'overlay'
+  | 'search'
+  | 'question'
+  | 'approval'
+  | 'viewer'
+  | 'agent-running'
+  | 'tasks'
+
+/** One action definition (plan §4). */
+export interface AppKeybindingDefinition {
+  readonly id: AppKeybindingId
+  readonly defaultKeys: readonly KeyId[]
+  readonly description: string
+  readonly category: string
+  readonly scope: KeybindingScope
+  /** Whether the user may override this action's keys (M3). */
+  readonly configurable: boolean
+  /** Whether the HOST ladder consumes this action's keys. `false` marks
+   * actions whose default key belongs to a focused component (e.g. Enter
+   * stays with the fork editor's submit path — paste-burst/backslash
+   * semantics); the builtin rule is then NOT compiled, but a user override
+   * still is (a custom submit key routes through submitDraft). */
+  readonly hostResolved?: boolean
+}
+
+/**
+ * The user-facing value of one action in the settings document (plan §12):
+ * - a string: a single key;
+ * - an array: multiple keys;
+ * - `false`: disable the user binding for this action (the action keeps
+ *   its builtin default unless the user ALSO disabled it — see
+ *   {@link UserKeybindingsConfig} semantics in config.ts);
+ * - a `<leader>X` string: a leader-sequence binding (M6).
+ */
+export type UserKeybindingValue = KeyId | readonly KeyId[] | false
+
+/**
+ * The user keybinding overrides (plan §13). `false` DISABLES the action's
+ * user binding; the action then falls back to its builtin default keys
+ * (the plan's fail-soft rule: a bad entry never disables the whole map).
+ */
+export type UserKeybindingsConfig = Partial<Record<AppKeybindingId, UserKeybindingValue>>
+
+/**
+ * The live surface context the resolver reads (plan §6). TuiApp builds it
+ * in ONE place (`keybindingContext()`); the resolver never reaches into
+ * TuiApp private fields, so the resolution logic stays unit-testable.
+ */
+export interface KeybindingContext {
+  /** Which seat owns the editor right now. */
+  readonly focusedSeat: 'editor' | 'overlay' | 'editor-panel' | 'none'
+  /** A user-questions flow currently owns the seat (capturing). */
+  readonly questionActive: boolean
+  /** An approval prompt is currently shown (capturing). */
+  readonly approvalActive: boolean
+  /** The subagent viewer mode. */
+  readonly viewerMode: 'none' | 'readonly' | 'continuable'
+  /** The transcript-search overlay is open (owns its keys). */
+  readonly searchActive: boolean
+  /** Any non-search overlay is mounted (owns the focused component). */
+  readonly overlayActive: boolean
+  /** The agent is currently running (busy). */
+  readonly agentRunning: boolean
+  /** The focused editor's draft is empty. */
+  readonly editorEmpty: boolean
+  /** The editor's autocomplete dropdown is open. */
+  readonly autocompleteActive: boolean
+  /** Background tasks/subagents are active (the ↓ browser affordance). */
+  readonly tasksActive: boolean
+}
+
+/** Where an effective rule came from (plan §7). */
+export type KeybindingSource = 'builtin' | 'plugin' | 'composition' | 'user'
+
+/** One compiled rule of the effective keymap (plan §7). */
+export interface EffectiveBindingRule {
+  readonly id: string
+  readonly action: string
+  readonly key: KeyId
+  readonly source: KeybindingSource
+  readonly scope: KeybindingScope
+  readonly priority: number
+  /** Optional context predicate (e.g. the empty-editor ↓ affordance). */
+  readonly predicate?: (context: KeybindingContext) => boolean
+}
+
+/** The outcome of one resolution (plan §7). */
+export interface KeybindingResolution {
+  readonly action: string
+  readonly key: KeyId
+  readonly source: KeybindingSource
+  readonly ruleId: string
+}
+
+/** One detected conflict (plan §15): same key + overlapping scope + same
+ * effective priority. Never silently last-write-wins. */
+export interface KeybindingConflict {
+  readonly key: KeyId
+  readonly actions: readonly {
+    readonly action: string
+    readonly scope: KeybindingScope
+    readonly source: KeybindingSource
+    /** The deactivated rule id (diagnostics). */
+    readonly ruleId: string
+  }[]
+}
+
+/** The immutable read model of the effective keymap (plan §2 M2). */
+export interface KeymapSnapshot {
+  readonly revision: number
+  readonly bindings: readonly {
+    readonly action: string
+    readonly keys: readonly KeyId[]
+    readonly scope: KeybindingScope
+    readonly source: KeybindingSource
+  }[]
+  readonly conflicts: readonly KeybindingConflict[]
+}
+
+/** The leader (M6) configuration. */
+export interface LeaderConfig {
+  /** The leader key (e.g. `ctrl+x`); undefined disables the leader. */
+  readonly key: KeyId | undefined
+  /** How long a pending leader sequence stays armed, in ms. */
+  readonly timeoutMs: number
+}
+
+/** One leader-sequence binding (`<leader>t` → action). */
+export interface LeaderBinding {
+  readonly action: AppKeybindingId
+  /** The completing key (e.g. `t` for `<leader>t`). */
+  readonly key: KeyId
+}

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -177,13 +177,16 @@ export interface KeybindingContext {
 /** Where an effective rule came from (plan §7). */
 export type KeybindingSource = 'builtin' | 'plugin' | 'composition' | 'user'
 
-/** Who EXECUTES a rule's key (convergence §3). `editor` rules are the
- * fork-editor-owned submit triggers: they participate in the unified
- * model (canonical/conflict/shadow/snapshot/read-model) but are NEVER
- * resolved by the HOST ladder — `resolve`/`hostResolves`/
- * `hostActiveKeys`/`hostKeysFor` exclude them, and the fork editor (via
- * `onEditorSubmitSync`) executes them, preserving paste-burst and
- * backslash-newline semantics. */
+/** Who EXECUTES a rule's key (convergence §3, review finding: the owner
+ * is "who runs the winner", NEVER a pre-filter of who may compete).
+ * `editor` rules are the fork-editor-owned submit triggers: they
+ * PARTICIPATE in the unified winner selection (a user submit override at
+ * priority 200 genuinely beats a builtin host rule on the same key —
+ * `submit: ctrl+s` really submits, it never steers), and the RESOLUTION
+ * carries the winner's owner so the caller can route execution: host →
+ * the Host dispatcher, editor → the fork editor (via `onEditorSubmitSync`
+ * + `hostResolves: false`), plugin → the plugin remainder. The editor
+ * path preserves paste-burst and backslash-newline semantics. */
 export type RuleOwner = 'host' | 'editor' | 'plugin'
 
 /** One compiled rule of the effective keymap (plan §7). */
@@ -201,12 +204,18 @@ export interface EffectiveBindingRule {
   readonly predicate?: (context: KeybindingContext) => boolean
 }
 
-/** The outcome of one resolution (plan §7). */
+/** The outcome of one resolution (plan §7). The winner is the highest-
+ * priority PREDICATE-PASSING rule across ALL owners (host, editor and
+ * plugin compete on equal footing); `owner` says who must EXECUTE it. */
 export interface KeybindingResolution {
   readonly action: string
   readonly key: KeyId
   readonly source: KeybindingSource
   readonly ruleId: string
+  /** The winner's executor (review finding): 'host' → the Host ladder
+   * dispatches; 'editor' → the fork editor executes (hostResolved: false);
+   * 'plugin' → the plugin remainder. */
+  readonly owner: RuleOwner
 }
 
 /** One detected conflict (plan §15): same key + overlapping scope + same

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -136,7 +136,9 @@ export interface AppKeybindingDefinition {
  * - an array: multiple keys (REPLACE the builtin defaults; a LEADER-ONLY
  *   declaration is an EMPTY array — the parser emits it for an action
  *   configured ONLY with `<leader>X` sequences, so the builtin default is
- *   replaced by the leader trigger);
+ *   replaced by the leader trigger; the marker is emitted ONLY when the
+ *   leader prefix is valid — a missing/invalid leader is fail-soft and
+ *   leaves the action on its builtin default, review round 39);
  * - `false`: DISABLE the action's effective keys entirely (no builtin, no
  *   user key, no leader sequence — every trigger is removed);
  * - a `<leader>X` string: a leader-sequence binding (M6).

--- a/src/local-shell-card.ts
+++ b/src/local-shell-card.ts
@@ -132,11 +132,14 @@ function visualTail(
  *   live; a settled card's hint is identical in wording).
  * @param partial - whether the cut happened inside a line (the hidden
  *   content is the earlier part of the kept line(s)).
+ * @param expandVerb - the EFFECTIVE expand label ('click' or the keymap's
+ *   expand key — the caller owns the keymap lookup, so a remap updates
+ *   the hint; this module never hard-codes the key).
  */
-export function localShellHiddenMarker(hidden: number, _running: boolean, partial = false): string {
+export function localShellHiddenMarker(hidden: number, _running: boolean, partial: boolean, expandVerb: string): string {
   if (hidden <= 0) return ''
   const what = partial ? 'earlier output hidden' : `${hidden} more lines`
-  return `${what} (ctrl+o to expand)`
+  return `${what} (${expandVerb} to expand)`
 }
 
 /** Whether a message is a LOCAL `!`/`!!` shell card (the runner pushes

--- a/src/question.ts
+++ b/src/question.ts
@@ -11,9 +11,10 @@
  * @module @xmoon76/dsh-pi-tui/question
  */
 
-import { Input, matchesKey, type KeyId } from '@xmoon76/pi-tui'
+import { Input, type KeyId } from '@xmoon76/pi-tui'
 import type { Component, Focusable } from '@xmoon76/pi-tui'
 import { visibleWidth, wrapTextWithAnsi } from '@xmoon76/pi-tui'
+import { componentKeymap } from './keybindings/component-keymap.ts'
 import { color } from './theme.ts'
 
 /** One question in a user-questions ask (dsh shape mirrored for testability). */
@@ -646,26 +647,28 @@ export class QuestionFlow implements Component, Focusable {
     // Text mode: printable/cursor keys go to the real Input; Enter/Esc are
     // the flow's own verbs. PageUp/PageDown scroll the body even while
     // typing ('e' stays a letter here — expand is a list-mode verb).
-    // All matches go through matchesKey so Kitty CSI-u (and modifyOtherKeys)
-    // sequences are recognized alongside legacy ones — the flow previously
-    // compared raw sequences ('\x1b[A' etc.), which silently dropped every
-    // key on terminals that report CSI-u (the zellij + Kitty-protocol case).
+    // All matches go through the component keymap (M5): the semantic
+    // question.* actions resolve through matchesKey, so Kitty CSI-u (and
+    // modifyOtherKeys) sequences are recognized alongside legacy ones —
+    // the flow previously compared raw sequences ('\x1b[A' etc.), which
+    // silently dropped every key on terminals that report CSI-u (the
+    // zellij + Kitty-protocol case).
     if (this.editingOther) {
-      if (matchesKey(data, 'enter')) {
+      if (componentKeymap.matches(data, 'question.confirm')) {
         this.commitOther(this.otherInput.getValue())
-      } else if (matchesKey(data, 'escape')) {
+      } else if (componentKeymap.matches(data, 'question.cancel')) {
         this.exitOther()
-      } else if (matchesKey(data, 'pageUp')) {
+      } else if (componentKeymap.matches(data, 'question.pageUp')) {
         this.scrollBody(-1)
-      } else if (matchesKey(data, 'pageDown')) {
+      } else if (componentKeymap.matches(data, 'question.pageDown')) {
         this.scrollBody(1)
-      } else if (matchesKey(data, 'left')) {
+      } else if (componentKeymap.matches(data, 'question.previous')) {
         if (this.tab > 0) {
           this.tab -= 1
           this.cursor = 0
           this.syncEditMode()
         }
-      } else if (matchesKey(data, 'right')) {
+      } else if (componentKeymap.matches(data, 'question.next')) {
         // → in text mode: same "move on" verb as in list mode — commit the
         // typed answer (an empty one counts as skipped) and advance. Enter
         // stays the primary save key; → never discards in-progress text.
@@ -683,11 +686,11 @@ export class QuestionFlow implements Component, Focusable {
       // question (drafts survive). The keys match user intuition and the
       // page carries one less state machine. `h` stays the vim alias for
       // ← (as in list mode).
-      if (matchesKey(data, 'enter')) {
+      if (componentKeymap.matches(data, 'question.confirm')) {
         this.submit()
-      } else if (matchesKey(data, 'escape')) {
+      } else if (componentKeymap.matches(data, 'question.cancel')) {
         this.onCancel()
-      } else if (matchesKey(data, 'left') || data === 'h') {
+      } else if (componentKeymap.matches(data, 'question.previous') || data === 'h') {
         // ← back to the last question (drafts survive).
         this.tab = Math.max(0, this.questions.length - 1)
         this.cursor = 0
@@ -705,7 +708,7 @@ export class QuestionFlow implements Component, Focusable {
       }
       return
     }
-    if (matchesKey(data, 'up') || data === 'k') {
+    if (componentKeymap.matches(data, 'question.cursorUp') || data === 'k') {
       if (rows.length === 0) return
       if (this.cursor === 0 && this.bodyScroll > 0) {
         // ↑ at the FIRST row with the page scrolled: scroll the body UP so
@@ -718,7 +721,7 @@ export class QuestionFlow implements Component, Focusable {
       this.pendingCursorScroll = true
       return
     }
-    if (matchesKey(data, 'down') || data === 'j') {
+    if (componentKeymap.matches(data, 'question.cursorDown') || data === 'j') {
       if (rows.length === 0) return
       const atLastRow = this.cursor === rows.length - 1
       const scrolled = this.lastExpandable && this.lastContentRows > this.bodyScroll + this.lastVisibleRows
@@ -733,21 +736,21 @@ export class QuestionFlow implements Component, Focusable {
       this.pendingCursorScroll = true
       return
     }
-    if (matchesKey(data, 'pageUp') || matchesKey(data, 'pageDown')) {
+    if (componentKeymap.matches(data, 'question.pageUp') || componentKeymap.matches(data, 'question.pageDown')) {
       // PageUp/PageDown: scroll the body scrollport (no-op when it fits).
-      this.scrollBody(matchesKey(data, 'pageUp') ? -1 : 1)
+      this.scrollBody(componentKeymap.matches(data, 'question.pageUp') ? -1 : 1)
       return
     }
-    if (data === 'e') {
+    if (componentKeymap.matches(data, 'question.toggleExpand')) {
       // Expand/collapse the body region (the scroll marker's keyboard twin).
       this.toggleExpanded()
       return
     }
-    if (matchesKey(data, 'enter')) {
+    if (componentKeymap.matches(data, 'question.confirm')) {
       this.confirm()
       return
     }
-    if (matchesKey(data, 'left') || data === 'h') {
+    if (componentKeymap.matches(data, 'question.previous') || data === 'h') {
       // ← back: previous question (keeps the draft).
       if (this.tab > 0) {
         this.tab -= 1
@@ -756,7 +759,7 @@ export class QuestionFlow implements Component, Focusable {
       }
       return
     }
-    if (matchesKey(data, 'right') || data === 'l') {
+    if (componentKeymap.matches(data, 'question.next') || data === 'l') {
       // → move on (the arrows own back/skip now, replacing the old 's'
       // skip key): an UNANSWERED question is marked skipped and advances
       // (web QuestionComposer skip parity); an ANSWERED one keeps its draft
@@ -778,7 +781,7 @@ export class QuestionFlow implements Component, Focusable {
       }
       return
     }
-    if (matchesKey(data, 'escape')) {
+    if (componentKeymap.matches(data, 'question.cancel')) {
       this.onCancel()
     }
   }

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -30,10 +30,14 @@ import type { AuthorizationTarget } from '../authorization.ts'
 /** The TUI settings document (theme/iconStyle/footer/fullscreen/busyEnter/
  * localShellSandbox/homeEndKeys/focusMode). The old `history` field moved
  * to $DSH_HOME/user-history/*.jsonl and is deliberately NOT part of the
- * document anymore. The user keybinding overrides (`keybindings`, an
- * unknown-key pass-through of the schemastery-registered document — the
- * keybindings parser in src/keybindings/config.ts owns its validation)
- * ride along. */
+ * document anymore. The user keybinding overrides (`keybindings`) ride
+ * along as an unknown-key pass-through of the schemastery-registered
+ * document — the field is RAW EXTENSION DATA, deliberately not a semantic
+ * DTO: the keybinding shape is owned by src/keybindings/config.ts (the
+ * only validator), and the settings document is the storage the Direct
+ * adapter passes through verbatim. A future Remote adapter MUST preserve
+ * this raw field verbatim too (get/replace round-trip), never reinterpret
+ * it — add a Remote-shaped contract test when the wire backend lands. */
 export interface TuiSettingsDoc {
   theme: string
   iconStyle: string

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -30,7 +30,10 @@ import type { AuthorizationTarget } from '../authorization.ts'
 /** The TUI settings document (theme/iconStyle/footer/fullscreen/busyEnter/
  * localShellSandbox/homeEndKeys/focusMode). The old `history` field moved
  * to $DSH_HOME/user-history/*.jsonl and is deliberately NOT part of the
- * document anymore. */
+ * document anymore. The user keybinding overrides (`keybindings`, an
+ * unknown-key pass-through of the schemastery-registered document — the
+ * keybindings parser in src/keybindings/config.ts owns its validation)
+ * ride along. */
 export interface TuiSettingsDoc {
   theme: string
   iconStyle: string
@@ -40,6 +43,7 @@ export interface TuiSettingsDoc {
   localShellSandbox: string
   homeEndKeys: string
   focusMode: string
+  keybindings?: unknown
 }
 
 /** The TUI settings document surface (get/replace — the same shape the

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -52,14 +52,19 @@ export interface TuiSettingsDoc {
 
 /** The TUI settings document surface (get/replace — the same shape the
  * commands surface consumes; the runner wires the registered settings
- * document). */
+ * document). The port is deliberately get/replace ONLY: no watch /
+ * subscribe callback. Change observation is explicit on the consumer
+ * side — e.g. `/keybindings reload` re-reads the document — because a
+ * callback could not map across the process boundary in the future
+ * Remote adapter (migration rule: no callbacks across the wire). */
 export interface TuiSettingsConfig {
   get(): TuiSettingsDoc
   replace(doc: TuiSettingsDoc): unknown
 }
 
 /** The TUI settings document surface as the commands surface names it
- * (kept as the public commands-surface type — see commands.ts). */
+ * (kept as the public commands-surface type — see commands.ts). Like
+ * TuiSettingsConfig: get/replace only, never a watch callback. */
 export interface TuiSettingsLike {
   get(): TuiSettingsDoc
   replace(doc: TuiSettingsDoc): unknown

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -11,8 +11,9 @@
  * @module @xmoon76/dsh-pi-tui/task-panel
  */
 
-import { Input, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@xmoon76/pi-tui'
+import { Input, truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@xmoon76/pi-tui'
 import type { Component, Focusable } from '@xmoon76/pi-tui'
+import { componentKeymap } from './keybindings/component-keymap.ts'
 import { color, taskStatusColor } from './theme.ts'
 import { SelectedMarquee } from './marquee.ts'
 
@@ -289,19 +290,21 @@ export class TaskBrowserPanel implements Component, Focusable {
     // the SelectList pattern: a filter box must be editable, not just
     // typeable.
     //
-    // All key matches go through matchesKey (never raw sequence compares):
-    // it recognizes legacy AND Kitty CSI-u / modifyOtherKeys encodings, so
-    // terminals that report CSI-u (zellij + Kitty-protocol, Windows
-    // Terminal, WezTerm, kitty…) keep the panel navigable — the raw
-    // compares ('\x1b[A' etc.) silently dropped every arrow/page key there.
+    // All key matches go through the component keymap (M5): the semantic
+    // tasks.* actions resolve through matchesKey (never raw sequence
+    // compares) — it recognizes legacy AND Kitty CSI-u / modifyOtherKeys
+    // encodings, so terminals that report CSI-u (zellij + Kitty-protocol,
+    // Windows Terminal, WezTerm, kitty…) keep the panel navigable — the
+    // raw compares ('\x1b[A' etc.) silently dropped every arrow/page key
+    // there.
     //
     // The `k`/`j` vim aliases for ↑/↓ apply ONLY when search is OFF: with a
     // search box up, `k`/`j` are ordinary letters a query may contain
     // ("task", "jq") — routing them as navigation would make those queries
     // untruncatable.
-    const isNavUp = matchesKey(data, 'up') || (!this.searchEnabled && data === 'k')
-    const isNavDown = matchesKey(data, 'down') || (!this.searchEnabled && data === 'j')
-    const isPage = matchesKey(data, 'pageUp') || matchesKey(data, 'pageDown')
+    const isNavUp = componentKeymap.matches(data, 'tasks.cursorUp') || (!this.searchEnabled && data === 'k')
+    const isNavDown = componentKeymap.matches(data, 'tasks.cursorDown') || (!this.searchEnabled && data === 'j')
+    const isPage = componentKeymap.matches(data, 'tasks.pageUp') || componentKeymap.matches(data, 'tasks.pageDown')
     // Row-level interrupt (`i`): fires while the search box is CLOSED, or
     // while it is open but EMPTY and the selection sits on an
     // INTERRUPTIBLE row (a continuable subagent — the only kind
@@ -314,13 +317,13 @@ export class TaskBrowserPanel implements Component, Focusable {
       const item = this.filtered[this.selected]
       return item !== undefined && item.interruptible === true
     }
-    if (data === 'i' && this.onAction !== undefined && !this.searchEnabled && interruptibleSelected()) {
+    if (componentKeymap.matches(data, 'tasks.interrupt') && this.onAction !== undefined && !this.searchEnabled && interruptibleSelected()) {
       const item = this.filtered[this.selected]
       if (item !== undefined) this.onAction(item.value, 'interrupt')
       return
     }
     if (
-      data === 'i' && this.onAction !== undefined && this.searchEnabled
+      componentKeymap.matches(data, 'tasks.interrupt') && this.onAction !== undefined && this.searchEnabled
       && (this.searchInput.getValue() ?? '') === ''
       && interruptibleSelected()
     ) {
@@ -330,11 +333,11 @@ export class TaskBrowserPanel implements Component, Focusable {
     }
     // Tab cycles the type filter (All → subagent → bash → pwsh → …).
     // Consumed before the search input so a query can never contain a tab.
-    if (matchesKey(data, 'tab')) {
+    if (componentKeymap.matches(data, 'tasks.cycleType')) {
       this.cycleType()
       return
     }
-    if (!isNavUp && !isNavDown && !isPage && !matchesKey(data, 'enter') && !matchesKey(data, 'escape') && this.searchEnabled) {
+    if (!isNavUp && !isNavDown && !isPage && !componentKeymap.matches(data, 'tasks.confirm') && !componentKeymap.matches(data, 'tasks.cancel') && this.searchEnabled) {
       // Typing a search query is a user interaction with the list: a later
       // enrichment must not re-focus the head over the user's filter.
       this.selectionTouched = true
@@ -359,17 +362,17 @@ export class TaskBrowserPanel implements Component, Focusable {
     if (isPage) {
       if (this.filtered.length === 0) return
       this.selectionTouched = true
-      if (matchesKey(data, 'pageUp')) this.selected = Math.max(0, this.selected - this.maxVisible)
+      if (componentKeymap.matches(data, 'tasks.pageUp')) this.selected = Math.max(0, this.selected - this.maxVisible)
       else this.selected = Math.min(this.filtered.length - 1, this.selected + this.maxVisible)
       this.ensureVisible()
       return
     }
-    if (matchesKey(data, 'enter')) {
+    if (componentKeymap.matches(data, 'tasks.confirm')) {
       const item = this.filtered[this.selected]
       if (item !== undefined) this.onSelect(item.value)
       return
     }
-    if (matchesKey(data, 'escape')) {
+    if (componentKeymap.matches(data, 'tasks.cancel')) {
       this.onCancel()
     }
   }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2436,6 +2436,12 @@ export class TuiApp {
     // subscribe, invalidate) becomes inert; a late plugin callback can no
     // longer mutate the seat or dispatch a real submission.
     this.editorSeatHolder.dispose()
+    // The keybinding manager's final disposal: a PENDING leader timeout
+    // must never fire after the surface is gone (its onStateChange →
+    // renderFooter would schedule work against the stopped app — PR
+    // review finding). The manager's dispose also latches the disposed
+    // flag, making the leader machine inert.
+    this.keybindings.dispose()
   }
 
   /** The surface generation (M0): stable across start/stop/fullscreen/

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2839,6 +2839,19 @@ export class TuiApp {
       this.handleExitKey(data)
       return true
     }
+    if (action === 'app.input.submit' && data !== '') {
+      // The fork editor OWNS the direct submit keys (paste-burst and
+      // backslash-newline semantics live in its tui.input.submit — the
+      // effective keys are synced there by onEditorSubmitSync). The host
+      // ladder never consumes a DIRECT submit key: resolving it here would
+      // bypass the editor's full submit logic (PR review finding — a
+      // remapped Ctrl+X submitted via submitDraft and skipped the
+      // backslash-newline/paste-burst handling). Fall through so the
+      // editor processes the key natively. The LEADER-activated submit
+      // (data === '') is the exception: the leader machine already
+      // consumed the completing key, so the host dispatches it.
+      return false
+    }
     return this.actionDispatcher.dispatch(action, key)
   }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2824,12 +2824,25 @@ export class TuiApp {
     const resolution = this.keybindings.resolve(data, this.keybindingContext())
     let hostDeclined = false
     if (resolution !== undefined) {
-      const consumed = this.dispatchResolvedAction(resolution.action as AppKeybindingId, data, resolution.key)
-      if (consumed) return { consume: true }
-      // The HOST dispatcher declined (e.g. pasteMedia without a handler):
-      // the key must reach the editor/plugin remainder — never be
-      // re-reserved by the same host action (convergence §6/§4.9).
-      hostDeclined = true
+      // OWNER-AWARE DISPATCH (review finding): the resolution's owner says
+      // WHO executes the winner — 'host'/'plugin' → the host dispatcher
+      // (a plugin-owner winner still dispatches its semantic action; the
+      // plugin remainder only claims keys nothing earlier consumed);
+      // 'editor' → the FORK EDITOR executes (hostResolved: false — the
+      // editor's tui.input.submit was synced by onEditorSubmitSync, so
+      // the key really submits there with paste-burst/backslash-newline
+      // semantics). An editor-owned winner must NOT be dispatched here:
+      // the old code skipped editor rules before winner selection, so
+      // `submit: ctrl+s` resolved to the steer builtin and steered at
+      // runtime while the read model advertised submit (round-9 finding).
+      if (resolution.owner !== 'editor') {
+        const consumed = this.dispatchResolvedAction(resolution.action as AppKeybindingId, data, resolution.key)
+        if (consumed) return { consume: true }
+        // The HOST dispatcher declined (e.g. pasteMedia without a
+        // handler): the key must reach the editor/plugin remainder — never
+        // be re-reserved by the same host action (convergence §6/§4.9).
+        hostDeclined = true
+      }
     }
     // M6: the router first determines whether a capturing path owns the key.
     // A replacement editor gets the first chance for editor-routed input;

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2824,18 +2824,22 @@ export class TuiApp {
     const resolution = this.keybindings.resolve(data, this.keybindingContext())
     let hostDeclined = false
     if (resolution !== undefined) {
-      // OWNER-AWARE DISPATCH (review finding): the resolution's owner says
-      // WHO executes the winner — 'host'/'plugin' → the host dispatcher
-      // (a plugin-owner winner still dispatches its semantic action; the
-      // plugin remainder only claims keys nothing earlier consumed);
-      // 'editor' → the FORK EDITOR executes (hostResolved: false — the
-      // editor's tui.input.submit was synced by onEditorSubmitSync, so
-      // the key really submits there with paste-burst/backslash-newline
-      // semantics). An editor-owned winner must NOT be dispatched here:
-      // the old code skipped editor rules before winner selection, so
-      // `submit: ctrl+s` resolved to the steer builtin and steered at
-      // runtime while the read model advertised submit (round-9 finding).
-      if (resolution.owner !== 'editor') {
+      // OWNER-AWARE DISPATCH (review findings): the resolution's owner
+      // says WHO executes the winner —
+      // - 'host' → the Host dispatcher (the only owner that may run the
+      //   Host-private app.* actions);
+      // - 'editor' → the FORK EDITOR executes (hostResolved: false — the
+      //   editor's tui.input.submit was synced by onEditorSubmitSync, so
+      //   the key really submits there with paste-burst/backslash-newline
+      //   semantics);
+      // - 'plugin' → NEVER the AppActionDispatcher: a Stable plugin may
+      //   only trigger the PUBLIC TuiAction set, and those execute
+      //   through the router's plugin remainder (onExtensionAction).
+      //   Sending a plugin-owner winner into the Host dispatcher would
+      //   let a smuggled action string (e.g. `app.exit.request`) run a
+      //   Host-private semantic action (round-12 finding — capability
+      //   boundary).
+      if (resolution.owner === 'host') {
         const consumed = this.dispatchResolvedAction(resolution.action as AppKeybindingId, data, resolution.key)
         if (consumed) return { consume: true }
         // The HOST dispatcher declined (e.g. pasteMedia without a
@@ -2843,6 +2847,8 @@ export class TuiApp {
         // be re-reserved by the same host action (convergence §6/§4.9).
         hostDeclined = true
       }
+      // owner === 'editor' | 'plugin': fall through to the editor / the
+      // router's Stable plugin remainder below.
     }
     // M6: the router first determines whether a capturing path owns the key.
     // A replacement editor gets the first chance for editor-routed input;

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -126,7 +126,6 @@ import {
   RUNNING_PREVIEW_LINES,
   SETTLED_PREVIEW_VISUAL_ROWS,
 } from './local-shell-card.ts'
-import { RESERVED_HOST_KEYS } from './keybinding-registry.ts'
 import type { RendererRegistry } from './renderer-registry.ts'
 import { OverlayBroker } from './overlay-broker.ts'
 import { EditorSeatHolder } from './editor-seat-holder.ts'
@@ -2038,7 +2037,7 @@ export class TuiApp {
     this.unstableInputsLive = options.unstableInputsLive
     this.unstableInputsRevision = options.unstableInputsRevision
     this.unstableFailSafeRelease = options.unstableFailSafeRelease
-    this.inputRouter = new InputRouter(RESERVED_HOST_KEYS)
+    this.inputRouter = new InputRouter()
     // The keybinding manager (M0–M6): the app ALWAYS builds it (the
     // runner configures it afterwards through keybindingsManager() — user
     // overrides, safe mode, plugin rules), so the surface callbacks
@@ -2073,6 +2072,19 @@ export class TuiApp {
         // search) must fall through like a direct key — the completing
         // key is NOT consumed by the sequence (review finding).
         return this.dispatchResolvedAction(action as AppKeybindingId, '')
+      },
+      // A user remap/disable of app.input.submit must REALLY move/remove
+      // the editor's submission: the fork editor routes the submit key
+      // through its OWN tui.input.submit binding, so we sync the
+      // effective keys there (review finding — the editor path was
+      // previously physical-only and ignored user config). Empty = the
+      // action is disabled (no key submits; plain Enter becomes inert).
+      onEditorSubmitSync: (keys) => {
+        const kb = getKeybindings()
+        kb.setUserBindings({
+          ...kb.getUserBindings(),
+          'tui.input.submit': keys.length === 0 ? [] : keys.length === 1 ? keys[0]! : [...keys],
+        })
       },
     })
     this.actionDispatcher = new AppActionDispatcher(this.buildActionHost())
@@ -2506,7 +2518,7 @@ export class TuiApp {
       }
       return { consume: true }
     }
-    if (matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {
+    if (this.isSubmitKey(data)) {
       this.submitDraft(false)
       return { consume: true }
     }
@@ -2640,7 +2652,7 @@ export class TuiApp {
         if (!matchesKey(data, 'escape') && !this.keybindings.matches(data, 'app.transcript.toggleExpand')) {
           return { consume: true }
         }
-      } else if (matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {
+      } else if (this.isSubmitKey(data)) {
         this.submitSubagentDraft()
         return { consume: true }
       } else if (this.viewerParentLockedKey(data)) {
@@ -2697,7 +2709,7 @@ export class TuiApp {
     // owns it — so this seam stays physical: it is the focused-editor
     // contract, not a host shortcut.)
     if (this.seatEditor().handleInput !== undefined
-      && matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {
+      && this.isSubmitKey(data)) {
       this.editorSeatHolder.handleHostFallbackInput(data)
       return { consume: true }
     }
@@ -2835,6 +2847,17 @@ export class TuiApp {
    * cancel, the shell-mode exit pass-through, and the idle double-Esc
    * cancel/rewind. Returns undefined when the key must fall through
    * (autocomplete open, replacement editor). */
+  /** Whether one raw input is the EFFECTIVE submit key (app.input.submit —
+   * a user remap moves submission to the new key; Shift+Enter stays the
+   * newline, never a submit). The fork editor owns the actual submit
+   * semantics (paste-burst / backslash-newline); this check drives the
+   * HOST-owned seams that must mirror it: the continuable viewer's child
+   * submit and the replacement-editor Enter forward. */
+  private isSubmitKey(data: string): boolean {
+    if (matchesKey(data, 'shift+enter')) return false
+    return this.keybindings.editorSubmitKeysFor().some(key => matchesKey(data, key))
+  }
+
   private handleEscapeKey(data: string): TuiInputListenerResult | undefined {
     // Overlays (pickers, settings) own Esc while they are up.
     if (this.activeScreen.hasOverlayEntries) return undefined
@@ -3161,6 +3184,12 @@ export class TuiApp {
       // pass-through, the search overlay ownership) consult the EFFECTIVE
       // keymap, so a user remap stays authoritative (review finding).
       matchesEffective: (action: string, data: string) => this.keybindings.matches(data, action as unknown as AppKeybindingId),
+      // The runtime reservation is ACTION-driven: a key is reserved for
+      // the host ONLY while an active host action binds it. A remapped-
+      // away old key (e.g. Ctrl+V after pasteMedia moved to Ctrl+P) is
+      // NOT reserved and falls through to the editor/plugin (PR review
+      // finding — no static physical-key swallowing).
+      hostResolves: (data) => this.keybindings.resolve(data, this.keybindingContext()) !== undefined,
       editorReplacement: this.seatEditor().handleInput !== undefined,
       // P1-06: the focused EDITOR owns its keys. The fork dispatches to
       // app-level listeners BEFORE the focused component, so the router
@@ -8561,7 +8590,13 @@ export class TuiApp {
     // (the same line-2 slot — the leader is an explicit interaction too).
     const leader = this.keybindings.leaderMachine()
     const line2 = this.ctrlCExitArmed
-      ? `Press ${this.keybindings.keyHint('app.exit.request')} again to exit`
+      // The clear-then-exit chord is Ctrl+C-SPECIFIC (only a second
+      // Ctrl+C exits; a second Ctrl+X — or any other exit key — exits
+      // immediately instead). The armed hint must therefore name Ctrl+C
+      // literally, never the action's primary key (PR review finding:
+      // keyHint('app.exit.request') could say "Press Ctrl+X again" for a
+      // ['ctrl+x', 'ctrl+c'] binding, which is semantically wrong).
+      ? 'Press Ctrl+C again to exit'
       : leader !== undefined && leader.pending
         ? this.leaderHint(leader)
         : this.footerPreset === 'compact' ? '' : this.status.statsLine

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1493,6 +1493,12 @@ interface MessageComponentEntry {
    * hint resolves the EFFECTIVE key through the keymap (a remap updates
    * the copy; the identity field stays semantic). */
   expandHint: ExpandHint
+  /** The keymap revision the fold-hint string was rendered at: the
+   * RENDERED hint bakes the EFFECTIVE key, so a keymap rebuild (user
+   * remap, safe-mode flip, plugin sync) must invalidate every cached
+   * fold hint — the semantic owner alone cannot detect a remap (review
+   * finding). */
+  keymapRev: number
   /** The values the component was built from, for O(1) staleness checks:
    * text-bearing kinds compare the CURRENT text object — an unchanged
    * message keeps the same string instance, so the check is O(1) and
@@ -2040,7 +2046,16 @@ export class TuiApp {
     // builtin defaults keep the surface behavior identical without any
     // runner wiring.
     this.keybindings = new HostKeybindingManager({
-      onInvalidate: () => this.requestRender(),
+      // A keymap rebuild (user remap / safe mode / plugin sync) must
+      // refresh BOTH the cached transcript fold hints (their RENDERED
+      // key strings are baked into the components) and the footer/which-
+      // key copy — a plain repaint reuses the cached components (review
+      // finding). Guarded: the initial manager build runs before
+      // messagesView exists.
+      onInvalidate: () => {
+        if (this.messagesView !== undefined) this.rebuildMessages()
+        this.requestRender()
+      },
       onLeaderStateChange: () => this.renderFooter(),
       onLeaderActivate: (action) => {
         // M6: a leader sequence must never bypass the viewer's
@@ -2051,9 +2066,13 @@ export class TuiApp {
         if (target !== undefined
           && isViewerAccessInteractive(resolveViewerAccess(target.mode, target.access))
           && VIEWER_BLOCKED_PARENT_ACTIONS.has(action as AppKeybindingId)) {
-          return
+          return true
         }
-        this.dispatchResolvedAction(action as AppKeybindingId, '')
+        // The dispatch result propagates to the feed consumer: an action
+        // that DECLINES (pasteMedia without a handler, unbound history
+        // search) must fall through like a direct key — the completing
+        // key is NOT consumed by the sequence (review finding).
+        return this.dispatchResolvedAction(action as AppKeybindingId, '')
       },
     })
     this.actionDispatcher = new AppActionDispatcher(this.buildActionHost())
@@ -2626,9 +2645,12 @@ export class TuiApp {
       // Esc (exit) and Ctrl+O (fold) fall through to the host ladder.
     }
     // Transcript search owns these keys while its overlay is up; everything
-    // else falls through to the focused search input. The keys route
-    // through the keymap's DEFAULT keys (the search actions are
-    // non-configurable overlay contracts — plan §3.3).
+    // else falls through to the focused search input. The close/next/
+    // previous keys are NON-CONFIGURABLE overlay contracts (scope
+    // 'search', plan §3.3) and route through the keymap's DEFAULT keys;
+    // the search TOGGLE (app.transcript.search) is user-configurable, so
+    // a remap of the toggle must work while the overlay is open too —
+    // matching the EFFECTIVE keys (review finding).
     if (this.searchOverlay !== undefined) {
       if (this.keybindings.matchesDefault(data, 'app.transcript.search.close')) {
         this.closeTranscriptSearch()
@@ -2642,8 +2664,9 @@ export class TuiApp {
         this.events.onSearchPrev?.()
         return { consume: true }
       }
-      if (this.keybindings.matchesDefault(data, 'app.transcript.search')) {
-        // Ctrl+F is the search toggle; a second press closes the overlay.
+      if (this.keybindings.matches(data, 'app.transcript.search')) {
+        // Ctrl+F (or the remapped toggle) closes the overlay on a second
+        // press.
         this.closeTranscriptSearch()
         return { consume: true }
       }
@@ -2684,8 +2707,14 @@ export class TuiApp {
     const leader = this.keybindings.leaderMachine()
     if (leader !== undefined) {
       const outcome = leader.feed(data)
-      if (outcome.kind === 'consumed' || outcome.kind === 'cancelled-consume' || outcome.kind === 'activated') {
+      if (outcome.kind === 'consumed' || outcome.kind === 'cancelled-consume') {
         return { consume: true }
+      }
+      if (outcome.kind === 'activated') {
+        // Consume ONLY when the dispatch actually consumed the key; a
+        // declined action falls through to the editor/plugin stages
+        // (review finding).
+        if (outcome.consumed) return { consume: true }
       }
       // cancelled-pass: the pending state was cancelled; the key is
       // processed normally below.
@@ -6549,6 +6578,7 @@ export class TuiApp {
       || entry.expanded !== state.expanded
       || entry.fullReveal !== state.fullReveal
       || entry.expandHint !== state.expandHint
+      || entry.keymapRev !== this.keybindings.revision()
       || rendererRevisionChanged
       || this.componentStale(entry, message)) {
       // Dispose the OLD component (a thumbnail's loader subscription) so a
@@ -6570,6 +6600,7 @@ export class TuiApp {
       entry.expanded = rebuilt.expanded
       entry.fullReveal = rebuilt.fullReveal
       entry.expandHint = rebuilt.expandHint
+      entry.keymapRev = rebuilt.keymapRev
       entry.rendererId = rebuilt.rendererId
       entry.rendererRevision = rebuilt.rendererRevision
       this.captureComponentState(entry, message)
@@ -6630,6 +6661,10 @@ export class TuiApp {
       expanded: state.expanded,
       fullReveal: state.fullReveal,
       expandHint: state.expandHint,
+      // The RENDERED fold hints bake the EFFECTIVE key: the keymap
+      // revision joins the cache identity so a remap/safe-mode/plugin
+      // rebuild refreshes every hint-bearing card (review finding).
+      keymapRev: this.keybindings.revision(),
       rendererId: rendered?.rendererId,
       rendererRevision: registry === undefined ? undefined : registry.snapshot().revision,
     }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -5,13 +5,18 @@
  * entry point (startProcessTui) supplies ProcessTerminal.
  *
  * Surface layout (regular mode): header (todo status), message transcript,
- * editor, footer status line. Fullscreen mode (Ctrl+F) renders the same
- * component tree through TuiAltScreen's layout engine, where the transcript
- * scrolls inside the alt screen.
+ * editor, footer status line. Fullscreen mode renders the same component
+ * tree through TuiAltScreen's layout engine, where the transcript scrolls
+ * inside the alt screen.
  *
- * Keys: Enter submit, Ctrl+C/Ctrl+D exit, Ctrl+O expand/collapse recent turns
- * (in fullscreen Focus it bulk-toggles the Thought roots),
- * Ctrl+F toggle fullscreen, Tab autocomplete (slash commands + paths).
+ * KEYS ARE NOT HARD-CODED HERE: host shortcuts are semantic actions
+ * (app.*) resolved through the user-orchestrable keymap (plan M0–M6). The
+ * single source of truth for default keys is
+ * src/keybindings/definitions.ts; the effective map (user overrides
+ * applied) is inspectable at runtime with `/keybindings`. Comments in this
+ * file name keys only when the SEMANTICS are key-specific (e.g. the
+ * Ctrl+C clear-then-exit chord); every other mention is a shorthand for
+ * the action and must never be relied on as the live binding.
  * @module @xmoon76/dsh-pi-tui/tui-app
  */
 
@@ -880,8 +885,8 @@ export interface TuiAppEventsBase {
   /** The user submitted a line in the editor. */
   onSubmit: (text: string) => void
   /**
-   * Ctrl+V with image intake (plan M3): the host consumed the key and asks
-   * the runner to probe the clipboard — an image lands as a draft
+   * Clipboard paste with image intake (the paste-media action, plan M3):
+   * the host consumed the key and asks the runner to probe the clipboard — an image lands as a draft
    * placeholder, plain text as an editor insert. Optional; absent keeps
    * the pre-pipeline behavior (the key falls through to the editor).
    */
@@ -901,31 +906,36 @@ export interface TuiAppEventsBase {
    * absent means the draft text is the only emptiness authority.
    */
   isImageDraft?: () => boolean
-  /** The user asked to quit (Ctrl+C in the TUI's own raw mode). */
+  /** The user asked to quit (the exit action; Ctrl+C keeps its
+   * clear-then-exit chord in the TUI's own raw mode). */
   onExit: () => void
-  /** Stop the current activity (busy: a SINGLE Esc fires this directly;
-   * idle: a double-Esc within the window fires it when the editor is
-   * non-empty — an empty editor opens the rewind picker instead, see
+  /** Stop the current activity (the interrupt action, default: Esc — a
+   * SINGLE press fires this directly while busy; idle, a double press
+   * within the window fires it when the editor is non-empty, and an
+   * empty editor opens the rewind picker instead, see
    * {@link onRewind}). The runner's handler interrupts the agent while
    * preserving its queue (web Stop parity). Optional. */
   onCancel?: () => void
   /**
-   * Conversation rewind (pi parity): an idle double-Esc within the window
-   * with an EMPTY editor asks the host to open the rewind picker (fork the
-   * conversation from an earlier user turn). Busy Esc, overlays,
-   * autocomplete, replacement editors and a NON-empty draft never reach
-   * this (they keep their existing semantics). Optional; absent keeps the
-   * historical double-Esc cancel.
+   * Conversation rewind (pi parity): an idle double press of the
+   * interrupt key (default: Esc) within the window with an EMPTY editor
+   * asks the host to open the rewind picker (fork the conversation from
+   * an earlier user turn). A busy press, overlays, autocomplete,
+   * replacement editors and a NON-empty draft never reach this (they keep
+   * their existing semantics). Optional; absent keeps the historical
+   * double-press cancel.
    */
   onRewind?: () => void
   /**
-   * Ctrl+S: steer with the current draft (possibly empty). The runner sends
-   * the whole queue when it has messages, with the draft riding along, and
-   * falls back to the draft alone otherwise. Optional.
+   * Steer with the current draft, possibly empty (the steer action,
+   * default: Ctrl+S). The runner sends the whole queue when it has
+   * messages, with the draft riding along, and falls back to the draft
+   * alone otherwise. Optional.
    */
   onSteer?: (text: string) => void
   /**
-   * The busy-Enter opposite chord (Ctrl+Enter): submit the draft in the
+   * The busy-Enter opposite chord (the queue action, default: Ctrl+Enter):
+   * submit the draft in the
    * QUEUE delivery mode regardless of the busyEnter preference (web
    * busyEnter parity — the accelerated chord uses the other behavior).
    * Optional.
@@ -940,38 +950,42 @@ export interface TuiAppEventsBase {
    * is rejected, through the app's viewer-draft API. Optional.
    */
   onSubagentSubmit?: (request: SubagentViewerSubmit) => void
-  /** Fullscreen mode changed (Ctrl+F toggle or a settings-panel write). Optional. */
+  /** Fullscreen mode changed (a fullscreen toggle or a settings-panel
+   * write — the toggle action has no default key; Ctrl+F is transcript
+   * search). Optional. */
   onFullscreenChange?: (fullscreen: boolean) => void
-  /** The transcript-search query changed (Ctrl+Shift+F opens the search). Optional. */
+  /** The transcript-search query changed (the search action opened it;
+   * the search keys are fixed overlay contracts). Optional. */
   onSearchQuery?: (query: string) => void
-  /** Enter inside the search: jump to the next match. Optional. */
+  /** The search's next-match key (fixed overlay contract): jump to the next match. Optional. */
   onSearchNext?: () => void
-  /** Shift+Enter inside the search: jump to the previous match. Optional. */
+  /** The search's previous-match key (fixed): jump to the previous match. Optional. */
   onSearchPrev?: () => void
-  /** The search was closed (Escape). Optional. */
+  /** The search was closed (its close key, fixed). Optional. */
   onSearchClose?: () => void
   /**
-   * The FIRST Esc press with no overlay up. The host may consume it (return
-   * true) to exit a runner-owned mode (e.g. the subagent viewer) instead of
-   * arming the double-Esc cancel. Optional.
+   * The FIRST press of the interrupt key (default: Esc) with no overlay
+   * up. The host may consume it (return true) to exit a runner-owned mode
+   * (e.g. the subagent viewer) instead of arming the double-press
+   * cancel. Optional.
    */
   onSingleEscape?: () => boolean | void
   /**
-   * Shift+Tab with no overlay up: cycle the permission preset (read-only →
-   * workspace-write → danger-full-access). The host applies the switch and
-   * refreshes the footer. Optional.
+   * Cycle the permission preset (the permission-cycle action, default:
+   * Shift+Tab; read-only → workspace-write → danger-full-access). The host
+   * applies the switch and refreshes the footer. Optional.
    */
   onCyclePermission?: () => void
   /**
-   * ↓ / Ctrl+J with an EMPTY editor and active background tasks: open the
-   * task browser (running jobs/subagents). The host lists the jobs and
-   * mounts the picker/viewer. Optional.
+   * The empty-editor ↓ affordance (the app.tasks.open action) with active
+   * background tasks: open the task browser (running jobs/subagents). The
+   * host lists the tasks and mounts the picker/viewer. Optional.
    */
   onOpenTasks?: () => void
   /**
-   * Alt+↑ with queued input and no overlay up: pull every queued message back
-   * into the editor draft (pi's dequeue). The host clears the inbox and the
-   * draft lands via {@link TuiApp.setDraft}. Optional.
+   * The dequeue action (default: Alt+↑): pull every queued message back
+   * into the editor draft (pi's dequeue). The host clears the inbox and
+   * the draft lands via {@link TuiApp.setDraft}. Optional.
    */
   onDequeue?: () => void
   /**
@@ -996,17 +1010,17 @@ export interface TuiAppEventsBase {
 /**
  * The application-surface events. The external-editor capability is a
  * BOUND pair declared only in the union: wiring `openExternalEditor`
- * REQUIRES `runOwned` — the Ctrl+G flow routes through the owned entry
- * (AGENTS.md), so a host cannot legally wire an editor hook without the
- * runner. Enforced at the type level (union) AND at construction time
- * (runtime check); without the editor hook neither field is needed and
- * Ctrl+G is a no-op.
+ * REQUIRES `runOwned` — the external-editor action routes through the
+ * owned entry (AGENTS.md), so a host cannot legally wire an editor hook
+ * without the runner. Enforced at the type level (union) AND at
+ * construction time (runtime check); without the editor hook neither
+ * field is needed and the action is a no-op.
  */
 export type TuiAppEvents = TuiAppEventsBase & (
   | {
-      /** Ctrl+G: open the external editor with the current draft. The TUI
-       * stops before the call and restarts after it resolves; return the
-       * new text. */
+      /** Open the external editor with the current draft (the
+       * external-editor action, default: Ctrl+G). The TUI stops before
+       * the call and restarts after it resolves; return the new text. */
       openExternalEditor: (draft: string) => Promise<string>
       runOwned: OwnedRunner
     }
@@ -1956,7 +1970,8 @@ export class TuiApp {
   private viewerFooter: SubagentViewerFooter | undefined
 
   constructor(terminal: Terminal, events: TuiAppEvents, options: TuiAppOptions = {}) {
-    // The external-editor capability is a BOUND pair: the Ctrl+G flow
+    // The external-editor capability is a BOUND pair: the external-editor
+    // action flow
     // routes through the owned-task entry, so an editor hook without the
     // runner would silently swallow the key. The type union already
     // forbids it at compile time; this catches runtime violations (plain
@@ -2130,7 +2145,7 @@ export class TuiApp {
     // session switch changes `sessionCwd()` — see the field doc).
     this.historySearchCwd = options.historySearchCwd
     // Same for the session identity: a session switch must make the next
-    // Ctrl+R search the NEW session (see the field doc).
+    // history search the NEW session (see the field doc).
     this.historySearchSessionId = options.historySearchSessionId
     this.editorSeatHolder = new EditorSeatHolder({
       hostAdapter: () => this.hostEditorAdapter(),
@@ -2358,7 +2373,7 @@ export class TuiApp {
     // must never focus() or repaint a dead component.
     this.searchOverlay = undefined
     this.searchComponent = undefined
-    // The Ctrl+R history panel dies with the surface: its in-flight search
+    // The history-search panel dies with the surface: its in-flight search
     // is aborted (a late result must never touch a dead component).
     this.historyPanel?.dispose()
     this.historyPanel = undefined
@@ -2955,7 +2970,7 @@ export class TuiApp {
         return true
       },
       dequeueDraft: () => {
-        // Dequeue (Alt+↑): pull queued input back into the editor.
+        // The dequeue action: pull queued input back into the editor.
         this.events.onDequeue?.()
         return true
       },
@@ -3047,7 +3062,7 @@ export class TuiApp {
         return true
       },
       openHistorySearch: () => {
-        // Ctrl+R input-history search: unbound (no historySearchSource)
+        // Input-history search: unbound (no historySearchSource)
         // falls through to the editor like any un-reserved key; the
         // continuable subagent viewer keeps its OWN live editor — the
         // chord is a no-op there (never the child draft, never the parent
@@ -3057,7 +3072,8 @@ export class TuiApp {
         return true
       },
       dismissSettledShell: () => {
-        // Dismiss settled local shell cards (Alt+K — plan §5.4 quick
+        // Dismiss settled local shell cards (the dismiss-settled action —
+        // plan §5.4 quick
         // clear): completed `!`/`!!` runs leave the live view; running
         // cards never do (the process is NOT cancelled — Esc owns that).
         this.dismissSettledLocalShell()
@@ -4654,7 +4670,8 @@ export class TuiApp {
     const todoBottom = Math.max(0, Math.min(height, height - footerHeight - editorHeight - workingHeight - queueHeight - goalHeight))
     const todoTop = Math.max(0, todoBottom - todoHeight)
     // The dock strip (the todo summary row) sits directly above the panel:
-    // clicking it opens the panel (mouse parity with Ctrl+T). The summary
+    // clicking it opens the panel (mouse parity with the todo-toggle
+    // action). The summary
     // is hidden while the panel is open, so the dock renders zero rows and
     // this branch is inert — the two regions never fight.
     const dockHeight = this.dock.render(width).length
@@ -4664,7 +4681,7 @@ export class TuiApp {
     }
     // A click on the todo panel's own rows runs the three-state loop
     // (compact → full list → back to the summary row), so the mouse opens
-    // AND closes the panel without Ctrl+T.
+    // AND closes the panel without the todo-toggle action.
     if (todoTop < todoBottom && y >= todoTop && y < todoBottom) {
       this.handleTodoPanelClick()
       return
@@ -6496,6 +6513,7 @@ export class TuiApp {
     // turns never reach this method: their process rows are absent from
     // the projection.
     const state = this.messageRenderState(message, boundary)
+
     // M7 (plan §12.1): the cache identity embeds the RENDERER id + the
     // registry revision — a renderer registering/unloading rebuilds the
     // affected components (an HMR must never hit an old component).
@@ -6918,9 +6936,9 @@ export class TuiApp {
         ? color.error('[error]')
         : color.textDim('[running]')
     const head = `${color.textDim(`${icon}${header.title}${summary}`)} ${pill}`
-    // LOCAL `!`/`!!` shell cards read the master Ctrl+O switch (plan §5.3),
+    // LOCAL `!`/`!!` shell cards read the master expand switch (plan §5.3),
     // never the unbounded turn marker: collapsed by default so a long log
-    // cannot fill the TUI, expanded only while Ctrl+O is on.
+    // cannot fill the TUI, expanded only while the expand switch is on.
     const localShell = isLocalShellCard(message)
     if (expanded) {
       card.addChild(new Text(head, 0, 0))
@@ -7815,7 +7833,7 @@ export class TuiApp {
   /** Toggle the todo panel between the transcript and the editor. */
   toggleTodoPanel(): boolean {
     this.todoPanelVisible = !this.todoPanelVisible
-    // Hiding resets the expansion: the next Ctrl+T shows the compact panel.
+    // Hiding resets the expansion: the next todo-toggle shows the compact panel.
     if (!this.todoPanelVisible) this.todoExpanded = false
     this.renderTodoPanel()
     // The dock summary hides while the panel is expanded (it would sit on

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1458,7 +1458,7 @@ function deepFreeze(value: unknown): unknown {
  * `undefined` — a card that is ALWAYS expanded (regular Focus
  * non-Thinking secondaries, no hint needed). Each disclosure has exactly
  * one bulk owner: Ctrl+O never touches Thinking. */
-type ExpandHint = 'click' | 'ctrl+o' | 'alt+t' | undefined
+type ExpandHint = 'click' | 'fold' | 'thinking' | undefined
 
 /** One cached component for a transcript message (stage J render cache). */
 interface MessageComponentEntry {
@@ -6492,15 +6492,17 @@ export class TuiApp {
     const insideFocusSecondary = 'turn' in message
       && this.isInsideExpandedFocus(message, boundary)
       && isFocusSecondaryDisclosure(message)
-    // The fold-hint owner (plan §12): Thinking is Alt+T-owned in regular
-    // and click-owned in fullscreen; fullscreen Focus SECONDARY cards are
-    // click-owned; every other fold is Ctrl+O-owned. A regular Focus
-    // non-Thinking secondary is ALWAYS full — no hint.
+    // The fold-hint OWNER (plan §12): Thinking is thinking-owned in
+    // regular and click-owned in fullscreen; fullscreen Focus SECONDARY
+    // cards are click-owned; every other fold is fold-owned. A regular
+    // Focus non-Thinking secondary is ALWAYS full — no hint. The owner is
+    // SEMANTIC (never a physical key — the rendered copy resolves the
+    // EFFECTIVE key through the keymap).
     const expandHint: ExpandHint = message.kind === 'thinking'
-      ? (this.fullscreen !== undefined ? 'click' : 'alt+t')
+      ? (this.fullscreen !== undefined ? 'click' : 'thinking')
       : insideFocusSecondary
         ? (this.fullscreen !== undefined ? 'click' : undefined)
-        : 'ctrl+o'
+        : 'fold'
     // The FULL-REVEAL flag for tool bodies (large diffs): true for the
     // per-card override AND for any REGULAR Focus expanded root (the
     // surface contract — no mouse, so a capped diff would be unreadable);
@@ -7205,7 +7207,7 @@ export class TuiApp {
       rows.push(`${indent}${truncateToWidth(color.textDim(line), contentWidth, '…')}`)
     }
     if (preview.hidden > 0) {
-      rows.push(color.textDim(`${indent}${localShellHiddenMarker(preview.hidden, running, preview.partial, this.expandHint(false))}`))
+      rows.push(color.textDim(`${indent}${localShellHiddenMarker(preview.hidden, running, preview.partial, this.expandHint('fold'))}`))
     }
     card.addChild(new Text(rows.join('\n'), 0, 0))
   }
@@ -8534,12 +8536,12 @@ export class TuiApp {
 
   /** The fold-hint verb of one collapsible card: 'click' for the
    * click-expandable owners, else the EFFECTIVE key of the owning action
-   * ('alt+t' → the Thinking bulk owner, 'ctrl+o' → the expand master; a
+   * ('thinking' → the Thinking bulk owner, 'fold' → the expand master; a
    * user remap updates every `to expand` hint; a disabled action falls
    * back to a neutral phrase instead of a stale default). */
   private expandHint(hint: ExpandHint): string {
     if (hint === 'click') return 'click'
-    if (hint === 'alt+t') {
+    if (hint === 'thinking') {
       const thinking = this.keybindings.keyHint('app.transcript.toggleThinking')
       return thinking === '' ? 'the thinking key' : thinking.toLowerCase()
     }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2067,6 +2067,16 @@ export class TuiApp {
           && VIEWER_BLOCKED_PARENT_ACTIONS.has(action as AppKeybindingId)) {
           return true
         }
+        // A leader completion is another TRIGGER of the same semantic
+        // action and MUST obey the action's context predicate — never a
+        // predicate bypass (convergence §4.7: `<leader>t` opens the task
+        // browser only when the direct ↓ affordance would). A
+        // predicate-failed completion is reported as NOT consumed so the
+        // completing key falls through (never fires the action out of
+        // context).
+        if (!this.keybindings.canActivate(action as AppKeybindingId, this.keybindingContext())) {
+          return false
+        }
         // The dispatch result propagates to the feed consumer: an action
         // that DECLINES (pasteMedia without a handler, unbound history
         // search) must fall through like a direct key — the completing
@@ -2801,15 +2811,20 @@ export class TuiApp {
     // preserves that ordering exactly; do not move the keymap after the
     // advanced captures without re-reviewing the tradeoff.
     const resolution = this.keybindings.resolve(data, this.keybindingContext())
+    let hostDeclined = false
     if (resolution !== undefined) {
       const consumed = this.dispatchResolvedAction(resolution.action as AppKeybindingId, data, resolution.key)
       if (consumed) return { consume: true }
+      // The HOST dispatcher declined (e.g. pasteMedia without a handler):
+      // the key must reach the editor/plugin remainder — never be
+      // re-reserved by the same host action (convergence §6/§4.9).
+      hostDeclined = true
     }
     // M6: the router first determines whether a capturing path owns the key.
     // A replacement editor gets the first chance for editor-routed input;
     // only an explicit decline is eligible for a plugin binding. The host
     // editor keeps the normal last-stage plugin binding behavior.
-    const context = this.inputRouterContext()
+    const context = { ...this.inputRouterContext(), hostDeclined }
     const replacement = this.seatEditor().handleInput
     // A generic managed overlay owns the focused component. Do not probe the
     // seat editor or plugin bindings here; returning undefined lets pi-tui
@@ -2904,11 +2919,15 @@ export class TuiApp {
     return this.actionDispatcher.dispatch(action, key)
   }
 
-  /** The Esc path (app.agent.interrupt): autocomplete/replacement-editor
-   * pass-through, the runner's single-Esc modes, the busy single-Esc
-   * cancel, the shell-mode exit pass-through, and the idle double-Esc
-   * cancel/rewind. Returns undefined when the key must fall through
-   * (autocomplete open, replacement editor). */
+  /** The semantic interrupt core (app.agent.interrupt): the runner's
+   * single-Esc modes, the busy single-Esc cancel, and the idle double
+   * -Esc cancel/rewind. A REMAPPED interrupt key (e.g. Ctrl+X) takes
+   * THIS path — it must not inherit the physical-Escape editor seams
+   * (autocomplete pass-through, replacement-editor Esc, shell-mode
+   * exit); those belong to the physical Escape key alone (convergence
+   * §5/§4.8). Returns whether the key was consumed (undefined = fall
+   * through). */
+
   /** Whether one raw input is the EFFECTIVE submit key (app.input.submit —
    * a user remap moves submission to the new key; Shift+Enter stays the
    * newline, never a submit). The fork editor owns the actual submit
@@ -2920,17 +2939,7 @@ export class TuiApp {
     return this.keybindings.editorSubmitKeysFor().some(key => matchesKey(data, key))
   }
 
-  private handleEscapeKey(data: string): TuiInputListenerResult | undefined {
-    // Overlays (pickers, settings) own Esc while they are up.
-    if (this.activeScreen.hasOverlayEntries) return undefined
-    // Autocomplete owns Esc while the dropdown is open: let the editor
-    // close it (TuiEditor intercepts; kimi parity). Without this the
-    // app-level consume swallows Esc and the dropdown cannot close.
-    // Capability-detected: a REPLACEMENT editor with its own dropdown
-    // gets the same pass-through (its focused component handles Esc).
-    if ((this.seatEditor() as { isShowingAutocomplete?: () => boolean }).isShowingAutocomplete?.() === true) {
-      return undefined
-    }
+  private handleInterruptAction(data: string): TuiInputListenerResult | undefined {
     // The host may consume the first Esc (runner-owned modes like the
     // subagent viewer); otherwise it arms the double-Esc cancel. A
     // CONSUMED Esc is a fresh action: it disarms any pending window (a
@@ -2951,6 +2960,52 @@ export class TuiApp {
       this.lastEscapeAt = undefined
       this.events.onCancel?.()
       return { consume: true }
+    }
+    const now = Date.now()
+    if (this.lastEscapeAt !== undefined && now - this.lastEscapeAt < TuiApp.ESCAPE_CANCEL_WINDOW_MS) {
+      this.lastEscapeAt = undefined
+      // Conversation rewind (pi parity): an EMPTY editor opens the rewind
+      // picker; a non-empty draft keeps the historical cancel semantics —
+      // a half-written draft is never dragged into a rewind (plan Case C).
+      // A host without rewind keeps the cancel for both cases.
+      if (this.seatEditor().getText().trim() === '' && this.events.onRewind !== undefined) {
+        this.events.onRewind()
+      } else {
+        this.events.onCancel?.()
+      }
+    } else {
+      this.lastEscapeAt = now
+    }
+    return { consume: true }
+  }
+
+  /** The PHYSICAL Escape path (app.agent.interrupt on the escape key):
+   * the editor-owned Escape seams (overlay pass-through, autocomplete
+   * pass-through, replacement-editor Esc, shell-mode exit) run FIRST,
+   * then the semantic interrupt core. A REMAPPED interrupt key bypasses
+   * this and goes straight to {@link handleInterruptAction} (convergence
+   * §5 — only physical Escape owns the Escape-specific editor behavior).
+   * Returns undefined when the key must fall through. */
+  private handleEscapeKey(data: string): TuiInputListenerResult | undefined {
+    // The BUSY cancel keeps its Host-owned priority over EVERY physical
+    // Escape seam (shell-mode exit, replacement-editor Esc): a busy Esc
+    // must stop the agent, never vanish into a shell-mode exit or a
+    // plugin's modal handling (convergence §5 — the priority order is
+    // preserved from the pre-split ladder).
+    if (this.busy) {
+      this.lastEscapeAt = undefined
+      this.events.onCancel?.()
+      return { consume: true }
+    }
+    // Overlays (pickers, settings) own Esc while they are up.
+    if (this.activeScreen.hasOverlayEntries) return undefined
+    // Autocomplete owns Esc while the dropdown is open: let the editor
+    // close it (TuiEditor intercepts; kimi parity). Without this the
+    // app-level consume swallows Esc and the dropdown cannot close.
+    // Capability-detected: a REPLACEMENT editor with its own dropdown
+    // gets the same pass-through (its focused component handles Esc).
+    if ((this.seatEditor() as { isShowingAutocomplete?: () => boolean }).isShowingAutocomplete?.() === true) {
+      return undefined
     }
     // P1-6: a REPLACEMENT editor owns Esc for its own modal state
     // machine (vim normal-mode entry) — route it through the editor
@@ -2978,22 +3033,8 @@ export class TuiApp {
     if (this.seatEditor().id === 'host' && this.editor.getInputMode() !== 'prompt' && this.seatEditor().getText() === '') {
       return undefined
     }
-    const now = Date.now()
-    if (this.lastEscapeAt !== undefined && now - this.lastEscapeAt < TuiApp.ESCAPE_CANCEL_WINDOW_MS) {
-      this.lastEscapeAt = undefined
-      // Conversation rewind (pi parity): an EMPTY editor opens the rewind
-      // picker; a non-empty draft keeps the historical cancel semantics —
-      // a half-written draft is never dragged into a rewind (plan Case C).
-      // A host without rewind keeps the cancel for both cases.
-      if (this.seatEditor().getText().trim() === '' && this.events.onRewind !== undefined) {
-        this.events.onRewind()
-      } else {
-        this.events.onCancel?.()
-      }
-    } else {
-      this.lastEscapeAt = now
-    }
-    return { consume: true }
+    // After the physical-Escape editor seams, the semantic core runs.
+    return this.handleInterruptAction(data)
   }
 
   /** The exit path (app.exit.request): Ctrl+C keeps the clear-then-exit
@@ -3058,17 +3099,18 @@ export class TuiApp {
       submitDraft: (forceQueue = false) => {
         if (forceQueue) {
           // The busy-Enter opposite chord (web busyEnter parity): without
-          // a wired onQueueSubmit the key falls through to the editor
-          // instead of dropping the draft; an EMPTY draft falls through
-          // too — plain Enter on an empty editor does not submit, and an
-          // empty chord would otherwise dispatch a session-creating empty
-          // followup.
-          if (this.events.onQueueSubmit === undefined) return false
+          // a wired onQueueSubmit, or with an EMPTY draft, the chord is a
+          // HOST-GUARDED NO-OP — the host OWNS Ctrl+Enter and consumes it
+          // (an empty chord would otherwise dispatch a session-creating
+          // empty followup). Guard no-ops stay host-owned; only GENUINE
+          // feature absence (pasteMedia with no handler) declines to the
+          // remainder (convergence §4.9).
+          if (this.events.onQueueSubmit === undefined) return true
           // Emptiness is judged on the SERIALIZED wire form: a bare
           // `!` / `!!` shell mode has an empty BODY but a non-empty wire
           // form, and must reach the queue protocol like the literal
           // prefix did before the mode feature.
-          if (this.serializeSeatDraft(this.seatEditor().getText()).trim() === '') return false
+          if (this.serializeSeatDraft(this.seatEditor().getText()).trim() === '') return true
         }
         this.submitDraft(forceQueue)
         return true
@@ -3186,12 +3228,15 @@ export class TuiApp {
         return true
       },
       openHistorySearch: () => {
-        // Input-history search: unbound (no historySearchSource)
-        // falls through to the editor like any un-reserved key; the
-        // continuable subagent viewer keeps its OWN live editor — the
-        // chord is a no-op there (never the child draft, never the parent
-        // draft).
-        if (this.historySearchSource === undefined || this.viewerMode !== undefined) return false
+        // Input-history search: unbound (no historySearchSource) is a
+        // HOST-GUARDED NO-OP — the host owns Ctrl+R and consumes it even
+        // when there is nothing to search; it must NEVER fall through to a
+        // plugin for that reason (convergence §4.9: only GENUINE feature
+        // absence — pasteMedia with no handler — declines to the
+        // remainder; a guard no-op stays host-owned). The continuable
+        // subagent viewer keeps its OWN live editor — the chord is a
+        // no-op there (never the child draft, never the parent draft).
+        if (this.historySearchSource === undefined || this.viewerMode !== undefined) return true
         this.openHistorySearch()
         return true
       },

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2649,11 +2649,16 @@ export class TuiApp {
     // of Esc would trip the double-Esc cancel. The framework already filters
     // releases for the focused component; listeners are on their own.
     if (isKeyRelease(data) || isKeyRepeat(data)) return undefined
-    // The double-Esc window is a CONSECUTIVE-press chord: any real
-    // non-Esc key press between the two Esc presses disarms it (review
-    // E12 — `Esc → Left → Esc` must not rewind). Releases/repeats already
-    // returned above, so only genuine presses reach this line.
-    if (!matchesKey(data, 'escape')) this.lastEscapeAt = undefined
+    // The double-action window is a CONSECUTIVE-press chord: any real
+    // key press between the two presses of the interrupt trigger disarms
+    // it (review E12 — `Esc → Left → Esc` must not rewind). Releases/
+    // repeats already returned above, so only genuine presses reach this
+    // line. The disarming key is the PHYSICAL Escape key OR the
+    // EFFECTIVE interrupt trigger (a remapped Ctrl+X keeps its own
+    // consecutive-press semantics — two Ctrl+X presses in the window
+    // still fire the idle double action; convergence §5 finding).
+    if (!matchesKey(data, 'escape')
+      && !this.keybindings.matches(data, 'app.agent.interrupt')) this.lastEscapeAt = undefined
     if (this.activeQuestions !== undefined) {
       return this.handleQuestionKey(data)
     }
@@ -2897,7 +2902,16 @@ export class TuiApp {
    * whole Esc path to the new key. Returns whether the key was consumed. */
   private dispatchResolvedAction(action: AppKeybindingId, data: string, key?: KeyId): boolean {
     if (action === 'app.agent.interrupt') {
-      return this.handleEscapeKey(data) !== undefined
+      // Convergence §5: the PHYSICAL Escape key runs the full
+      // handleEscapeKey (editor Escape seams + semantic core); a REMAPPED
+      // interrupt key (e.g. Ctrl+X) goes STRAIGHT to the semantic core —
+      // it must never inherit the physical-Escape editor behavior (a
+      // replacement editor could otherwise consume the remapped interrupt
+      // instead of interrupting the agent).
+      if (matchesKey(data, 'escape')) {
+        return this.handleEscapeKey(data) !== undefined
+      }
+      return this.handleInterruptAction(data) !== undefined
     }
     if (action === 'app.exit.request') {
       this.handleExitKey(data)

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2633,7 +2633,11 @@ export class TuiApp {
     if (this.viewerMode !== undefined && !this.activeScreen.hasOverlayEntries) {
       const viewer = this.viewerMode
       if (!isViewerAccessInteractive(resolveViewerAccess(viewer.mode, viewer.access))) {
-        if (!matchesKey(data, 'escape') && !matchesKey(data, 'ctrl+o')) {
+        // Esc is a fixed lifecycle key (never user-configurable); the
+        // FOLD pass-through resolves the EFFECTIVE fold key (a remap of
+        // app.transcript.toggleExpand must still let the viewed
+        // transcript fold — review finding).
+        if (!matchesKey(data, 'escape') && !this.keybindings.matches(data, 'app.transcript.toggleExpand')) {
           return { consume: true }
         }
       } else if (matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {
@@ -2642,7 +2646,7 @@ export class TuiApp {
       } else if (this.viewerParentLockedKey(data)) {
         return { consume: true }
       }
-      // Esc (exit) and Ctrl+O (fold) fall through to the host ladder.
+      // Esc (exit) and the effective fold key fall through to the host ladder.
     }
     // Transcript search owns these keys while its overlay is up; everything
     // else falls through to the focused search input. The close/next/
@@ -3153,6 +3157,10 @@ export class TuiApp {
         : isViewerAccessInteractive(resolveViewerAccess(this.viewerMode.mode, this.viewerMode.access)) ? 'continuable' : 'readonly',
       hasOverlay: this.activeScreen.hasOverlayEntries,
       searchActive: this.searchOverlay !== undefined,
+      // The router's physical-key seams (the read-only viewer fold
+      // pass-through, the search overlay ownership) consult the EFFECTIVE
+      // keymap, so a user remap stays authoritative (review finding).
+      matchesEffective: (action: string, data: string) => this.keybindings.matches(data, action as unknown as AppKeybindingId),
       editorReplacement: this.seatEditor().handleInput !== undefined,
       // P1-06: the focused EDITOR owns its keys. The fork dispatches to
       // app-level listeners BEFORE the focused component, so the router

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2022,6 +2022,16 @@ export class TuiApp {
       onInvalidate: () => this.requestRender(),
       onLeaderStateChange: () => this.renderFooter(),
       onLeaderActivate: (action) => {
+        // M6: a leader sequence must never bypass the viewer's
+        // parent-action guard — a `<leader>X` binding of a parent action
+        // (e.g. app.input.steer) is inert inside the continuable viewer,
+        // exactly like the direct key (plan §1.2/M1).
+        const target = this.viewerMode
+        if (target !== undefined
+          && isViewerAccessInteractive(resolveViewerAccess(target.mode, target.access))
+          && VIEWER_BLOCKED_PARENT_ACTIONS.has(action as AppKeybindingId)) {
+          return
+        }
         this.dispatchResolvedAction(action as AppKeybindingId, '')
       },
     })
@@ -2665,6 +2675,16 @@ export class TuiApp {
     // the host methods. A resolution that DECLINES (e.g. pasteMedia
     // without a clipboard handler) falls through to the editor/plugin
     // stages below.
+    //
+    // ORDERING (by design, review round 1): this resolution runs BEFORE
+    // the advanced captures below. The pre-migration phase contract
+    // (AGENTS.md decision 13) placed the host ladder — the reserved
+    // lifecycle keys, which the host semantic actions ARE — before the
+    // advanced stage, and an advanced plugin may preempt ordinary
+    // editor/panel input but never a Host question/approval/overlay or a
+    // session-safety path (steer/queue/exit/interrupt). The migration
+    // preserves that ordering exactly; do not move the keymap after the
+    // advanced captures without re-reviewing the tradeoff.
     const resolution = this.keybindings.resolve(data, this.keybindingContext())
     if (resolution !== undefined) {
       const consumed = this.dispatchResolvedAction(resolution.action as AppKeybindingId, data, resolution.key)

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2649,16 +2649,15 @@ export class TuiApp {
     // of Esc would trip the double-Esc cancel. The framework already filters
     // releases for the focused component; listeners are on their own.
     if (isKeyRelease(data) || isKeyRepeat(data)) return undefined
-    // The double-action window is a CONSECUTIVE-press chord: any real
-    // key press between the two presses of the interrupt trigger disarms
-    // it (review E12 — `Esc → Left → Esc` must not rewind). Releases/
-    // repeats already returned above, so only genuine presses reach this
-    // line. The disarming key is the PHYSICAL Escape key OR the
-    // EFFECTIVE interrupt trigger (a remapped Ctrl+X keeps its own
-    // consecutive-press semantics — two Ctrl+X presses in the window
-    // still fire the idle double action; convergence §5 finding).
-    if (!matchesKey(data, 'escape')
-      && !this.keybindings.matches(data, 'app.agent.interrupt')) this.lastEscapeAt = undefined
+    // The double-action window is a CONSECUTIVE-press chord of the
+    // EFFECTIVE interrupt trigger: any OTHER key between the two presses
+    // disarms it (review E12 — `Esc → Left → Esc` must not rewind;
+    // convergence §4 finding — after a remap, the physical Esc is just
+    // another key, so `Ctrl+X → Esc → Ctrl+X` must NOT fire the double
+    // action; the default Escape matches app.agent.interrupt naturally).
+    // Releases/repeats already returned above, so only genuine presses
+    // reach this line.
+    if (!this.keybindings.matches(data, 'app.agent.interrupt')) this.lastEscapeAt = undefined
     if (this.activeQuestions !== undefined) {
       return this.handleQuestionKey(data)
     }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -3219,7 +3219,7 @@ export class TuiApp {
       // away old key (e.g. Ctrl+V after pasteMedia moved to Ctrl+P) is
       // NOT reserved and falls through to the editor/plugin (PR review
       // finding — no static physical-key swallowing).
-      hostResolves: (data) => this.keybindings.resolve(data, this.keybindingContext()) !== undefined,
+      hostResolves: (data) => this.keybindings.hostResolves(data, this.keybindingContext()),
       editorReplacement: this.seatEditor().handleInput !== undefined,
       // P1-06: the focused EDITOR owns its keys. The fork dispatches to
       // app-level listeners BEFORE the focused component, so the router

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2662,20 +2662,43 @@ export class TuiApp {
     if (this.viewerMode !== undefined && !this.activeScreen.hasOverlayEntries) {
       const viewer = this.viewerMode
       if (!isViewerAccessInteractive(resolveViewerAccess(viewer.mode, viewer.access))) {
-        // Esc is a fixed lifecycle key (never user-configurable); the
-        // FOLD pass-through resolves the EFFECTIVE fold key (a remap of
-        // app.transcript.toggleExpand must still let the viewed
-        // transcript fold — review finding).
-        if (!matchesKey(data, 'escape') && !this.keybindings.matches(data, 'app.transcript.toggleExpand')) {
+        // The read-only viewer's EXIT is a FIXED lifecycle key — Esc is
+        // the viewer's own close contract (like question.cancel /
+        // search.close / tasks.cancel), INDEPENDENT of the user-
+        // configurable app.agent.interrupt. A remap of interrupt to
+        // Ctrl+X must not break the viewer exit: Esc here runs the
+        // runner's single-Esc handler DIRECTLY (the viewer's close path)
+        // and is consumed. The FOLD pass-through resolves the EFFECTIVE
+        // fold key (a remap of app.transcript.toggleExpand must still
+        // let the viewed transcript fold). Every other key is consumed —
+        // a remapped interrupt (Ctrl+X) is inert inside the read-only
+        // viewer, never the parent's (PR review finding).
+        if (matchesKey(data, 'escape')) {
+          this.events.onSingleEscape?.()
           return { consume: true }
         }
-      } else if (this.isSubmitKey(data)) {
-        this.submitSubagentDraft()
-        return { consume: true }
-      } else if (this.viewerParentLockedKey(data)) {
-        return { consume: true }
+        if (!this.keybindings.matches(data, 'app.transcript.toggleExpand')) {
+          return { consume: true }
+        }
+      } else {
+        // The CONTINUABLE viewer keeps the child editor live, but Esc is
+        // STILL the viewer's fixed exit lifecycle key — it closes the
+        // viewer (single-Esc close path), independent of the user-
+        // configurable app.agent.interrupt (whose remap could otherwise
+        // swallow the exit — PR review finding).
+        if (matchesKey(data, 'escape')) {
+          this.events.onSingleEscape?.()
+          return { consume: true }
+        }
+        if (this.isSubmitKey(data)) {
+          this.submitSubagentDraft()
+          return { consume: true }
+        } else if (this.viewerParentLockedKey(data)) {
+          return { consume: true }
+        }
       }
-      // Esc (exit) and the effective fold key fall through to the host ladder.
+      // The effective fold key falls through to the host ladder (the
+      // fold toggle); Esc was consumed above as the viewer exit.
     }
     // Transcript search owns these keys while its overlay is up; everything
     // else falls through to the focused search input. The close/next/

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2367,6 +2367,11 @@ export class TuiApp {
   dispose(): void {
     if (this.disposed) return
     this.disposed = true
+    // The keybinding manager dies FIRST: every later teardown callback
+    // (approval settles, extension/editor disposal) could rebuild the
+    // keymap and schedule rendering — the disposed manager makes those
+    // rebuilds inert (PR review finding).
+    this.keybindings.dispose()
     // Restore the fork's global submit binding to the builtin default:
     // the fork keybindings are PROCESS-GLOBAL, and a disposed surface
     // must not leak its remap/disable into a LATER TuiApp instance (PR
@@ -2436,12 +2441,6 @@ export class TuiApp {
     // subscribe, invalidate) becomes inert; a late plugin callback can no
     // longer mutate the seat or dispatch a real submission.
     this.editorSeatHolder.dispose()
-    // The keybinding manager's final disposal: a PENDING leader timeout
-    // must never fire after the surface is gone (its onStateChange →
-    // renderFooter would schedule work against the stopped app — PR
-    // review finding). The manager's dispose also latches the disposed
-    // flag, making the leader machine inert.
-    this.keybindings.dispose()
   }
 
   /** The surface generation (M0): stable across start/stop/fullscreen/

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -43,6 +43,7 @@ import {
   type SlashCommand,
   type Terminal,
   type TuiInputListenerResult,
+  type KeyId,
 } from '@xmoon76/pi-tui'
 import { ImageThumbnail } from './components/media/image-thumbnail.ts'
 import {
@@ -106,6 +107,13 @@ import { cancellationError, type OwnedTaskOptions } from './detached.ts'
 import { safeErrorMessage } from './error-boundary.ts'
 import type { SurfaceHost } from './extension/internal/surface-host.ts'
 import { InputRouter } from './input-router.ts'
+import { AppActionDispatcher, type AppActionHost } from './keybindings/action-dispatcher.ts'
+import { deriveKeybindingContext } from './keybindings/context.ts'
+import { APP_KEYBINDINGS, VIEWER_BLOCKED_PARENT_ACTIONS } from './keybindings/definitions.ts'
+import { formatKeyId } from './keybindings/hints.ts'
+import type { LeaderStateMachine } from './keybindings/leader.ts'
+import { HostKeybindingManager } from './keybindings/manager.ts'
+import type { AppKeybindingId, KeybindingContext, UserKeybindingsConfig } from './keybindings/types.ts'
 import {
   isLocalShellCard,
   localShellHiddenMarker,
@@ -1777,6 +1785,12 @@ export class TuiApp {
   private readonly pluginActionIdFor: ((key: import('./extension/public-types.ts').NormalizedKey) => string | undefined) | undefined
   /** M6: the host-owned input precedence router (normalization + rules). */
   private readonly inputRouter: InputRouter
+  /** The user-orchestrable keybinding manager (M0–M6): the semantic
+   * action resolver + leader machine. Built by the constructor when the
+   * runner did not inject one. */
+  private readonly keybindings: HostKeybindingManager
+  /** The semantic action → host method router (plan §9). */
+  private readonly actionDispatcher: AppActionDispatcher
   /** M7: the transcript/tool renderer registry (optional). */
   private readonly renderers: RendererRegistry | undefined
   /** M9: the editor registry (optional). */
@@ -1998,6 +2012,20 @@ export class TuiApp {
     this.unstableInputsRevision = options.unstableInputsRevision
     this.unstableFailSafeRelease = options.unstableFailSafeRelease
     this.inputRouter = new InputRouter(RESERVED_HOST_KEYS)
+    // The keybinding manager (M0–M6): the app ALWAYS builds it (the
+    // runner configures it afterwards through keybindingsManager() — user
+    // overrides, safe mode, plugin rules), so the surface callbacks
+    // (repaint, which-key footer, leader dispatch) are never lost. The
+    // builtin defaults keep the surface behavior identical without any
+    // runner wiring.
+    this.keybindings = new HostKeybindingManager({
+      onInvalidate: () => this.requestRender(),
+      onLeaderStateChange: () => this.renderFooter(),
+      onLeaderActivate: (action) => {
+        this.dispatchResolvedAction(action as AppKeybindingId, '')
+      },
+    })
+    this.actionDispatcher = new AppActionDispatcher(this.buildActionHost())
     this.renderers = options.renderers
     this.editorRegistry = options.editorRegistry
     this.copySelection = options.copySelection
@@ -2567,21 +2595,23 @@ export class TuiApp {
       // Esc (exit) and Ctrl+O (fold) fall through to the host ladder.
     }
     // Transcript search owns these keys while its overlay is up; everything
-    // else falls through to the focused search input.
+    // else falls through to the focused search input. The keys route
+    // through the keymap's DEFAULT keys (the search actions are
+    // non-configurable overlay contracts — plan §3.3).
     if (this.searchOverlay !== undefined) {
-      if (matchesKey(data, 'escape')) {
+      if (this.keybindings.matchesDefault(data, 'app.transcript.search.close')) {
         this.closeTranscriptSearch()
         return { consume: true }
       }
-      if (matchesKey(data, 'enter')) {
+      if (this.keybindings.matchesDefault(data, 'app.transcript.search.next')) {
         this.events.onSearchNext?.()
         return { consume: true }
       }
-      if (matchesKey(data, 'shift+enter')) {
+      if (this.keybindings.matchesDefault(data, 'app.transcript.search.previous')) {
         this.events.onSearchPrev?.()
         return { consume: true }
       }
-      if (matchesKey(data, 'ctrl+f')) {
+      if (this.keybindings.matchesDefault(data, 'app.transcript.search')) {
         // Ctrl+F is the search toggle; a second press closes the overlay.
         this.closeTranscriptSearch()
         return { consume: true }
@@ -2599,302 +2629,46 @@ export class TuiApp {
     // lifecycle handlers must not consume its keys before pi-tui dispatches
     // them to that component.
     if (this.activeScreen.hasOverlayEntries) return undefined
-    // Ctrl+R input-history search (host-reserved lifecycle key, §29): the
-    // overlay guard above keeps the key with any active overlay/question/
-    // approval/viewer (plan §28/§30); with nothing up, the host opens the
-    // history panel. Unbound (no historySearchSource): falls through to the
-    // editor like any un-reserved key. The continuable subagent viewer keeps
-    // its OWN live editor — plan §30 M1 restricts Ctrl+R to the MAIN editor,
-    // so the chord is a no-op there (never the child draft, never the parent
-    // draft): the viewer's parent-owned chords already consume Enter etc.
-    if (matchesKey(data, 'ctrl+r') && this.historySearchSource !== undefined
-      && this.viewerMode === undefined) {
-      this.openHistorySearch()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'ctrl+shift+f') || matchesKey(data, 'ctrl+f')) {
-      this.startTranscriptSearch()
-      return { consume: true }
-    }
     // P1-10: a PLUGIN editor occupying the seat receives editor-routed input
     // before plugin keybindings. Enter remains host-owned: forward it through
     // the hidden host editor so active autocomplete gets its normal confirm /
     // submit semantics before the resulting draft is synchronized back. The
     // plugin editor never receives host-owned Enter; Shift+Enter stays with
-    // the plugin (its own multiline editing).
+    // the plugin (its own multiline editing). (Enter itself is NOT a host
+    // keybinding — app.input.submit is hostResolved: false, the fork editor
+    // owns it — so this seam stays physical: it is the focused-editor
+    // contract, not a host shortcut.)
     if (this.seatEditor().handleInput !== undefined
       && matchesKey(data, 'enter') && !matchesKey(data, 'shift+enter')) {
       this.editorSeatHolder.handleHostFallbackInput(data)
       return { consume: true }
     }
-    if (matchesKey(data, 'shift+tab')) {
-      // Cycle the permission preset; overlays keep Shift+Tab for themselves.
-      if (this.activeScreen.hasOverlayEntries) return undefined
-      this.events.onCyclePermission?.()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'alt+up')) {
-      // Dequeue (Alt+↑): pull queued input back into the editor; overlays
-      // keep the key for themselves.
-      if (this.activeScreen.hasOverlayEntries) return undefined
-      this.events.onDequeue?.()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'alt+k')) {
-      // Dismiss settled local shell cards (Alt+K — plan §5.4 quick clear):
-      // completed `!`/`!!` runs leave the live view; running cards never
-      // do (the process is NOT cancelled — Esc owns that). Overlays keep
-      // the key for themselves like the other Alt chords.
-      if (this.activeScreen.hasOverlayEntries) return undefined
-      this.dismissSettledLocalShell()
-      this.requestRender()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'ctrl+enter')) {
-      // The busy-Enter opposite chord (web busyEnter parity): Ctrl+Enter
-      // forces the QUEUE delivery mode while the agent is busy, regardless
-      // of the busyEnter preference (plain Enter then steers when the
-      // preference is 'steer'). Overlays keep the key for themselves; the
-      // editor never sees the chord — the submit mirrors a plain Enter
-      // (history + notify clear + draft clear). Without a wired
-      // onQueueSubmit the key falls through to the editor instead of
-      // dropping the draft; an EMPTY draft falls through too — plain Enter
-      // on an empty editor does not submit, and an empty chord would
-      // otherwise dispatch a session-creating empty followup.
-      if (this.activeScreen.hasOverlayEntries) return undefined
-      if (this.events.onQueueSubmit === undefined) return undefined
-      const text = this.seatEditor().getText()
-      const serialized = this.serializeSeatDraft(text)
-      // Emptiness is judged on the SERIALIZED wire form: a bare `!` / `!!`
-      // shell mode has an empty BODY but a non-empty wire form, and must
-      // reach the queue protocol like the literal prefix did before the
-      // mode feature.
-      if (serialized.trim() === '') return undefined
-      this.rememberInput(serialized)
-      this.clearNotify()
-      this.seatEditor().setText('')
-      this.editorSeatHolder.notifyChanged()
-      // Reset BEFORE the dispatch: a synchronous rejection restores the
-      // serialized text (and with it the mode) through setEditorText.
-      this.resetEditorMode()
-      // Consumed at the app level: request the frame ourselves (the
-      // stale-clear trap — see the Ctrl+C branch).
-      this.requestRender()
-      this.events.onQueueSubmit(serialized)
-      return { consume: true }
-    }
-    if (matchesKey(data, 'escape')) {
-      // Overlays (pickers, settings) own Esc while they are up.
-      if (this.activeScreen.hasOverlayEntries) return undefined
-      // Autocomplete owns Esc while the dropdown is open: let the editor
-      // close it (TuiEditor intercepts; kimi parity). Without this the
-      // app-level consume swallows Esc and the dropdown cannot close.
-      // Capability-detected: a REPLACEMENT editor with its own dropdown
-      // gets the same pass-through (its focused component handles Esc).
-      if ((this.seatEditor() as { isShowingAutocomplete?: () => boolean }).isShowingAutocomplete?.() === true) {
-        return undefined
-      }
-      // The host may consume the first Esc (runner-owned modes like the
-      // subagent viewer); otherwise it arms the double-Esc cancel. A
-      // CONSUMED Esc is a fresh action: it disarms any pending window (a
-      // prior declined Esc may have armed it — the consumed Esc must not
-      // leave a stale cancel armed for an unrelated later press).
-      if (this.events.onSingleEscape?.() === true) {
-        this.lastEscapeAt = undefined
+// M6: the leader sequence machine (armed only when a leader key is
+    // configured). Fed AFTER the capturing flows and overlays, BEFORE the
+    // host action ladder — a completing key is consumed by the sequence,
+    // and a paste burst / non-matching key cancels the pending state and
+    // passes through (typing is never swallowed). The machine's onActivate
+    // callback ALREADY dispatched the action (the manager wires it to
+    // dispatchResolvedAction) — this branch only consumes the key.
+    const leader = this.keybindings.leaderMachine()
+    if (leader !== undefined) {
+      const outcome = leader.feed(data)
+      if (outcome.kind === 'consumed' || outcome.kind === 'cancelled-consume' || outcome.kind === 'activated') {
         return { consume: true }
       }
-      // pi parity: a SINGLE Esc while the agent is busy stops the current
-      // activity (turn, tool run, compaction) — partial content stays on
-      // screen. Idle keeps the double-Esc cancel. The busy cancel is
-      // Host-owned session control and keeps its priority over BOTH the
-      // shell-mode exit below and a replacement editor's own Esc state
-      // machine (a busy Esc must stop the agent, never vanish into a
-      // plugin's modal handling).
-      if (this.busy) {
-        this.lastEscapeAt = undefined
-        this.events.onCancel?.()
-        return { consume: true }
-      }
-      // P1-6: a REPLACEMENT editor owns Esc for its own modal state
-      // machine (vim normal-mode entry) — route it through the editor
-      // channel below instead of the host's double-Esc cancel. If the
-      // plugin DECLINES it, the editor route hands it back to the host
-      // fallback (which includes this cancel path on re-entry).
-      if (this.seatEditor().handleInput !== undefined) {
-        const routed = this.handleReplacementEditorInput(data, this.inputRouterContext(), true)
-        if (routed !== undefined) {
-          // A CONSUMED plugin Esc is a fresh action: disarm any pending
-          // double-Esc window (a prior declined Esc may have armed it).
-          this.lastEscapeAt = undefined
-          return routed
-        }
-        // The plugin DECLINED Esc: continue through the host Esc fallback
-        // (shell-mode exit, double-Esc cancel) instead of dropping the
-        // key — a dropped Esc would never arm the cancel.
-      }
-      // Shell-mode exit: the host editor in a shell mode with an EMPTY
-      // body owns Esc — it cancels the shell mode (the double-Esc cancel
-      // must not fire while the user is composing a shell command). The
-      // pass-through lets the focused editor handle the key, exactly like
-      // the autocomplete branch above. Host-owned priorities (the viewer's
-      // onSingleEscape, the busy cancel, overlays) keep their precedence.
-      if (this.seatEditor().id === 'host' && this.editor.getInputMode() !== 'prompt' && this.seatEditor().getText() === '') {
-        return undefined
-      }
-      const now = Date.now()
-      if (this.lastEscapeAt !== undefined && now - this.lastEscapeAt < TuiApp.ESCAPE_CANCEL_WINDOW_MS) {
-        this.lastEscapeAt = undefined
-        // Conversation rewind (pi parity): an EMPTY editor opens the rewind
-        // picker; a non-empty draft keeps the historical cancel semantics —
-        // a half-written draft is never dragged into a rewind (plan Case C).
-        // A host without rewind keeps the cancel for both cases.
-        if (this.seatEditor().getText().trim() === '' && this.events.onRewind !== undefined) {
-          this.events.onRewind()
-        } else {
-          this.events.onCancel?.()
-        }
-      } else {
-        this.lastEscapeAt = now
-      }
-      return { consume: true }
+      // cancelled-pass: the pending state was cancelled; the key is
+      // processed normally below.
     }
-    if (matchesKey(data, 'ctrl+o')) {
-      // Fullscreen + Focus: Ctrl+O is the Thought-root bulk owner (plan
-      // §3) — no expanded root → expand the recent `EXPAND_RECENT_TURNS`
-      // eligible roots; any expanded root → Collapse All. Every other
-      // surface/Focus combination keeps the historical tool/system detail
-      // master (regular behavior untouched).
-      if (this.fullscreen !== undefined && this.focusModeEnabled) {
-        this.toggleFullscreenFocusRoots()
-        return { consume: true }
-      }
-      this.toolOutputExpanded = !this.toolOutputExpanded
-      this.rebuildMessages()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'ctrl+v')) {
-      // Clipboard paste with image intake (plan M3): with a host handler
-      // the key is consumed and the runner probes the clipboard once — an
-      // image becomes a draft placeholder and plain text falls back to an
-      // editor insert. WITHOUT a handler the key falls through to the
-      // editor exactly like the pre-pipeline behavior (round-1 finding 6).
-      if (this.events.onClipboardPaste === undefined) return { consume: false }
-      this.events.onClipboardPaste()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'ctrl+t')) {
-      // Todo panel toggle (kimi semantics; Ctrl+T never reaches the editor).
-      this.toggleTodoPanel()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'alt+t')) {
-      // Alt+T = the Thinking DETAIL bulk owner (never hide/show): every
-      // Thinking block collapses or expands together, Focus ON/OFF and
-      // both surfaces alike. Per-message overrides are cleared first so
-      // the result is predictable (plan §9).
-      this.toggleThinkingExpanded()
-      return { consume: true }
-    }
-    if (matchesKey(data, 'ctrl+s')) {
-      // Steer: send the draft into the running turn and clear the editor.
-      // An empty draft still fires the event — the runner steers every
-      // queued message when the queue is non-empty, and only ignores the
-      // key when there is nothing to send at all.
-      if (this.activeScreen.hasOverlayEntries) return { consume: true }
-      const draft = this.seatEditor().getText()
-      const serialized = this.serializeSeatDraft(draft)
-      this.seatEditor().setText('')
-      this.editorSeatHolder.notifyChanged()
-      this.resetEditorMode()
-      // Consumed at the app level: request the frame ourselves (the
-      // stale-clear trap — see the Ctrl+C branch).
-      this.requestRender()
-      this.events.onSteer?.(serialized)
-      return { consume: true }
-    }
-    if (matchesKey(data, 'down')) {
-      // Task browser: with active background tasks and an EMPTY editor, ↓
-      // opens the task list (nothing to move the cursor through). With text
-      // present the key keeps its editing meaning; overlays own it. (The
-      // former Ctrl+J chord is gone: legacy terminals send Ctrl+J as LF,
-      // which the editor treats as Enter — the key was unreliable, and ↓
-      // plus `/tasks` remain the two entries.) A shell-mode editor with an
-      // empty BODY is composing a command — ↓ keeps its editing meaning
-      // (a no-op on the empty line), never the browser.
-      if (this.tasksActive && !this.activeScreen.hasOverlayEntries
-        && this.seatEditor().getText().trim() === '' && this.seatInputMode() === 'prompt') {
-        this.events.onOpenTasks?.()
-        return { consume: true }
-      }
-    }
-    if (matchesKey(data, 'ctrl+g')) {
-      // External editor; overlays own Ctrl+G while up (alt-screen search).
-      // An owned workflow routed through the host's runOwned (diag attached
-      // by the runner): a spawn failure lands in diagnostics and notifies
-      // here — never a bare `void somePromise()` (AGENTS.md). The editor
-      // hook and runOwned are a BOUND pair (type union + constructor
-      // check): without the editor hook Ctrl+G is a documented no-op.
-      // Single-flight: while one launch is pending (the latch inside
-      // launchExternalEditor is set synchronously), further Ctrl+G presses
-      // are consumed without starting another editor.
-      if (this.activeScreen.hasOverlayEntries) return { consume: true }
-      if (this.events.openExternalEditor !== undefined && !this.externalEditorInFlight) {
-        this.events.runOwned('external editor', () => this.launchExternalEditor(), {
-          onError: (error: unknown) => {
-            this.notify(`external editor failed: ${safeErrorMessage(error)}`, 'error')
-          },
-        })
-      }
-      return { consume: true }
-    }
-    if (matchesKey(data, 'ctrl+c')) {
-      // pi parity (handleCtrlC): a first press CLEARS a non-empty editor
-      // (recording the time); a second press within the window on the now
-      // EMPTY editor exits. Overlays own the key (the global overlay guard
-      // above already passed them through). Issue #8: every arm shows the
-      // footer hint for EXACTLY the exit window (armCtrlCExit), and the
-      // exit path disarms it — the hint never outlives the window.
-      const text = this.seatEditor().getText()
-      // A shell-mode draft is non-empty in its SERIALIZED form: the
-      // first press clears BOTH the body and the mode — an empty `! ` /
-      // `!!` editor would otherwise show a cleared body under a stale
-      // shell prompt, and the next Ctrl+C would exit instead of
-      // completing the pre-mode clear contract.
-      if (text !== '' || this.seatInputMode() !== 'prompt') {
-        this.seatEditor().setText('')
-        this.resetEditorMode()
-        this.editorSeatHolder.notifyChanged()
-        this.armCtrlCExit()
-        // The key is CONSUMED at the app level, so the fork's input path
-        // never reaches the focused editor and never requests its own
-        // frame — without an explicit render the cleared draft stays on
-        // screen until the next keypress (the stale-clear trap, seen in
-        // tmux: the editor reads empty but the old text is still
-        // visible). Same pattern as setDraft/submitDraft.
-        this.requestRender()
-        return { consume: true }
-      }
-      const now = Date.now()
-      if (this.lastCtrlCAt !== undefined && now - this.lastCtrlCAt < this.ctrlCExitWindowMs) {
-        this.clearCtrlCExit()
-        this.events.onExit()
-      } else {
-        // First press on an EMPTY editor changes nothing visible, and the
-        // exit window is easy to miss — announce the armed state so a
-        // slow second press is not a silent no-op (the next Enter would
-        // otherwise send an empty draft). The second press within the
-        // window exits.
-        this.armCtrlCExit()
-      }
-      return { consume: true }
-    }
-    if (matchesKey(data, 'ctrl+d')) {
-      // Ctrl+D quits like /exit (and Ctrl+C). The editor's delete-char-
-      // forward remains on the Delete key. Issue #8: an armed exit chord
-      // must not leave its hint behind on a Ctrl+D exit.
-      this.clearCtrlCExit()
-      this.events.onExit()
-      return { consume: true }
+
+    // M1/M2: the host semantic action ladder. The keymap resolves the raw
+    // event against the live context; the dispatcher routes the action to
+    // the host methods. A resolution that DECLINES (e.g. pasteMedia
+    // without a clipboard handler) falls through to the editor/plugin
+    // stages below.
+    const resolution = this.keybindings.resolve(data, this.keybindingContext())
+    if (resolution !== undefined) {
+      const consumed = this.dispatchResolvedAction(resolution.action as AppKeybindingId, data, resolution.key)
+      if (consumed) return { consume: true }
     }
     // M6: the router first determines whether a capturing path owns the key.
     // A replacement editor gets the first chance for editor-routed input;
@@ -2959,6 +2733,339 @@ export class TuiApp {
       return { consume: true }
     }
     return undefined
+  }
+
+  /** The keybinding manager (M3/M4): the runner applies user config, safe
+   * mode and plugin rules through it; diagnostics read its snapshot. */
+  keybindingsManager(): HostKeybindingManager {
+    return this.keybindings
+  }
+
+  /** Dispatch one resolved semantic action (plan §9). The Esc and exit
+   * paths are the two context-heavy host paths and stay host methods,
+   * keyed by the ACTION — a user remap of app.agent.interrupt moves the
+   * whole Esc path to the new key. Returns whether the key was consumed. */
+  private dispatchResolvedAction(action: AppKeybindingId, data: string, key?: KeyId): boolean {
+    if (action === 'app.agent.interrupt') {
+      return this.handleEscapeKey(data) !== undefined
+    }
+    if (action === 'app.exit.request') {
+      this.handleExitKey(data)
+      return true
+    }
+    return this.actionDispatcher.dispatch(action, key)
+  }
+
+  /** The Esc path (app.agent.interrupt): autocomplete/replacement-editor
+   * pass-through, the runner's single-Esc modes, the busy single-Esc
+   * cancel, the shell-mode exit pass-through, and the idle double-Esc
+   * cancel/rewind. Returns undefined when the key must fall through
+   * (autocomplete open, replacement editor). */
+  private handleEscapeKey(data: string): TuiInputListenerResult | undefined {
+    // Overlays (pickers, settings) own Esc while they are up.
+    if (this.activeScreen.hasOverlayEntries) return undefined
+    // Autocomplete owns Esc while the dropdown is open: let the editor
+    // close it (TuiEditor intercepts; kimi parity). Without this the
+    // app-level consume swallows Esc and the dropdown cannot close.
+    // Capability-detected: a REPLACEMENT editor with its own dropdown
+    // gets the same pass-through (its focused component handles Esc).
+    if ((this.seatEditor() as { isShowingAutocomplete?: () => boolean }).isShowingAutocomplete?.() === true) {
+      return undefined
+    }
+    // The host may consume the first Esc (runner-owned modes like the
+    // subagent viewer); otherwise it arms the double-Esc cancel. A
+    // CONSUMED Esc is a fresh action: it disarms any pending window (a
+    // prior declined Esc may have armed it — the consumed Esc must not
+    // leave a stale cancel armed for an unrelated later press).
+    if (this.events.onSingleEscape?.() === true) {
+      this.lastEscapeAt = undefined
+      return { consume: true }
+    }
+    // pi parity: a SINGLE Esc while the agent is busy stops the current
+    // activity (turn, tool run, compaction) — partial content stays on
+    // screen. Idle keeps the double-Esc cancel. The busy cancel is
+    // Host-owned session control and keeps its priority over BOTH the
+    // shell-mode exit below and a replacement editor's own Esc state
+    // machine (a busy Esc must stop the agent, never vanish into a
+    // plugin's modal handling).
+    if (this.busy) {
+      this.lastEscapeAt = undefined
+      this.events.onCancel?.()
+      return { consume: true }
+    }
+    // P1-6: a REPLACEMENT editor owns Esc for its own modal state
+    // machine (vim normal-mode entry) — route it through the editor
+    // channel below instead of the host's double-Esc cancel. If the
+    // plugin DECLINES it, the editor route hands it back to the host
+    // fallback (which includes this cancel path on re-entry).
+    if (this.seatEditor().handleInput !== undefined) {
+      const routed = this.handleReplacementEditorInput(data, this.inputRouterContext(), true)
+      if (routed !== undefined) {
+        // A CONSUMED plugin Esc is a fresh action: disarm any pending
+        // double-Esc window (a prior declined Esc may have armed it).
+        this.lastEscapeAt = undefined
+        return routed
+      }
+      // The plugin DECLINED Esc: continue through the host Esc fallback
+      // (shell-mode exit, double-Esc cancel) instead of dropping the
+      // key — a dropped Esc would never arm the cancel.
+    }
+    // Shell-mode exit: the host editor in a shell mode with an EMPTY
+    // body owns Esc — it cancels the shell mode (the double-Esc cancel
+    // must not fire while the user is composing a shell command). The
+    // pass-through lets the focused editor handle the key, exactly like
+    // the autocomplete branch above. Host-owned priorities (the viewer's
+    // onSingleEscape, the busy cancel, overlays) keep their precedence.
+    if (this.seatEditor().id === 'host' && this.editor.getInputMode() !== 'prompt' && this.seatEditor().getText() === '') {
+      return undefined
+    }
+    const now = Date.now()
+    if (this.lastEscapeAt !== undefined && now - this.lastEscapeAt < TuiApp.ESCAPE_CANCEL_WINDOW_MS) {
+      this.lastEscapeAt = undefined
+      // Conversation rewind (pi parity): an EMPTY editor opens the rewind
+      // picker; a non-empty draft keeps the historical cancel semantics —
+      // a half-written draft is never dragged into a rewind (plan Case C).
+      // A host without rewind keeps the cancel for both cases.
+      if (this.seatEditor().getText().trim() === '' && this.events.onRewind !== undefined) {
+        this.events.onRewind()
+      } else {
+        this.events.onCancel?.()
+      }
+    } else {
+      this.lastEscapeAt = now
+    }
+    return { consume: true }
+  }
+
+  /** The exit path (app.exit.request): Ctrl+C keeps the clear-then-exit
+   * chord (a first press clears a non-empty draft and arms the window; a
+   * second press within it exits); every other key bound to the action
+   * (Ctrl+D or a user remap) exits immediately. */
+  private handleExitKey(data: string): TuiInputListenerResult {
+    if (matchesKey(data, 'ctrl+c')) {
+      // pi parity (handleCtrlC): a first press CLEARS a non-empty editor
+      // (recording the time); a second press within the window on the now
+      // EMPTY editor exits. Issue #8: every arm shows the footer hint for
+      // EXACTLY the exit window (armCtrlCExit), and the exit path disarms
+      // it — the hint never outlives the window.
+      const text = this.seatEditor().getText()
+      // A shell-mode draft is non-empty in its SERIALIZED form: the
+      // first press clears BOTH the body and the mode — an empty `! ` /
+      // `!!` editor would otherwise show a cleared body under a stale
+      // shell prompt, and the next Ctrl+C would exit instead of
+      // completing the pre-mode clear contract.
+      if (text !== '' || this.seatInputMode() !== 'prompt') {
+        this.seatEditor().setText('')
+        this.resetEditorMode()
+        this.editorSeatHolder.notifyChanged()
+        this.armCtrlCExit()
+        // The key is CONSUMED at the app level, so the fork's input path
+        // never reaches the focused editor and never requests its own
+        // frame — without an explicit render the cleared draft stays on
+        // screen until the next keypress (the stale-clear trap, seen in
+        // tmux: the editor reads empty but the old text is still
+        // visible). Same pattern as setDraft/submitDraft.
+        this.requestRender()
+        return { consume: true }
+      }
+      const now = Date.now()
+      if (this.lastCtrlCAt !== undefined && now - this.lastCtrlCAt < this.ctrlCExitWindowMs) {
+        this.clearCtrlCExit()
+        this.events.onExit()
+      } else {
+        // First press on an EMPTY editor changes nothing visible, and the
+        // exit window is easy to miss — announce the armed state so a
+        // slow second press is not a silent no-op (the next Enter would
+        // otherwise send an empty draft). The second press within the
+        // window exits.
+        this.armCtrlCExit()
+      }
+      return { consume: true }
+    }
+    // Ctrl+D (or a user-bound exit key) quits like /exit. The editor's
+    // delete-char-forward remains on the Delete key. Issue #8: an armed
+    // exit chord must not leave its hint behind on a non-chord exit.
+    this.clearCtrlCExit()
+    this.events.onExit()
+    return { consume: true }
+  }
+
+  /** The semantic action → host method surface (plan §9). The dispatcher
+   * never re-implements business state — every method calls the existing
+   * host path, which owns its guards. A method returns false when the key
+   * must fall through (e.g. pasteMedia without a clipboard handler). */
+  private buildActionHost(): AppActionHost {
+    return {
+      submitDraft: (forceQueue = false) => {
+        if (forceQueue) {
+          // The busy-Enter opposite chord (web busyEnter parity): without
+          // a wired onQueueSubmit the key falls through to the editor
+          // instead of dropping the draft; an EMPTY draft falls through
+          // too — plain Enter on an empty editor does not submit, and an
+          // empty chord would otherwise dispatch a session-creating empty
+          // followup.
+          if (this.events.onQueueSubmit === undefined) return false
+          // Emptiness is judged on the SERIALIZED wire form: a bare
+          // `!` / `!!` shell mode has an empty BODY but a non-empty wire
+          // form, and must reach the queue protocol like the literal
+          // prefix did before the mode feature.
+          if (this.serializeSeatDraft(this.seatEditor().getText()).trim() === '') return false
+        }
+        this.submitDraft(forceQueue)
+        return true
+      },
+      steerDraft: () => {
+        // Steer: send the draft into the running turn and clear the
+        // editor. An empty draft still fires the event — the runner
+        // steers every queued message when the queue is non-empty, and
+        // only ignores the key when there is nothing to send at all.
+        // The shell-editor-mode boundary, like the Ctrl+S path: the
+        // editor buffer holds the bare command body, so the wire form is
+        // re-serialized here (serializeSeatDraft) and the mode reset with
+        // the draft.
+        const draft = this.seatEditor().getText()
+        const serialized = this.serializeSeatDraft(draft)
+        this.seatEditor().setText('')
+        this.editorSeatHolder.notifyChanged()
+        this.resetEditorMode()
+        // Consumed at the app level: request the frame ourselves (the
+        // stale-clear trap — see the Ctrl+C branch).
+        this.requestRender()
+        this.events.onSteer?.(serialized)
+        return true
+      },
+      dequeueDraft: () => {
+        // Dequeue (Alt+↑): pull queued input back into the editor.
+        this.events.onDequeue?.()
+        return true
+      },
+      interruptActivity: () => true,
+      requestExit: () => true,
+      openTranscriptSearch: () => {
+        this.startTranscriptSearch()
+        return true
+      },
+      closeTranscriptSearch: () => {
+        this.closeTranscriptSearch()
+        return true
+      },
+      searchNext: () => {
+        this.events.onSearchNext?.()
+        return true
+      },
+      searchPrevious: () => {
+        this.events.onSearchPrev?.()
+        return true
+      },
+      toggleTranscriptExpand: () => {
+        // Fullscreen + Focus: Ctrl+O is the Thought-root bulk owner (plan
+        // §3) — no expanded root → expand the recent `EXPAND_RECENT_TURNS`
+        // eligible roots; any expanded root → Collapse All. Every other
+        // surface/Focus combination keeps the historical tool/system detail
+        // master (regular behavior untouched).
+        if (this.fullscreen !== undefined && this.focusModeEnabled) {
+          this.toggleFullscreenFocusRoots()
+          return true
+        }
+        this.toolOutputExpanded = !this.toolOutputExpanded
+        this.rebuildMessages()
+        return true
+      },
+      toggleThinking: () => {
+        // Alt+T = the Thinking DETAIL bulk owner (never hide/show): every
+        // Thinking block collapses or expands together, Focus ON/OFF and
+        // both surfaces alike. Per-message overrides are cleared first so
+        // the result is predictable (plan §9).
+        this.toggleThinkingExpanded()
+        return true
+      },
+      toggleFullscreen: () => {
+        this.toggleFullscreen()
+        return true
+      },
+      toggleTodo: () => {
+        // Todo panel toggle (kimi semantics; the key never reaches the
+        // editor).
+        this.toggleTodoPanel()
+        return true
+      },
+      cyclePermission: () => {
+        this.events.onCyclePermission?.()
+        return true
+      },
+      openExternalEditor: () => {
+        // External editor. An owned workflow routed through the host's
+        // runOwned (diag attached by the runner): a spawn failure lands in
+        // diagnostics and notifies here — never a bare `void somePromise()`
+        // (AGENTS.md). The editor hook and runOwned are a BOUND pair (type
+        // union + constructor check): without the editor hook the action
+        // is a documented no-op. Single-flight: while one launch is
+        // pending (the latch inside launchExternalEditor is set
+        // synchronously), further presses are consumed without starting
+        // another editor.
+        if (this.events.openExternalEditor !== undefined && !this.externalEditorInFlight) {
+          this.events.runOwned('external editor', () => this.launchExternalEditor(), {
+            onError: (error: unknown) => {
+              this.notify(`external editor failed: ${safeErrorMessage(error)}`, 'error')
+            },
+          })
+        }
+        return true
+      },
+      pasteMedia: () => {
+        // Clipboard paste with image intake (plan M3): with a host handler
+        // the key is consumed and the runner probes the clipboard once —
+        // an image becomes a draft placeholder and plain text falls back
+        // to an editor insert. WITHOUT a handler the key falls through to
+        // the editor exactly like the pre-pipeline behavior.
+        if (this.events.onClipboardPaste === undefined) return false
+        this.events.onClipboardPaste()
+        return true
+      },
+      openTasks: () => {
+        this.events.onOpenTasks?.()
+        return true
+      },
+      openHistorySearch: () => {
+        // Ctrl+R input-history search: unbound (no historySearchSource)
+        // falls through to the editor like any un-reserved key; the
+        // continuable subagent viewer keeps its OWN live editor — the
+        // chord is a no-op there (never the child draft, never the parent
+        // draft).
+        if (this.historySearchSource === undefined || this.viewerMode !== undefined) return false
+        this.openHistorySearch()
+        return true
+      },
+      dismissSettledShell: () => {
+        // Dismiss settled local shell cards (Alt+K — plan §5.4 quick
+        // clear): completed `!`/`!!` runs leave the live view; running
+        // cards never do (the process is NOT cancelled — Esc owns that).
+        this.dismissSettledLocalShell()
+        this.requestRender()
+        return true
+      },
+    }
+  }
+
+  /** The live keybinding context (plan §6): built in ONE place so the
+   * resolver never reads TuiApp private fields. `editorEmpty` is LAZY —
+   * the live editor is only read when a rule predicate actually needs it
+   * (the input path must not add a draft read per keystroke). */
+  private keybindingContext(): KeybindingContext {
+    return deriveKeybindingContext({
+      focusedSeat: this.activeScreen.hasOverlayEntries ? 'overlay' : 'editor',
+      questionActive: this.activeQuestions !== undefined,
+      approvalActive: this.activeApproval !== undefined,
+      viewerMode: this.viewerMode === undefined || this.activeScreen.hasOverlayEntries
+        ? 'none'
+        : isViewerAccessInteractive(resolveViewerAccess(this.viewerMode.mode, this.viewerMode.access)) ? 'continuable' : 'readonly',
+      searchActive: this.searchOverlay !== undefined,
+      overlayActive: this.activeScreen.hasOverlayEntries,
+      agentRunning: this.busy,
+      editorEmpty: () => this.seatEditor().getText().trim() === '',
+      autocompleteActive: (this.seatEditor() as { isShowingAutocomplete?: () => boolean }).isShowingAutocomplete?.() === true,
+      tasksActive: this.tasksActive,
+    })
   }
 
   /** The live surface context the InputRouter reads (M6). */
@@ -3054,6 +3161,9 @@ export class TuiApp {
     if (this.disposed) {
       return { hide: () => {}, setHidden: () => {}, isHidden: () => true, focus: () => {}, unfocus: () => {}, isFocused: () => false }
     }
+    // M6: an overlay owns the focused component now — any pending leader
+    // sequence is cancelled (focus-transition cancellation).
+    this.keybindings.cancelLeader()
     const handle = this.activeScreen.showOverlay(component, options)
     // M8: the stacking graph + suspension rules live in the broker (plan
     // §13 — behavior identical; the existing modal-stacking tests gate
@@ -3287,6 +3397,9 @@ export class TuiApp {
    */
   setFullscreen(enabled: boolean): void {
     if (this.disposed) return
+    // M6: the screen swap is a focus transition — any pending leader
+    // sequence is cancelled.
+    this.keybindings.cancelLeader()
     const active = this.fullscreen !== undefined
     if (enabled === active) return
     const pending = this.activeApproval
@@ -4907,6 +5020,9 @@ export class TuiApp {
    * @param mode - the viewer target; `undefined` leaves the viewer.
    */
   setViewerMode(mode: SubagentViewerTarget | undefined): void {
+    // M6: the viewer owns the input policy now — any pending leader
+    // sequence is cancelled (focus-transition cancellation).
+    this.keybindings.cancelLeader()
     if (mode === undefined) {
       if (this.viewerMode === undefined) return
       const leaving = this.viewerMode
@@ -5096,28 +5212,14 @@ export class TuiApp {
   /** Keys the interactive (continuable) viewer consumes so they can never
    * act on the PARENT session: the host ladder handles them for the main
    * editor, and inside the viewer they must be inert (the child is the
-   * only input target). Esc/Ctrl+O/Enter are deliberately NOT listed —
-   * they fall through to the host's exit/fold/submit paths. */
+   * only input target). ACTION-based (plan §1.2/M1): the key resolves
+   * through the effective keymap, so a user remap of a parent action
+   * stays blocked automatically — the guard never maintains a physical
+   * key list. Esc/Ctrl+O/Enter are deliberately NOT listed — they fall
+   * through to the host's exit/fold/submit paths. */
   private viewerParentLockedKey(data: string): boolean {
-    if (matchesKey(data, 'down') && this.tasksActive && this.seatEditor().getText().trim() === ''
-      && this.seatInputMode() === 'prompt') {
-      // The empty-editor ↓ task-browser trigger must not open the
-      // PARENT's browser from inside the viewer. A shell-mode editor with
-      // an empty body is composing a command — ↓ keeps its editing
-      // meaning, never the browser.
-      return true
-    }
-    return matchesKey(data, 'ctrl+s')        // steer all (parent)
-      || matchesKey(data, 'ctrl+enter')      // queue submit (parent)
-      || matchesKey(data, 'alt+up')          // dequeue (parent)
-      || matchesKey(data, 'shift+tab')       // permission cycle (parent)
-      || matchesKey(data, 'ctrl+f') || matchesKey(data, 'ctrl+shift+f') // main-transcript search
-      || matchesKey(data, 'ctrl+c')          // clear/exit chord (would exit the TUI)
-      || matchesKey(data, 'ctrl+d')          // exit
-      || matchesKey(data, 'ctrl+g')          // external editor (main draft)
-      || matchesKey(data, 'ctrl+t')          // todo panel
-      || matchesKey(data, 'alt+t')           // thinking detail bulk toggle
-      || matchesKey(data, 'ctrl+v')          // clipboard image intake (main draft store)
+    const action = this.keybindings.actionFor(data, this.keybindingContext())
+    return action !== undefined && VIEWER_BLOCKED_PARENT_ACTIONS.has(action as AppKeybindingId)
   }
 
   /** Show a render-time placeholder hint on the host editor (empty draft
@@ -8366,12 +8468,24 @@ export class TuiApp {
     // the exit hint for EXACTLY the exit window (one shared timer) — it
     // temporarily covers the stats, and even the compact preset shows it
     // (the user just triggered an explicit interaction and needs the
-    // feedback).
+    // feedback). M6: a pending leader sequence shows the which-key hint
+    // (the same line-2 slot — the leader is an explicit interaction too).
+    const leader = this.keybindings.leaderMachine()
     const line2 = this.ctrlCExitArmed
-      ? 'Press Ctrl+C again to exit'
-      : this.footerPreset === 'compact' ? '' : this.status.statsLine
+      ? `Press ${this.keybindings.keyHint('app.exit.request')} again to exit`
+      : leader !== undefined && leader.pending
+        ? this.leaderHint(leader)
+        : this.footerPreset === 'compact' ? '' : this.status.statsLine
     this.footer.setText(this.footerRows(line1, line2, width))
     this.requestRender()
+  }
+
+  /** The M6 which-key hint: the pending leader sequence and its
+   * completions (the footer wraps/truncates long lists). */
+  private leaderHint(leader: LeaderStateMachine): string {
+    const completions = leader.leaderBindings
+      .map(binding => `${formatKeyId(binding.key)}: ${APP_KEYBINDINGS[binding.action]?.description ?? binding.action}`)
+    return `Leader: waiting for key — ${completions.join(' · ')} (Esc cancels)`
   }
 
   /** The shared footer layout (plan §14): line 1 wraps with the host row
@@ -9128,6 +9242,9 @@ export class TuiApp {
     }
     this.renderApprovalDialog(pending)
     this.activeApproval = pending
+    // M6: a capturing surface owns the input now — any pending leader
+    // sequence is cancelled (focus-transition cancellation).
+    this.keybindings.cancelLeader()
   }
 
   /** Build and mount the approval dialog for one prompt on the active screen. */
@@ -9289,6 +9406,9 @@ export class TuiApp {
 
   /** Mount one flow into the editor seat and make it the active one. */
   private presentQuestion(state: QuestionState): void {
+    // M6: a question owns the seat now — any pending leader sequence is
+    // cancelled (focus-transition cancellation).
+    this.keybindings.cancelLeader()
     // Set the active flow BEFORE touching overlays: showOverlayOnHost and
     // the suspension bookkeeping branch on it.
     this.activeQuestions = state

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2674,6 +2674,12 @@ export class TuiApp {
         // a remapped interrupt (Ctrl+X) is inert inside the read-only
         // viewer, never the parent's (PR review finding).
         if (matchesKey(data, 'escape')) {
+          // A CONSUMED viewer-close Esc is a fresh action: it disarms any
+          // pending double-Esc window (a prior main-session Esc may have
+          // armed it — the next main-session Esc after closing the viewer
+          // must not read as a second consecutive Esc; PR review
+          // finding). Same discipline as handleEscapeKey.
+          this.lastEscapeAt = undefined
           this.events.onSingleEscape?.()
           return { consume: true }
         }
@@ -2687,6 +2693,9 @@ export class TuiApp {
         // configurable app.agent.interrupt (whose remap could otherwise
         // swallow the exit — PR review finding).
         if (matchesKey(data, 'escape')) {
+          // Same disarm discipline as above: a consumed viewer-close Esc
+          // must not leave a stale double-Esc window for the main session.
+          this.lastEscapeAt = undefined
           this.events.onSingleEscape?.()
           return { consume: true }
         }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -603,7 +603,11 @@ export class BulletedComponent implements Component {
  */
 export class ThinkingCompactComponent implements Component {
   private readonly message: Extract<TranscriptMessage, { kind: 'thinking' }>
-  private readonly hint: ExpandHint
+  /** The rendered fold-hint verb ('alt+t' → the EFFECTIVE thinking key,
+   * 'ctrl+o' → the EFFECTIVE expand key, 'click' for the click-owned
+   * fullscreen secondaries): resolved by the host at build time so a user
+   * remap updates the copy without invalidating the per-width cache. */
+  private readonly hint: string
   private readonly iconStyle: IconStyle
   /** TRUE per-width cache: the same component + same width returns the
    * same array instance even after intermediate widths (a single
@@ -611,7 +615,7 @@ export class ThinkingCompactComponent implements Component {
    * sequence and break the reference-stable contract). */
   private readonly cached = new Map<number, string[]>()
 
-  constructor(message: Extract<TranscriptMessage, { kind: 'thinking' }>, hint: ExpandHint, iconStyle: IconStyle = 'emoji') {
+  constructor(message: Extract<TranscriptMessage, { kind: 'thinking' }>, hint: string, iconStyle: IconStyle = 'emoji') {
     this.message = message
     this.hint = hint
     this.iconStyle = iconStyle
@@ -632,7 +636,7 @@ export class ThinkingCompactComponent implements Component {
       // replay edge): the bare title — never a fake "No reasoning" row.
       lines = [truncateToWidth(title, Math.max(1, width), '…')]
     } else {
-      const hintVerb = this.hint ?? 'ctrl+o'
+      const hintVerb = this.hint || 'the expand key'
       lines = [
         truncateToWidth(title, Math.max(1, width), '…'),
         truncateToWidth(color.textDimItalic(`  ${previewLine}`), Math.max(1, width), '…'),
@@ -1482,10 +1486,12 @@ interface MessageComponentEntry {
    * OR any REGULAR expanded root. Part of the cache identity — a
    * Focus toggle must rebuild the diff presentation. */
   fullReveal: boolean
-  /** The fold-hint owner: click (fullscreen mouse-owned), ctrl+o (the
+/** The fold-hint owner: click (fullscreen mouse-owned), ctrl+o (the
    * keyboard master), alt+t (the Thinking bulk owner) or undefined
    * (regular Focus secondaries are always full). Part of the cache
-   * identity — a surface switch must not reuse the old hint. */
+   * identity — a surface switch must not reuse the old hint. The RENDERED
+   * hint resolves the EFFECTIVE key through the keymap (a remap updates
+   * the copy; the identity field stays semantic). */
   expandHint: ExpandHint
   /** The values the component was built from, for O(1) staleness checks:
    * text-bearing kinds compare the CURRENT text object — an unchanged
@@ -6817,7 +6823,7 @@ export class TuiApp {
       // output), wrapping normally per the Text/Markdown policy; the
       // compact preview is never repeated next to the full body.
       if (!expanded) {
-        return new ThinkingCompactComponent(message, expandHint, this.iconStyle)
+        return new ThinkingCompactComponent(message, this.expandHint(expandHint), this.iconStyle)
       }
       const head = color.textDim(`${iconLead('thinking', this.iconStyle)}Thinking`)
       const body = message.text === '' ? '' : message.text.split('\n').map(line => `  ${line}`).join('\n')
@@ -6868,7 +6874,7 @@ export class TuiApp {
           // contract), so the baked line fits the paint width exactly and
           // the row can never wrap.
           row.addChild(new Text(truncateToWidth(
-            color.textMuted(`${icon}Context injection ${message.label}${summary} (${expandHint ?? 'ctrl+o'} to expand)`),
+            color.textMuted(`${icon}Context injection ${message.label}${summary} (${this.expandHint(expandHint)} to expand)`),
             width,
             '…',
           ), 0, 0))
@@ -6878,7 +6884,7 @@ export class TuiApp {
       const unwrapped = systemContextBody(message.text)?.join('\n') ?? message.text
       const text = expanded
         ? `${color.textMuted('§')} ${color.textDim(unwrapped)}`
-        : color.textMuted(`§ ${truncateToWidth(preview(unwrapped, 2), Math.max(1, width - 22), '…')} (${expandHint ?? 'ctrl+o'} to expand)`)
+        : color.textMuted(`§ ${truncateToWidth(preview(unwrapped, 2), Math.max(1, width - 22), '…')} (${this.expandHint(expandHint)} to expand)`)
       return new Text(text, 0, 0)
     }
     if (message.kind === 'summary') {
@@ -6912,7 +6918,7 @@ export class TuiApp {
       } else {
         const summary = counts === '' ? '' : counts
         card.addChild(new Text(truncateToWidth(
-          color.textDim(`${summary}${summary === '' ? '' : ' '}(${expandHint ?? 'ctrl+o'} to expand)`),
+          color.textDim(`${summary}${summary === '' ? '' : ' '}(${this.expandHint(expandHint)} to expand)`),
           width,
           '…',
         ), 0, 0))
@@ -7045,7 +7051,7 @@ export class TuiApp {
           rows.push(`${indent}${' '.repeat(visibleWidth(prompt))}${truncateToWidth(color.textDim(line), contentWidth, '…')}`)
         }
         if (commandLines.length > FOLDED_COMMAND_LINES) {
-          rows.push(color.textDim(`${indent}… ${commandLines.length - FOLDED_COMMAND_LINES} more command lines (${expandHint ?? 'ctrl+o'} to expand)`))
+          rows.push(color.textDim(`${indent}… ${commandLines.length - FOLDED_COMMAND_LINES} more command lines (${this.expandHint(expandHint)} to expand)`))
         }
         // The result preview gets its own row so the command never shares a
         // line with output (kimi ShellExecution layout).
@@ -7056,7 +7062,7 @@ export class TuiApp {
         rows.push(truncateToWidth(`${headWithPreview}`, width, '…'))
         for (const line of renderDiffView(callPreview.diffs, this.workspaceRoot, {
           maxLines: FOLDED_DIFF_LINES,
-          expandHint: `${expandHint ?? 'ctrl+o'} to expand`,
+          expandHint: `${this.expandHint(expandHint)} to expand`,
         })) {
           rows.push(`  ${line}`)
         }
@@ -8178,7 +8184,7 @@ export class TuiApp {
     }
     const hasSteerable = userRows.length > 0
     const hint = hasSteerable
-      ? 'ctrl+s to steer all · alt+↑ to edit all'
+      ? `${(this.keybindings.keyHint('app.input.steer') || 'the steer key').toLowerCase()} to steer all · ${(this.keybindings.keyHint('app.input.dequeue') || 'the recall key').toLowerCase()} to edit all`
       : 'notices deliver after the current task · /tasks to view'
     lines.push(color.textDim(truncateToWidth(`  ${hint}`, Math.max(1, width - 2), '…')))
     this.queuePane.setText(lines.join('\n'))
@@ -8524,6 +8530,21 @@ export class TuiApp {
     const completions = leader.leaderBindings
       .map(binding => `${formatKeyId(binding.key)}: ${APP_KEYBINDINGS[binding.action]?.description ?? binding.action}`)
     return `Leader: waiting for key — ${completions.join(' · ')} (Esc cancels)`
+  }
+
+  /** The fold-hint verb of one collapsible card: 'click' for the
+   * click-expandable owners, else the EFFECTIVE key of the owning action
+   * ('alt+t' → the Thinking bulk owner, 'ctrl+o' → the expand master; a
+   * user remap updates every `to expand` hint; a disabled action falls
+   * back to a neutral phrase instead of a stale default). */
+  private expandHint(hint: ExpandHint): string {
+    if (hint === 'click') return 'click'
+    if (hint === 'alt+t') {
+      const thinking = this.keybindings.keyHint('app.transcript.toggleThinking')
+      return thinking === '' ? 'the thinking key' : thinking.toLowerCase()
+    }
+    const expand = this.keybindings.keyHint('app.transcript.toggleExpand')
+    return expand === '' ? 'the expand key' : expand.toLowerCase()
   }
 
   /** The shared footer layout (plan §14): line 1 wraps with the host row

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7205,7 +7205,7 @@ export class TuiApp {
       rows.push(`${indent}${truncateToWidth(color.textDim(line), contentWidth, '…')}`)
     }
     if (preview.hidden > 0) {
-      rows.push(color.textDim(`${indent}${localShellHiddenMarker(preview.hidden, running, preview.partial)}`))
+      rows.push(color.textDim(`${indent}${localShellHiddenMarker(preview.hidden, running, preview.partial, this.expandHint(false))}`))
     }
     card.addChild(new Text(rows.join('\n'), 0, 0))
   }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2354,6 +2354,13 @@ export class TuiApp {
     // Issue #8: the exit-chord timer dies with the surface — a stopped
     // TUI must never fire a stale disarm into a dead footer.
     this.clearCtrlCExit()
+    // A stop/start cycle is a fresh surface lifecycle: a PENDING leader
+    // sequence must be cancelled (its timeout must never fire into the
+    // stopped surface) and the interrupt double-action window must not
+    // survive the restart (a post-start interrupt must not read as the
+    // second press of a pre-stop one — convergence findings).
+    this.keybindings.cancelLeader()
+    this.lastEscapeAt = undefined
     this.working.dispose()
     // Every pending question flow settles rejected: a stopped TUI must not
     // leave askQuestions promises hanging forever.

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2367,6 +2367,18 @@ export class TuiApp {
   dispose(): void {
     if (this.disposed) return
     this.disposed = true
+    // Restore the fork's global submit binding to the builtin default:
+    // the fork keybindings are PROCESS-GLOBAL, and a disposed surface
+    // must not leak its remap/disable into a LATER TuiApp instance (PR
+    // review finding — remap → stop → new app inherited ctrl+x/inert
+    // Enter). The manager's constructor re-syncs the builtin default for
+    // a fresh instance too; this covers the no-new-instance case.
+    try {
+      const kb = getKeybindings()
+      kb.setUserBindings({ ...kb.getUserBindings(), 'tui.input.submit': 'enter' })
+    } catch {
+      // Best effort: the global keybindings may already be torn down.
+    }
     // Settle every pending approval BEFORE stop(): settling hides overlay
     // handles (hideCursor), and stop() ends with showCursor — the reverse
     // order would leave the user's cursor hidden after exit. Iterate a COPY:

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -16,6 +16,7 @@ import { Context } from '@deepseek-ai/cordis'
 import { CommandId } from '@deepseek-ai/dsh-commands'
 import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from '../src/commands.ts'
 import { LOCAL_COMMANDS, shouldSteerOnEnter } from '../src/index.ts'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
 import { createDiag } from '../src/diag.ts'
 import { TuiApp } from '../src/tui-app.ts'
 import { DraftImageStore } from '../src/image/draft-store.ts'
@@ -199,11 +200,23 @@ function setup(options: { busyEnter?: string; localShellSandbox?: string } = {})
       rawInput,
       signal: new AbortController().signal,
     })
+  // Run ANY registered command (defaults to /settings for the existing
+  // tests; /help uses the same surface).
+  const runCommand = async (name: string, rawInput = ''): Promise<unknown> => {
+    const found = commands.defs.find(entry => entry.name === name)
+    assert.ok(found?.handler !== undefined, `${name} handler missing`)
+    return (found!.handler as (inv: { commandId: string; agent: never; rawInput: string; signal: AbortSignal }) => unknown)({
+      commandId: CommandId('cmd-test-1'),
+      agent: undefined as never,
+      rawInput,
+      signal: new AbortController().signal,
+    })
+  }
   const view = async (): Promise<string> => {
     await vt.waitForRender()
     return vt.getViewport().join('\n')
   }
-  return { vt, app, run, view, settings, registered: commands.defs.map(def => def.name) }
+  return { vt, app, run, runCommand, view, settings, registered: commands.defs.map(def => def.name) }
 }
 
 test('every command registerTuiCommands registers is in LOCAL_COMMANDS', () => {
@@ -220,7 +233,10 @@ test('/settings shows the busy-enter row with the persisted value', async () => 
   const t = setup({ busyEnter: 'steer' })
   await t.run('')
   const view = await t.view()
-  assert.ok(view.includes('Enter while busy'), `busy-enter row missing:\n${view}`)
+  // Key-neutral label (review round 37): the preference is the semantic
+  // SUBMIT action's busy behavior — never a physical Enter claim (the
+  // submit key may be remapped).
+  assert.ok(view.includes('Submit while busy'), `busy-enter row missing:\n${view}`)
   assert.ok(view.includes('steer'), `persisted value missing:\n${view}`)
   t.app.stop()
 })
@@ -304,4 +320,35 @@ test('shouldSteerOnEnter: /skill <name> with args steers; the bare picker does n
   assert.equal(bare, false, 'the bare /skill picker stays local')
   const idle = shouldSteerOnEnter({ name: 'skill', rawInput: 'grilling x' }, false, 'steer', false)
   assert.equal(idle, false, 'idle never steers')
+})
+
+test('/help copy is key-neutral after a remap — no stale bare Esc/Enter claims (review round 37)', async () => {
+  // The effective-key copy convention: after remapping interrupt -> ctrl+x
+  // and submit -> ctrl+z, /help must NOT claim the physical Esc (the
+  // double-action follows the EFFECTIVE interrupt key) or Enter (submit).
+  // The prose is semantic/key-neutral; the LABEL column shows the
+  // effective keys (`Ctrl+X`, `Ctrl+Z`). The settings panel shows the
+  // SELECTED row's description only, so navigate to each row.
+  const t = setup()
+  t.app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    'app.agent.interrupt': 'ctrl+x',
+    'app.input.submit': 'ctrl+z',
+  }))
+  await t.runCommand('help')
+  let view = await t.view()
+  // The first row (submit) is selected: its label shows the effective key
+  // and its description is visible.
+  assert.ok(view.includes('Ctrl+Z'), `the effective submit key must be shown:\n${view}`)
+  const submitRow = view.split('\n').find(line => line.includes('Submit the draft'))
+  assert.ok(submitRow !== undefined, 'the selected submit row must render its description')
+  assert.ok(!submitRow!.includes('Enter'), `the submit row must not claim physical Enter:\n${submitRow}`)
+  // Navigate down to the cancel row (row 3: submit, queue, exit, cancel).
+  for (let i = 0; i < 3; i += 1) t.vt.sendInput('\x1b[B')
+  view = await t.view()
+  // The cancel description wraps across panel lines — search the whole
+  // viewport (the label row itself only carries the effective key).
+  assert.ok(view.includes('Cancel the active turn'), 'the selected cancel row must render its description')
+  assert.ok(!view.includes('one Esc while'), `the cancel copy must not claim physical Esc:\n${view}`)
+  assert.ok(view.includes('interrupt action twice'), 'the cancel prose is key-neutral (semantic action)')
+  t.app.stop()
 })

--- a/test/extension-cordis-lifecycle.test.ts
+++ b/test/extension-cordis-lifecycle.test.ts
@@ -662,7 +662,22 @@ test('M5: the keybinding registry rejects non-public actions and printable keys 
       id: 'bad-space',
       key: { key: 'space', ctrl: false, alt: false, shift: false, super: false },
       action: 'open-search',
-    }), /printable/, 'a printable key must be rejected through the public path')
+    }), /text-producing/, 'a text-producing key must be rejected through the public path')
+    // Shift-only text keys are text on every protocol (Shift+A is the 'A'
+    // byte on legacy, 'a'+shift on Kitty) — rejected like unmodified ones
+    // (round-17 finding: they used to steal typing on Kitty).
+    assert.throws(() => service.registerKeybinding({
+      id: 'bad-shift-a',
+      key: { key: 'a', ctrl: false, alt: false, shift: true, super: false },
+      action: 'open-search',
+    }), /text-producing/, 'Shift+A must be rejected through the public path')
+    // A key name the fork grammar can never produce can never fire:
+    // rejected at registration (round-17 finding).
+    assert.throws(() => service.registerKeybinding({
+      id: 'bad-name',
+      key: { key: 'definitely-not-a-key', ctrl: true, alt: false, shift: false, super: false },
+      action: 'open-search',
+    }), /not a valid key/, 'a non-grammar key name must be rejected through the public path')
     // A legacy C0 alias (Ctrl+I is the Tab byte on legacy terminals) can
     // never fire through the plugin stage either: rejected through the
     // public path, sharing the config parser's legacy inventory (round-13

--- a/test/extension-cordis-lifecycle.test.ts
+++ b/test/extension-cordis-lifecycle.test.ts
@@ -597,7 +597,10 @@ test('M5: command/theme/setting registrations are fiber-bound (owner unload clea
       svc.registerAutocomplete({ id: 'auto-a', provider: { getSuggestions: async () => null } })
       svc.registerKeybinding({
         id: 'key-a',
-        key: { key: 'k', ctrl: false, alt: false, shift: false, super: false },
+        // A modified chord: a plain printable key is rejected at
+        // registration (the router keeps printable keys with the editor,
+        // so the binding could never fire — round-12 finding).
+        key: { key: 'k', ctrl: true, alt: true, shift: false, super: false },
         action: 'open-search',
       })
     })
@@ -620,6 +623,56 @@ test('M5: command/theme/setting registrations are fiber-bound (owner unload clea
     assert.equal(service.themes.hasAny(), false)
     assert.equal(service.settings.hasAny(), false)
     assert.equal(service.autocomplete.hasAny(), false)
+    assert.equal(service.keybindings.hasAny(), false)
+    await host()
+    await startup()
+  } finally {
+    for (const runtime of [...ctx.registry.values()]) {
+      for (const fiber of runtime.fibers) await Promise.resolve(fiber.dispose())
+    }
+  }
+})
+
+test('M5: the keybinding registry rejects non-public actions and printable keys through the PUBLIC path (round 12)', async () => {
+  const ctx = new Context()
+  try {
+    await ctx.plugin(Loader)
+    const startup = await mount(ctx, startupPlugin)
+    const host = await mount(ctx, applyExtensionHost)
+    const service = ctx.get(PI_TUI_EXTENSIONS_SERVICE) as {
+      registerKeybinding(contribution: {
+        id: string
+        key: { key: string; ctrl: boolean; alt: boolean; shift: boolean; super: boolean }
+        action: string
+      }): { id: string; dispose(): void }
+      keybindings: { hasAny(): boolean }
+    }
+    assert.ok(service !== undefined)
+    // A Host-private app.* action is NOT a public TuiAction: the runtime
+    // whitelist must reject it through the PUBLIC extension path — a
+    // JS/`as any` plugin can never trigger the Host dispatcher with it
+    // (capability boundary, round-12 finding).
+    assert.throws(() => service.registerKeybinding({
+      id: 'bad-exit',
+      key: { key: 'x', ctrl: true, alt: false, shift: false, super: false },
+      action: 'app.exit.request' as never,
+    }), /not a public TuiAction/, 'a Host-private action string must be rejected through the public path')
+    // A plain printable key can never reach the plugin stage: rejected too.
+    assert.throws(() => service.registerKeybinding({
+      id: 'bad-space',
+      key: { key: 'space', ctrl: false, alt: false, shift: false, super: false },
+      action: 'open-search',
+    }), /printable/, 'a printable key must be rejected through the public path')
+    // A public action + modified chord registers fine.
+    const handle = service.registerKeybinding({
+      id: 'good',
+      key: { key: 'x', ctrl: true, alt: true, shift: false, super: false },
+      action: 'open-search',
+    })
+    await settle()
+    assert.equal(service.keybindings.hasAny(), true)
+    handle.dispose()
+    await settle()
     assert.equal(service.keybindings.hasAny(), false)
     await host()
     await startup()

--- a/test/extension-cordis-lifecycle.test.ts
+++ b/test/extension-cordis-lifecycle.test.ts
@@ -678,6 +678,14 @@ test('M5: the keybinding registry rejects non-public actions and printable keys 
       key: { key: 'definitely-not-a-key', ctrl: true, alt: false, shift: false, super: false },
       action: 'open-search',
     }), /not a valid key/, 'a non-grammar key name must be rejected through the public path')
+    // A fork EDITOR-owned key (Tab) is consumed by the focused editor
+    // before the plugin stage — the registration is rejected instead of
+    // advertising a dead rule (round-19 finding).
+    assert.throws(() => service.registerKeybinding({
+      id: 'bad-tab',
+      key: { key: 'tab', ctrl: false, alt: false, shift: false, super: false },
+      action: 'open-search',
+    }), /editor/, 'an editor-owned key must be rejected through the public path')
     // A legacy C0 alias (Ctrl+I is the Tab byte on legacy terminals) can
     // never fire through the plugin stage either: rejected through the
     // public path, sharing the config parser's legacy inventory (round-13

--- a/test/extension-cordis-lifecycle.test.ts
+++ b/test/extension-cordis-lifecycle.test.ts
@@ -663,6 +663,16 @@ test('M5: the keybinding registry rejects non-public actions and printable keys 
       key: { key: 'space', ctrl: false, alt: false, shift: false, super: false },
       action: 'open-search',
     }), /printable/, 'a printable key must be rejected through the public path')
+    // A legacy C0 alias (Ctrl+I is the Tab byte on legacy terminals) can
+    // never fire through the plugin stage either: rejected through the
+    // public path, sharing the config parser's legacy inventory (round-13
+    // finding — the EffectiveKeymap would resolve it but the router's
+    // normalized lookup never would).
+    assert.throws(() => service.registerKeybinding({
+      id: 'bad-legacy',
+      key: { key: 'i', ctrl: true, alt: false, shift: false, super: false },
+      action: 'open-search',
+    }), /legacy terminal/, 'a legacy C0 key must be rejected through the public path')
     // A public action + modified chord registers fine.
     const handle = service.registerKeybinding({
       id: 'good',

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -552,15 +552,17 @@ test('KeybindingRegistry: duplicate keys conflict; unload removes bindings', () 
   const registry = new KeybindingRegistry()
   const handle = registry.register({
     id: 'k1',
-    key: { key: 'y', ctrl: false, alt: true, shift: false, super: false },
+    // Ctrl+Alt+Y: not editor-owned (yank is Alt+Y / Ctrl+Y — round-19
+    // finding), so it is a bindable plugin chord.
+    key: { key: 'y', ctrl: true, alt: true, shift: false, super: false },
     action: 'open-search',
   }, 'o')
   assert.throws(() => registry.register({
     id: 'k2',
-    key: { key: 'y', ctrl: false, alt: true, shift: false, super: false },
+    key: { key: 'y', ctrl: true, alt: true, shift: false, super: false },
     action: 'cancel-activity',
   }, 'o2'), /duplicate keybinding/)
-  assert.equal(registry.actionFor({ key: 'y', ctrl: false, alt: true, shift: false, super: false }), 'open-search')
+  assert.equal(registry.actionFor({ key: 'y', ctrl: true, alt: true, shift: false, super: false }), 'open-search')
   handle.dispose()
   assert.equal(registry.actionFor({ key: 'y', ctrl: false, alt: true, shift: false, super: false }), undefined)
 })

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -496,9 +496,10 @@ test('KeybindingRegistry: reserved host keys are rejected (full lifecycle invent
     { key: 'g', ctrl: true, shift: false },
     { key: 'r', ctrl: true, shift: false },   // Ctrl+R input-history search
     { key: 'v', ctrl: true, shift: false },   // Ctrl+V clipboard image intake
-    // Ctrl+J is deliberately NOT reserved anymore: legacy terminals send
-    // it as LF (the editor's Enter), so the host dropped the binding and a
-    // plugin may claim the chord itself.
+    // Ctrl+J is NOT in the reserved inventory (the host no longer binds
+    // it — legacy LF ambiguity), but the SHARED legacy-collision policy
+    // rejects a plugin registration on it anyway (round-13 finding): on a
+    // legacy terminal the byte IS Enter, so the binding could never fire.
     { key: 'enter', ctrl: true, shift: false },
   ]
   for (let index = 0; index < reserved.length; index++) {
@@ -535,15 +536,16 @@ test('KeybindingRegistry: reserved host keys are rejected (full lifecycle invent
       action: 'open-search',
     }, 'o'), /reserved/, `${binding.alt ? 'Alt+' : 'Shift+'}${binding.key} must be reserved`)
   }
-  // Ctrl+J is free for plugins: the host no longer binds it (legacy LF
-  // ambiguity), so a plugin registration must NOT be rejected.
-  const handle = registry.register({
+  // Ctrl+J is NOT free for plugins either (round-13 finding): on legacy
+  // terminals it IS the LF/Enter byte — the registry shares the config
+  // parser's legacy-collision policy, so the registration is rejected
+  // (the router's normalized lookup could never match the raw byte, and
+  // the editor would consume it first).
+  assert.throws(() => registry.register({
     id: 'k-ctrl-j',
     key: { key: 'j', ctrl: true, alt: false, shift: false, super: false },
     action: 'open-search',
-  }, 'o')
-  assert.ok(handle !== undefined, 'a plugin must be able to claim Ctrl+J')
-  handle.dispose()
+  }, 'o'), /legacy terminal/, 'Ctrl+J must be rejected as a legacy collision, not claimable')
 })
 
 test('KeybindingRegistry: duplicate keys conflict; unload removes bindings', () => {

--- a/test/input-router.test.ts
+++ b/test/input-router.test.ts
@@ -18,9 +18,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { InputRouter } from '../src/input-router.ts'
-import { RESERVED_HOST_KEYS } from '../src/keybinding-registry.ts'
 import type { NormalizedKey, TuiAction } from '../src/extension/public-types.ts'
 
+/** The default context: NO host action resolves anything (the effective
+ * keymap is empty) — so no key is runtime-reserved. Tests that need the
+ * OLD reserved behavior pass `hostResolves` explicitly. */
 function context(overrides: Partial<Parameters<InputRouter['route']>[1]> = {}): Parameters<InputRouter['route']>[1] {
   return {
     questionActive: false,
@@ -28,12 +30,13 @@ function context(overrides: Partial<Parameters<InputRouter['route']>[1]> = {}): 
     viewerInputMode: 'none',
     hasOverlay: false,
     searchActive: false,
+    hostResolves: () => false,
     ...overrides,
   }
 }
 
 function router(): InputRouter {
-  return new InputRouter(RESERVED_HOST_KEYS)
+  return new InputRouter()
 }
 
 function noBindings(): (key: NormalizedKey) => TuiAction | undefined {
@@ -94,11 +97,21 @@ test('InputRouter: the interactive (continuable) viewer keeps the editor live as
   // bindings LAST in the ladder — but its route is NOT viewer-editor.
   const chord = r.route('\x1b\x18', interactive, () => 'open-search' as TuiAction)
   assert.equal(chord.kind, 'plugin-action')
-  // Reserved keys stay consumed (the HOST consumes Enter and the parent
-  // chords BEFORE the router — see the TuiApp-level tests).
-  assert.equal(r.route('\r', interactive, noBindings()).kind, 'consumed')
-  assert.equal(r.route('\x1b[13;5u', interactive, noBindings()).kind, 'consumed')
-  assert.equal(r.route('\x1b[115;5u', interactive, noBindings()).kind, 'consumed')
+  // Active host keys stay consumed (the HOST consumes Enter and the
+  // parent chords — the TuiApp ladder runs BEFORE the router, and the
+  // router's action-driven reservation reports them consumed so a plugin
+  // can never claim them). In the unit context the host actions are
+  // explicit via hostResolves.
+  const withHost = context({
+    viewerInputMode: 'continuable',
+    hostResolves: (data) => data === '\r' || data === '\x1b[13;5u' || data === '\x1b[115;5u',
+  })
+  assert.equal(r.route('\r', withHost, noBindings()).kind, 'consumed')
+  assert.equal(r.route('\x1b[13;5u', withHost, noBindings()).kind, 'consumed')
+  assert.equal(r.route('\x1b[115;5u', withHost, noBindings()).kind, 'consumed')
+  // With NO active host action the same keys are NOT reserved — they
+  // route to the child editor (the remapped-away case).
+  assert.equal(r.route('\r', interactive, noBindings()).kind, 'viewer-editor')
 })
 
 test('InputRouter: a replacement editor inside the interactive viewer still routes editor-first', () => {
@@ -113,29 +126,50 @@ test('InputRouter: a replacement editor inside the interactive viewer still rout
   assert.equal(bindingCalls, 0, 'plugin bindings are not consulted before the editor route')
 })
 
-test('InputRouter: Ctrl+F transcript search is reserved from plugin bindings', () => {
+test('InputRouter: a key an ACTIVE host action binds is reserved from plugin bindings', () => {
   const r = router()
-  assert.equal(r.route('\x06', context(), () => 'open-search').kind, 'consumed')
+  // Ctrl+F with app.transcript.search active: the host ladder owns it —
+  // the router reports consumed so a plugin can never claim it.
+  const withHost = context({ hostResolves: (data) => data === '\x06' })
+  assert.equal(r.route('\x06', withHost, () => 'open-search').kind, 'consumed')
+  // The same key with NO active host action is NOT reserved — it falls
+  // through (the remapped-away old key case).
+  assert.equal(r.route('\x06', context(), () => 'open-search' as TuiAction).kind, 'plugin-action')
 })
 
-test('InputRouter: Ctrl+R input-history search is reserved from plugin bindings', () => {
+test('InputRouter: Ctrl+R is runtime-reserved only while a host action binds it', () => {
   const r = router()
+  const withHost = context({ hostResolves: (data) => data === '\x12' })
   // Legacy Ctrl+R is \x12; kitty/modifyOtherKeys reports ctrl+r too.
-  assert.equal(r.route('\x12', context(), () => 'open-search').kind, 'consumed')
-  // The key stays consumed under an overlay (the overlay owns it) and in
-  // the read-only viewer (the viewer locks everything except Esc/Ctrl+O).
+  assert.equal(r.route('\x12', withHost, () => 'open-search').kind, 'consumed')
+  // Under an overlay the overlay owns the key regardless.
   assert.equal(r.route('\x12', context({ hasOverlay: true }), () => 'open-search').kind, 'consumed')
+  // No host action → not reserved → plugin/editor path.
+  assert.equal(r.route('\x12', context(), () => 'open-search' as TuiAction).kind, 'plugin-action')
 })
 
-test('InputRouter: reserved host lifecycle keys never reach a plugin binding', () => {
+test('InputRouter: a remapped-away legacy host key falls through (action-driven reservation)', () => {
   const r = router()
-  // Ctrl+C is reserved: the host ladder handles it; the router reports the
-  // route as consumed BEFORE the plugin stage (the plugin can never claim
-  // it — the M5 registry already rejects registration).
-  const result = r.route('\x03', context(), () => 'open-search' as TuiAction)
+  // The PR review repro: app.clipboard.pasteMedia was remapped from
+  // Ctrl+V to Ctrl+P. Ctrl+V is NO LONGER an active host action — the
+  // router must NOT swallow it; it falls through to the editor/plugin.
+  const noHostForV = context({ hostResolves: () => false })
+  // The plugin can claim Ctrl+V now (it is not runtime-reserved).
+  assert.equal(r.route('\x16', noHostForV, () => 'open-search' as TuiAction).kind, 'plugin-action')
+  // With the host action STILL live on Ctrl+V, it stays consumed.
+  const hostOnV = context({ hostResolves: (data) => data === '\x16' })
+  assert.equal(r.route('\x16', hostOnV, () => 'open-search' as TuiAction).kind, 'consumed')
+})
+
+test('InputRouter: a reserved host lifecycle key never reaches a plugin binding when active', () => {
+  const r = router()
+  // Ctrl+C with the exit action active: consumed before the plugin stage.
+  const withExit = context({ hostResolves: (data) => data === '\x03' })
+  const result = r.route('\x03', withExit, () => 'open-search' as TuiAction)
   assert.equal(result.kind, 'consumed')
-  // Enter is reserved too.
-  const enter = r.route('\r', context(), () => 'open-search' as TuiAction)
+  // Enter with submit active: consumed (the host/editor owns it).
+  const withSubmit = context({ hostResolves: (data) => data === '\r' })
+  const enter = r.route('\r', withSubmit, () => 'open-search' as TuiAction)
   assert.equal(enter.kind, 'consumed')
 })
 
@@ -340,7 +374,7 @@ test('TuiApp: an untracked keybinding error is not reported under the key name',
   app.stop()
 })
 
-test('TuiApp: Enter / Ctrl+J / Ctrl+Enter never fire a plugin binding (round-1 P1)', async () => {
+test('TuiApp: active host lifecycle keys never fire a plugin binding (action-driven)', async () => {
   const { VirtualTerminal } = await import('./virtual-terminal.ts')
   const { TuiApp } = await import('../src/tui-app.ts')
   const vt = new VirtualTerminal(80, 24)
@@ -351,26 +385,62 @@ test('TuiApp: Enter / Ctrl+J / Ctrl+Enter never fire a plugin binding (round-1 P
     onExtensionAction: (action) => { actions.push(action) },
   }, {
     // A resolver that would claim EVERY key — the router must stop the
-    // reserved ones before it is consulted.
+    // ACTIVE host lifecycle ones before it is consulted.
     pluginActionFor: (key) => `open-search` as const,
   })
   app.start()
   await vt.waitForRender()
-  // Plain Enter (reserved): must NOT fire — the editor consumes it.
+  // Plain Enter: the editor consumes it (tui.input.submit) — never a
+  // plugin binding.
   vt.sendInput('\r')
   await vt.waitForRender()
   assert.deepEqual(actions, [], 'Enter must never fire a plugin binding')
-  // Ctrl+J with no tasks (the host handler falls through): the reserved
-  // gate must still stop it.
-  vt.sendInput('\x1b[106;5u') // kitty ctrl+j — check normalization
-  await vt.waitForRender()
-  // Ctrl+Enter without an onQueueSubmit handler: reserved, must not fire.
+  // Ctrl+Enter (app.input.queue): an ACTIVE host action in the default
+  // keymap — consumed by the host ladder, never a plugin binding.
   vt.sendInput('\x1b[13;5u') // kitty ctrl+enter
   await vt.waitForRender()
-  // Ctrl+O (reserved host fold toggle). Kitty ctrl+o = modifier 5.
+  // Ctrl+O (app.transcript.toggleExpand): ACTIVE host action — never a
+  // plugin binding. Kitty ctrl+o = modifier 5.
   vt.sendInput('\x1b[111;5u')
   await vt.waitForRender()
-  assert.deepEqual(actions, [], 'reserved keys must never fire a plugin binding')
+  assert.deepEqual(actions, [], 'active host lifecycle keys must never fire a plugin binding')
+  app.stop()
+})
+
+test('TuiApp: a key with NO active host action falls through to a plugin binding (remapped-away)', async () => {
+  const { VirtualTerminal } = await import('./virtual-terminal.ts')
+  const { TuiApp } = await import('../src/tui-app.ts')
+  const vt = new VirtualTerminal(80, 24)
+  const actions: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onExtensionAction: (action) => { actions.push(action) },
+  }, {
+    // The PR review repro: a plugin binds Ctrl+V — legal AFTER the host
+    // remapped app.clipboard.pasteMedia away from Ctrl+V (action-driven
+    // reservation: no host action binds Ctrl+V anymore, so the plugin
+    // may claim it). With the DEFAULT keymap Ctrl+V IS a host action, so
+    // this plugin binding must NOT fire — verify both sides.
+    pluginActionFor: (key) => key.key === 'v' && key.ctrl ? 'open-search' as const : undefined,
+  })
+  app.start()
+  await vt.waitForRender()
+  // Default keymap: Ctrl+V is app.clipboard.pasteMedia (ACTIVE host
+  // action) — the host ladder consumes it, the plugin never sees it.
+  vt.sendInput('\x16')
+  await vt.waitForRender()
+  assert.deepEqual(actions, [], 'an active host action key must not reach a plugin binding')
+  // Remap pasteMedia away from Ctrl+V: now NOT reserved — but the host
+  // ladder also does not consume it, so with the HOST EDITOR in the seat
+  // the key reaches the editor (the plugin binding is consulted only for
+  // keys the editor declines; Ctrl+V is editor-owned copy). The key is
+  // never SWALLOWED: it reaches the editor instead of being dropped.
+  const { parseUserKeybindings } = await import('../src/keybindings/config.ts')
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.clipboard.pasteMedia': 'ctrl+p' }))
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.length > 0, 'the surface keeps rendering after the remap')
   app.stop()
 })
 

--- a/test/input-router.test.ts
+++ b/test/input-router.test.ts
@@ -379,13 +379,17 @@ test('TuiApp: active host lifecycle keys never fire a plugin binding (action-dri
   const { TuiApp } = await import('../src/tui-app.ts')
   const vt = new VirtualTerminal(80, 24)
   const actions: string[] = []
+  const queued: string[] = []
   const app = new TuiApp(vt, {
     onSubmit: () => {},
     onExit: () => {},
+    // A real queue handler: with it wired, Ctrl+Enter is a live host
+    // action that CONSUMES (never declines) — the plugin must not see it.
+    onQueueSubmit: (text) => { queued.push(text) },
     onExtensionAction: (action) => { actions.push(action) },
   }, {
     // A resolver that would claim EVERY key — the router must stop the
-    // ACTIVE host lifecycle ones before it is consulted.
+    // ACTIVE (non-declining) host lifecycle ones before it is consulted.
     pluginActionFor: (key) => `open-search` as const,
   })
   app.start()
@@ -395,10 +399,13 @@ test('TuiApp: active host lifecycle keys never fire a plugin binding (action-dri
   vt.sendInput('\r')
   await vt.waitForRender()
   assert.deepEqual(actions, [], 'Enter must never fire a plugin binding')
-  // Ctrl+Enter (app.input.queue): an ACTIVE host action in the default
-  // keymap — consumed by the host ladder, never a plugin binding.
+  // Ctrl+Enter (app.input.queue) with a LIVE handler AND a non-empty
+  // draft: the host action CONSUMES (queues) — never a plugin binding.
+  app.setDraft('queued text')
+  await vt.waitForRender()
   vt.sendInput('\x1b[13;5u') // kitty ctrl+enter
   await vt.waitForRender()
+  assert.deepEqual(queued, ['queued text'], 'Ctrl+Enter must queue (host-owned)')
   // Ctrl+O (app.transcript.toggleExpand): ACTIVE host action — never a
   // plugin binding. Kitty ctrl+o = modifier 5.
   vt.sendInput('\x1b[111;5u')
@@ -412,24 +419,31 @@ test('TuiApp: a key with NO active host action falls through to a plugin binding
   const { TuiApp } = await import('../src/tui-app.ts')
   const vt = new VirtualTerminal(80, 24)
   const actions: string[] = []
+  const pasted: number[] = []
   const app = new TuiApp(vt, {
     onSubmit: () => {},
     onExit: () => {},
+    // A LIVE paste handler: with it wired, Ctrl+V is a CONSUMING host
+    // action (never declines) — the plugin must not see it. (The
+    // decline-to-plugin case is covered separately by "a declined host
+    // action is not re-reserved".)
+    onClipboardPaste: () => { pasted.push(1) },
     onExtensionAction: (action) => { actions.push(action) },
   }, {
     // The PR review repro: a plugin binds Ctrl+V — legal AFTER the host
     // remapped app.clipboard.pasteMedia away from Ctrl+V (action-driven
     // reservation: no host action binds Ctrl+V anymore, so the plugin
-    // may claim it). With the DEFAULT keymap Ctrl+V IS a host action, so
-    // this plugin binding must NOT fire — verify both sides.
+    // may claim it). With the DEFAULT keymap Ctrl+V IS a CONSUMING host
+    // action, so this plugin binding must NOT fire — verify both sides.
     pluginActionFor: (key) => key.key === 'v' && key.ctrl ? 'open-search' as const : undefined,
   })
   app.start()
   await vt.waitForRender()
-  // Default keymap: Ctrl+V is app.clipboard.pasteMedia (ACTIVE host
-  // action) — the host ladder consumes it, the plugin never sees it.
+  // Default keymap: Ctrl+V is app.clipboard.pasteMedia (ACTIVE, CONSUMING
+  // host action) — the host ladder consumes it, the plugin never sees it.
   vt.sendInput('\x16')
   await vt.waitForRender()
+  assert.equal(pasted.length, 1, 'the live paste handler must run')
   assert.deepEqual(actions, [], 'an active host action key must not reach a plugin binding')
   // Remap pasteMedia away from Ctrl+V: now NOT reserved — but the host
   // ladder also does not consume it, so with the HOST EDITOR in the seat

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -139,3 +139,30 @@ test('nested bindings map merges with top-level entries', () => {
     'app.todo.toggle': 'ctrl+shift+t',
   })
 })
+
+test('a duplicate action declaration is a diagnostic, never last-write-wins', () => {
+  // Review round 1: the same action at the top level AND in `bindings`
+  // must not silently overwrite — the FIRST declaration wins.
+  const parsed = parseUserKeybindings({
+    'app.input.steer': 'ctrl+s',
+    bindings: { 'app.input.steer': 'ctrl+y' },
+  })
+  assert.deepEqual(parsed.bindings, { 'app.input.steer': 'ctrl+s' })
+  assert.equal(parsed.diagnostics.length, 1)
+  assert.ok(parsed.diagnostics[0]!.includes('declared more than once'))
+})
+
+test('false disables a leader sequence for the same action', () => {
+  // Review round 1: `false` must win over a `<leader>X` binding of the
+  // same action (the manager filters disabled actions out of the leader
+  // machine).
+  const parsed = parseUserKeybindings({
+    leader: 'ctrl+x',
+    'app.tasks.open': false,
+    bindings: { 'app.tasks.open': '<leader>t' },
+  })
+  assert.deepEqual(parsed.bindings, { 'app.tasks.open': false })
+  assert.deepEqual(parsed.leaderBindings, [])
+  assert.equal(parsed.diagnostics.length, 1)
+  assert.ok(parsed.diagnostics[0]!.includes('declared more than once'))
+})

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -107,7 +107,14 @@ test('leader key + leader sequences parse', () => {
     { action: 'app.tasks.open', key: 't' },
     { action: 'app.history.search', key: 'r' },
   ])
-  assert.deepEqual(parsed.bindings, {})
+  // Round 37: a LEADER-ONLY declaration emits an EMPTY-ARRAY marker per
+  // action — the effective keymap sees a user declaration and REPLACES
+  // the builtin default (the unified override contract: any declaration
+  // replaces the builtin; only `false` removes every trigger).
+  assert.deepEqual(parsed.bindings, {
+    'app.tasks.open': [],
+    'app.history.search': [],
+  })
 })
 
 test('leader sequences without a leader key are inert with a diagnostic', () => {

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -118,10 +118,42 @@ test('leader key + leader sequences parse', () => {
 })
 
 test('leader sequences without a leader key are inert with a diagnostic', () => {
-  const parsed = parseUserKeybindings({ 'app.tasks.open': `${LEADER_PREFIX}t` })
+  // Review round 39: a missing leader makes the sequences inert
+  // (fail-soft) — the action must fall back to its builtin default. The
+  // empty-array marker must NOT be left behind: a diagnosed-and-ignored
+  // config must not suppress the builtin (app.todo.toggle's builtin
+  // Ctrl+T survives).
+  const parsed = parseUserKeybindings({ 'app.todo.toggle': `${LEADER_PREFIX}t` })
+  assert.deepEqual(parsed.bindings, {}, 'no empty-array marker — the builtin survives')
   assert.deepEqual(parsed.leaderBindings, [])
   assert.equal(parsed.diagnostics.length, 1)
   assert.ok(parsed.diagnostics[0]!.includes('no "leader" key'))
+})
+
+test('an invalid leader key leaves leader-only actions on their builtin defaults', () => {
+  // Review round 39: a leader that fails validation (text-producing,
+  // runtime-unbindable, terminal-ambiguous) is diagnosed and ignored —
+  // the same fail-soft contract as a missing leader: no empty-array
+  // marker, the builtin survives.
+  for (const badLeader of ['shift+a', 'shift+f5', 'ctrl+[']) {
+    const parsed = parseUserKeybindings({ leader: badLeader, 'app.todo.toggle': `${LEADER_PREFIX}t` })
+    assert.deepEqual(parsed.bindings, {}, `leader "${badLeader}" must not leave a marker`)
+    assert.deepEqual(parsed.leaderBindings, [])
+    assert.ok(parsed.diagnostics.some(message => message.includes('invalid leader key')),
+      `no leader diagnostic for "${badLeader}": ${parsed.diagnostics.join(' | ')}`)
+  }
+})
+
+test('a valid leader keeps the empty-array marker for leader-only actions', () => {
+  // Review round 39: only a VALID leader prefix earns the marker — the
+  // leader-only declaration then REPLACES the builtin (round 37 unified
+  // contract). A leader that is valid at parse time but dead at runtime
+  // (collision/ambiguity) keeps the marker and stays inert — no
+  // fabricated fallback (covered by the manager/integration tests).
+  const parsed = parseUserKeybindings({ leader: 'ctrl+x', 'app.todo.toggle': `${LEADER_PREFIX}t` })
+  assert.deepEqual(parsed.bindings, { 'app.todo.toggle': [] })
+  assert.equal(parsed.leader?.key, 'ctrl+x')
+  assert.deepEqual(parsed.leaderBindings, [{ action: 'app.todo.toggle', key: 't' }])
 })
 
 test('invalid leader sequence → diagnostic + ignore', () => {

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -137,6 +137,22 @@ test('a plain printable leader key is rejected (it would swallow typing)', () =>
   assert.equal(chord.leaderBindings.length, 1)
 })
 
+test('the space key is printable: rejected as a leader and as a direct binding', () => {
+  // Review finding: `space` is the fork alias for the spacebar (char 32),
+  // so a bare `space` leader or Host binding would swallow every typed
+  // space — the printable check must cover it, not just single chars.
+  const asLeader = parseUserKeybindings({ leader: 'space', 'app.tasks.open': `${LEADER_PREFIX}x` })
+  assert.equal(asLeader.leader, undefined)
+  assert.deepEqual(asLeader.leaderBindings, [])
+  assert.ok(asLeader.diagnostics.some(message => message.includes('invalid leader key')))
+  const asBinding = parseUserKeybindings({ 'app.todo.toggle': 'space' })
+  assert.deepEqual(asBinding.bindings, {})
+  assert.ok(asBinding.diagnostics.some(message => message.includes('plain printable key')))
+  // A MODIFIED space stays bindable (ctrl+space is a chord, not typing).
+  const chord = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+space' })
+  assert.deepEqual(chord.bindings, { 'app.todo.toggle': 'ctrl+space' })
+})
+
 test('terminal-unreliable keys warn but stay', () => {
   const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+j' })
   assert.deepEqual(parsed.bindings, { 'app.todo.toggle': 'ctrl+j' })

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -196,3 +196,17 @@ test('false disables a leader sequence for the same action', () => {
   assert.equal(parsed.diagnostics.length, 1)
   assert.ok(parsed.diagnostics[0]!.includes('declared more than once'))
 })
+
+test('a configurable action bound to a fixed overlay key warns (the overlay wins while open)', () => {
+  // Review finding: while a capturing overlay is open its non-configurable
+  // keys (search close/next/previous, question/tasks flows) win by
+  // precedence — a configurable action remapped to one of them is
+  // eclipsed inside the overlay. Warned, never dropped: the binding still
+  // works outside the overlay.
+  const parsed = parseUserKeybindings({ 'app.transcript.search': 'enter' })
+  assert.deepEqual(parsed.bindings, { 'app.transcript.search': 'enter' }, 'the binding is kept')
+  assert.ok(parsed.diagnostics.some(message => message.includes('non-configurable overlay owns')), `no precedence warning: ${parsed.diagnostics.join(' | ')}`)
+  // A non-colliding remap warns nothing.
+  const clean = parseUserKeybindings({ 'app.transcript.search': 'ctrl+x' })
+  assert.ok(!clean.diagnostics.some(message => message.includes('overlay owns')), `unexpected warning: ${clean.diagnostics.join(' | ')}`)
+})

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -73,7 +73,7 @@ test('plain printable bound to a Host action → rejected', () => {
   const parsed = parseUserKeybindings({ 'app.todo.toggle': 'x' })
   assert.deepEqual(parsed.bindings, {})
   assert.equal(parsed.diagnostics.length, 1)
-  assert.ok(parsed.diagnostics[0]!.includes('plain printable'))
+  assert.ok(parsed.diagnostics[0]!.includes('text-producing'))
 })
 
 test('non-configurable action → rejected', () => {
@@ -147,7 +147,7 @@ test('the space key is printable: rejected as a leader and as a direct binding',
   assert.ok(asLeader.diagnostics.some(message => message.includes('invalid leader key')))
   const asBinding = parseUserKeybindings({ 'app.todo.toggle': 'space' })
   assert.deepEqual(asBinding.bindings, {})
-  assert.ok(asBinding.diagnostics.some(message => message.includes('plain printable key')))
+  assert.ok(asBinding.diagnostics.some(message => message.includes('text-producing key')))
   // A MODIFIED space stays bindable (ctrl+space is a chord, not typing).
   const chord = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+space' })
   assert.deepEqual(chord.bindings, { 'app.todo.toggle': 'ctrl+space' })

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -153,10 +153,15 @@ test('the space key is printable: rejected as a leader and as a direct binding',
   assert.deepEqual(chord.bindings, { 'app.todo.toggle': 'ctrl+space' })
 })
 
-test('terminal-unreliable keys warn but stay', () => {
-  const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+j' })
-  assert.deepEqual(parsed.bindings, { 'app.todo.toggle': 'ctrl+j' })
-  assert.ok(parsed.diagnostics.some(message => message.includes('legacy terminals')))
+test('legacy terminal collisions are REJECTED bindings', () => {
+  // Convergence §4.5: a key indistinguishable from a lifecycle key on
+  // legacy terminals is unsupported — rejected with a diagnostic.
+  for (const key of ['ctrl+[', 'ctrl+j', 'ctrl+m']) {
+    const parsed = parseUserKeybindings({ 'app.todo.toggle': key })
+    assert.deepEqual(parsed.bindings, {}, `"${key}" must be rejected`)
+    assert.ok(parsed.diagnostics.some(message => message.includes('legacy terminals') || message.includes('collides')),
+      `no rejection diagnostic for "${key}": ${parsed.diagnostics.join(' | ')}`)
+  }
 })
 
 test('nested bindings map merges with top-level entries', () => {

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The user config validation contract (plan §13/§14/§21): valid scalar,
+ * valid list, false, unknown id, invalid key, duplicate values, printable
+ * Host-global rejection, leader sequences.
+ * @module @xmoon76/dsh-pi-tui/keybinding-config.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isValidKeyId, isPlainPrintableKey, LEADER_PREFIX, parseUserKeybindings } from '../src/keybindings/config.ts'
+
+test('KeyId validation accepts the fork grammar', () => {
+  assert.ok(isValidKeyId('ctrl+s'))
+  assert.ok(isValidKeyId('ctrl+shift+f'))
+  assert.ok(isValidKeyId('alt+up'))
+  assert.ok(isValidKeyId('pageUp'))
+  assert.ok(isValidKeyId('f5'))
+  assert.ok(isValidKeyId('super+1'))
+  assert.ok(isValidKeyId('ctrl+-'))
+  assert.ok(!isValidKeyId(''))
+  assert.ok(!isValidKeyId('ctrl'))
+  assert.ok(!isValidKeyId('ctrl+ctrl+s'))
+  assert.ok(!isValidKeyId('ctrl+foo'))
+  assert.ok(!isValidKeyId('ctrl+shift+'))
+})
+
+test('plain printable detection', () => {
+  assert.ok(isPlainPrintableKey('a'))
+  assert.ok(isPlainPrintableKey('1'))
+  assert.ok(isPlainPrintableKey('/'))
+  assert.ok(!isPlainPrintableKey('ctrl+a'))
+  assert.ok(!isPlainPrintableKey('shift+tab'))
+  assert.ok(!isPlainPrintableKey('enter'))
+})
+
+test('valid scalar', () => {
+  const parsed = parseUserKeybindings({ 'app.input.steer': 'ctrl+x' })
+  assert.deepEqual(parsed.bindings, { 'app.input.steer': 'ctrl+x' })
+  assert.deepEqual(parsed.diagnostics, [])
+})
+
+test('valid list', () => {
+  const parsed = parseUserKeybindings({ 'app.permission.cycle': ['shift+tab', 'ctrl+shift+p'] })
+  assert.deepEqual(parsed.bindings, { 'app.permission.cycle': ['shift+tab', 'ctrl+shift+p'] })
+})
+
+test('false disables the action', () => {
+  const parsed = parseUserKeybindings({ 'app.transcript.toggleThinking': false })
+  assert.deepEqual(parsed.bindings, { 'app.transcript.toggleThinking': false })
+})
+
+test('unknown action → diagnostic + ignore', () => {
+  const parsed = parseUserKeybindings({ 'app.foo.bar': 'ctrl+x', 'app.input.steer': 'ctrl+s' })
+  assert.deepEqual(parsed.bindings, { 'app.input.steer': 'ctrl+s' })
+  assert.equal(parsed.diagnostics.length, 1)
+  assert.ok(parsed.diagnostics[0]!.includes('unknown action'))
+})
+
+test('invalid key → diagnostic + ignore', () => {
+  const parsed = parseUserKeybindings({ 'app.input.steer': 'ctrl+zzz' })
+  assert.deepEqual(parsed.bindings, {})
+  assert.equal(parsed.diagnostics.length, 1)
+  assert.ok(parsed.diagnostics[0]!.includes('invalid key'))
+})
+
+test('duplicate values in one action are deduplicated by the keymap', () => {
+  const parsed = parseUserKeybindings({ 'app.input.steer': ['ctrl+s', 'ctrl+s'] })
+  assert.deepEqual(parsed.bindings, { 'app.input.steer': ['ctrl+s', 'ctrl+s'] })
+  // The keymap dedupes at rule level (keysFor returns unique keys).
+})
+
+test('plain printable bound to a Host action → rejected', () => {
+  const parsed = parseUserKeybindings({ 'app.todo.toggle': 'x' })
+  assert.deepEqual(parsed.bindings, {})
+  assert.equal(parsed.diagnostics.length, 1)
+  assert.ok(parsed.diagnostics[0]!.includes('plain printable'))
+})
+
+test('non-configurable action → rejected', () => {
+  const parsed = parseUserKeybindings({ 'question.confirm': 'ctrl+m' })
+  assert.deepEqual(parsed.bindings, {})
+  assert.ok(parsed.diagnostics[0]!.includes('not user-configurable'))
+})
+
+test('malformed value → diagnostic + ignore', () => {
+  const parsed = parseUserKeybindings({ 'app.input.steer': 42 })
+  assert.deepEqual(parsed.bindings, {})
+  assert.equal(parsed.diagnostics.length, 1)
+})
+
+test('non-object config → diagnostic + empty result', () => {
+  const parsed = parseUserKeybindings('nope')
+  assert.deepEqual(parsed.bindings, {})
+  assert.equal(parsed.diagnostics.length, 1)
+})
+
+test('leader key + leader sequences parse', () => {
+  const parsed = parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.tasks.open': `${LEADER_PREFIX}t`,
+      'app.history.search': `${LEADER_PREFIX}r`,
+    },
+  })
+  assert.equal(parsed.leader?.key, 'ctrl+x')
+  assert.deepEqual(parsed.leaderBindings, [
+    { action: 'app.tasks.open', key: 't' },
+    { action: 'app.history.search', key: 'r' },
+  ])
+  assert.deepEqual(parsed.bindings, {})
+})
+
+test('leader sequences without a leader key are inert with a diagnostic', () => {
+  const parsed = parseUserKeybindings({ 'app.tasks.open': `${LEADER_PREFIX}t` })
+  assert.deepEqual(parsed.leaderBindings, [])
+  assert.equal(parsed.diagnostics.length, 1)
+  assert.ok(parsed.diagnostics[0]!.includes('no "leader" key'))
+})
+
+test('invalid leader sequence → diagnostic + ignore', () => {
+  const parsed = parseUserKeybindings({ leader: 'ctrl+x', 'app.tasks.open': `${LEADER_PREFIX}zzz` })
+  assert.deepEqual(parsed.leaderBindings, [])
+  assert.equal(parsed.diagnostics.length, 1)
+})
+
+test('terminal-unreliable keys warn but stay', () => {
+  const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+j' })
+  assert.deepEqual(parsed.bindings, { 'app.todo.toggle': 'ctrl+j' })
+  assert.ok(parsed.diagnostics.some(message => message.includes('legacy terminals')))
+})
+
+test('nested bindings map merges with top-level entries', () => {
+  const parsed = parseUserKeybindings({
+    'app.input.steer': 'ctrl+s',
+    bindings: { 'app.todo.toggle': 'ctrl+shift+t' },
+  })
+  assert.deepEqual(parsed.bindings, {
+    'app.input.steer': 'ctrl+s',
+    'app.todo.toggle': 'ctrl+shift+t',
+  })
+})

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -123,6 +123,20 @@ test('invalid leader sequence → diagnostic + ignore', () => {
   assert.equal(parsed.diagnostics.length, 1)
 })
 
+test('a plain printable leader key is rejected (it would swallow typing)', () => {
+  // Review finding: the leader machine consumes its key while idle, so a
+  // printable leader (e.g. `t`) would swallow every typed `t` — the same
+  // rule as a direct printable binding applies to the leader key.
+  const parsed = parseUserKeybindings({ leader: 't', 'app.tasks.open': `${LEADER_PREFIX}x` })
+  assert.equal(parsed.leader, undefined)
+  assert.deepEqual(parsed.leaderBindings, [])
+  assert.ok(parsed.diagnostics.some(message => message.includes('invalid leader key')))
+  // A modifier chord stays a valid leader.
+  const chord = parseUserKeybindings({ leader: 'ctrl+x', 'app.tasks.open': `${LEADER_PREFIX}x` })
+  assert.equal(chord.leader?.key, 'ctrl+x')
+  assert.equal(chord.leaderBindings.length, 1)
+})
+
 test('terminal-unreliable keys warn but stay', () => {
   const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+j' })
   assert.deepEqual(parsed.bindings, { 'app.todo.toggle': 'ctrl+j' })

--- a/test/keybinding-conflicts.test.ts
+++ b/test/keybinding-conflicts.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The conflict model contract (plan §15/§21): same key + same scope →
+ * conflict; same key + disjoint scope → legal; user override vs builtin →
+ * user wins; plugin fallback vs Host → Host wins. Conflicts are
+ * deactivated with a diagnostic — never silent last-write-wins.
+ * @module @xmoon76/dsh-pi-tui/keybinding-conflicts.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { deriveKeybindingContext } from '../src/keybindings/context.ts'
+import { EffectiveKeymap } from '../src/keybindings/effective-keymap.ts'
+import { APP_KEYBINDINGS } from '../src/keybindings/definitions.ts'
+import { scopesOverlap } from '../src/keybindings/conflicts.ts'
+
+const editorContext = deriveKeybindingContext({ focusedSeat: 'editor' })
+
+test('scope overlap: editor and agent-running overlap, capturing scopes are disjoint', () => {
+  assert.ok(scopesOverlap('editor', 'agent-running'))
+  assert.ok(scopesOverlap('global', 'editor'))
+  assert.ok(scopesOverlap('question', 'question'))
+  assert.ok(!scopesOverlap('question', 'tasks'))
+  assert.ok(!scopesOverlap('search', 'viewer'))
+  assert.ok(!scopesOverlap('editor', 'question'), 'a capturing scope never conflicts with a non-capturing one')
+  assert.ok(!scopesOverlap('agent-running', 'search'))
+})
+
+test('same key + same scope + same priority → conflict, neither fires', () => {
+  const diagnostics: string[] = []
+  const km = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    userBindings: {
+      'app.history.search': 'ctrl+shift+h',
+      'app.todo.toggle': 'ctrl+shift+h',
+    },
+    onDiagnostic: (message) => diagnostics.push(message),
+  })
+  assert.equal(km.resolve('\x1b[104;6u', editorContext), undefined, 'conflicting rules must not fire')
+  assert.equal(km.keysFor('app.history.search').length, 0)
+  assert.equal(km.keysFor('app.todo.toggle').length, 0)
+  assert.equal(km.conflictsList().length, 1)
+  const conflict = km.conflictsList()[0]!
+  assert.equal(conflict.key, 'ctrl+shift+h')
+  assert.equal(conflict.actions.length, 2)
+  assert.ok(diagnostics.some(message => message.includes('conflict')))
+})
+
+test('same key + disjoint scope → legal (both stay active)', () => {
+  // A user rule (priority 200) never conflicts with a builtin (100) —
+  // the user wins (plan §21: "user override vs builtin → user wins").
+  const km = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    userBindings: { 'app.todo.toggle': 'enter' },
+  })
+  assert.equal(km.conflictsList().length, 0)
+  assert.equal(km.resolve('\r', editorContext)?.action, 'app.todo.toggle')
+  // A truly disjoint pair: a host action bound to a key a capturing
+  // surface owns (search.previous's shift+enter) is legal.
+  const km2 = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    userBindings: { 'app.todo.toggle': 'shift+enter' },
+  })
+  assert.equal(km2.conflictsList().length, 0)
+  assert.equal(km2.resolve('\x1b[13;2u', editorContext)?.action, 'app.todo.toggle') // shift+enter
+})
+
+test('user override vs builtin: user wins, no conflict', () => {
+  const km = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    userBindings: { 'app.input.steer': 'ctrl+x' },
+  })
+  assert.equal(km.conflictsList().length, 0)
+  assert.equal(km.resolve('\x18', editorContext)?.action, 'app.input.steer')
+})
+
+test('plugin fallback vs Host: Host wins, no conflict', () => {
+  const km = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    pluginRules: [{ id: 'plugin', action: 'submit-draft', key: 'ctrl+s' }],
+  })
+  assert.equal(km.conflictsList().length, 0)
+  assert.equal(km.resolve('\x13', editorContext)?.action, 'app.input.steer')
+})
+
+test('two plugin rules on the same key → conflict', () => {
+  const diagnostics: string[] = []
+  const km = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    pluginRules: [
+      { id: 'plugin-a', action: 'submit-draft', key: 'ctrl+alt+x' },
+      { id: 'plugin-b', action: 'open-search', key: 'ctrl+alt+x' },
+    ],
+    onDiagnostic: (message) => diagnostics.push(message),
+  })
+  assert.equal(km.resolve('\x1b[120;7u', editorContext), undefined)
+  assert.equal(km.conflictsList().length, 1)
+  assert.ok(diagnostics.some(message => message.includes('plugin-a') && message.includes('plugin-b')))
+})
+
+test('conflict diagnostics are fail-soft: other rules keep working', () => {
+  const km = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    userBindings: {
+      'app.history.search': 'ctrl+shift+h',
+      'app.todo.toggle': 'ctrl+shift+h', // conflicts with the above
+      'app.input.steer': 'ctrl+x', // unaffected
+    },
+  })
+  assert.equal(km.resolve('\x18', editorContext)?.action, 'app.input.steer')
+  assert.equal(km.resolve('\x13', editorContext), undefined, 'the replaced ctrl+s is gone')
+})

--- a/test/keybinding-conflicts.test.ts
+++ b/test/keybinding-conflicts.test.ts
@@ -109,3 +109,26 @@ test('conflict diagnostics are fail-soft: other rules keep working', () => {
   assert.equal(km.resolve('\x18', editorContext)?.action, 'app.input.steer')
   assert.equal(km.resolve('\x13', editorContext), undefined, 'the replaced ctrl+s is gone')
 })
+
+test('a conflict on ONE key of a multi-key action deactivates only that key', () => {
+  // Review finding: the rule id used to be `${action}@${source}` (shared
+  // by every key of one action), so a conflict on one key deactivated the
+  // action's OTHER keys too. Rule ids are per-key now.
+  const diagnostics: string[] = []
+  const km = new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    userBindings: {
+      // ctrl+r conflicts with the todo toggle below; ctrl+shift+r must survive.
+      'app.history.search': ['ctrl+r', 'ctrl+shift+r'],
+      'app.todo.toggle': 'ctrl+r',
+    },
+    onDiagnostic: (message) => diagnostics.push(message),
+  })
+  assert.equal(km.resolve('\x12', editorContext), undefined, 'the conflicting ctrl+r must not fire')
+  assert.equal(km.resolve('\x1b[114;6u', editorContext)?.action, 'app.history.search', 'ctrl+shift+r survives the per-key deactivation')
+  assert.deepEqual(km.keysFor('app.history.search'), ['ctrl+shift+r'], 'only the conflicting key is dropped')
+  const conflict = km.conflictsList()[0]!
+  assert.equal(conflict.key, 'ctrl+r')
+  assert.equal(conflict.actions.length, 2)
+  assert.ok(diagnostics.some(message => message.includes('conflict')))
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -1260,9 +1260,11 @@ test('7.7c shift-only text keys are rejected for USER configs and leaders too', 
   const leader = parseUserKeybindings({ leader: 'shift+s', bindings: { 'app.tasks.open': '<leader>t' } })
   assert.equal(leader.leader, undefined, 'a text-producing leader must be rejected')
   // Named non-text keys keep their chords (shift+tab is the permission
-  // cycle default; shift+f5 is a plain chord).
-  const named = parseUserKeybindings({ 'app.transcript.toggleExpand': 'shift+f5' })
-  assert.deepEqual(named.bindings, { 'app.transcript.toggleExpand': 'shift+f5' })
+  // cycle default; shift+left is a plain chord — the runtime matches it,
+  // round-22 finding: shift+f5 used to be the example but modified
+  // F-keys can never fire).
+  const named = parseUserKeybindings({ 'app.transcript.toggleExpand': 'shift+left' })
+  assert.deepEqual(named.bindings, { 'app.transcript.toggleExpand': 'shift+left' })
   assert.ok(!named.diagnostics.some(message => message.includes('text-producing')))
 })
 
@@ -1304,8 +1306,10 @@ test('7.8 the registry rejects fork EDITOR-owned keys (no advertised-but-dead ru
     { id: 'ok-chord', key: { key: 'x', ctrl: true, alt: true, shift: false, super: false }, action: 'open-search', description: 'chord' },
     'plugin',
   )
+  // Shift+Left is a REAL runtime chord (the fork matches CSI-u
+  // '\x1b[1;2D') — unlike modified F-keys (round-22 finding).
   registry.register(
-    { id: 'ok-f5', key: { key: 'f5', ctrl: false, alt: false, shift: true, super: false }, action: 'open-search', description: 'f5' },
+    { id: 'ok-shift-left', key: { key: 'left', ctrl: false, alt: false, shift: true, super: false }, action: 'open-search', description: 'shift-left' },
     'plugin',
   )
   assert.equal(registry.snapshot().bindings.length, 2)
@@ -1383,4 +1387,63 @@ test('7.9c the fork premise: raw 0x08 is Backspace on legacy, Ctrl+Backspace on 
       else process.env[name] = value
     }
   }
+})
+
+test('7.10 runtime-bindable gate: modified F-keys and modified Escape are rejected for USER configs', () => {
+  // isValidKeyId only checks the SYNTAX; the fork matcher hard-rejects
+  // ANY modifier on F-keys and Escape (keys.ts: `modifier !== 0` →
+  // false), so those combos can never fire on any terminal protocol —
+  // an advertised-but-dead binding (round-22 finding). The parser now
+  // applies the runtime-bindable gate.
+  for (const key of ['shift+f5', 'ctrl+f5', 'alt+f12', 'super+f1']) {
+    const direct = parseUserKeybindings({ 'app.todo.toggle': key })
+    assert.deepEqual(direct.bindings, {}, `"${key}" must be rejected`)
+    assert.ok(direct.diagnostics.some(message => message.includes('can never match')),
+      `no runtime gate rejection for "${key}": ${direct.diagnostics.join(' | ')}`)
+  }
+  for (const key of ['ctrl+escape', 'shift+escape', 'alt+escape', 'super+esc']) {
+    const direct = parseUserKeybindings({ 'app.todo.toggle': key })
+    assert.deepEqual(direct.bindings, {}, `"${key}" must be rejected`)
+    assert.ok(direct.diagnostics.some(message => message.includes('can never match')),
+      `no runtime gate rejection for "${key}": ${direct.diagnostics.join(' | ')}`)
+  }
+  // Leader prefix + completions get the same gate.
+  const leader = parseUserKeybindings({ leader: 'shift+f5', bindings: { 'app.tasks.open': '<leader>t' } })
+  assert.equal(leader.leader, undefined, 'a modified F-key leader must be rejected')
+  const completion = parseUserKeybindings({ leader: 'ctrl+x', bindings: { 'app.tasks.open': '<leader>ctrl+escape' } })
+  assert.deepEqual(completion.leaderBindings, [], 'a modified escape completion must be rejected')
+  // UNMODIFIED F-keys and Escape stay bindable (the matcher supports them).
+  const plain = parseUserKeybindings({ 'app.todo.toggle': 'f5' })
+  assert.deepEqual(plain.bindings, { 'app.todo.toggle': 'f5' })
+  assert.ok(!plain.diagnostics.some(message => message.includes('can never match')))
+})
+
+test('7.10b the registry applies the runtime-bindable gate too', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  for (const key of [
+    { key: 'f5', ctrl: false, alt: false, shift: true, super: false },
+    { key: 'f5', ctrl: true, alt: false, shift: false, super: false },
+    { key: 'escape', ctrl: true, alt: false, shift: false, super: false },
+    { key: 'esc', ctrl: false, alt: false, shift: true, super: false },
+  ]) {
+    assert.throws(() => registry.register(
+      { id: `runtime-${key.key}-${key.ctrl ? 'c' : ''}${key.shift ? 's' : ''}`, key, action: 'open-search', description: 'x' },
+      'plugin',
+    ), /can never be matched/, `modified ${key.key} must be rejected at registration`)
+  }
+  assert.equal(registry.snapshot().bindings.length, 0)
+})
+
+test('7.10c the runtime premise: modified F-keys/Escape never match; shift+left does', () => {
+  // The gate mirrors the fork matcher exactly (probe-verified).
+  assert.ok(!matchesKey('\x1b[15;2u', 'shift+f5' as never), 'CSI-u Shift+F5 never matches')
+  assert.ok(!matchesKey('\x1b[15;5u', 'ctrl+f5' as never), 'CSI-u Ctrl+F5 never matches')
+  assert.ok(!matchesKey('\x1b', 'ctrl+escape' as never), 'Ctrl+Escape never matches')
+  assert.ok(!matchesKey('\x1b[27;2u', 'shift+escape' as never), 'Shift+Escape never matches')
+  // The positive controls DO have a runtime path.
+  assert.ok(matchesKey('\x1b[15~', 'f5' as never), 'unmodified F5 matches on legacy')
+  assert.ok(matchesKey('\x1b', 'escape' as never), 'unmodified Escape matches')
+  assert.ok(matchesKey('\x1b[1;2D', 'shift+left' as never), 'Shift+Left matches (CSI-u)')
+  assert.ok(matchesKey('\x1b[1;5D', 'ctrl+left' as never), 'Ctrl+Left matches (CSI-u)')
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -1,0 +1,350 @@
+/**
+ * The keybinding CONVERGENCE contract (plan: the PR #34 architecture
+ * convergence). Phase 0: these tests assert the target invariants:
+ *
+ * 1. ONE canonical physical-key identity (aliases and modifier order can
+ *    never bypass conflict / leader collision).
+ * 2. declared / effective / shadowed / conflicted rules are distinct —
+ *    runtime, /help, /keybindings, footer and editor-submit sync see the
+ *    SAME facts; nothing advertises a key that cannot fire.
+ * 3. editor-owned submit lives in the unified rule model (conflict /
+ *    shadow / fail-soft all apply), while direct submit stays on the fork
+ *    editor path.
+ * 4. leader availability is unified: Escape completions rejected,
+ *    zero-effective leader has no machine, leader obeys action
+ *    predicates, viewer blocks direct/leader/remap alike.
+ * 5. a declined Host action falls through to editor/plugin — never
+ *    re-reserved.
+ *
+ * Several of these currently FAIL (they are the convergence target).
+ * @module @xmoon76/dsh-pi-tui/keybinding-convergence.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TuiApp } from '../src/tui-app.ts'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { HostKeybindingManager } from '../src/keybindings/manager.ts'
+import { deriveKeybindingContext } from '../src/keybindings/context.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+const editorContext = deriveKeybindingContext({ focusedSeat: 'editor' })
+
+// ── 4.1 canonical identity ────────────────────────────────────────────────
+
+test('4.1a esc and escape are the SAME physical key (conflict)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.history.search': 'escape',
+    'app.todo.toggle': 'esc',
+  }))
+  // The two USER rules collide on the canonical escape key and are
+  // deactivated — neither action may fire on Esc. (The BUILTIN
+  // app.agent.interrupt on escape legitimately survives.)
+  assert.equal(manager.resolve('\x1b', editorContext)?.action, 'app.agent.interrupt',
+    'the conflicting aliases must not fire — only the surviving builtin interrupt may')
+  assert.deepEqual(manager.keysFor('app.history.search'), [], 'the conflicted history must not keep escape')
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), [], 'the conflicted todo must not keep esc')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')),
+    `no conflict diagnostic for aliases: ${manager.diagnosticsList().join(' | ')}`)
+})
+
+test('4.1b enter and return are the SAME physical key (conflict)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.history.search': 'enter',
+    'app.todo.toggle': 'return',
+  }))
+  assert.equal(manager.resolve('\r', editorContext), undefined,
+    'enter/return aliases must conflict')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
+})
+
+test('4.1c modifier order is canonicalized (ctrl+shift+p == shift+ctrl+p)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.history.search': 'ctrl+shift+p',
+    'app.todo.toggle': 'shift+ctrl+p',
+  }))
+  assert.equal(manager.resolve('\x1b[112;6u', editorContext), undefined,
+    'modifier-order variants must conflict (same canonical key)')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
+})
+
+test('4.1d leader prefix alias (leader: esc) collides with the escape interrupt', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'esc',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  assert.equal(manager.leaderMachine(), undefined,
+    'leader: esc must collide with the default escape interrupt and be disabled')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('active host key')),
+    `no leader collision diagnostic: ${manager.diagnosticsList().join(' | ')}`)
+})
+
+test('4.1e leader completion aliases are ambiguous (enter vs return)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.history.search': '<leader>enter',
+      'app.todo.toggle': '<leader>return',
+    },
+  }))
+  assert.equal(manager.leaderMachine()?.leaderBindings.length ?? 0, 0,
+    'enter/return completions must be ambiguous — neither fires')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('ambiguous')))
+})
+
+// ── 4.2 duplicate direct key ──────────────────────────────────────────────
+
+test('4.2a a duplicate direct key dedupes (no self-conflict)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.input.steer': ['ctrl+s', 'ctrl+s'],
+  }))
+  assert.ok(!manager.diagnosticsList().some(message => message.includes('conflict')),
+    `duplicate keys of ONE action must not self-conflict: ${manager.diagnosticsList().join(' | ')}`)
+  assert.deepEqual(manager.keysFor('app.input.steer'), ['ctrl+s'])
+  assert.equal(manager.resolve('\x13', editorContext)?.action, 'app.input.steer')
+})
+
+test('4.2b canonicalized duplicates dedupe (ctrl+shift+s == shift+ctrl+s)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.input.steer': ['ctrl+shift+s', 'shift+ctrl+s'],
+  }))
+  assert.ok(!manager.diagnosticsList().some(message => message.includes('conflict')))
+  assert.deepEqual(manager.keysFor('app.input.steer'), ['ctrl+shift+s'])
+})
+
+// ── 4.3 priority shadow: runtime == UI ────────────────────────────────────
+
+test('4.3 priority shadow: the shadowed action is NOT advertised', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.todo.toggle': 'ctrl+s' }))
+  assert.equal(manager.resolve('\x13', editorContext)?.action, 'app.todo.toggle')
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+s'])
+  assert.deepEqual(manager.keysFor('app.input.steer'), [],
+    'the shadowed builtin ctrl+s must NOT be advertised for steer')
+  assert.equal(manager.keyHint('app.input.steer'), '',
+    'steer must not advertise a shadowed Ctrl+S')
+  const snapshot = manager.snapshot()
+  const steerRow = snapshot.bindings.find(binding => binding.action === 'app.input.steer')
+  assert.equal(steerRow, undefined,
+    'the snapshot must not carry a shadowed steer row')
+})
+
+// ── 4.4 conflict: no fabricated builtin fallback ──────────────────────────
+
+test('4.4 conflict: no fabricated Ctrl+R / Ctrl+T fallback', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.history.search': 'ctrl+x',
+    'app.todo.toggle': 'ctrl+x',
+  }))
+  assert.equal(manager.resolve('\x18', editorContext), undefined, 'neither conflicting rule fires')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
+  const snapshot = manager.snapshot()
+  const historyRow = snapshot.bindings.find(binding => binding.action === 'app.history.search')
+  assert.equal(historyRow, undefined,
+    'a conflicted user override must NOT fall back to the builtin Ctrl+R')
+  const todoRow = snapshot.bindings.find(binding => binding.action === 'app.todo.toggle')
+  assert.equal(todoRow, undefined,
+    'a conflicted user override must NOT fall back to the builtin Ctrl+T')
+})
+
+// ── 4.6 leader dead bindings ──────────────────────────────────────────────
+
+test('4.6a <leader>escape is rejected by the parser', () => {
+  const parsed = parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.history.search': '<leader>escape' },
+  })
+  assert.deepEqual(parsed.leaderBindings, [],
+    'escape completion must be parser-rejected (pending-cancel contract)')
+  assert.ok(parsed.diagnostics.some(message => message.includes('leader')))
+})
+
+test('4.6b zero effective completions → no leader machine', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.history.search': '<leader>r',
+      'app.todo.toggle': '<leader>r',
+    },
+  }))
+  assert.equal(manager.leaderMachine(), undefined,
+    'an all-ambiguous leader must not exist (Ctrl+X must not enter a dead pending state)')
+})
+
+// ── 4.7 leader obeys the action predicate ─────────────────────────────────
+
+test('4.7 leader completion obeys the action context predicate', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let tasksOpened = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onOpenTasks: () => { tasksOpened += 1 },
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  await vt.waitForRender()
+  // Editor has text → the tasks predicate is false → the leader must NOT open tasks.
+  app.setDraft('text')
+  await vt.waitForRender()
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('t')
+  await vt.waitForRender()
+  assert.equal(tasksOpened, 0, 'a non-empty editor must not open tasks via the leader')
+  // Empty editor + tasks ACTIVE → opens (the predicate needs live tasks).
+  app.setDraft('')
+  app.setTasks([{ id: 'job-1', label: 'bash', status: 'running', kind: 'job' }])
+  await vt.waitForRender()
+  vt.sendInput('\x18')
+  await vt.waitForRender()
+  vt.sendInput('t')
+  await vt.waitForRender()
+  assert.equal(tasksOpened, 1, 'empty editor + active tasks must open tasks via the leader')
+  app.stop()
+})
+
+// ── 4.8 remapped interrupt ────────────────────────────────────────────────
+
+test('4.8 a remapped interrupt (ctrl+x) keeps its semantic behavior', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const cancels: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels.push('cancel') },
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.agent.interrupt': 'ctrl+x' }))
+  await vt.waitForRender()
+  // Busy: ctrl+x must interrupt (the semantic action), never fall through
+  // to the editor as a plain chord.
+  app.setBusy(true)
+  await vt.waitForRender()
+  vt.sendInput('\x18')
+  await vt.waitForRender()
+  assert.deepEqual(cancels, ['cancel'], 'a remapped interrupt must cancel the busy agent')
+  app.stop()
+})
+
+// ── 4.10 viewer stale double-Esc ──────────────────────────────────────────
+
+test('4.10 a real armed window is disarmed by the viewer-close Esc', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let singleEscapes = 0
+  let cancels = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSingleEscape: () => { singleEscapes += 1; return singleEscapes === 1 ? false : true },
+    onCancel: () => { cancels += 1 },
+  })
+  app.start()
+  // First main Esc: NOT consumed → handleEscapeKey ARMS the window.
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 1)
+  // Open + close the read-only viewer with Esc (the close is consumed).
+  app.setViewerMode({ parentSessionId: 's', childSessionId: 'c', label: 'c', mode: 'one-shot', activity: 'inactive' })
+  await vt.waitForRender()
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 2, 'the viewer-close Esc ran the close path')
+  // Back in main: the next Esc must RE-ARM (not read as a double-Esc).
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 3)
+  assert.equal(cancels, 0, 'a stale window must not cancel after the viewer close')
+  app.stop()
+})
+
+// ── 4.9 dispatcher decline remainder ─────────────────────────────────────
+
+test('4.9a a declined host action is not re-reserved (reaches the plugin)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const actions: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    // NO onClipboardPaste handler → the host dispatcher DECLINES.
+    onExtensionAction: (action: string) => { actions.push(action) },
+  }, {
+    // A plugin binds Ctrl+V. With pasteMedia's host handler absent, the
+    // declined key must reach the plugin dispatch — never be swallowed
+    // by a re-reservation of the same (declined) host action.
+    pluginActionFor: (key) => key.key === 'v' && key.ctrl ? 'open-search' : undefined,
+  })
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('\x16') // ctrl+v
+  await vt.waitForRender()
+  assert.deepEqual(actions, ['open-search'],
+    'a declined host action must fall through to the plugin remainder, not be re-reserved')
+  app.stop()
+})
+
+test('4.9b a declined host action reaches a REPLACEMENT editor', async () => {
+  const { EditorRegistry } = await import('../src/editor-registry.ts')
+  const vt = new VirtualTerminal(80, 24)
+  const actions: string[] = []
+  const registry = new EditorRegistry()
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onExtensionAction: (action: string) => { actions.push(action) },
+  }, {
+    pluginActionFor: (key) => key.key === 'v' && key.ctrl ? 'open-search' : undefined,
+    editorRegistry: registry,
+  })
+  app.start()
+  // Register a replacement editor that DECLINES Ctrl+V (handleInput
+  // returns undefined). The declined host pasteMedia action must reach
+  // the replacement editor first, then the plugin.
+  registry.register({
+    id: 'declining',
+    priority: 0,
+    create: () => ({
+      component: { kind: 'text', spans: [{ text: 'declining' }] },
+      getText: () => '',
+      setText: () => {},
+      getCursor: () => 0,
+      setCursor: () => {},
+      focused: true,
+      handleInput: () => false, // declines
+      dispose: () => {},
+    }),
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  // pasteMedia has no host handler → declined; the replacement editor
+  // declines too → the plugin binding fires (the full remainder chain).
+  vt.sendInput('\x16') // ctrl+v
+  await vt.waitForRender()
+  assert.deepEqual(actions, ['open-search'], 'the declined key must reach the plugin after the editor declines')
+  app.stop()
+})
+
+// ── 4.11 reserved-unimplemented actions ──────────────────────────────────
+
+test('4.11 reserved session/model actions are not user-configurable', () => {
+  const parsed = parseUserKeybindings({ 'app.session.new': 'ctrl+n' })
+  assert.deepEqual(parsed.bindings, {}, 'a reserved action must not accept a user binding')
+  assert.ok(parsed.diagnostics.some(message => message.includes('not user-configurable')),
+    `no diagnostic for a reserved action: ${parsed.diagnostics.join(' | ')}`)
+  // Same for model.
+  const parsedModel = parseUserKeybindings({ 'app.model.open': 'ctrl+m' })
+  assert.deepEqual(parsedModel.bindings, {})
+  assert.ok(parsedModel.diagnostics.some(message => message.includes('not user-configurable')))
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -1082,6 +1082,36 @@ test('6.6c leader-only submit: the unified model carries NO Enter (resolve/match
   assert.deepEqual(mixed.editorSubmitKeysFor(), ['ctrl+z'], 'the direct key survives; no Enter')
 })
 
+test('6.6d a leader-only declaration WITHOUT a leader key leaves the builtin intact', async () => {
+  // Review round 39: a missing leader makes the sequences inert
+  // (fail-soft) — the action must fall back to its builtin default. The
+  // parser must not leave the empty-array marker behind (it used to: the
+  // marker was written before the leader check, so a
+  // diagnosed-and-ignored config still suppressed the builtin).
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    bindings: { 'app.todo.toggle': '<leader>t' },
+  }))
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'], 'the builtin Ctrl+T survives')
+  assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), [], 'no leader trigger without a leader key')
+  assert.equal(manager.keyHint('app.todo.toggle'), 'Ctrl+T')
+  // Runtime: Ctrl+T still toggles the todo panel.
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    bindings: { 'app.todo.toggle': '<leader>t' },
+  }))
+  await vt.waitForRender()
+  vt.sendInput('\x14') // ctrl+t — the builtin
+  await vt.waitForRender()
+  assert.equal(app.isTodoPanelVisible(), true, 'Ctrl+T must still toggle the todo panel (the ignored config leaves the builtin)')
+  app.stop()
+})
+
 test('6.6 a conditional top rule does not permanently hide the fallback in the read model', () => {
   const manager = new HostKeybindingManager()
   manager.setUserConfiguration(parseUserKeybindings({ 'app.tasks.open': 'ctrl+s' }))

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -26,6 +26,7 @@ import { TuiApp } from '../src/tui-app.ts'
 import { parseUserKeybindings } from '../src/keybindings/config.ts'
 import { HostKeybindingManager } from '../src/keybindings/manager.ts'
 import { deriveKeybindingContext } from '../src/keybindings/context.ts'
+import { InputRouter } from '../src/input-router.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 const editorContext = deriveKeybindingContext({ focusedSeat: 'editor' })
@@ -544,4 +545,55 @@ test('4.11b legacy terminal collisions are rejected bindings', () => {
     assert.ok(parsed.diagnostics.some(message => message.includes('legacy terminals') || message.includes('collides')),
       `no rejection diagnostic for "${key}": ${parsed.diagnostics.join(' | ')}`)
   }
+})
+
+// ── stop/start lifecycle (full-review findings) ───────────────────────────
+
+test('5.4 stop() cancels a pending leader sequence', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let tasksOpened = 0
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {}, onOpenTasks: () => { tasksOpened += 1 } })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  await vt.waitForRender()
+  vt.sendInput('\x18') // arm the leader
+  await vt.waitForRender()
+  app.stop() // stop with the leader pending
+  app.start() // restart (fresh lifecycle)
+  await vt.waitForRender()
+  // Complete the OLD sequence on the NEW surface: it must NOT fire.
+  vt.sendInput('t')
+  await vt.waitForRender()
+  assert.equal(tasksOpened, 0, 'a stopped-then-restarted surface must not fire a stale leader sequence')
+  app.stop()
+})
+
+test('5.5 stop() clears the interrupt double-action window', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let cancels = 0
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {}, onCancel: () => { cancels += 1 } })
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // first Esc (idle) arms the double window
+  await vt.waitForRender()
+  app.stop()
+  app.start()
+  await vt.waitForRender()
+  // A post-restart single Esc must NOT read as the second press (which
+  // would cancel/rewind an empty session).
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(cancels, 0, 'stop() must clear the pre-stop double-action window')
+  app.stop()
+})
+
+test('5.6 a plugin cannot bind the space key (it would swallow typing)', () => {
+  // isPrintableKey('space') must be true, so the router never routes a
+  // plain space to a plugin binding.
+  const router = new InputRouter()
+  const result = router.route(' ', { questionActive: false, approvalActive: false, viewerInputMode: 'none', hasOverlay: false, searchActive: false, hostDeclined: false }, () => 'open-search')
+  assert.equal(result.kind, 'editor', 'a plain space must reach the editor, never a plugin binding')
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -1447,3 +1447,68 @@ test('7.10c the runtime premise: modified F-keys/Escape never match; shift+left 
   assert.ok(matchesKey('\x1b[1;2D', 'shift+left' as never), 'Shift+Left matches (CSI-u)')
   assert.ok(matchesKey('\x1b[1;5D', 'ctrl+left' as never), 'Ctrl+Left matches (CSI-u)')
 })
+
+test('7.11 modified Clear is runtime-unbindable beyond shift/ctrl (USER config)', () => {
+  // The fork's `clear` case has NO kitty/modifyOtherKeys fallback:
+  // modifier 0 → the legacy sequence; otherwise ONLY matchesLegacyModifier-
+  // Sequence (exactly shift OR exactly ctrl). alt+clear / super+clear /
+  // ctrl+alt+clear / ctrl+shift+clear can never be matched (round-24
+  // finding — the capability table missed clear).
+  for (const key of ['alt+clear', 'super+clear', 'ctrl+alt+clear', 'ctrl+shift+clear']) {
+    const direct = parseUserKeybindings({ 'app.todo.toggle': key })
+    assert.deepEqual(direct.bindings, {}, `"${key}" must be rejected`)
+    assert.ok(direct.diagnostics.some(message => message.includes('can never match')),
+      `no runtime gate rejection for "${key}": ${direct.diagnostics.join(' | ')}`)
+    assert.ok(direct.diagnostics.some(message => message.includes('Clear takes only Shift/Ctrl')),
+      `the diagnostic must explain the Clear capability: ${direct.diagnostics.join(' | ')}`)
+  }
+  const leader = parseUserKeybindings({ leader: 'alt+clear', bindings: { 'app.tasks.open': '<leader>t' } })
+  assert.equal(leader.leader, undefined, 'an alt+clear leader must be rejected')
+  const completion = parseUserKeybindings({ leader: 'ctrl+x', bindings: { 'app.tasks.open': '<leader>super+clear' } })
+  assert.deepEqual(completion.leaderBindings, [], 'a super+clear completion must be rejected')
+  // The SUPPORTED forms stay bindable: clear, shift+clear, ctrl+clear.
+  for (const key of ['clear', 'shift+clear', 'ctrl+clear']) {
+    const direct = parseUserKeybindings({ 'app.todo.toggle': key })
+    assert.deepEqual(direct.bindings, { 'app.todo.toggle': key }, `"${key}" must stay bindable`)
+    assert.ok(!direct.diagnostics.some(message => message.includes('can never match')))
+  }
+})
+
+test('7.11b the registry applies the modified-Clear gate too', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  for (const key of [
+    { key: 'clear', ctrl: false, alt: true, shift: false, super: false },
+    { key: 'clear', ctrl: false, alt: false, shift: false, super: true },
+    { key: 'clear', ctrl: true, alt: false, shift: true, super: false },
+  ]) {
+    assert.throws(() => registry.register(
+      { id: `clear-${key.alt ? 'a' : key.super ? 's' : 'cs'}`, key, action: 'open-search', description: 'x' },
+      'plugin',
+    ), /can never be matched/, 'unsupported modified clear must be rejected')
+  }
+  // clear / shift+clear / ctrl+clear register fine.
+  for (const key of [
+    { key: 'clear', ctrl: false, alt: false, shift: false, super: false },
+    { key: 'clear', ctrl: false, alt: false, shift: true, super: false },
+    { key: 'clear', ctrl: true, alt: false, shift: false, super: false },
+  ]) {
+    registry.register(
+      { id: `ok-${key.ctrl ? 'c' : key.shift ? 's' : 'plain'}-clear`, key, action: 'open-search', description: 'ok' },
+      'plugin',
+    )
+  }
+  assert.equal(registry.snapshot().bindings.length, 3)
+})
+
+test('7.11c the runtime premise: clear supports only unmodified / shift / ctrl', () => {
+  assert.ok(matchesKey('\x1b[E', 'clear' as never), 'clear matches on legacy')
+  assert.ok(matchesKey('\x1b[e', 'shift+clear' as never), 'shift+clear matches on legacy')
+  assert.ok(matchesKey('\x1bOe', 'ctrl+clear' as never), 'ctrl+clear matches on legacy')
+  assert.ok(!matchesKey('\x1b[1;3E', 'alt+clear' as never), 'alt+clear has no matcher path')
+  assert.ok(!matchesKey('\x1bOe', 'super+clear' as never), 'super+clear has no matcher path')
+  assert.ok(!matchesKey('\x1b[1;6E', 'ctrl+shift+clear' as never), 'ctrl+shift+clear has no matcher path')
+  // Other named keys keep their kitty fallback (the capability table is
+  // complete: only escape / f1-f12 / clear are restricted).
+  assert.ok(matchesKey('\x1b[2;2~', 'shift+insert' as never), 'shift+insert still matches (kitty fallback)')
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -22,6 +22,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { matchesKey } from '@xmoon76/pi-tui'
 import { TuiApp } from '../src/tui-app.ts'
 import { parseUserKeybindings } from '../src/keybindings/config.ts'
 import { HostKeybindingManager } from '../src/keybindings/manager.ts'
@@ -1005,4 +1006,148 @@ test('6.6 a conditional top rule does not permanently hide the fallback in the r
   const unconditional = new HostKeybindingManager()
   unconditional.setUserConfiguration(parseUserKeybindings({ 'app.todo.toggle': 'ctrl+s' }))
   assert.deepEqual(unconditional.keysFor('app.input.steer'), [], 'an unconditional top trigger still hides the lower rule')
+})
+
+// ── 7.x Stable plugin boundary + legacy C0 inventory (round-12 findings) ───
+
+test('7.1 the registry REJECTS a non-public action string (runtime whitelist)', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  // A public TuiAction registers fine.
+  registry.register(
+    { id: 'good', key: { key: 'x', ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'ok' },
+    'plugin',
+  )
+  // A Host-private app.* action smuggled through the PUBLIC API must be
+  // rejected at registration — the registry has no runtime action
+  // whitelist, so a JS/`as any` plugin could otherwise register
+  // `app.exit.request` and the plugin-owner winner would reach the Host
+  // dispatcher (capability boundary — review finding). The public
+  // TuiAction set is the ONLY thing a plugin may trigger.
+  assert.throws(() => registry.register(
+    { id: 'smuggled-exit', key: { key: 'y', ctrl: true, alt: false, shift: false, super: false }, action: 'app.exit.request' as never, description: 'bad' },
+    'plugin',
+  ), /not a public TuiAction/, 'a Host-private action string must be rejected')
+  // Any arbitrary string is rejected the same way.
+  assert.throws(() => registry.register(
+    { id: 'smuggled-arbitrary', key: { key: 'z', ctrl: true, alt: false, shift: false, super: false }, action: 'definitely-not-an-action' as never, description: 'bad' },
+    'plugin',
+  ), /not a public TuiAction/)
+  // The rejected actions never entered the registry.
+  assert.equal(registry.snapshot().bindings.length, 1)
+})
+
+test('7.2 a plugin-owner winner NEVER enters the Host dispatcher', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let exits = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => { exits += 1 },
+  })
+  app.start()
+  // A smuggled plugin rule (the internal keymap path) carrying a
+  // HOST-private action — the registry rejects it at registration, and
+  // the host dispatcher must never execute it either (review finding:
+  // plugin-owner winners used to enter dispatchResolvedAction, so an
+  // `app.exit.request` string would run the Host exit path).
+  app.keybindingsManager().setPluginRules([{ id: 'smuggled', action: 'app.exit.request' as never, key: 'ctrl+alt+x' }])
+  await vt.waitForRender()
+  vt.sendInput('\x1b\x18') // ctrl+alt+x
+  await vt.waitForRender()
+  assert.equal(exits, 0, 'the Host dispatcher must never execute a plugin-supplied action string')
+  // The resolution is plugin-owned (the remainder owns it, not the Host).
+  const resolution = app.keybindingsManager().resolve('\x1b[120;7u', deriveKeybindingContext({ focusedSeat: 'editor' }))
+  assert.equal(resolution?.owner, 'plugin', 'the winner is plugin-owned')
+  app.stop()
+})
+
+test('7.2b a legit plugin action still executes through the Stable remainder', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const actions: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onExtensionAction: (action: string) => { actions.push(action) },
+  }, {
+    // The router's plugin stage maps the same key to the public action.
+    pluginActionFor: (key) => key.key === 'x' && key.ctrl && key.alt ? 'open-search' : undefined,
+  })
+  app.start()
+  app.keybindingsManager().setPluginRules([{ id: 'plugin', action: 'open-search', key: 'ctrl+alt+x' }])
+  await vt.waitForRender()
+  vt.sendInput('\x1b\x18') // ctrl+alt+x
+  await vt.waitForRender()
+  assert.deepEqual(actions, ['open-search'], 'the plugin action executes through the Stable plugin remainder')
+  app.stop()
+})
+
+test('7.3 the registry rejects plain printable keys (space/letters) at registration', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  // The router keeps printable keys with the editor's text entry, so a
+  // plugin binding on one can never fire — the registration must be
+  // rejected, not advertised as an effective rule (review finding).
+  assert.throws(() => registry.register(
+    { id: 'space', key: { key: 'space', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'space' },
+    'plugin',
+  ), /printable/, 'the spacebar must be rejected at registration')
+  assert.throws(() => registry.register(
+    { id: 'letter', key: { key: 'a', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'a' },
+    'plugin',
+  ), /printable/, 'a bare letter must be rejected at registration')
+  // A MODIFIED chord stays bindable (it really reaches the plugin stage).
+  registry.register(
+    { id: 'ctrl-space', key: { key: 'space', ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'chord' },
+    'plugin',
+  )
+  assert.equal(registry.actionFor({ key: 'space', ctrl: true, alt: false, shift: false, super: false }), 'open-search')
+})
+
+test('7.4 a live plugin key disables a colliding leader prefix (never a silent swallow)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setPluginRules([{ id: 'plugin-x', action: 'app.tasks.open', key: 'ctrl+alt+x' }])
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+alt+x',
+    bindings: { 'app.transcript.toggleFullscreen': '<leader>n' },
+  }))
+  // The leader machine feeds BEFORE the plugin stage, so a leader key
+  // that equals a live plugin key would silently swallow the plugin
+  // binding while the read model still advertised it (review finding).
+  assert.equal(manager.leaderMachine(), undefined, 'the leader must not swallow the plugin key')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('leader key') && message.includes('plugin key')),
+    `no plugin collision diagnostic: ${manager.diagnosticsList().join(' | ')}`)
+  assert.equal(manager.keyHint('app.transcript.toggleFullscreen'), '', 'the dead leader sequence is not advertised')
+  assert.ok(manager.keysFor('app.tasks.open').includes('ctrl+alt+x'), 'the plugin binding stays effective')
+})
+
+test('7.5 legacy C0 aliases are rejected everywhere (ctrl+i / ctrl+h / ctrl+_)', () => {
+  // On legacy terminals Ctrl+I is the Tab byte (0x09), Ctrl+H is
+  // Backspace (0x08) and Ctrl+_ / Ctrl+- are 0x1f — indistinguishable
+  // from the editor's own keys, so a binding on them is protocol-
+  // dependent and unsupported (review finding — same class as
+  // ctrl+[/ctrl+j/ctrl+m).
+  for (const key of ['ctrl+i', 'ctrl+h', 'ctrl+_']) {
+    const direct = parseUserKeybindings({ 'app.todo.toggle': key })
+    assert.deepEqual(direct.bindings, {}, `"${key}" direct must be rejected`)
+    assert.ok(direct.diagnostics.some(message => message.includes('legacy terminals')),
+      `no rejection for "${key}": ${direct.diagnostics.join(' | ')}`)
+    const submit = parseUserKeybindings({ 'app.input.submit': key })
+    assert.deepEqual(submit.bindings, {}, `"${key}" submit must be rejected`)
+    const leader = parseUserKeybindings({ leader: key, bindings: { 'app.tasks.open': '<leader>t' } })
+    assert.equal(leader.leader, undefined, `"${key}" leader prefix must be rejected`)
+    const completion = parseUserKeybindings({ leader: 'ctrl+x', bindings: { 'app.tasks.open': `<leader>${key}` } })
+    assert.deepEqual(completion.leaderBindings, [], `"<leader>${key}" completion must be rejected`)
+  }
+})
+
+test('7.5b the C0 byte premise: raw \\t / \\x08 / \\x1f are the legacy spellings', () => {
+  // Why the rejections exist: the fork's matchesKey accepts the raw
+  // control bytes for BOTH spellings of one physical key, so on a legacy
+  // terminal a `ctrl+i` binding fires on Tab bytes (and vice versa).
+  assert.ok(matchesKey('\t', 'ctrl+i' as never), 'Ctrl+I is the Tab byte on legacy terminals')
+  assert.ok(matchesKey('\t', 'tab' as never), '…and the same byte is Tab for the editor')
+  assert.ok(matchesKey('\x08', 'ctrl+h' as never), 'Ctrl+H is the Backspace byte on legacy terminals')
+  assert.ok(matchesKey('\x08', 'backspace' as never), '…and the same byte is Backspace for the editor')
+  assert.ok(matchesKey('\x1f', 'ctrl+_' as never), 'Ctrl+_ is the 0x1f byte')
+  assert.ok(matchesKey('\x1f', 'ctrl+-' as never), 'Ctrl+- is the SAME 0x1f byte (the fork maps - to _)')
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -867,10 +867,11 @@ test('6.2 submit on fork-editor PRE-SUBMIT keys is rejected (they can never fire
   assert.deepEqual(aliased.bindings, {}, 'shift+Backspace must canonicalize into the rejected set')
   assert.ok(aliased.diagnostics.some(message => message.includes('editor consumes')))
   // A key the fork editor does NOT consume before submit stays bindable:
-  // ctrl+backspace is not in the fork's editor keybindings, so a submit
-  // remap on it genuinely reaches the submit check.
-  const works = parseUserKeybindings({ 'app.input.submit': 'ctrl+backspace' })
-  assert.deepEqual(works.bindings, { 'app.input.submit': 'ctrl+backspace' })
+  // ctrl+alt+backspace is not in the fork's editor keybindings (and not
+  // terminal-ambiguous — plain ctrl+backspace is, round-20 finding), so
+  // a submit remap on it genuinely reaches the submit check.
+  const works = parseUserKeybindings({ 'app.input.submit': 'ctrl+alt+backspace' })
+  assert.deepEqual(works.bindings, { 'app.input.submit': 'ctrl+alt+backspace' })
   assert.ok(!works.diagnostics.some(message => message.includes('editor consumes')))
   // OTHER actions may still bind an editor-pre-submit key: the HOST ladder
   // consumes them before the editor, so they really fire.
@@ -1182,15 +1183,15 @@ test('7.6 the registry REJECTS legacy C0 alias keys (ctrl+i / ctrl+h / ctrl+_ / 
   assert.equal(registry.snapshot().bindings.length, 0)
   // The canonical identity of the registered key is one shared policy:
   // the config parser and the registry reject the SAME key ids.
-  const { isLegacyCollisionKeyId, LEGACY_COLLISION_KEY_IDS } = await import('../src/keybindings/config.ts')
-  assert.ok(isLegacyCollisionKeyId('ctrl+i' as never))
-  assert.ok(isLegacyCollisionKeyId('ctrl+h' as never))
-  assert.ok(isLegacyCollisionKeyId('ctrl+_' as never))
-  assert.ok(isLegacyCollisionKeyId('ctrl+-' as never))
-  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+i'))
-  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+h'))
-  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+_'))
-  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+-'))
+  const { isTerminalAmbiguousKeyId, TERMINAL_AMBIGUOUS_KEY_IDS } = await import('../src/keybindings/config.ts')
+  assert.ok(isTerminalAmbiguousKeyId('ctrl+i' as never))
+  assert.ok(isTerminalAmbiguousKeyId('ctrl+h' as never))
+  assert.ok(isTerminalAmbiguousKeyId('ctrl+_' as never))
+  assert.ok(isTerminalAmbiguousKeyId('ctrl+-' as never))
+  assert.ok(TERMINAL_AMBIGUOUS_KEY_IDS.has('ctrl+i'))
+  assert.ok(TERMINAL_AMBIGUOUS_KEY_IDS.has('ctrl+h'))
+  assert.ok(TERMINAL_AMBIGUOUS_KEY_IDS.has('ctrl+_'))
+  assert.ok(TERMINAL_AMBIGUOUS_KEY_IDS.has('ctrl+-'))
 })
 
 test('7.7 the registry rejects SHIFT-only text keys and non-grammar key names', async () => {
@@ -1325,4 +1326,61 @@ test('7.8b a rejected editor-owned plugin key never disables a colliding leader'
     `no plugin collision expected: ${manager.diagnosticsList().join(' | ')}`)
   assert.ok(!manager.snapshot().bindings.some(binding => binding.action === 'open-search'),
     'no dead plugin rule is advertised')
+})
+
+test('7.9 ctrl+backspace is terminal-ambiguous: rejected for user configs', () => {
+  // The fork treats raw 0x08 as Ctrl+Backspace on Windows Terminal and
+  // plain Backspace on legacy terminals/tmux (matchesRawBackspace
+  // branches on WT_SESSION) — a ctrl+backspace binding fires on some
+  // terminals and can never fire on others (round-20 finding: the
+  // terminal-ambiguity policy missed it).
+  const direct = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+backspace' })
+  assert.deepEqual(direct.bindings, {}, 'ctrl+backspace must be rejected')
+  assert.ok(direct.diagnostics.some(message => message.includes('legacy terminals')),
+    `no rejection: ${direct.diagnostics.join(' | ')}`)
+  const submit = parseUserKeybindings({ 'app.input.submit': 'ctrl+backspace' })
+  assert.deepEqual(submit.bindings, {}, 'submit on ctrl+backspace must be rejected')
+  const leader = parseUserKeybindings({ leader: 'ctrl+backspace', bindings: { 'app.tasks.open': '<leader>t' } })
+  assert.equal(leader.leader, undefined, 'a ctrl+backspace leader must be rejected')
+  const completion = parseUserKeybindings({ leader: 'ctrl+x', bindings: { 'app.tasks.open': '<leader>ctrl+backspace' } })
+  assert.deepEqual(completion.leaderBindings, [], 'a ctrl+backspace completion must be rejected')
+})
+
+test('7.9b the registry rejects ctrl+backspace too', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  assert.throws(() => registry.register(
+    { id: 'ctrl-bs', key: { key: 'backspace', ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'x' },
+    'plugin',
+  ), (error: unknown) => /legacy terminal/.test(String(error))
+    && /Windows Terminal/.test(String(error))
+    && /Ctrl\+Backspace/.test(String(error)),
+  'ctrl+backspace must be rejected at registration with the ambiguity explained')
+  assert.equal(registry.snapshot().bindings.length, 0)
+})
+
+test('7.9c the fork premise: raw 0x08 is Backspace on legacy, Ctrl+Backspace on Windows Terminal', () => {
+  // isWindowsTerminalSession() requires WT_SESSION AND no SSH_* vars (the
+  // fork excludes remote sessions) — the probe clears both sides.
+  const saved: Record<string, string | undefined> = {
+    WT_SESSION: process.env.WT_SESSION,
+    SSH_CONNECTION: process.env.SSH_CONNECTION,
+    SSH_CLIENT: process.env.SSH_CLIENT,
+    SSH_TTY: process.env.SSH_TTY,
+  }
+  try {
+    for (const name of ['SSH_CONNECTION', 'SSH_CLIENT', 'SSH_TTY']) delete process.env[name]
+    delete process.env.WT_SESSION
+    assert.ok(matchesKey('\x08', 'backspace' as never), 'raw 0x08 is plain Backspace on legacy terminals')
+    assert.ok(!matchesKey('\x08', 'ctrl+backspace' as never),
+      '...so a ctrl+backspace binding can never fire on legacy terminals')
+    process.env.WT_SESSION = 'probe'
+    assert.ok(matchesKey('\x08', 'ctrl+backspace' as never),
+      '...while Windows Terminal reads the same byte as Ctrl+Backspace')
+  } finally {
+    for (const [name, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+  }
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -700,3 +700,29 @@ test('5.11 a reserved key ALIAS (esc/return) is rejected at registration', async
     'plugin',
   ), /reserved by the host/, 'return is the reserved enter and must be rejected')
 })
+
+test('5.12 canonical named keys still display as PageUp/PageDown', async () => {
+  const { formatKeyId, formatKeyList } = await import('../src/keybindings/hints.ts')
+  const { canonicalizeKeyId } = await import('../src/keybindings/key-identity.ts')
+  assert.equal(canonicalizeKeyId('pageUp' as never), 'pageup')
+  assert.equal(canonicalizeKeyId('pageDown' as never), 'pagedown')
+  // The DISPLAY of the canonical form must be the proper label (a
+  // lowercase canonical key must not leak into UI hints).
+  assert.equal(formatKeyId('pageup' as never), 'PageUp')
+  assert.equal(formatKeyId('pagedown' as never), 'PageDown')
+  assert.equal(formatKeyList(['pageup'] as never), 'PageUp')
+  // The keymap's canonical rules and the hint renderers agree. The user
+  // writes the fork-grammar spelling (pageUp); the parser canonicalizes it
+  // to pageup internally and the hint renders PageUp.
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.transcript.toggleExpand': 'pageUp' }))
+  assert.equal(manager.keyHint('app.transcript.toggleExpand'), 'PageUp',
+    'a canonical pageup binding must be advertised as PageUp')
+  assert.deepEqual(manager.keysFor('app.transcript.toggleExpand'), ['pageup'])
+  // The LOWERCASE spelling (pageup) is the same physical key at parse
+  // time — one canonical identity regardless of casing.
+  const lower = new HostKeybindingManager()
+  lower.setUserConfiguration(parseUserKeybindings({ 'app.transcript.toggleExpand': 'pageup' }))
+  assert.deepEqual(lower.keysFor('app.transcript.toggleExpand'), ['pageup'])
+  assert.equal(lower.keyHint('app.transcript.toggleExpand'), 'PageUp')
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -619,7 +619,7 @@ test('5.7 the registry notifies subscribers on register/dispose (dynamic sync)',
   )
   assert.equal(notified, 1, 'register must notify subscribers (the runner resyncs the keymap)')
   const handle = registry.register(
-    { id: 'second', key: { key: 'y', ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'second' },
+    { id: 'second', key: { key: 'y', ctrl: true, alt: true, shift: false, super: false }, action: 'open-search', description: 'second' },
     'plugin',
   )
   assert.equal(notified, 2)
@@ -679,13 +679,14 @@ test('5.10 the registry canonicalizes modifier-order keys and named-key casing',
     'plugin',
   )
   assert.equal(registry.actionFor({ key: 'p', shift: true, ctrl: true, alt: false, super: false }), 'open-search')
-  // Named-key casing: register pageUp; look up pageup (the runtime parser
-  // lowercases) — convergence finding: both must be the same key.
+  // Named-key casing: register F5; look up f5 (the runtime parser
+  // lowercases) — convergence finding: both must be the same key. (pageUp
+  // is editor-owned now — a plugin cannot claim it, round-19 finding.)
   registry.register(
-    { id: 'page', key: { key: 'pageUp', ctrl: false, alt: false, shift: false, super: false }, action: 'toggle-fullscreen', description: 'page' },
+    { id: 'page', key: { key: 'F5', ctrl: false, alt: false, shift: false, super: false }, action: 'toggle-fullscreen', description: 'page' },
     'plugin',
   )
-  assert.equal(registry.actionFor({ key: 'pageup', ctrl: false, alt: false, shift: false, super: false }), 'toggle-fullscreen')
+  assert.equal(registry.actionFor({ key: 'f5', ctrl: false, alt: false, shift: false, super: false }), 'toggle-fullscreen')
   // Duplicate detection sees canonical-equivalent keys as one.
   assert.throws(() => registry.register(
     { id: 'mod-b', key: { key: 'p', shift: true, ctrl: true, alt: false, super: false }, action: 'open-search', description: 'b' },
@@ -1241,9 +1242,10 @@ test('7.7b shift+letter routes to the EDITOR on every protocol (legacy and CSI-u
     'legacy uppercase A types into the editor, never a plugin action')
   assert.equal(router.route('\x1b[97;2u', context, alwaysPlugin).kind, 'editor',
     'Kitty CSI-u Shift+A types into the editor, never a plugin action')
-  // Named non-text keys stay bindable chords.
-  assert.equal(router.route('\x1b[Z', context, alwaysPlugin).kind, 'plugin-action',
-    'Shift+Tab is a named chord, not text — it may reach the plugin stage')
+  // Named non-text keys stay ROUTER-eligible chords (the registry applies
+  // the further editor-owned/reserved rejections — round-19 finding).
+  assert.equal(router.route('\x1b[1;2D', context, alwaysPlugin).kind, 'plugin-action',
+    'Shift+Left is a named chord, not text — it may reach the plugin stage')
 })
 
 test('7.7c shift-only text keys are rejected for USER configs and leaders too', () => {
@@ -1261,4 +1263,66 @@ test('7.7c shift-only text keys are rejected for USER configs and leaders too', 
   const named = parseUserKeybindings({ 'app.transcript.toggleExpand': 'shift+f5' })
   assert.deepEqual(named.bindings, { 'app.transcript.toggleExpand': 'shift+f5' })
   assert.ok(!named.diagnostics.some(message => message.includes('text-producing')))
+})
+
+test('7.8 the registry rejects fork EDITOR-owned keys (no advertised-but-dead rules)', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  // The focused editor consumes these keys BEFORE the plugin stage (the
+  // InputRouter's editorAccepts probe claims the whole fork editor
+  // binding set), so a plugin registration on one of them could never
+  // fire — yet it used to enter the effective keymap, show up in
+  // /keybindings and even disable a colliding leader (round-19 finding).
+  const editorOwned: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean }[] = [
+    { key: 'tab' },
+    { key: 'enter', shift: true }, // shift+enter — the newline key
+    { key: 'backspace' },
+    { key: 'delete' },
+    { key: 'left' },
+    { key: 'right' },
+    { key: 'up' },
+    { key: 'down' },
+    { key: 'home' },
+    { key: 'end' },
+    { key: 'pageUp' },
+    { key: 'pageDown' },
+    { key: 'left', ctrl: true }, // ctrl+left — word navigation
+    { key: 'b', alt: true }, // alt+b — word navigation
+    { key: 'a', ctrl: true }, // ctrl+a — line start
+    { key: 'k', ctrl: true }, // ctrl+k — delete to line end
+    { key: 'y', ctrl: true }, // ctrl+y — yank
+  ]
+  for (const key of editorOwned) {
+    assert.throws(() => registry.register(
+      { id: `editor-${key.key}`, key: { key: key.key, ctrl: key.ctrl ?? false, alt: key.alt ?? false, shift: key.shift ?? false, super: false }, action: 'open-search', description: 'editor' },
+      'plugin',
+    ), /editor/, `a plugin must not claim the editor-owned ${key.ctrl ? 'Ctrl+' : key.alt ? 'Alt+' : key.shift ? 'Shift+' : ''}${key.key}`)
+  }
+  // Real plugin chords stay bindable.
+  registry.register(
+    { id: 'ok-chord', key: { key: 'x', ctrl: true, alt: true, shift: false, super: false }, action: 'open-search', description: 'chord' },
+    'plugin',
+  )
+  registry.register(
+    { id: 'ok-f5', key: { key: 'f5', ctrl: false, alt: false, shift: true, super: false }, action: 'open-search', description: 'f5' },
+    'plugin',
+  )
+  assert.equal(registry.snapshot().bindings.length, 2)
+})
+
+test('7.8b a rejected editor-owned plugin key never disables a colliding leader', () => {
+  const manager = new HostKeybindingManager()
+  // Tab can never become a plugin rule (the registry rejects it), so the
+  // keymap has NO plugin rule on tab — a user leader on tab must stay
+  // alive instead of being disabled by a dead "plugin binding" (round-19
+  // finding: pluginActiveKeys used to count editor-owned keys as live).
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'tab',
+    bindings: { 'app.transcript.toggleFullscreen': '<leader>n' },
+  }))
+  assert.ok(manager.leaderMachine() !== undefined, 'the leader stays alive (no plugin rule exists to collide)')
+  assert.ok(!manager.diagnosticsList().some(message => message.includes('plugin key')),
+    `no plugin collision expected: ${manager.diagnosticsList().join(' | ')}`)
+  assert.ok(!manager.snapshot().bindings.some(binding => binding.action === 'open-search'),
+    'no dead plugin rule is advertised')
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -248,25 +248,32 @@ test('4.10 a real armed window is disarmed by the viewer-close Esc', async () =>
   const app = new TuiApp(vt, {
     onSubmit: () => {},
     onExit: () => {},
-    onSingleEscape: () => { singleEscapes += 1; return singleEscapes === 1 ? false : true },
+    // First main Esc declines (arms the window); EVERY viewer-close Esc
+    // consumes (run the close path). The FINAL main Esc declines again —
+    // handleInterruptAction must then genuinely check (and find disarmed)
+    // lastEscapeAt.
+    onSingleEscape: () => { singleEscapes += 1; return singleEscapes === 2 ? true : false },
     onCancel: () => { cancels += 1 },
   })
   app.start()
-  // First main Esc: NOT consumed → handleEscapeKey ARMS the window.
+  // First main Esc: not consumed → handleInterruptAction ARMS the window.
   vt.sendInput('\x1b')
   await vt.waitForRender()
   assert.equal(singleEscapes, 1)
-  // Open + close the read-only viewer with Esc (the close is consumed).
+  // Open + close the read-only viewer with Esc (the close consumes).
   app.setViewerMode({ parentSessionId: 's', childSessionId: 'c', label: 'c', mode: 'one-shot', activity: 'inactive' })
   await vt.waitForRender()
   vt.sendInput('\x1b')
   await vt.waitForRender()
   assert.equal(singleEscapes, 2, 'the viewer-close Esc ran the close path')
-  // Back in main: the next Esc must RE-ARM (not read as a double-Esc).
+  // REALLY return to main: the viewer is gone, so the next Esc enters
+  // handleInterruptAction (not the viewer-close branch).
+  app.setViewerMode(undefined)
+  await vt.waitForRender()
   vt.sendInput('\x1b')
   await vt.waitForRender()
-  assert.equal(singleEscapes, 3)
-  assert.equal(cancels, 0, 'a stale window must not cancel after the viewer close')
+  assert.equal(singleEscapes, 3, 'the third Esc runs the main interrupt path (viewer closed)')
+  assert.equal(cancels, 0, 'a stale window must not cancel after the viewer close disarmed it')
   app.stop()
 })
 
@@ -425,4 +432,116 @@ test('5.3 Shift+Enter cannot be bound to submit (the editor newline key)', () =>
   const aliased = parseUserKeybindings({ 'app.input.submit': 'shift+return' })
   assert.deepEqual(aliased.bindings, {})
   assert.ok(aliased.diagnostics.some(message => message.includes('newline')))
+})
+
+// ── 4.5 submit participates in conflict (P1 finding) ──────────────────────
+
+test('4.5a a CONFLICTED submit override fails soft back to the builtin Enter', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.input.submit': 'ctrl+x',
+    'app.history.search': 'ctrl+x',
+  }))
+  // Both user rules conflict on ctrl+x: neither fires — but the dead
+  // override must NOT disable Enter (fail-soft on the EFFECTIVE rules).
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
+  assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'],
+    'a conflicted submit override must restore the builtin Enter')
+  assert.equal(manager.keyHint('app.input.submit'), 'Enter')
+  assert.equal(manager.resolve('\x18', editorContext), undefined, 'the conflicted ctrl+x fires nothing')
+})
+
+test('4.5b an explicit false submit stays strictly disabled', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.input.submit': false }))
+  assert.deepEqual(manager.editorSubmitKeysFor(), [], 'false must strictly disable submit')
+  assert.equal(manager.keyHint('app.input.submit'), '')
+})
+
+test('4.5c another action taking Enter does NOT leave submit advertised', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.todo.toggle': 'enter' }))
+  // Todo (user, 200) shadows the builtin submit Enter (editor, 100): the
+  // runtime resolves Enter to Todo; submit must NOT advertise Enter.
+  assert.equal(manager.resolve('\r', editorContext)?.action, 'app.todo.toggle')
+  assert.deepEqual(manager.editorSubmitKeysFor(), [],
+    'a shadowed submit Enter must not be advertised')
+  assert.equal(manager.keyHint('app.input.submit'), '')
+})
+
+// ── leader-only action actually EXECUTES (P1 finding) ────────────────────
+
+test('4.6c a leader-only action actually fires its completion', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let fullscreenToggles = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.transcript.toggleFullscreen': '<leader>n' },
+  }))
+  await vt.waitForRender()
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('n')
+  await vt.waitForRender()
+  assert.ok(app.isFullscreen(), 'the leader-only action must actually fire (fullscreen on)')
+  vt.sendInput('\x18')
+  await vt.waitForRender()
+  vt.sendInput('n')
+  await vt.waitForRender()
+  assert.ok(!app.isFullscreen(), 'the leader-only action fires again (fullscreen off)')
+  app.stop()
+})
+
+// ── priority shadow respects predicates (P2 finding) ──────────────────────
+
+test('4.3b a conditional high-priority rule does not shadow a lower rule when its predicate is false', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.tasks.open': 'ctrl+s' }))
+  // tasks.open (user, 200) inherits the empty-editor+tasks predicate;
+  // steer (builtin, 100) is on ctrl+s. When the tasks predicate is false
+  // (editor non-empty / no tasks), Ctrl+S must still STEER.
+  const contextWithTasks = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: true, tasksActive: true })
+  const contextNoTasks = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: false, tasksActive: false })
+  assert.equal(manager.resolve('\x13', contextWithTasks)?.action, 'app.tasks.open', 'predicate holds → tasks')
+  assert.equal(manager.resolve('\x13', contextNoTasks)?.action, 'app.input.steer',
+    'predicate false → the shadowed lower rule fires (context-aware shadow)')
+})
+
+// ── remapped interrupt double-window (P2 finding) ─────────────────────────
+
+test('4.8b Ctrl+X → Esc → Ctrl+X does NOT fire the idle double action', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let rewinds = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onRewind: () => { rewinds += 1 },
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.agent.interrupt': 'ctrl+x' }))
+  await vt.waitForRender()
+  vt.sendInput('\x18') // ctrl+x — arm the interrupt window
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // a DIFFERENT key (physical Esc is no longer the trigger)
+  await vt.waitForRender()
+  vt.sendInput('\x18') // ctrl+x again — must NOT read as a second consecutive trigger
+  await vt.waitForRender()
+  assert.equal(rewinds, 0, 'an intervening non-trigger key must disarm the window')
+  app.stop()
+})
+
+// ── legacy collisions rejected (P2 finding) ───────────────────────────────
+
+test('4.11b legacy terminal collisions are rejected bindings', () => {
+  for (const key of ['ctrl+[', 'ctrl+j', 'ctrl+m']) {
+    const parsed = parseUserKeybindings({ 'app.todo.toggle': key })
+    assert.deepEqual(parsed.bindings, {}, `"${key}" must be rejected`)
+    assert.ok(parsed.diagnostics.some(message => message.includes('legacy terminals') || message.includes('collides')),
+      `no rejection diagnostic for "${key}": ${parsed.diagnostics.join(' | ')}`)
+  }
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -985,6 +985,103 @@ test('6.5b a LEADER-ONLY submit override removes the builtin Enter from the snap
   assert.deepEqual(binding!.leaderKeys, ['s'], 'the leader sequence is carried')
 })
 
+// ── 6.6 unified override contract: leader-only REPLACES the builtin (round 37) ──
+
+test('6.6a leader-only REPLACES the builtin direct key of a normal Host action', async () => {
+  // Round 37 contract: absent = builtin; any user declaration (direct,
+  // leader-only, direct + leader) REPLACES the builtin. `app.todo.toggle:
+  // <leader>t` must make Leader T fire and Ctrl+T STOP firing.
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.todo.toggle': '<leader>t' },
+  }))
+  // The builtin Ctrl+T is gone — the leader-only declaration replaced it.
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), [], 'the builtin Ctrl+T must NOT be advertised')
+  assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), ['t'], 'the leader sequence is the only trigger')
+  assert.equal(manager.keyHint('app.todo.toggle'), 'Leader T')
+  // Runtime: Ctrl+T no longer toggles the todo panel; Leader T does.
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.todo.toggle': '<leader>t' },
+  }))
+  await vt.waitForRender()
+  vt.sendInput('\x14') // ctrl+t — the OLD builtin
+  await vt.waitForRender()
+  assert.equal(app.isTodoPanelVisible(), false, 'Ctrl+T must no longer toggle the todo panel (the leader-only declaration replaced the builtin)')
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('t')
+  await vt.waitForRender()
+  assert.equal(app.isTodoPanelVisible(), true, 'Leader T must toggle the todo panel (the leader-only trigger)')
+  app.stop()
+})
+
+test('6.6b leader-only REPLACES the builtin steer key (Ctrl+S no longer steers)', async () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.steer': '<leader>s' },
+  }))
+  assert.deepEqual(manager.keysFor('app.input.steer'), [], 'the builtin Ctrl+S must NOT be advertised')
+  assert.deepEqual(manager.leaderKeysFor('app.input.steer'), ['s'], 'the leader sequence is the only steer trigger')
+  const vt = new VirtualTerminal(80, 24)
+  const steered: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSteer: (text: string) => steered.push(text),
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.steer': '<leader>s' },
+  }))
+  await vt.waitForRender()
+  vt.sendInput('\x13') // ctrl+s — the OLD builtin
+  await vt.waitForRender()
+  assert.deepEqual(steered, [], 'Ctrl+S must no longer steer (the leader-only declaration replaced the builtin)')
+  app.setDraft('draft')
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('s')
+  await vt.waitForRender()
+  assert.deepEqual(steered, ['draft'], 'Leader S must steer')
+  app.stop()
+})
+
+test('6.6c leader-only submit: the unified model carries NO Enter (resolve/matches/editorSync/snapshot)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.submit': '<leader>s' },
+  }))
+  // The reviewer's required quartet: the unified model itself must not
+  // declare the builtin Enter — not just the manager projection.
+  assert.equal(manager.resolve('\r', editorContext), undefined, 'resolve(Enter) must be undefined (the unified model has no Enter submit rule)')
+  assert.equal(manager.matches('\r', 'app.input.submit'), false, 'matches(Enter, submit) must be false')
+  assert.deepEqual(manager.editorSubmitKeysFor(), [], 'the editor sync carries no Enter')
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.input.submit')
+  assert.ok(binding !== undefined)
+  assert.deepEqual(binding!.keys, [], 'the snapshot carries no Enter')
+  // A direct+leader mix keeps the direct key AND the leader (both user
+  // triggers; the builtin is removed).
+  const mixed = new HostKeybindingManager()
+  mixed.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.submit': ['ctrl+z', '<leader>s'] },
+  }))
+  assert.equal(mixed.resolve('\x1a', editorContext)?.action, 'app.input.submit', 'the direct ctrl+z still resolves')
+  assert.equal(mixed.resolve('\r', editorContext), undefined, 'Enter is gone from the unified model')
+  assert.deepEqual(mixed.editorSubmitKeysFor(), ['ctrl+z'], 'the direct key survives; no Enter')
+})
+
 test('6.6 a conditional top rule does not permanently hide the fallback in the read model', () => {
   const manager = new HostKeybindingManager()
   manager.setUserConfiguration(parseUserKeybindings({ 'app.tasks.open': 'ctrl+s' }))

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -348,3 +348,81 @@ test('4.11 reserved session/model actions are not user-configurable', () => {
   assert.deepEqual(parsedModel.bindings, {})
   assert.ok(parsedModel.diagnostics.some(message => message.includes('not user-configurable')))
 })
+
+// ── 5.x remapped interrupt: semantic core, double-action, no editor steal ──
+
+test('5.1 a remapped interrupt (ctrl+x) does NOT enter the physical-Escape editor seams', async () => {
+  const { EditorRegistry } = await import('../src/editor-registry.ts')
+  const vt = new VirtualTerminal(80, 24)
+  const cancels: number[] = []
+  const registry = new EditorRegistry()
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels.push(1) },
+  }, {
+    editorRegistry: registry,
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.agent.interrupt': 'ctrl+x' }))
+  // A replacement editor whose handleInput CONSUMES Ctrl+X — the remapped
+  // interrupt must NOT be routed to it (a replacement editor's Esc seams
+  // belong to the PHYSICAL Escape key only, convergence §5).
+  registry.register({
+    id: 'consuming',
+    priority: 0,
+    create: () => ({
+      component: { kind: 'text', spans: [{ text: 'vim' }] },
+      getText: () => '',
+      setText: () => {},
+      getCursor: () => 0,
+      setCursor: () => {},
+      focused: true,
+      handleInput: () => true, // consumes everything
+      dispose: () => {},
+    }),
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  app.setBusy(true)
+  await vt.waitForRender()
+  vt.sendInput('\x18') // ctrl+x — the remapped interrupt
+  await vt.waitForRender()
+  assert.deepEqual(cancels, [1], 'a remapped interrupt must interrupt the busy agent, never the editor')
+  app.stop()
+})
+
+test('5.2 a remapped interrupt keeps its consecutive-press idle semantics', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let cancels = 0
+  let rewinds = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels += 1 },
+    onRewind: () => { rewinds += 1 },
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.agent.interrupt': 'ctrl+x' }))
+  await vt.waitForRender()
+  // Idle: two Ctrl+X presses within the window = the idle double action
+  // (rewind on an empty editor). The remapped key must NOT be disarmed by
+  // its own first press (convergence §5 finding).
+  vt.sendInput('\x18')
+  await vt.waitForRender()
+  vt.sendInput('\x18')
+  await vt.waitForRender()
+  assert.equal(rewinds, 1, 'two remapped-interrupt presses must fire the idle double action')
+  app.stop()
+})
+
+test('5.3 Shift+Enter cannot be bound to submit (the editor newline key)', () => {
+  const parsed = parseUserKeybindings({ 'app.input.submit': 'shift+enter' })
+  assert.deepEqual(parsed.bindings, {}, 'shift+enter submit must be rejected')
+  assert.ok(parsed.diagnostics.some(message => message.includes('newline')),
+    `no diagnostic for shift+enter submit: ${parsed.diagnostics.join(' | ')}`)
+  // The alias spelling (shift+return) is rejected the same way.
+  const aliased = parseUserKeybindings({ 'app.input.submit': 'shift+return' })
+  assert.deepEqual(aliased.bindings, {})
+  assert.ok(aliased.diagnostics.some(message => message.includes('newline')))
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -943,7 +943,7 @@ test('6.4 canonical casing: ctrl+A == ctrl+a; SPACE/Space are printable', () => 
   for (const spelling of ['SPACE', 'Space']) {
     const direct = parseUserKeybindings({ 'app.todo.toggle': spelling })
     assert.deepEqual(direct.bindings, {}, `${spelling} direct must be rejected`)
-    assert.ok(direct.diagnostics.some(message => message.includes('plain printable')),
+    assert.ok(direct.diagnostics.some(message => message.includes('text-producing')),
       `no printable rejection for ${spelling}: ${direct.diagnostics.join(' | ')}`)
     const leader = parseUserKeybindings({ leader: spelling, bindings: { 'app.tasks.open': '<leader>t' } })
     assert.equal(leader.leader, undefined, `${spelling} leader must be rejected`)
@@ -1090,11 +1090,11 @@ test('7.3 the registry rejects plain printable keys (space/letters) at registrat
   assert.throws(() => registry.register(
     { id: 'space', key: { key: 'space', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'space' },
     'plugin',
-  ), /printable/, 'the spacebar must be rejected at registration')
+  ), /text-producing/, 'the spacebar must be rejected at registration')
   assert.throws(() => registry.register(
     { id: 'letter', key: { key: 'a', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'a' },
     'plugin',
-  ), /printable/, 'a bare letter must be rejected at registration')
+  ), /text-producing/, 'a bare letter must be rejected at registration')
   // A MODIFIED chord stays bindable (it really reaches the plugin stage).
   registry.register(
     { id: 'ctrl-space', key: { key: 'space', ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'chord' },
@@ -1190,4 +1190,75 @@ test('7.6 the registry REJECTS legacy C0 alias keys (ctrl+i / ctrl+h / ctrl+_ / 
   assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+h'))
   assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+_'))
   assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+-'))
+})
+
+test('7.7 the registry rejects SHIFT-only text keys and non-grammar key names', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  // Shift+A is TEXT on every protocol: legacy terminals deliver the raw
+  // 'A' byte, Kitty CSI-u normalizes it to 'a'+shift — either way the
+  // editor must receive it, so a plugin binding on it would steal the
+  // user's typing on some terminals and stay dead on others (round-17
+  // finding: the printable guard used to treat ANY shift as a chord).
+  const textKeys = [
+    { key: 'a', ctrl: false, alt: false, shift: true, super: false },
+    { key: 'space', ctrl: false, alt: false, shift: true, super: false },
+    { key: '1', ctrl: false, alt: false, shift: true, super: false },
+    { key: '/', ctrl: false, alt: false, shift: true, super: false },
+  ]
+  for (const key of textKeys) {
+    assert.throws(() => registry.register(
+      { id: `shift-${key.key}`, key, action: 'open-search', description: 'shift' },
+      'plugin',
+    ), /text-producing/, `shift+${key.key} must be rejected at registration`)
+  }
+  // A key name the fork grammar can never produce is a dead binding
+  // (parseKey can never emit it — the router's only runtime identity
+  // source) — rejected at registration (round-17 finding).
+  for (const key of ['definitely-not-a-key', 'f13', 'something-random']) {
+    assert.throws(() => registry.register(
+      { id: `bad-${key}`, key: { key, ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'bad' },
+      'plugin',
+    ), /not a valid key/, `"${key}" must be grammar-rejected`)
+  }
+  assert.equal(registry.snapshot().bindings.length, 0)
+})
+
+test('7.7b shift+letter routes to the EDITOR on every protocol (legacy and CSI-u)', () => {
+  const router = new InputRouter()
+  const context = {
+    questionActive: false,
+    approvalActive: false,
+    viewerInputMode: 'none' as const,
+    hasOverlay: false,
+    searchActive: false,
+    hostDeclined: false,
+  }
+  // The strongest probe: a plugin binding exists for EVERY normalized key
+  // — text-producing keys must still never reach the plugin stage.
+  const alwaysPlugin = (): 'open-search' => 'open-search'
+  assert.equal(router.route('A', context, alwaysPlugin).kind, 'editor',
+    'legacy uppercase A types into the editor, never a plugin action')
+  assert.equal(router.route('\x1b[97;2u', context, alwaysPlugin).kind, 'editor',
+    'Kitty CSI-u Shift+A types into the editor, never a plugin action')
+  // Named non-text keys stay bindable chords.
+  assert.equal(router.route('\x1b[Z', context, alwaysPlugin).kind, 'plugin-action',
+    'Shift+Tab is a named chord, not text — it may reach the plugin stage')
+})
+
+test('7.7c shift-only text keys are rejected for USER configs and leaders too', () => {
+  // The SAME text-producing policy applies to the user config parser:
+  // matchesKey('A','shift+a') is TRUE on legacy terminals (probe-verified),
+  // so a Host binding on shift+a would steal every typed uppercase A.
+  const direct = parseUserKeybindings({ 'app.todo.toggle': 'shift+a' })
+  assert.deepEqual(direct.bindings, {}, 'shift+a must not bind a Host action')
+  assert.ok(direct.diagnostics.some(message => message.includes('text-producing')),
+    `no text-producing rejection: ${direct.diagnostics.join(' | ')}`)
+  const leader = parseUserKeybindings({ leader: 'shift+s', bindings: { 'app.tasks.open': '<leader>t' } })
+  assert.equal(leader.leader, undefined, 'a text-producing leader must be rejected')
+  // Named non-text keys keep their chords (shift+tab is the permission
+  // cycle default; shift+f5 is a plain chord).
+  const named = parseUserKeybindings({ 'app.transcript.toggleExpand': 'shift+f5' })
+  assert.deepEqual(named.bindings, { 'app.transcript.toggleExpand': 'shift+f5' })
+  assert.ok(!named.diagnostics.some(message => message.includes('text-producing')))
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -726,3 +726,46 @@ test('5.12 canonical named keys still display as PageUp/PageDown', async () => {
   assert.deepEqual(lower.keysFor('app.transcript.toggleExpand'), ['pageup'])
   assert.equal(lower.keyHint('app.transcript.toggleExpand'), 'PageUp')
 })
+
+// ── uppercase aliases + leader legacy collisions + LF submit (round-7) ────
+
+test('5.13 uppercase aliases canonicalize to the same key (ESC/escape, RETURN/enter)', async () => {
+  const { canonicalizeKeyId } = await import('../src/keybindings/key-identity.ts')
+  assert.equal(canonicalizeKeyId('ESC' as never), 'escape')
+  assert.equal(canonicalizeKeyId('RETURN' as never), 'enter')
+  assert.equal(canonicalizeKeyId('CTRL+RETURN' as never), 'ctrl+enter')
+  assert.equal(canonicalizeKeyId('Shift+Ctrl+ESC' as never), 'ctrl+shift+escape')
+  // An uppercase-alias config conflicts with the canonical spelling.
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.history.search': 'ESC', 'app.todo.toggle': 'escape' }))
+  assert.deepEqual(manager.keysFor('app.history.search'), [], 'ESC and escape must conflict as one key')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
+})
+
+test('5.14 the leader prefix and completions reject legacy lifecycle collisions', () => {
+  // leader: ctrl+[ would swallow Esc on legacy terminals.
+  const leader = parseUserKeybindings({ leader: 'ctrl+[', bindings: { 'app.tasks.open': '<leader>t' } })
+  assert.equal(leader.leader, undefined, 'a legacy-collision leader must be rejected')
+  assert.ok(leader.diagnostics.some(message => message.includes('legacy terminals')))
+  // A completion on ctrl+j would swallow Enter on legacy terminals.
+  const completion = parseUserKeybindings({ leader: 'ctrl+x', bindings: { 'app.tasks.open': '<leader>ctrl+j' } })
+  assert.deepEqual(completion.leaderBindings, [], 'a legacy-collision completion must be rejected')
+  assert.ok(completion.diagnostics.some(message => message.includes('legacy terminals')))
+})
+
+test('5.15 a disabled submit never fires on LF/Enter through the host editor', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text: string) => submitted.push(text), onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': false }))
+  await vt.waitForRender()
+  app.setDraft('stays')
+  await vt.waitForRender()
+  vt.sendInput('\r') // Enter
+  await vt.waitForRender()
+  vt.sendInput('\n') // LF (Ctrl+J)
+  await vt.waitForRender()
+  assert.deepEqual(submitted, [], 'a disabled submit must not fire on Enter or LF')
+  app.stop()
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -56,8 +56,15 @@ test('4.1b enter and return are the SAME physical key (conflict)', () => {
     'app.history.search': 'enter',
     'app.todo.toggle': 'return',
   }))
-  assert.equal(manager.resolve('\r', editorContext), undefined,
-    'enter/return aliases must conflict')
+  // The two USER rules conflict and deactivate; the surviving Enter rule is
+  // the EDITOR-OWNED builtin submit (owner-aware winner selection — the
+  // resolver reports WHO executes, it never erases the key). The host
+  // ladder must NOT consume the editor-owned winner.
+  assert.equal(manager.resolve('\r', editorContext)?.action, 'app.input.submit',
+    'enter/return aliases must conflict — only the builtin editor-owned submit survives')
+  assert.equal(manager.resolve('\r', editorContext)?.owner, 'editor')
+  assert.equal(manager.hostResolves('\r', editorContext), false,
+    'the surviving editor-owned submit must not be host-resolved')
   assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
 })
 
@@ -768,4 +775,234 @@ test('5.15 a disabled submit never fires on LF/Enter through the host editor', a
   await vt.waitForRender()
   assert.deepEqual(submitted, [], 'a disabled submit must not fire on Enter or LF')
   app.stop()
+})
+
+// ── 6.x owner-aware winner selection (round-9 findings) ────────────────────
+
+test('6.1a submit remapped onto a HOST key: the editor-owned winner submits, steer NEVER fires', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const steered: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: (text: string) => submitted.push(text),
+    onSteer: (text: string) => steered.push(text),
+    onExit: () => {},
+  })
+  app.start()
+  // The user moves submit onto Ctrl+S — the steer BUILTIN's key. The user
+  // rule (200) beats the builtin (100), and the WINNER's owner decides the
+  // executor: editor → the fork editor submits. The host ladder must NOT
+  // dispatch steer first (round-9 P1 finding: the resolver used to skip
+  // editor-owned rules BEFORE picking a winner, so steer won at runtime
+  // while the read model advertised submit).
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': 'ctrl+s' }))
+  await vt.waitForRender()
+  app.setDraft('draft')
+  await vt.waitForRender()
+  vt.sendInput('\x13') // ctrl+s
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['draft'], 'Ctrl+S must submit through the editor-owned winner')
+  assert.deepEqual(steered, [], 'Ctrl+S must NEVER steer')
+  // The read model agrees: Ctrl+S belongs to submit only.
+  assert.deepEqual(app.keybindingsManager().keysFor('app.input.submit'), ['ctrl+s'])
+  assert.deepEqual(app.keybindingsManager().keysFor('app.input.steer'), [],
+    'steer must not advertise the ctrl+s it lost')
+  const snapshot = app.keybindingsManager().snapshot()
+  const submitRow = snapshot.bindings.find(binding => binding.action === 'app.input.submit')
+  assert.deepEqual(submitRow?.keys, ['ctrl+s'], 'the snapshot advertises submit on Ctrl+S')
+  const steerRow = snapshot.bindings.find(binding => binding.action === 'app.input.steer')
+  assert.equal(steerRow, undefined, 'the snapshot must not carry steer on ctrl+s')
+  app.stop()
+})
+
+test('6.1b resolve() carries the EXECUTING owner; hostResolves follows the winner', () => {
+  // Default surface: the builtin Enter resolves to the EDITOR-owned submit.
+  const plain = new HostKeybindingManager()
+  assert.equal(plain.resolve('\r', editorContext)?.action, 'app.input.submit')
+  assert.equal(plain.resolve('\r', editorContext)?.owner, 'editor')
+  assert.equal(plain.hostResolves('\r', editorContext), false,
+    'the editor-owned winner must never be host-resolved')
+  // A host-owned key stays host-resolved.
+  assert.equal(plain.resolve('\x13', editorContext)?.owner, 'host') // ctrl+s → steer
+  assert.equal(plain.hostResolves('\x13', editorContext), true)
+  // submit: ctrl+s — the editor-owned user rule WINS the key; the host
+  // must not resolve it.
+  const remapped = new HostKeybindingManager()
+  remapped.setUserConfiguration(parseUserKeybindings({ 'app.input.submit': 'ctrl+s' }))
+  const resolution = remapped.resolve('\x13', editorContext)
+  assert.equal(resolution?.action, 'app.input.submit')
+  assert.equal(resolution?.owner, 'editor')
+  assert.equal(resolution?.ruleId, 'app.input.submit@user:ctrl+s')
+  assert.equal(remapped.hostResolves('\x13', editorContext), false)
+  // A plugin-owner winner stays out of hostResolves too.
+  const withPlugin = new HostKeybindingManager()
+  withPlugin.setPluginRules([{ id: 'p1', action: 'app.todo.toggle', key: 'ctrl+alt+x' }])
+  assert.equal(withPlugin.resolve('\x1b[120;7u', editorContext)?.owner, 'plugin')
+  assert.equal(withPlugin.hostResolves('\x1b[120;7u', editorContext), false)
+})
+
+test('6.2 submit on fork-editor PRE-SUBMIT keys is rejected (they can never fire)', () => {
+  // The fork editor dispatches these bindings BEFORE its submit check
+  // (packages/pi-tui/src/components/editor.ts), so a submit remap onto one
+  // of them would be advertised by the read model but could never fire.
+  // Same unsupported-key policy as the Shift+Enter newline rejection
+  // (round-9 finding: submit: tab silently stayed autocomplete).
+  const preSubmit = [
+    'tab', 'backspace', 'delete', 'ctrl+a', 'ctrl+e', 'ctrl+u', 'ctrl+k',
+    'ctrl+w', 'ctrl+y', 'ctrl+c', 'ctrl+d', 'ctrl+-', 'alt+backspace',
+    'alt+delete', 'alt+d', 'alt+y', 'alt+b', 'alt+f', 'alt+left', 'alt+right',
+    'ctrl+left', 'ctrl+right', 'home', 'end', 'ctrl+home', 'ctrl+end',
+    'shift+backspace', 'shift+delete',
+  ]
+  for (const key of preSubmit) {
+    const parsed = parseUserKeybindings({ 'app.input.submit': key })
+    assert.deepEqual(parsed.bindings, {}, `submit on "${key}" must be rejected`)
+    assert.ok(parsed.diagnostics.some(message => message.includes('editor consumes')),
+      `no rejection diagnostic for "${key}": ${parsed.diagnostics.join(' | ')}`)
+  }
+  // The alias spellings canonicalize onto the same rejected keys.
+  const aliased = parseUserKeybindings({ 'app.input.submit': 'shift+Backspace' })
+  assert.deepEqual(aliased.bindings, {}, 'shift+Backspace must canonicalize into the rejected set')
+  assert.ok(aliased.diagnostics.some(message => message.includes('editor consumes')))
+  // A key the fork editor does NOT consume before submit stays bindable:
+  // ctrl+backspace is not in the fork's editor keybindings, so a submit
+  // remap on it genuinely reaches the submit check.
+  const works = parseUserKeybindings({ 'app.input.submit': 'ctrl+backspace' })
+  assert.deepEqual(works.bindings, { 'app.input.submit': 'ctrl+backspace' })
+  assert.ok(!works.diagnostics.some(message => message.includes('editor consumes')))
+  // OTHER actions may still bind an editor-pre-submit key: the HOST ladder
+  // consumes them before the editor, so they really fire.
+  const other = parseUserKeybindings({ 'app.todo.toggle': 'tab' })
+  assert.deepEqual(other.bindings, { 'app.todo.toggle': 'tab' }, 'tab stays bindable for a host action')
+  assert.ok(!other.diagnostics.some(message => message.includes('editor consumes')))
+})
+
+test('6.3 mixed direct + leader submit: BOTH triggers stay, Enter is removed', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text: string) => submitted.push(text), onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.submit': ['ctrl+z', '<leader>s'] },
+  }))
+  await vt.waitForRender()
+  // The DIRECT key survives the leader sequence (round-9 finding: any
+  // leader binding used to clear EVERY direct editor key).
+  assert.deepEqual(app.keybindingsManager().editorSubmitKeysFor(), ['ctrl+z'])
+  assert.equal(app.keybindingsManager().keyHint('app.input.submit'), 'Ctrl+Z / Leader S')
+  const snapshot = app.keybindingsManager().snapshot()
+  const submitRow = snapshot.bindings.find(binding => binding.action === 'app.input.submit')
+  assert.deepEqual(submitRow?.keys, ['ctrl+z'])
+  assert.deepEqual(submitRow?.leaderKeys, ['s'])
+  // Ctrl+Z submits…
+  app.setDraft('one')
+  await vt.waitForRender()
+  vt.sendInput('\x1a') // ctrl+z
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['one'], 'the direct key submits')
+  // …Enter does NOT…
+  app.setDraft('two')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['one'], 'Enter must not submit (the override replaced the builtin)')
+  // …and the leader sequence submits too.
+  app.setDraft('three')
+  await vt.waitForRender()
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('s')
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['one', 'three'], 'the leader sequence must submit')
+  app.stop()
+})
+
+test('6.4 canonical casing: ctrl+A == ctrl+a; SPACE/Space are printable', () => {
+  // Single-character bases canonicalize to lowercase — ctrl+A and ctrl+a
+  // are the SAME physical key and must conflict (round-9 finding: the
+  // canonicalizer skipped single-char bases, the fork runtime lowercases,
+  // so two spellings of one key coexisted).
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    'app.history.search': 'ctrl+A',
+    'app.todo.toggle': 'ctrl+a',
+  }))
+  assert.deepEqual(manager.keysFor('app.history.search'), [], 'ctrl+A and ctrl+a must conflict')
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), [])
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')),
+    `no conflict diagnostic: ${manager.diagnosticsList().join(' | ')}`)
+  // The canonical spelling is lowercase everywhere.
+  const single = new HostKeybindingManager()
+  single.setUserConfiguration(parseUserKeybindings({ 'app.transcript.toggleExpand': 'ctrl+A' }))
+  assert.deepEqual(single.keysFor('app.transcript.toggleExpand'), ['ctrl+a'])
+  // UPPERCASE space spellings are still the printable spacebar: rejected as
+  // direct bindings and as the leader prefix (round-9 finding: the policy
+  // checks ran on the RAW spelling, so `SPACE` bypassed the typing guard).
+  for (const spelling of ['SPACE', 'Space']) {
+    const direct = parseUserKeybindings({ 'app.todo.toggle': spelling })
+    assert.deepEqual(direct.bindings, {}, `${spelling} direct must be rejected`)
+    assert.ok(direct.diagnostics.some(message => message.includes('plain printable')),
+      `no printable rejection for ${spelling}: ${direct.diagnostics.join(' | ')}`)
+    const leader = parseUserKeybindings({ leader: spelling, bindings: { 'app.tasks.open': '<leader>t' } })
+    assert.equal(leader.leader, undefined, `${spelling} leader must be rejected`)
+  }
+})
+
+test('6.5 a working submit remap is not advertised alongside the replaced Enter (snapshot)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.input.submit': 'ctrl+x' }))
+  assert.deepEqual(manager.editorSubmitKeysFor(), ['ctrl+x'])
+  assert.equal(manager.keyHint('app.input.submit'), 'Ctrl+X')
+  // Round-9 finding: the keymap snapshot iterated the raw top-trigger set
+  // and re-advertised the builtin Enter next to the working override —
+  // /keybindings lied while /help was right. Snapshot now projects the
+  // SAME visible rules as keysFor/keyHint/editorSubmitKeysFor.
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.input.submit')
+  assert.ok(binding !== undefined)
+  assert.deepEqual(binding!.keys, ['ctrl+x'], 'the snapshot must not re-advertise the replaced Enter')
+})
+
+test('6.5b a LEADER-ONLY submit override removes the builtin Enter from the snapshot too', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.submit': '<leader>s' },
+  }))
+  // The leader-only override removes Enter from the editor sync and the
+  // hints (review round: the leader is the ONLY trigger) — the snapshot
+  // must agree (external-review finding: it still advertised the builtin
+  // Enter, so /keybindings lied while Enter was inert at runtime).
+  assert.deepEqual(manager.editorSubmitKeysFor(), [], 'the leader is the only submit trigger')
+  assert.deepEqual(manager.keysFor('app.input.submit'), [])
+  assert.equal(manager.keyHint('app.input.submit'), 'Leader S')
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.input.submit')
+  assert.ok(binding !== undefined)
+  assert.deepEqual(binding!.keys, [], 'the snapshot must not advertise the removed Enter')
+  assert.deepEqual(binding!.leaderKeys, ['s'], 'the leader sequence is carried')
+})
+
+test('6.6 a conditional top rule does not permanently hide the fallback in the read model', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ 'app.tasks.open': 'ctrl+s' }))
+  // tasks.open (conditional — the empty-editor affordance predicate) claims
+  // ctrl+s at priority 200; steer's builtin ctrl+s (100) is the CONTEXT
+  // FALLBACK. The read model must show BOTH (round-9 finding: the static
+  // read model shadowed the lower rule forever, so keyHint/snapshot hid
+  // steer even in contexts where steer genuinely fires).
+  assert.ok(manager.keysFor('app.tasks.open').includes('ctrl+s'), 'tasks.open advertises its conditional ctrl+s claim')
+  assert.deepEqual(manager.keysFor('app.input.steer'), ['ctrl+s'],
+    'a conditional claim must not hide the fallback in the read model')
+  assert.equal(manager.keyHint('app.input.steer'), 'Ctrl+S')
+  const steerRow = manager.snapshot().bindings.find(entry => entry.action === 'app.input.steer')
+  assert.ok(steerRow !== undefined, 'the snapshot must carry the fallback steer row')
+  assert.deepEqual(steerRow!.keys, ['ctrl+s'])
+  // The runtime still resolves by the predicate (the fallback FIRES when
+  // the conditional claim cannot).
+  const noTasks = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: false, tasksActive: false })
+  assert.equal(manager.resolve('\x13', noTasks)?.action, 'app.input.steer')
+  // An UNCONDITIONAL higher rule still shadows in the read model.
+  const unconditional = new HostKeybindingManager()
+  unconditional.setUserConfiguration(parseUserKeybindings({ 'app.todo.toggle': 'ctrl+s' }))
+  assert.deepEqual(unconditional.keysFor('app.input.steer'), [], 'an unconditional top trigger still hides the lower rule')
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -645,3 +645,47 @@ test('5.8 the manager leaderTimeoutMs override is applied to the machine', () =>
   const cfg = (machine as unknown as { config: { timeoutMs: number } }).config
   assert.equal(cfg.timeoutMs, 777, 'the manager override must win over the config default')
 })
+
+// ── plugin id collision + registry canonicalization (round-4 findings) ────
+
+test('5.9 a plugin rule id cannot shadow-deactivate a HOST rule', () => {
+  const manager = new HostKeybindingManager()
+  // The plugin uses a public id that EQUALS the host builtin ctrl+s rule
+  // id. Two plugins claim the same key with colliding ids — the HOST
+  // builtin must survive (its rule id is namespaced away).
+  manager.setPluginRules([
+    { id: 'app.input.steer@builtin:ctrl+s', action: 'app.todo.toggle', key: 'ctrl+t' },
+    { id: 'app.input.steer@builtin:ctrl+s', action: 'app.history.search', key: 'ctrl+t' },
+  ])
+  assert.deepEqual(manager.keysFor('app.input.steer'), ['ctrl+s'],
+    'the host builtin steer ctrl+s must survive plugin-id collisions')
+})
+
+test('5.10 the registry canonicalizes alias keys (esc/escape, return/enter)', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  // Register with the alias spelling.
+  registry.register(
+    { id: 'alias-esc', key: { key: 'esc', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'alias' },
+    'plugin',
+  )
+  // Lookup with the CANONICAL spelling must find it.
+  assert.equal(registry.actionFor({ key: 'escape', ctrl: false, alt: false, shift: false, super: false }), 'open-search',
+    'a plugin registered with "esc" must be found by "escape"')
+  // And the reverse: register return, find by enter.
+  registry.register(
+    { id: 'alias-return', key: { key: 'return', ctrl: false, alt: false, shift: false, super: false }, action: 'toggle-fullscreen', description: 'alias' },
+    'plugin',
+  )
+  assert.equal(registry.actionFor({ key: 'enter', ctrl: false, alt: false, shift: false, super: false }), 'toggle-fullscreen')
+  // Duplicate detection sees canonical-equivalent keys as one (modifier
+  // order variants — neither is a reserved host key).
+  registry.register(
+    { id: 'mod-a', key: { key: 'p', ctrl: true, shift: true, alt: false, super: false }, action: 'open-search', description: 'a' },
+    'plugin',
+  )
+  assert.throws(() => registry.register(
+    { id: 'mod-b', key: { key: 'p', shift: true, ctrl: true, alt: false, super: false }, action: 'open-search', description: 'b' },
+    'plugin',
+  ), /duplicate keybinding/, 'ctrl+shift+p and shift+ctrl+p must be detected as the same key')
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -597,3 +597,51 @@ test('5.6 a plugin cannot bind the space key (it would swallow typing)', () => {
   const result = router.route(' ', { questionActive: false, approvalActive: false, viewerInputMode: 'none', hasOverlay: false, searchActive: false, hostDeclined: false }, () => 'open-search')
   assert.equal(result.kind, 'editor', 'a plain space must reach the editor, never a plugin binding')
 })
+
+// ── dynamic plugin keybinding lifecycle (full-review finding) ─────────────
+
+test('5.7 the registry notifies subscribers on register/dispose (dynamic sync)', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  let notified = 0
+  const unsubscribe = registry.subscribe(() => { notified += 1 })
+  registry.register(
+    { id: 'late', key: { key: 'z', ctrl: true, alt: true, shift: false, super: false }, action: 'open-search', description: 'late' },
+    'plugin',
+  )
+  assert.equal(notified, 1, 'register must notify subscribers (the runner resyncs the keymap)')
+  const handle = registry.register(
+    { id: 'second', key: { key: 'y', ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'second' },
+    'plugin',
+  )
+  assert.equal(notified, 2)
+  handle.dispose()
+  assert.equal(notified, 3, 'dispose must notify subscribers (an unloaded binding stops firing)')
+  unsubscribe()
+  registry.register(
+    { id: 'after-unsub', key: { key: 'x', ctrl: true, alt: false, shift: false, super: false }, action: 'open-search', description: 'after' },
+    'plugin',
+  )
+  assert.equal(notified, 3, 'unsubscribe must stop notifications')
+  // The runner wiring (index.ts) subscribes and calls setPluginRules on
+  // every notification — the pieces are now covered: registry notify +
+  // the manager's setPluginRules resync.
+  const manager = new HostKeybindingManager()
+  manager.setPluginRules([{ id: 'late', action: 'app.transcript.toggleFullscreen', key: 'ctrl+alt+z' }])
+  assert.deepEqual(manager.keysFor('app.transcript.toggleFullscreen'), ['ctrl+alt+z'])
+  manager.setPluginRules([])
+  assert.deepEqual(manager.keysFor('app.transcript.toggleFullscreen'), [], 'removing the plugin rule stops it')
+})
+
+// ── leaderTimeoutMs override (full-review finding) ────────────────────────
+
+test('5.8 the manager leaderTimeoutMs override is applied to the machine', () => {
+  const manager = new HostKeybindingManager({ leaderTimeoutMs: 777 })
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.transcript.toggleFullscreen': '<leader>n' },
+  }, { leaderTimeoutMs: 1500 }))
+  const machine = manager.leaderMachine()
+  const cfg = (machine as unknown as { config: { timeoutMs: number } }).config
+  assert.equal(cfg.timeoutMs, 777, 'the manager override must win over the config default')
+})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -661,31 +661,42 @@ test('5.9 a plugin rule id cannot shadow-deactivate a HOST rule', () => {
     'the host builtin steer ctrl+s must survive plugin-id collisions')
 })
 
-test('5.10 the registry canonicalizes alias keys (esc/escape, return/enter)', async () => {
+test('5.10 the registry canonicalizes modifier-order keys and named-key casing', async () => {
   const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
   const registry = new KeybindingRegistry()
-  // Register with the alias spelling.
-  registry.register(
-    { id: 'alias-esc', key: { key: 'esc', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'alias' },
-    'plugin',
-  )
-  // Lookup with the CANONICAL spelling must find it.
-  assert.equal(registry.actionFor({ key: 'escape', ctrl: false, alt: false, shift: false, super: false }), 'open-search',
-    'a plugin registered with "esc" must be found by "escape"')
-  // And the reverse: register return, find by enter.
-  registry.register(
-    { id: 'alias-return', key: { key: 'return', ctrl: false, alt: false, shift: false, super: false }, action: 'toggle-fullscreen', description: 'alias' },
-    'plugin',
-  )
-  assert.equal(registry.actionFor({ key: 'enter', ctrl: false, alt: false, shift: false, super: false }), 'toggle-fullscreen')
-  // Duplicate detection sees canonical-equivalent keys as one (modifier
-  // order variants — neither is a reserved host key).
+  // Register ctrl+shift+p; look up by shift+ctrl+p (modifier order
+  // canonicalizes to one identity).
   registry.register(
     { id: 'mod-a', key: { key: 'p', ctrl: true, shift: true, alt: false, super: false }, action: 'open-search', description: 'a' },
     'plugin',
   )
+  assert.equal(registry.actionFor({ key: 'p', shift: true, ctrl: true, alt: false, super: false }), 'open-search')
+  // Named-key casing: register pageUp; look up pageup (the runtime parser
+  // lowercases) — convergence finding: both must be the same key.
+  registry.register(
+    { id: 'page', key: { key: 'pageUp', ctrl: false, alt: false, shift: false, super: false }, action: 'toggle-fullscreen', description: 'page' },
+    'plugin',
+  )
+  assert.equal(registry.actionFor({ key: 'pageup', ctrl: false, alt: false, shift: false, super: false }), 'toggle-fullscreen')
+  // Duplicate detection sees canonical-equivalent keys as one.
   assert.throws(() => registry.register(
     { id: 'mod-b', key: { key: 'p', shift: true, ctrl: true, alt: false, super: false }, action: 'open-search', description: 'b' },
     'plugin',
   ), /duplicate keybinding/, 'ctrl+shift+p and shift+ctrl+p must be detected as the same key')
+})
+
+test('5.11 a reserved key ALIAS (esc/return) is rejected at registration', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  // Registering the alias spelling of a reserved key must be rejected
+  // AFTER canonicalization (convergence finding — the reserved check ran
+  // before canonicalize and let `esc`/`return` through).
+  assert.throws(() => registry.register(
+    { id: 'alias-esc', key: { key: 'esc', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'alias' },
+    'plugin',
+  ), /reserved by the host/, 'esc is the reserved escape and must be rejected')
+  assert.throws(() => registry.register(
+    { id: 'alias-return', key: { key: 'return', ctrl: false, alt: false, shift: false, super: false }, action: 'open-search', description: 'alias' },
+    'plugin',
+  ), /reserved by the host/, 'return is the reserved enter and must be rejected')
 })

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -850,7 +850,7 @@ test('6.2 submit on fork-editor PRE-SUBMIT keys is rejected (they can never fire
   // (round-9 finding: submit: tab silently stayed autocomplete).
   const preSubmit = [
     'tab', 'backspace', 'delete', 'ctrl+a', 'ctrl+e', 'ctrl+u', 'ctrl+k',
-    'ctrl+w', 'ctrl+y', 'ctrl+c', 'ctrl+d', 'ctrl+-', 'alt+backspace',
+    'ctrl+w', 'ctrl+y', 'ctrl+c', 'ctrl+d', 'alt+backspace',
     'alt+delete', 'alt+d', 'alt+y', 'alt+b', 'alt+f', 'alt+left', 'alt+right',
     'ctrl+left', 'ctrl+right', 'home', 'end', 'ctrl+home', 'ctrl+end',
     'shift+backspace', 'shift+delete',
@@ -1120,13 +1120,16 @@ test('7.4 a live plugin key disables a colliding leader prefix (never a silent s
   assert.ok(manager.keysFor('app.tasks.open').includes('ctrl+alt+x'), 'the plugin binding stays effective')
 })
 
-test('7.5 legacy C0 aliases are rejected everywhere (ctrl+i / ctrl+h / ctrl+_)', () => {
+test('7.5 legacy C0 aliases are rejected everywhere (ctrl+i / ctrl+h / ctrl+_ / ctrl+-)', () => {
   // On legacy terminals Ctrl+I is the Tab byte (0x09), Ctrl+H is
   // Backspace (0x08) and Ctrl+_ / Ctrl+- are 0x1f — indistinguishable
   // from the editor's own keys, so a binding on them is protocol-
   // dependent and unsupported (review finding — same class as
-  // ctrl+[/ctrl+j/ctrl+m).
-  for (const key of ['ctrl+i', 'ctrl+h', 'ctrl+_']) {
+  // ctrl+[/ctrl+j/ctrl+m). ctrl+- shares the 0x1f byte with ctrl+_ (the
+  // fork's rawCtrlChar maps - to 31), so BOTH spellings of the one
+  // legacy key are rejected (round-16 finding: ctrl+- used to bypass the
+  // inventory).
+  for (const key of ['ctrl+i', 'ctrl+h', 'ctrl+_', 'ctrl+-']) {
     const direct = parseUserKeybindings({ 'app.todo.toggle': key })
     assert.deepEqual(direct.bindings, {}, `"${key}" direct must be rejected`)
     assert.ok(direct.diagnostics.some(message => message.includes('legacy terminals')),
@@ -1150,4 +1153,41 @@ test('7.5b the C0 byte premise: raw \\t / \\x08 / \\x1f are the legacy spellings
   assert.ok(matchesKey('\x08', 'backspace' as never), '…and the same byte is Backspace for the editor')
   assert.ok(matchesKey('\x1f', 'ctrl+_' as never), 'Ctrl+_ is the 0x1f byte')
   assert.ok(matchesKey('\x1f', 'ctrl+-' as never), 'Ctrl+- is the SAME 0x1f byte (the fork maps - to _)')
+})
+
+test('7.6 the registry REJECTS legacy C0 alias keys (ctrl+i / ctrl+h / ctrl+_ / ctrl+-)', async () => {
+  const { KeybindingRegistry } = await import('../src/keybinding-registry.ts')
+  const registry = new KeybindingRegistry()
+  // On a legacy terminal the registry key `ctrl+i` is the Tab byte: the
+  // EffectiveKeymap resolves it (matchesKey('\t','ctrl+i') is true), but
+  // the router's plugin stage normalizes \t to `tab` and can never match
+  // the registration — an advertised plugin rule that can never fire
+  // (round-13 finding: the legacy inventory was user-config-only). The
+  // registry shares the SAME policy as the config parser — including
+  // ctrl+- (the 0x1f twin of ctrl+_, round-16 finding).
+  const legacyKeys = [
+    { key: 'i', ctrl: true, alt: false, shift: false, super: false },
+    { key: 'h', ctrl: true, alt: false, shift: false, super: false },
+    { key: '_', ctrl: true, alt: false, shift: false, super: false },
+    { key: '-', ctrl: true, alt: false, shift: false, super: false },
+  ]
+  for (const key of legacyKeys) {
+    assert.throws(() => registry.register(
+      { id: `legacy-${key.key}`, key, action: 'open-search', description: 'legacy' },
+      'plugin',
+    ), /legacy terminal/, `ctrl+${key.key} must be rejected at registration`)
+  }
+  // The rejected keys never entered the registry.
+  assert.equal(registry.snapshot().bindings.length, 0)
+  // The canonical identity of the registered key is one shared policy:
+  // the config parser and the registry reject the SAME key ids.
+  const { isLegacyCollisionKeyId, LEGACY_COLLISION_KEY_IDS } = await import('../src/keybindings/config.ts')
+  assert.ok(isLegacyCollisionKeyId('ctrl+i' as never))
+  assert.ok(isLegacyCollisionKeyId('ctrl+h' as never))
+  assert.ok(isLegacyCollisionKeyId('ctrl+_' as never))
+  assert.ok(isLegacyCollisionKeyId('ctrl+-' as never))
+  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+i'))
+  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+h'))
+  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+_'))
+  assert.ok(LEGACY_COLLISION_KEY_IDS.has('ctrl+-'))
 })

--- a/test/keybinding-definitions.test.ts
+++ b/test/keybinding-definitions.test.ts
@@ -112,10 +112,21 @@ test('viewer-blocked parent actions are all defined and configurable', () => {
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.tasks.open'))
 })
 
-test('non-configurable actions are exactly the focused-component set', () => {
+test('non-configurable actions are the focused-component set plus the reserved session/model tier', () => {
   for (const action of NON_CONFIGURABLE_ACTIONS) {
     assert.ok(action.startsWith('question.') || action.startsWith('tasks.')
-      || action.startsWith('app.transcript.search.'),
+      || action.startsWith('app.transcript.search.')
+      // The RESERVED session/model actions are not implemented this
+      // version — never user-configurable no-op keys (convergence §7).
+      || action.startsWith('app.session.') || action === 'app.model.open',
     `unexpected non-configurable action "${action}"`)
+  }
+  // Every non-configurable action must be either a fixed component
+  // contract or explicitly marked reserved.
+  for (const action of NON_CONFIGURABLE_ACTIONS) {
+    const definition = APP_KEYBINDINGS[action]
+    if (action.startsWith('app.session.') || action === 'app.model.open') {
+      assert.equal(definition.availability, 'reserved', `"${action}" must be availability:reserved`)
+    }
   }
 })

--- a/test/keybinding-definitions.test.ts
+++ b/test/keybinding-definitions.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The action definition table contract (plan §21): unique ids, valid
+ * default keys, protected actions, and no accidental duplicate overlapping
+ * defaults. This is the M0 gate — the defaults MUST match the
+ * pre-migration behavior.
+ * @module @xmoon76/dsh-pi-tui/keybinding-definitions.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { APP_KEYBINDINGS, NON_CONFIGURABLE_ACTIONS, PROTECTED_HOST_ACTIONS, VIEWER_BLOCKED_PARENT_ACTIONS } from '../src/keybindings/definitions.ts'
+import { isValidKeyId } from '../src/keybindings/config.ts'
+import { scopesOverlap } from '../src/keybindings/conflicts.ts'
+import type { AppKeybindingId } from '../src/keybindings/types.ts'
+
+test('every action id is unique and matches its own key', () => {
+  const ids = Object.keys(APP_KEYBINDINGS)
+  assert.equal(new Set(ids).size, ids.length, 'action ids must be unique')
+  for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
+    assert.equal(definition.id, id, 'definition.id must equal its key')
+  }
+})
+
+test('every default key is a valid KeyId', () => {
+  for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
+    for (const key of definition.defaultKeys) {
+      assert.ok(isValidKeyId(key), `default key "${key}" of "${id}" must be a valid KeyId`)
+    }
+  }
+})
+
+test('every definition carries description, category and scope', () => {
+  for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
+    assert.ok(definition.description.length > 0, `"${id}" needs a description`)
+    assert.ok(definition.category.length > 0, `"${id}" needs a category`)
+    assert.ok(definition.scope.length > 0, `"${id}" needs a scope`)
+  }
+})
+
+test('the M0 gate: default keys match the pre-migration behavior', () => {
+  const defaults = (id: AppKeybindingId): readonly string[] => APP_KEYBINDINGS[id].defaultKeys
+  assert.deepEqual(defaults('app.input.submit'), ['enter'])
+  assert.deepEqual(defaults('app.input.queue'), ['ctrl+enter'])
+  assert.deepEqual(defaults('app.input.steer'), ['ctrl+s'])
+  assert.deepEqual(defaults('app.input.dequeue'), ['alt+up'])
+  assert.deepEqual(defaults('app.agent.interrupt'), ['escape'])
+  assert.deepEqual(defaults('app.exit.request'), ['ctrl+c', 'ctrl+d'])
+  assert.deepEqual(defaults('app.transcript.search'), ['ctrl+f', 'ctrl+shift+f'])
+  assert.deepEqual(defaults('app.transcript.toggleExpand'), ['ctrl+o'])
+  assert.deepEqual(defaults('app.transcript.toggleThinking'), ['alt+t'])
+  assert.deepEqual(defaults('app.transcript.toggleFullscreen'), [])
+  assert.deepEqual(defaults('app.editor.external'), ['ctrl+g'])
+  assert.deepEqual(defaults('app.clipboard.pasteMedia'), ['ctrl+v'])
+  assert.deepEqual(defaults('app.permission.cycle'), ['shift+tab'])
+  assert.deepEqual(defaults('app.todo.toggle'), ['ctrl+t'])
+  assert.deepEqual(defaults('app.tasks.open'), [])
+  assert.deepEqual(defaults('app.history.search'), ['ctrl+r'])
+  assert.deepEqual(defaults('app.shell.dismissSettled'), ['alt+k'])
+})
+
+test('no accidental duplicate overlapping defaults within the host keymap', () => {
+  const byKey = new Map<string, string[]>()
+  for (const [id, definition] of Object.entries(APP_KEYBINDINGS)) {
+    for (const key of definition.defaultKeys) {
+      const list = byKey.get(key) ?? []
+      list.push(id)
+      byKey.set(key, list)
+    }
+  }
+  for (const [key, ids] of byKey) {
+    if (ids.length < 2) continue
+    // Same key on multiple actions is legal ONLY when the scopes are
+    // disjoint (they live in different keymaps or contexts).
+    for (let i = 0; i < ids.length; i += 1) {
+      for (let j = i + 1; j < ids.length; j += 1) {
+        const left = APP_KEYBINDINGS[ids[i] as AppKeybindingId]
+        const right = APP_KEYBINDINGS[ids[j] as AppKeybindingId]
+        assert.ok(
+          !scopesOverlap(left.scope, right.scope),
+          `default key "${key}" overlaps between "${ids[i]}" (${left.scope}) and "${ids[j]}" (${right.scope})`,
+        )
+      }
+    }
+  }
+})
+
+test('protected host actions are a subset of the definitions', () => {
+  for (const action of PROTECTED_HOST_ACTIONS) {
+    assert.ok(action in APP_KEYBINDINGS, `protected action "${action}" must be defined`)
+  }
+  assert.ok(PROTECTED_HOST_ACTIONS.has('app.exit.request'))
+  assert.ok(PROTECTED_HOST_ACTIONS.has('app.agent.interrupt'))
+  assert.ok(PROTECTED_HOST_ACTIONS.has('app.input.submit'))
+})
+
+test('viewer-blocked parent actions are all defined and configurable', () => {
+  for (const action of VIEWER_BLOCKED_PARENT_ACTIONS) {
+    assert.ok(action in APP_KEYBINDINGS, `viewer-blocked action "${action}" must be defined`)
+  }
+  // The viewer guard must cover every parent-owned chord of the current
+  // implementation (M1 gate: the physical-key blacklist is fully replaced).
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.steer'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.queue'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.dequeue'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.permission.cycle'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.transcript.search'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.exit.request'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.editor.external'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.todo.toggle'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.transcript.toggleThinking'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.clipboard.pasteMedia'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.tasks.open'))
+})
+
+test('non-configurable actions are exactly the focused-component set', () => {
+  for (const action of NON_CONFIGURABLE_ACTIONS) {
+    assert.ok(action.startsWith('question.') || action.startsWith('tasks.')
+      || action.startsWith('app.transcript.search.'),
+    `unexpected non-configurable action "${action}"`)
+  }
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -227,7 +227,8 @@ test('a remap of the thinking key refreshes cached fold hints (keymap revision)'
   await vt.waitForRender()
   let view = vt.getViewport().join('\n')
   assert.ok(view.includes('(alt+t to expand)'), `default thinking hint missing:\n${view}`)
-  // Remap the thinking owner (hot reload path: manager rebuild bumps the revision).
+  // Remap the thinking owner (explicit manager rebuild path: the rebuild
+  // bumps the keymap revision, so the cached card copy follows).
   managerWith({ 'app.transcript.toggleThinking': 'ctrl+x' })(app.keybindingsManager())
   await vt.waitForRender()
   view = vt.getViewport().join('\n')

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -1,0 +1,175 @@
+/**
+ * The keybinding integration contract (plan §21): user overrides, the
+ * action-based viewer guard (the plan's key test — a remap stays blocked),
+ * the leader sequence, the which-key hint, focus-transition cancellation,
+ * and safe mode — all through the REAL TuiApp input path.
+ * @module @xmoon76/dsh-pi-tui/keybinding-integration.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TuiApp } from '../src/tui-app.ts'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { HostKeybindingManager } from '../src/keybindings/manager.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+function startApp(
+  overrides: Record<string, unknown> = {},
+  configure?: (manager: HostKeybindingManager) => void,
+): { vt: VirtualTerminal; app: TuiApp } {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    ...overrides,
+  })
+  app.start()
+  if (configure !== undefined) configure(app.keybindingsManager())
+  return { vt, app }
+}
+
+function managerWith(config: Record<string, unknown>): (manager: HostKeybindingManager) => void {
+  return (manager) => {
+    const parsed = parseUserKeybindings(config)
+    manager.setUserConfiguration(parsed)
+  }
+}
+
+test('user remap: ctrl+x steers, ctrl+s no longer does', async () => {
+  const steered: string[] = []
+  const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, managerWith({ 'app.input.steer': 'ctrl+x' }))
+  vt.sendInput('\x18') // ctrl+x
+  await vt.waitForRender()
+  assert.deepEqual(steered, [''], 'the remapped key must steer')
+  vt.sendInput('\x13') // ctrl+s
+  await vt.waitForRender()
+  assert.deepEqual(steered, [''], 'the old key must no longer steer')
+  app.stop()
+})
+
+test('the viewer guard follows the remap: ctrl+x is blocked inside the continuable viewer', async () => {
+  // The plan's key test: the user remaps app.input.steer to ctrl+x; the
+  // viewer receives ctrl+x — the PARENT must still NOT be steered (the
+  // guard is action-based, never a physical-key list).
+  const steered: string[] = []
+  const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, managerWith({ 'app.input.steer': 'ctrl+x' }))
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'continuable',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  vt.sendInput('\x18') // ctrl+x — the remapped steer key
+  await vt.waitForRender()
+  assert.deepEqual(steered, [], 'the parent must never be steered from inside the viewer')
+  app.stop()
+})
+
+test('the viewer guard still blocks the DEFAULT parent keys', async () => {
+  const steered: string[] = []
+  const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) })
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'continuable',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  vt.sendInput('\x13') // ctrl+s
+  await vt.waitForRender()
+  assert.deepEqual(steered, [], 'the default steer key must be blocked inside the viewer')
+  app.stop()
+})
+
+test('leader sequence: leader+t opens the task browser', async () => {
+  let tasksOpened = 0
+  const { vt, app } = startApp({ onOpenTasks: () => { tasksOpened += 1 } }, managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('t') // completing key
+  await vt.waitForRender()
+  assert.equal(tasksOpened, 1, 'the leader sequence must fire the bound action')
+  app.stop()
+})
+
+test('a non-matching key cancels the pending leader and passes through', async () => {
+  let tasksOpened = 0
+  const { vt, app } = startApp({ onOpenTasks: () => { tasksOpened += 1 } }, managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('z') // non-matching: cancels, passes through (types into the editor)
+  await vt.waitForRender()
+  assert.equal(tasksOpened, 0)
+  assert.equal(app.getDraft(), 'z', 'the non-matching key must reach the editor')
+  app.stop()
+})
+
+test('the pending leader shows the which-key hint in the footer', async () => {
+  const { vt, app } = startApp({}, managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Leader: waiting'), `the which-key hint must render:\n${view}`)
+  app.stop()
+})
+
+test('a focus transition cancels the pending leader', async () => {
+  let tasksOpened = 0
+  const { vt, app } = startApp({ onOpenTasks: () => { tasksOpened += 1 } }, managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  vt.sendInput('\x18') // leader arms the pending state
+  await vt.waitForRender()
+  // A viewer open is a focus transition: the pending state must cancel.
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'one-shot',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  app.setViewerMode(undefined)
+  await vt.waitForRender()
+  vt.sendInput('t') // must NOT complete the cancelled sequence
+  await vt.waitForRender()
+  assert.equal(tasksOpened, 0, 'the cancelled leader must not fire')
+  app.stop()
+})
+
+test('safe mode ignores user overrides', async () => {
+  const steered: string[] = []
+  const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, (manager) => {
+    managerWith({ 'app.input.steer': 'ctrl+x' })(manager)
+    manager.setSafeMode(true)
+  })
+  vt.sendInput('\x13') // ctrl+s — the builtin steer key
+  await vt.waitForRender()
+  assert.deepEqual(steered, [''], 'safe mode must keep the builtin defaults')
+  vt.sendInput('\x18') // ctrl+x — the overridden key
+  await vt.waitForRender()
+  assert.deepEqual(steered, [''], 'safe mode must ignore the user override')
+  app.stop()
+})
+
+test('a disabled action no longer fires', async () => {
+  const steered: string[] = []
+  const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, managerWith({ 'app.input.steer': false }))
+  vt.sendInput('\x13') // ctrl+s
+  await vt.waitForRender()
+  assert.deepEqual(steered, [], 'a disabled action must not fire')
+  app.stop()
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -679,26 +679,30 @@ test('closing a viewer with Esc disarms the main-session double-Esc window (PR r
   app.stop()
 })
 
-test('a SHADOWED leader-only submit restores the builtin Enter (PR review P1)', () => {
+test('a SHADOWED leader-only submit is inert — no fabricated Enter fallback (review round 37)', () => {
   const manager = new HostKeybindingManager()
   // leader: ctrl+f collides with app.transcript.search — the leader is
   // shadowed, so the <leader>s submit sequence can never fire. The
-  // builtin Enter must be restored (fail-soft), NOT disabled alongside
-  // the dead leader.
+  // leader-only declaration REPLACED the builtin Enter in the unified
+  // model, so a dead leader leaves submit with NO trigger — the
+  // diagnostic explains why (no fabricated fallback: the codebase rule
+  // for conflicted/shadowed overrides, convergence §4.4; a restored
+  // Enter would silently re-add a key the user explicitly removed).
   manager.setUserConfiguration(parseUserKeybindings({
     leader: 'ctrl+f',
     bindings: { 'app.input.submit': '<leader>s' },
   }))
   assert.equal(manager.leaderMachine(), undefined, 'the colliding leader is disabled')
   assert.ok(manager.diagnosticsList().some(message => message.includes('active host key')))
-  assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'], 'the dead leader-only submit restores Enter')
-  assert.equal(manager.keyHint('app.input.submit'), 'Enter', 'the UI advertises the restored Enter')
+  assert.deepEqual(manager.editorSubmitKeysFor(), [], 'the dead leader-only submit is inert (no fabricated Enter)')
+  assert.equal(manager.keyHint('app.input.submit'), '', 'the UI advertises nothing for the dead leader-only submit')
 })
 
-test('an AMBIGUOUS leader-only submit restores the builtin Enter (PR review P1)', () => {
+test('an AMBIGUOUS leader-only submit is inert — no fabricated Enter fallback (review round 37)', () => {
   const manager = new HostKeybindingManager()
   // Two actions bound to the same completing key <leader>s: ambiguous —
-  // neither fires. The submit sequence is dead, so Enter must be restored.
+  // neither fires. The leader-only declaration replaced Enter; the dead
+  // sequence leaves submit with no trigger (the diagnostic explains).
   manager.setUserConfiguration(parseUserKeybindings({
     leader: 'ctrl+x',
     bindings: {
@@ -708,6 +712,6 @@ test('an AMBIGUOUS leader-only submit restores the builtin Enter (PR review P1)'
   }))
   assert.equal(manager.leaderMachine()?.leaderBindings.length ?? 0, 0, 'the ambiguous sequence is dropped')
   assert.ok(manager.diagnosticsList().some(message => message.includes('ambiguous leader sequence')))
-  assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'], 'the ambiguous leader-only submit restores Enter')
-  assert.equal(manager.keyHint('app.input.submit'), 'Enter', 'the UI advertises the restored Enter')
+  assert.deepEqual(manager.editorSubmitKeysFor(), [], 'the ambiguous leader-only submit is inert (no fabricated Enter)')
+  assert.equal(manager.keyHint('app.input.submit'), '', 'the UI advertises nothing for the dead leader-only submit')
 })

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -545,3 +545,78 @@ test('a plugin key does NOT collide with the leader prefix (PR review P2)', () =
   assert.ok(!manager.diagnosticsList().some(message => message.includes('active host key')),
     `no collision expected: ${manager.diagnosticsList().join(' | ')}`)
 })
+
+test('read-only viewer: Esc ALWAYS closes it, even with interrupt remapped (PR review P1)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let singleEscapes = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSingleEscape: () => { singleEscapes += 1; return true },
+  })
+  app.start()
+  // Remap interrupt away from Esc to Ctrl+X.
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.agent.interrupt': 'ctrl+x' }))
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'one-shot',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  // Esc must still close the read-only viewer (the fixed lifecycle key),
+  // even though interrupt no longer resolves on Esc.
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 1, 'Esc must run the viewer close (single-Esc) path')
+  app.stop()
+})
+
+test('read-only viewer: a remapped interrupt key (Ctrl+X) is inert, never the parent (PR review P1)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let singleEscapes = 0
+  let cancels = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSingleEscape: () => { singleEscapes += 1; return true },
+    onCancel: () => { cancels += 1 },
+  })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.agent.interrupt': 'ctrl+x' }))
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'one-shot',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  // Ctrl+X inside the read-only viewer: consumed as locked — neither the
+  // viewer closes nor the parent cancels.
+  vt.sendInput('\x18')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 0, 'Ctrl+X must not run the viewer close path')
+  assert.equal(cancels, 0, 'Ctrl+X must not cancel the parent agent')
+  // Esc still closes normally.
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 1)
+  app.stop()
+})
+
+test('a leader-prefix collision stops advertising the leader bindings (PR review P2)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+f', // collides with app.transcript.search's ctrl+f
+    bindings: { 'app.session.new': '<leader>n' },
+  }))
+  assert.equal(manager.leaderMachine(), undefined, 'the colliding leader is disabled')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('active host key')))
+  // The UI must NOT advertise the dead leader sequence anywhere.
+  assert.equal(manager.keyHint('app.session.new'), '', 'keyHint must not advertise the shadowed leader')
+  assert.equal(manager.keysLabelFor('app.session.new'), '', 'keysLabelFor must not advertise the shadowed leader')
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.session.new')
+  assert.equal(binding?.leaderKeys, undefined, 'the snapshot must not carry the shadowed leader')
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -466,3 +466,30 @@ test('a leader-only submit override: Enter does NOT submit (PR review P1)', asyn
   assert.deepEqual(submitted, ['via leader'], 'the leader sequence must submit')
   app.stop()
 })
+
+test('safe mode restores the default Enter submit even after a user disable (PR review P1)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text: string) => submitted.push(text), onExit: () => {} })
+  app.start()
+  // User disables submit, then SAFE MODE is enabled: the builtin default
+  // must win — Enter submits again.
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': false }))
+  app.keybindingsManager().setSafeMode(true)
+  await vt.waitForRender()
+  app.setDraft('safe mode')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['safe mode'], 'safe mode must restore the default Enter submit')
+  app.stop()
+})
+
+test('leader: enter collides with the editor-owned submit key — leader disabled (PR review P1)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({ leader: 'enter', bindings: { 'app.tasks.open': '<leader>t' } }))
+  assert.equal(manager.leaderMachine(), undefined, 'a leader key that collides with the editor submit must be disabled')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('leader key') && message.includes('active host key')),
+    `no collision diagnostic: ${manager.diagnosticsList().join(' | ')}`)
+  assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'], 'the editor submit key stays intact')
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -493,3 +493,55 @@ test('leader: enter collides with the editor-owned submit key — leader disable
     `no collision diagnostic: ${manager.diagnosticsList().join(' | ')}`)
   assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'], 'the editor submit key stays intact')
 })
+
+test('a plugin-only key is NOT host-reserved — it reaches the plugin dispatch (PR review P1)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const actions: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onExtensionAction: (action: string) => { actions.push(action) },
+  }, {
+    // A plugin binds Ctrl+Alt+X (no host action uses it): the router's
+    // hostResolves must NOT claim it — the plugin dispatch fires.
+    pluginActionFor: (key) => key.key === 'x' && key.ctrl && key.alt ? 'open-search' : undefined,
+  })
+  app.start()
+  await vt.waitForRender()
+  vt.sendInput('\x1b\x18') // ctrl+alt+x
+  await vt.waitForRender()
+  assert.deepEqual(actions, ['open-search'], 'the plugin-only key must reach the plugin dispatch')
+  app.stop()
+})
+
+test('a plugin submit binding is ADDITIVE — the builtin Enter stays (PR review P1)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: (text: string) => submitted.push(text),
+    onExit: () => {},
+  }, {
+    // A plugin binds app.input.submit to ctrl+p: additive — Enter must
+    // STILL submit (the plugin never replaces the host's key).
+    pluginActionFor: (key) => key.key === 'p' && key.ctrl ? 'submit-draft' : undefined,
+  })
+  app.start()
+  app.keybindingsManager().setPluginRules([{ id: 'plugin-submit', action: 'app.input.submit', key: 'ctrl+p' }])
+  await vt.waitForRender()
+  assert.deepEqual(app.keybindingsManager().editorSubmitKeysFor(), ['enter'], 'the builtin Enter survives a plugin submit binding')
+  app.setDraft('via enter')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['via enter'], 'Enter still submits under an additive plugin binding')
+  app.stop()
+})
+
+test('a plugin key does NOT collide with the leader prefix (PR review P2)', () => {
+  const manager = new HostKeybindingManager()
+  manager.setPluginRules([{ id: 'plugin-x', action: 'app.tasks.open', key: 'ctrl+alt+x' }])
+  manager.setUserConfiguration(parseUserKeybindings({ leader: 'ctrl+alt+x', bindings: { 'app.session.new': '<leader>n' } }))
+  assert.ok(manager.leaderMachine() !== undefined, 'a plugin-only key must not disable the leader')
+  assert.ok(!manager.diagnosticsList().some(message => message.includes('active host key')),
+    `no collision expected: ${manager.diagnosticsList().join(' | ')}`)
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -267,3 +267,99 @@ test('the read-only viewer lets a REMAPPED fold key reach the host fold (effecti
   assert.equal(app.isToolOutputExpanded(), !before, 'the old ctrl+o must stay inert inside the viewer')
   app.stop()
 })
+
+test('app.input.submit remap: the NEW key submits and Enter no longer does (PR review)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text: string) => submitted.push(text), onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': 'ctrl+x' }))
+  await vt.waitForRender()
+  app.setDraft('hello')
+  await vt.waitForRender()
+  vt.sendInput('\x18') // ctrl+x — the remapped submit key
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['hello'], 'the remapped key must submit')
+  app.setDraft('again')
+  await vt.waitForRender()
+  vt.sendInput('\r') // Enter — must NOT submit anymore
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['hello'], 'Enter must no longer submit after the remap')
+  assert.equal(app.getDraft(), 'again', 'the draft survives a now-inert Enter')
+  app.stop()
+})
+
+test('app.input.submit disabled: Enter never submits (PR review)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text: string) => submitted.push(text), onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': false }))
+  await vt.waitForRender()
+  app.setDraft('keep me')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual(submitted, [], 'a disabled submit must never fire')
+  assert.equal(app.getDraft(), 'keep me', 'the draft is untouched by the inert Enter')
+  app.stop()
+})
+
+test('leader key colliding with an active host key: disabled with a diagnostic (PR review)', () => {
+  const manager = new HostKeybindingManager()
+  // leader: ctrl+f collides with app.transcript.search's default ctrl+f.
+  manager.setUserConfiguration(parseUserKeybindings({ leader: 'ctrl+f', bindings: { 'app.tasks.open': '<leader>t' } }))
+  assert.equal(manager.leaderMachine(), undefined, 'the colliding leader must be disabled')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('leader key') && message.includes('active host key')),
+    `no collision diagnostic: ${manager.diagnosticsList().join(' | ')}`)
+  // A non-colliding leader still works.
+  manager.setUserConfiguration(parseUserKeybindings({ leader: 'ctrl+x', bindings: { 'app.tasks.open': '<leader>t' } }))
+  assert.ok(manager.leaderMachine() !== undefined, 'a non-colliding leader stays active')
+  assert.ok(!manager.diagnosticsList().some(message => message.includes('active host key')))
+})
+
+test('pasteMedia remapped: the OLD key is not swallowed by a stale reservation (PR review)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const pasted: number[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onClipboardPaste: () => { pasted.push(1) },
+  })
+  app.start()
+  await vt.waitForRender()
+  // Default: Ctrl+V fires pasteMedia.
+  vt.sendInput('\x16')
+  await vt.waitForRender()
+  assert.equal(pasted.length, 1, 'the default Ctrl+V must paste')
+  // Remap pasteMedia to Ctrl+P: Ctrl+V is no longer an ACTIVE host key —
+  // it must fall through to the editor (NOT be swallowed as a stale
+  // reservation, and NOT paste).
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.clipboard.pasteMedia': 'ctrl+p' }))
+  await vt.waitForRender()
+  vt.sendInput('\x16') // ctrl+v — old key
+  await vt.waitForRender()
+  assert.equal(pasted.length, 1, 'the remapped-away Ctrl+V must not paste')
+  vt.sendInput('\x10') // ctrl+p — the new paste key
+  await vt.waitForRender()
+  assert.equal(pasted.length, 2, 'the remapped Ctrl+P must paste')
+  app.stop()
+})
+
+test('exit multi-key binding: the footer hint advertises the Ctrl+C chord specifically (PR review)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.exit.request': ['ctrl+x', 'ctrl+c'] }))
+  await vt.waitForRender()
+  // Arm the Ctrl+C exit chord: the footer must advertise Ctrl+C (the
+  // chord's own key), never the generic primary (Ctrl+X).
+  app.setDraft('draft')
+  await vt.waitForRender()
+  vt.sendInput('\x03') // ctrl+c — first press clears the draft + arms
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Ctrl+C'), `the armed exit hint must name Ctrl+C:\n${view}`)
+  assert.ok(!view.includes('Press Ctrl+X'), `the hint must not name the generic primary:\n${view}`)
+  app.stop()
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -542,13 +542,17 @@ test('a plugin submit binding is ADDITIVE — the builtin Enter stays (PR review
   app.stop()
 })
 
-test('a plugin key does NOT collide with the leader prefix (PR review P2)', () => {
+test('a live plugin key colliding with the leader prefix disables the leader (review round 12)', () => {
   const manager = new HostKeybindingManager()
   manager.setPluginRules([{ id: 'plugin-x', action: 'app.tasks.open', key: 'ctrl+alt+x' }])
   manager.setUserConfiguration(parseUserKeybindings({ leader: 'ctrl+alt+x', bindings: { 'app.transcript.toggleFullscreen': '<leader>n' } }))
-  assert.ok(manager.leaderMachine() !== undefined, 'a plugin-only key must not disable the leader')
-  assert.ok(!manager.diagnosticsList().some(message => message.includes('active host key')),
-    `no collision expected: ${manager.diagnosticsList().join(' | ')}`)
+  // The leader machine feeds BEFORE the plugin stage: a leader key equal
+  // to a live plugin key would silently swallow the plugin binding while
+  // the read model still advertised it. Fail-soft like a host-key
+  // collision: the plugin key wins, the leader machine is disabled.
+  assert.equal(manager.leaderMachine(), undefined, 'a live plugin key must disable the leader')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('leader key') && message.includes('plugin key')),
+    `no plugin collision diagnostic: ${manager.diagnosticsList().join(' | ')}`)
 })
 
 test('read-only viewer: Esc ALWAYS closes it, even with interrupt remapped (PR review P1)', async () => {

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -165,6 +165,50 @@ test('safe mode ignores user overrides', async () => {
   app.stop()
 })
 
+test('a leader sequence cannot bypass the viewer parent-action guard', async () => {
+  // Review round 1: `<leader>t → app.input.steer` must be inert inside
+  // the continuable viewer, exactly like the direct key.
+  const steered: string[] = []
+  const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.steer': '<leader>t' },
+  }))
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'continuable',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('t') // completing key → app.input.steer
+  await vt.waitForRender()
+  assert.deepEqual(steered, [], 'the parent must never be steered from inside the viewer')
+  app.stop()
+})
+
+test('safe mode disables the leader machine too', async () => {
+  // Review round 1: safe mode ignores the user configuration ENTIRELY —
+  // including the leader key and its sequences.
+  let tasksOpened = 0
+  const { vt, app } = startApp({ onOpenTasks: () => { tasksOpened += 1 } }, (manager) => {
+    managerWith({
+      leader: 'ctrl+x',
+      bindings: { 'app.tasks.open': '<leader>t' },
+    })(manager)
+    manager.setSafeMode(true)
+  })
+  vt.sendInput('\x18') // leader — must be inert in safe mode
+  await vt.waitForRender()
+  vt.sendInput('t')
+  await vt.waitForRender()
+  assert.equal(tasksOpened, 0, 'safe mode must disable the leader sequences')
+  assert.equal(app.keybindingsManager().leaderMachine(), undefined, 'no leader machine in safe mode')
+  app.stop()
+})
+
 test('a disabled action no longer fires', async () => {
   const steered: string[] = []
   const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, managerWith({ 'app.input.steer': false }))

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -414,3 +414,26 @@ test('a remapped submit does not leak into a NEW TuiApp instance (PR review P1)'
   assert.deepEqual(second, ['fresh'], 'Enter must submit in the fresh default app')
   app2.dispose()
 })
+
+test('disposing the app with an armed leader prefix clears the pending timer (PR review P2)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let tasksOpened = 0
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {}, onOpenTasks: () => { tasksOpened += 1 } })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.tasks.open': '<leader>t' },
+  }))
+  await vt.waitForRender()
+  vt.sendInput('\x18') // leader — arms the pending state + starts the timeout
+  await vt.waitForRender()
+  assert.ok(app.keybindingsManager().leaderMachine()?.pending === true, 'the leader must be pending')
+  // Dispose with the leader armed: the manager's dispose clears the
+  // timeout, so nothing fires against the stopped app afterwards.
+  app.dispose()
+  // Let any (incorrectly) pending macrotask land: nothing must throw and
+  // the leader must be gone.
+  await new Promise(resolve => setTimeout(resolve, 30))
+  assert.equal(app.keybindingsManager().leaderMachine(), undefined, 'the leader machine is gone after dispose')
+  assert.equal(tasksOpened, 0, 'no action may fire after dispose')
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -209,6 +209,28 @@ test('safe mode disables the leader machine too', async () => {
   app.stop()
 })
 
+test('a remap of the thinking key refreshes cached fold hints (keymap revision)', async () => {
+  // Review finding: the transcript component cache keyed the fold hint on
+  // the semantic owner only — a remap of the owner action left already-
+  // rendered cards showing the OLD key until an unrelated rebuild. The
+  // keymap revision now joins the cache identity, so the card copy
+  // follows the effective key within one repaint.
+  const { vt, app } = startApp()
+  // A compact Thinking card renders its hint through ThinkingCompactComponent
+  // (the THINKING owner: the effective app.transcript.toggleThinking key).
+  app.setTranscript([{ kind: 'thinking', turn: 0, text: 'a preview line' }])
+  await vt.waitForRender()
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('(alt+t to expand)'), `default thinking hint missing:\n${view}`)
+  // Remap the thinking owner (hot reload path: manager rebuild bumps the revision).
+  managerWith({ 'app.transcript.toggleThinking': 'ctrl+x' })(app.keybindingsManager())
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('(ctrl+x to expand)'), `the cached card must show the remapped key:\n${view}`)
+  assert.ok(!view.includes('(alt+t to expand)'), `the old key must not linger in cached cards:\n${view}`)
+  app.stop()
+})
+
 test('a disabled action no longer fires', async () => {
   const steered: string[] = []
   const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, managerWith({ 'app.input.steer': false }))

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -629,16 +629,22 @@ test('closing a viewer with Esc disarms the main-session double-Esc window (PR r
   const app = new TuiApp(vt, {
     onSubmit: () => {},
     onExit: () => {},
-    onSingleEscape: () => { singleEscapes += 1; return true },
+    // P3 test fix: the FIRST main-session Esc must NOT consume (return
+    // false) so handleEscapeKey actually ARMS the double-Esc window
+    // (lastEscapeAt = now); the viewer-close Esc consumes (returns true).
+    // With the old always-true callback the "arm" was a fake — the window
+    // was never armed, making the disarm assertion vacuous.
+    onSingleEscape: () => { singleEscapes += 1; return singleEscapes === 1 ? false : true },
     onCancel: () => { cancels += 1 },
     onRewind: () => { rewinds += 1 },
   })
   app.start()
-  // Arm a double-Esc window in the main session (first Esc while idle —
-  // the runner's single-Esc handler runs and arms the window).
+  // Arm a double-Esc window in the main session: the first Esc returns
+  // false (not consumed) → handleEscapeKey arms the window.
   vt.sendInput('\x1b')
   await vt.waitForRender()
-  assert.equal(singleEscapes, 1, 'the main-session Esc armed the single-Esc path')
+  assert.equal(singleEscapes, 1, 'the main-session Esc ran the single-Esc path')
+  assert.equal(cancels, 0)
   // Open the read-only viewer, then close it with Esc — the consumed
   // close must DISARM the pending window.
   app.setViewerMode({
@@ -653,11 +659,45 @@ test('closing a viewer with Esc disarms the main-session double-Esc window (PR r
   await vt.waitForRender()
   assert.equal(singleEscapes, 2, 'the viewer-close Esc ran the viewer close path')
   // Back in the main session: a single Esc must NOT read as the second
-  // consecutive Esc (no cancel/rewind).
+  // consecutive Esc (no cancel/rewind). If the disarm were missing, this
+  // Esc would be within the window and trigger onCancel.
   vt.sendInput('\x1b')
   await vt.waitForRender()
   assert.equal(singleEscapes, 3, 'the main-session Esc runs the single-Esc path again')
   assert.equal(cancels, 0, 'the disarmed main-session Esc must not cancel')
   assert.equal(rewinds, 0, 'the disarmed main-session Esc must not rewind')
   app.stop()
+})
+
+test('a SHADOWED leader-only submit restores the builtin Enter (PR review P1)', () => {
+  const manager = new HostKeybindingManager()
+  // leader: ctrl+f collides with app.transcript.search — the leader is
+  // shadowed, so the <leader>s submit sequence can never fire. The
+  // builtin Enter must be restored (fail-soft), NOT disabled alongside
+  // the dead leader.
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+f',
+    bindings: { 'app.input.submit': '<leader>s' },
+  }))
+  assert.equal(manager.leaderMachine(), undefined, 'the colliding leader is disabled')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('active host key')))
+  assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'], 'the dead leader-only submit restores Enter')
+  assert.equal(manager.keyHint('app.input.submit'), 'Enter', 'the UI advertises the restored Enter')
+})
+
+test('an AMBIGUOUS leader-only submit restores the builtin Enter (PR review P1)', () => {
+  const manager = new HostKeybindingManager()
+  // Two actions bound to the same completing key <leader>s: ambiguous —
+  // neither fires. The submit sequence is dead, so Enter must be restored.
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.input.submit': '<leader>s',
+      'app.session.new': '<leader>s',
+    },
+  }))
+  assert.equal(manager.leaderMachine()?.leaderBindings.length ?? 0, 0, 'the ambiguous sequence is dropped')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('ambiguous leader sequence')))
+  assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'], 'the ambiguous leader-only submit restores Enter')
+  assert.equal(manager.keyHint('app.input.submit'), 'Enter', 'the UI advertises the restored Enter')
 })

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -620,3 +620,44 @@ test('a leader-prefix collision stops advertising the leader bindings (PR review
   const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.session.new')
   assert.equal(binding?.leaderKeys, undefined, 'the snapshot must not carry the shadowed leader')
 })
+
+test('closing a viewer with Esc disarms the main-session double-Esc window (PR review P2)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let singleEscapes = 0
+  let cancels = 0
+  let rewinds = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSingleEscape: () => { singleEscapes += 1; return true },
+    onCancel: () => { cancels += 1 },
+    onRewind: () => { rewinds += 1 },
+  })
+  app.start()
+  // Arm a double-Esc window in the main session (first Esc while idle —
+  // the runner's single-Esc handler runs and arms the window).
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 1, 'the main-session Esc armed the single-Esc path')
+  // Open the read-only viewer, then close it with Esc — the consumed
+  // close must DISARM the pending window.
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'one-shot',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 2, 'the viewer-close Esc ran the viewer close path')
+  // Back in the main session: a single Esc must NOT read as the second
+  // consecutive Esc (no cancel/rewind).
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 3, 'the main-session Esc runs the single-Esc path again')
+  assert.equal(cancels, 0, 'the disarmed main-session Esc must not cancel')
+  assert.equal(rewinds, 0, 'the disarmed main-session Esc must not rewind')
+  app.stop()
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -363,3 +363,22 @@ test('exit multi-key binding: the footer hint advertises the Ctrl+C chord specif
   assert.ok(!view.includes('Press Ctrl+X'), `the hint must not name the generic primary:\n${view}`)
   app.stop()
 })
+
+test('a remapped submit key keeps the editor backslash-newline semantics (PR review P1)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text: string) => submitted.push(text), onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': 'ctrl+x' }))
+  await vt.waitForRender()
+  // A trailing backslash should insert a NEWLINE, not submit (the fork
+  // editor's backslash-Enter workaround) — the remapped key must route
+  // through the editor, never the host submitDraft.
+  app.setDraft('line\\')
+  await vt.waitForRender()
+  vt.sendInput('\x18') // ctrl+x — the remapped submit
+  await vt.waitForRender()
+  assert.deepEqual(submitted, [], 'a trailing backslash must not submit through the remapped key')
+  assert.ok(app.getDraft().includes('line'), `the draft must gain a newline, not submit:\n${JSON.stringify(app.getDraft())}`)
+  app.stop()
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -239,3 +239,31 @@ test('a disabled action no longer fires', async () => {
   assert.deepEqual(steered, [], 'a disabled action must not fire')
   app.stop()
 })
+
+test('the read-only viewer lets a REMAPPED fold key reach the host fold (effective keymap)', async () => {
+  // Review finding: the read-only viewer guard hard-coded Ctrl+O as the
+  // fold pass-through — a remap of app.transcript.toggleExpand would be
+  // consumed as an inert key. The pass-through now resolves the EFFECTIVE
+  // fold key, so the remapped chord reaches the host fold path and the
+  // OLD key is consumed as inert instead.
+  const { vt, app } = startApp({}, managerWith({ 'app.transcript.toggleExpand': 'ctrl+x' }))
+  const before = app.isToolOutputExpanded()
+  app.setViewerMode({
+    parentSessionId: 'session-main',
+    childSessionId: 'session-child',
+    label: 'child',
+    mode: 'one-shot',
+    activity: 'inactive',
+  })
+  await vt.waitForRender()
+  // ctrl+x (the remapped fold key) passes through the read-only viewer and
+  // reaches the host ladder: the fold master flips.
+  vt.sendInput('\x18') // ctrl+x
+  await vt.waitForRender()
+  assert.equal(app.isToolOutputExpanded(), !before, 'the remapped fold key must reach the host fold path')
+  // ctrl+o is no longer the fold key: consumed as inert (no second flip).
+  vt.sendInput('\x0f') // ctrl+o
+  await vt.waitForRender()
+  assert.equal(app.isToolOutputExpanded(), !before, 'the old ctrl+o must stay inert inside the viewer')
+  app.stop()
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -382,3 +382,35 @@ test('a remapped submit key keeps the editor backslash-newline semantics (PR rev
   assert.ok(app.getDraft().includes('line'), `the draft must gain a newline, not submit:\n${JSON.stringify(app.getDraft())}`)
   app.stop()
 })
+
+test('a remapped submit does not leak into a NEW TuiApp instance (PR review P1)', async () => {
+  // The fork keybindings are PROCESS-GLOBAL: the first app remaps/
+  // disables submit, then stops. A fresh DEFAULT app must NOT inherit
+  // the old state — its Enter must submit again.
+  const vt1 = new VirtualTerminal(80, 24)
+  const first: string[] = []
+  const app1 = new TuiApp(vt1, { onSubmit: (text: string) => first.push(text), onExit: () => {} })
+  app1.start()
+  app1.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': false }))
+  await vt1.waitForRender()
+  app1.setDraft('x')
+  await vt1.waitForRender()
+  vt1.sendInput('\r')
+  await vt1.waitForRender()
+  assert.deepEqual(first, [], 'the disabled submit must not fire in the first app')
+  app1.dispose()
+
+  // A brand-new default app: Enter must submit again (the global binding
+  // was restored on dispose).
+  const vt2 = new VirtualTerminal(80, 24)
+  const second: string[] = []
+  const app2 = new TuiApp(vt2, { onSubmit: (text: string) => second.push(text), onExit: () => {} })
+  app2.start()
+  await vt2.waitForRender()
+  app2.setDraft('fresh')
+  await vt2.waitForRender()
+  vt2.sendInput('\r')
+  await vt2.waitForRender()
+  assert.deepEqual(second, ['fresh'], 'Enter must submit in the fresh default app')
+  app2.dispose()
+})

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -84,17 +84,22 @@ test('the viewer guard still blocks the DEFAULT parent keys', async () => {
   app.stop()
 })
 
-test('leader sequence: leader+t opens the task browser', async () => {
+test('leader sequence: leader+t opens the task browser when the action predicate holds', async () => {
+  // Convergence §4.7: a leader completion obeys the action's context
+  // predicate (the empty-editor ↓ tasks affordance) — it is another
+  // TRIGGER, never a predicate bypass.
   let tasksOpened = 0
   const { vt, app } = startApp({ onOpenTasks: () => { tasksOpened += 1 } }, managerWith({
     leader: 'ctrl+x',
     bindings: { 'app.tasks.open': '<leader>t' },
   }))
+  app.setTasks([{ id: 'job-1', label: 'bash', status: 'running', kind: 'job' }])
+  await vt.waitForRender()
   vt.sendInput('\x18') // leader
   await vt.waitForRender()
   vt.sendInput('t') // completing key
   await vt.waitForRender()
-  assert.equal(tasksOpened, 1, 'the leader sequence must fire the bound action')
+  assert.equal(tasksOpened, 1, 'the leader sequence must fire when the predicate holds')
   app.stop()
 })
 
@@ -540,7 +545,7 @@ test('a plugin submit binding is ADDITIVE — the builtin Enter stays (PR review
 test('a plugin key does NOT collide with the leader prefix (PR review P2)', () => {
   const manager = new HostKeybindingManager()
   manager.setPluginRules([{ id: 'plugin-x', action: 'app.tasks.open', key: 'ctrl+alt+x' }])
-  manager.setUserConfiguration(parseUserKeybindings({ leader: 'ctrl+alt+x', bindings: { 'app.session.new': '<leader>n' } }))
+  manager.setUserConfiguration(parseUserKeybindings({ leader: 'ctrl+alt+x', bindings: { 'app.transcript.toggleFullscreen': '<leader>n' } }))
   assert.ok(manager.leaderMachine() !== undefined, 'a plugin-only key must not disable the leader')
   assert.ok(!manager.diagnosticsList().some(message => message.includes('active host key')),
     `no collision expected: ${manager.diagnosticsList().join(' | ')}`)
@@ -610,14 +615,14 @@ test('a leader-prefix collision stops advertising the leader bindings (PR review
   const manager = new HostKeybindingManager()
   manager.setUserConfiguration(parseUserKeybindings({
     leader: 'ctrl+f', // collides with app.transcript.search's ctrl+f
-    bindings: { 'app.session.new': '<leader>n' },
+    bindings: { 'app.transcript.toggleFullscreen': '<leader>n' },
   }))
   assert.equal(manager.leaderMachine(), undefined, 'the colliding leader is disabled')
   assert.ok(manager.diagnosticsList().some(message => message.includes('active host key')))
   // The UI must NOT advertise the dead leader sequence anywhere.
-  assert.equal(manager.keyHint('app.session.new'), '', 'keyHint must not advertise the shadowed leader')
-  assert.equal(manager.keysLabelFor('app.session.new'), '', 'keysLabelFor must not advertise the shadowed leader')
-  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.session.new')
+  assert.equal(manager.keyHint('app.transcript.toggleFullscreen'), '', 'keyHint must not advertise the shadowed leader')
+  assert.equal(manager.keysLabelFor('app.transcript.toggleFullscreen'), '', 'keysLabelFor must not advertise the shadowed leader')
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.transcript.toggleFullscreen')
   assert.equal(binding?.leaderKeys, undefined, 'the snapshot must not carry the shadowed leader')
 })
 
@@ -693,7 +698,7 @@ test('an AMBIGUOUS leader-only submit restores the builtin Enter (PR review P1)'
     leader: 'ctrl+x',
     bindings: {
       'app.input.submit': '<leader>s',
-      'app.session.new': '<leader>s',
+      'app.transcript.toggleFullscreen': '<leader>s',
     },
   }))
   assert.equal(manager.leaderMachine()?.leaderBindings.length ?? 0, 0, 'the ambiguous sequence is dropped')

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -429,11 +429,40 @@ test('disposing the app with an armed leader prefix clears the pending timer (PR
   await vt.waitForRender()
   assert.ok(app.keybindingsManager().leaderMachine()?.pending === true, 'the leader must be pending')
   // Dispose with the leader armed: the manager's dispose clears the
-  // timeout, so nothing fires against the stopped app afterwards.
+  // timeout, so nothing fires against the stopped app afterwards. The
+  // assertion is DETERMINISTIC (the repo's race-test rule — no fixed
+  // sleeps): flushing the microtask queue lets any (incorrectly) pending
+  // continuation land, and the disposed leader machine is gone.
   app.dispose()
-  // Let any (incorrectly) pending macrotask land: nothing must throw and
-  // the leader must be gone.
-  await new Promise(resolve => setTimeout(resolve, 30))
+  await Promise.resolve()
+  await Promise.resolve()
   assert.equal(app.keybindingsManager().leaderMachine(), undefined, 'the leader machine is gone after dispose')
   assert.equal(tasksOpened, 0, 'no action may fire after dispose')
+})
+
+test('a leader-only submit override: Enter does NOT submit (PR review P1)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const submitted: string[] = []
+  const app = new TuiApp(vt, { onSubmit: (text: string) => submitted.push(text), onExit: () => {} })
+  app.start()
+  // app.input.submit: <leader>s — NO direct keys. Enter must not submit;
+  // only the leader sequence does.
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.submit': '<leader>s' },
+  }))
+  await vt.waitForRender()
+  app.setDraft('via leader')
+  await vt.waitForRender()
+  vt.sendInput('\r') // Enter — must NOT submit (the override removed it)
+  await vt.waitForRender()
+  assert.deepEqual(submitted, [], 'Enter must not submit under a leader-only submit override')
+  assert.equal(app.getDraft(), 'via leader', 'the draft survives the inert Enter')
+  // The leader sequence DOES submit.
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('s') // completing key
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['via leader'], 'the leader sequence must submit')
+  app.stop()
 })

--- a/test/keybinding-leader.test.ts
+++ b/test/keybinding-leader.test.ts
@@ -23,7 +23,7 @@ function createMachine(
   const activated: string[] = []
   let stateChanges = 0
   const machine = new LeaderStateMachine(config, bindings, {
-    onActivate: (action) => activated.push(action),
+    onActivate: (action) => { activated.push(action); return true },
     onStateChange: () => { stateChanges += 1 },
   })
   // The counter is exposed as a GETTER — a by-value copy would freeze at 0
@@ -50,8 +50,24 @@ test('a completing key activates the bound action', () => {
   const { machine, activated } = createMachine()
   machine.feed('\x18') // leader
   const result = machine.feed('t')
-  assert.deepEqual(result, { kind: 'activated', action: 'app.tasks.open' })
+  assert.deepEqual(result, { kind: 'activated', action: 'app.tasks.open', consumed: true })
   assert.deepEqual(activated, ['app.tasks.open'])
+  assert.equal(machine.pending, false)
+})
+
+test('a DECLINED action activation reports consumed: false (the key falls through)', () => {
+  // Review finding: the leader machine must not unconditionally consume a
+  // completing key when the dispatched action DECLINES (e.g. pasteMedia
+  // without a clipboard handler) — the app only consumes when
+  // onActivate returns true, mirroring the direct-key resolver contract.
+  const bindings: LeaderBinding[] = [{ action: 'app.clipboard.pasteMedia', key: 'p' }]
+  const machine = new LeaderStateMachine(CONFIG, bindings, {
+    onActivate: () => false,
+    onStateChange: () => {},
+  })
+  machine.feed('\x18') // leader
+  const result = machine.feed('p')
+  assert.deepEqual(result, { kind: 'activated', action: 'app.clipboard.pasteMedia', consumed: false })
   assert.equal(machine.pending, false)
 })
 

--- a/test/keybinding-leader.test.ts
+++ b/test/keybinding-leader.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The leader / multi-key sequence contract (plan §6 M6): pending prefix
+ * state, timeout, ambiguous prefix, cancel, paste/typing isolation, and
+ * focus-transition cancellation.
+ * @module @xmoon76/dsh-pi-tui/keybinding-leader.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { LeaderStateMachine } from '../src/keybindings/leader.ts'
+import type { LeaderBinding, LeaderConfig } from '../src/keybindings/types.ts'
+
+const CONFIG: LeaderConfig = { key: 'ctrl+x', timeoutMs: 1000 }
+const BINDINGS: readonly LeaderBinding[] = [
+  { action: 'app.tasks.open', key: 't' },
+  { action: 'app.history.search', key: 'r' },
+]
+
+function createMachine(
+  config: LeaderConfig = CONFIG,
+  bindings: readonly LeaderBinding[] = BINDINGS,
+): { machine: LeaderStateMachine; activated: string[]; stateChanges: () => number } {
+  const activated: string[] = []
+  let stateChanges = 0
+  const machine = new LeaderStateMachine(config, bindings, {
+    onActivate: (action) => activated.push(action),
+    onStateChange: () => { stateChanges += 1 },
+  })
+  // The counter is exposed as a GETTER — a by-value copy would freeze at 0
+  // (the AGENTS.md mutable-counter trap).
+  return { machine, activated, stateChanges: () => stateChanges }
+}
+
+test('idle: the leader key arms the pending state', () => {
+  const { machine, stateChanges } = createMachine()
+  assert.equal(machine.pending, false)
+  const result = machine.feed('\x18') // ctrl+x
+  assert.deepEqual(result, { kind: 'consumed' })
+  assert.equal(machine.pending, true)
+  assert.ok(stateChanges() >= 1)
+})
+
+test('idle: other keys pass through', () => {
+  const { machine } = createMachine()
+  assert.deepEqual(machine.feed('a'), { kind: 'passed' })
+  assert.equal(machine.pending, false)
+})
+
+test('a completing key activates the bound action', () => {
+  const { machine, activated } = createMachine()
+  machine.feed('\x18') // leader
+  const result = machine.feed('t')
+  assert.deepEqual(result, { kind: 'activated', action: 'app.tasks.open' })
+  assert.deepEqual(activated, ['app.tasks.open'])
+  assert.equal(machine.pending, false)
+})
+
+test('a non-matching key cancels the pending state and passes through', () => {
+  const { machine, activated } = createMachine()
+  machine.feed('\x18')
+  const result = machine.feed('z')
+  assert.deepEqual(result, { kind: 'cancelled-pass' })
+  assert.equal(machine.pending, false)
+  assert.deepEqual(activated, [])
+})
+
+test('Esc cancels the pending state and is consumed', () => {
+  const { machine } = createMachine()
+  machine.feed('\x18')
+  const result = machine.feed('\x1b') // escape
+  assert.deepEqual(result, { kind: 'cancelled-consume' })
+  assert.equal(machine.pending, false)
+})
+
+test('a paste burst cancels the pending state and passes the text through', () => {
+  const { machine } = createMachine()
+  machine.feed('\x18')
+  const result = machine.feed('hello world')
+  assert.deepEqual(result, { kind: 'cancelled-pass' })
+  assert.equal(machine.pending, false)
+})
+
+test('protocol artifacts (release/repeat) are ignored while pending', () => {
+  const { machine } = createMachine()
+  machine.feed('\x18')
+  // A release of the leader key must not cancel the sequence it armed.
+  assert.deepEqual(machine.feed('\x1b[120;5:3u'), { kind: 'consumed' }) // ctrl+x release (CSI-u)
+  assert.equal(machine.pending, true)
+})
+
+test('timeout cancels the pending state', async () => {
+  const { machine, stateChanges } = createMachine({ key: 'ctrl+x', timeoutMs: 20 })
+  machine.feed('\x18')
+  assert.equal(machine.pending, true)
+  await new Promise(resolve => setTimeout(resolve, 40))
+  assert.equal(machine.pending, false)
+  assert.ok(stateChanges() >= 2)
+})
+
+test('no leader key: everything passes through', () => {
+  const { machine } = createMachine({ key: undefined, timeoutMs: 1000 })
+  assert.deepEqual(machine.feed('\x18'), { kind: 'passed' })
+  assert.equal(machine.pending, false)
+})
+
+test('focus-transition cancellation via cancel()', () => {
+  const { machine, stateChanges } = createMachine()
+  machine.feed('\x18')
+  assert.equal(machine.pending, true)
+  machine.cancel()
+  assert.equal(machine.pending, false)
+  assert.ok(stateChanges() >= 2)
+  // Cancel is idempotent.
+  machine.cancel()
+})
+
+test('dispose clears the timer and makes the machine inert', () => {
+  const { machine } = createMachine()
+  machine.feed('\x18')
+  machine.dispose()
+  assert.equal(machine.pending, false)
+  assert.deepEqual(machine.feed('t'), { kind: 'passed' })
+})

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The HostKeybindingManager contract (review round 2): a DISABLED action
+ * (user `false`) is never advertised — keyHint returns nothing and the
+ * snapshot drops it, whether the action was direct-bound or leader-bound.
+ * @module @xmoon76/dsh-pi-tui/keybinding-manager.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { HostKeybindingManager } from '../src/keybindings/manager.ts'
+
+function managerWith(config: Record<string, unknown>): HostKeybindingManager {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(config)
+  manager.setUserConfiguration(parsed)
+  return manager
+}
+
+test('a disabled direct-bound action advertises no hint and no snapshot entry', () => {
+  const manager = managerWith({ 'app.input.steer': false })
+  assert.equal(manager.keyHint('app.input.steer'), '')
+  const snapshot = manager.snapshot()
+  assert.ok(!snapshot.bindings.some(binding => binding.action === 'app.input.steer'),
+    'a disabled action must not appear in the snapshot')
+})
+
+test('a disabled leader-bound action advertises no hint', () => {
+  const manager = managerWith({
+    leader: 'ctrl+x',
+    'app.tasks.open': false,
+  })
+  assert.equal(manager.keyHint('app.tasks.open'), '')
+  const snapshot = manager.snapshot()
+  assert.ok(!snapshot.bindings.some(binding => binding.action === 'app.tasks.open'))
+})
+
+test('an enabled action keeps its hint and snapshot entry', () => {
+  const manager = managerWith({ 'app.input.steer': 'ctrl+x' })
+  assert.equal(manager.keyHint('app.input.steer'), 'Ctrl+X')
+  const snapshot = manager.snapshot()
+  const steer = snapshot.bindings.find(binding => binding.action === 'app.input.steer')
+  assert.ok(steer !== undefined)
+  assert.deepEqual(steer.keys, ['ctrl+x'])
+})
+
+test('safe mode restores the advertised defaults for a disabled action', () => {
+  const manager = managerWith({ 'app.input.steer': false })
+  manager.setSafeMode(true)
+  assert.equal(manager.keyHint('app.input.steer'), 'Ctrl+S')
+  const snapshot = manager.snapshot()
+  assert.ok(snapshot.bindings.some(binding => binding.action === 'app.input.steer'))
+})

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -159,7 +159,9 @@ test('duplicate leader bindings of the SAME action are not ambiguous (review rou
   })
   assert.ok(!manager.diagnosticsList().some(message => message.includes('ambiguous')), `no ambiguity expected: ${manager.diagnosticsList().join(' | ')}`)
   assert.deepEqual(manager.leaderKeysFor('app.history.search'), ['h'], 'the deduped binding fires')
-  assert.equal(manager.keyHint('app.history.search'), 'Ctrl+R / Leader H', 'the default direct key plus the deduped leader')
+  // Round 37: a leader-only declaration REPLACES the builtin default —
+  // the deduped leader is the ONLY trigger (no Ctrl+R advertised).
+  assert.equal(manager.keyHint('app.history.search'), 'Leader H', 'the leader-only declaration replaced the builtin Ctrl+R')
   // Two DIFFERENT actions on the same completing key are still ambiguous.
   const ambiguous = managerWith({
     leader: 'ctrl+x',

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -129,3 +129,41 @@ test('keysLabelFor shows ALL direct and leader keys (the /help source)', () => {
   const disabled = managerWith({ 'app.history.search': false })
   assert.equal(disabled.keysLabelFor('app.history.search'), '')
 })
+
+test('keysLabelFor falls back to an overlay action default (the /help source)', () => {
+  // Review finding: capturing-scope actions (search close/next/previous,
+  // question/tasks flows) are excluded from the HOST keymap, so keysFor()
+  // is empty and keysLabelFor must render their defaults — /help showed
+  // '—' for Enter submission and the fixed overlay controls.
+  const manager = managerWith({})
+  assert.equal(manager.keysLabelFor('app.input.submit'), 'Enter', 'submit keeps its default label')
+  assert.equal(manager.keysLabelFor('app.transcript.search.close'), 'Esc')
+  assert.equal(manager.keysLabelFor('app.transcript.search.next'), 'Enter')
+  assert.equal(manager.keysLabelFor('app.transcript.search.previous'), 'Shift+Enter')
+  // Disabled actions still advertise nothing.
+  const disabled = managerWith({ 'app.input.submit': false })
+  assert.equal(disabled.keysLabelFor('app.input.submit'), '')
+})
+
+test('duplicate leader bindings of the SAME action are not ambiguous (review round)', () => {
+  // Review finding: ['<leader>h', '<leader>h'] on ONE action grouped two
+  // entries under the same completing key and was flagged ambiguous —
+  // neither fired. Identical (action, key) pairs are deduped first.
+  const manager = managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.history.search': ['<leader>h', '<leader>h'] },
+  })
+  assert.ok(!manager.diagnosticsList().some(message => message.includes('ambiguous')), `no ambiguity expected: ${manager.diagnosticsList().join(' | ')}`)
+  assert.deepEqual(manager.leaderKeysFor('app.history.search'), ['h'], 'the deduped binding fires')
+  assert.equal(manager.keyHint('app.history.search'), 'Ctrl+R / Leader H', 'the default direct key plus the deduped leader')
+  // Two DIFFERENT actions on the same completing key are still ambiguous.
+  const ambiguous = managerWith({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.history.search': '<leader>h',
+      'app.session.new': '<leader>h',
+    },
+  })
+  assert.ok(ambiguous.diagnosticsList().some(message => message.includes('ambiguous')), 'cross-action same-key stays ambiguous')
+  assert.deepEqual(ambiguous.leaderKeysFor('app.history.search'), [], 'ambiguous actions advertise no leader key')
+})

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -82,3 +82,19 @@ test('matches() reflects a remap of a configurable action; matchesDefault() stay
   assert.ok(manager.matchesDefault('\r', 'app.transcript.search.next'), 'the fixed overlay keys keep their defaults')
   assert.ok(manager.matchesDefault('\x1b[13;2u', 'app.transcript.search.previous'), 'the fixed overlay keys keep their defaults')
 })
+
+test('a leader-only action appears in the snapshot with its leader sequence (review round)', () => {
+  // Review finding: an action with NO default keys configured only as
+  // `<leader>X` (e.g. app.session.new) was advertised by keyHint but
+  // absent from the /keybindings table. The snapshot now includes it with
+  // the leader flag so the table renders `Leader N`.
+  const manager = managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.session.new': '<leader>n' },
+  })
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.session.new')
+  assert.ok(binding !== undefined, 'the leader-only action must appear in the snapshot')
+  assert.equal(binding!.leader, true, 'the leader-only binding is flagged for display')
+  assert.deepEqual(binding!.keys, ['n'], 'the raw completing key is carried')
+  assert.equal(manager.keyHint('app.session.new'), 'Leader N', 'keyHint and snapshot agree')
+})

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -113,3 +113,19 @@ test('mixed direct + leader keys both appear in the snapshot and the hint (revie
   assert.deepEqual(binding!.leaderKeys, ['h'], 'the leader completing key is carried separately')
   assert.equal(manager.keyHint('app.history.search'), 'Ctrl+Z / Leader H', 'the hint shows both forms')
 })
+
+test('keysLabelFor shows ALL direct and leader keys (the /help source)', () => {
+  // Review finding: /help used keysFor() (direct only) — a mixed
+  // ['ctrl+z', '<leader>h'] action showed only the direct key. The
+  // manager's keysLabelFor renders every effective form.
+  const manager = managerWith({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.history.search': ['ctrl+z', 'ctrl+shift+z', '<leader>h'],
+    },
+  })
+  assert.equal(manager.keysLabelFor('app.history.search'), 'Ctrl+Z / Ctrl+Shift+Z / Leader H')
+  // Disabled actions advertise nothing.
+  const disabled = managerWith({ 'app.history.search': false })
+  assert.equal(disabled.keysLabelFor('app.history.search'), '')
+})

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -94,7 +94,22 @@ test('a leader-only action appears in the snapshot with its leader sequence (rev
   })
   const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.session.new')
   assert.ok(binding !== undefined, 'the leader-only action must appear in the snapshot')
-  assert.equal(binding!.leader, true, 'the leader-only binding is flagged for display')
-  assert.deepEqual(binding!.keys, ['n'], 'the raw completing key is carried')
+  assert.deepEqual(binding!.keys, [], 'no direct keys')
+  assert.deepEqual(binding!.leaderKeys, ['n'], 'the raw completing key is carried')
   assert.equal(manager.keyHint('app.session.new'), 'Leader N', 'keyHint and snapshot agree')
+})
+
+test('mixed direct + leader keys both appear in the snapshot and the hint (review round)', () => {
+  // Review finding: an action configured as ['ctrl+z', '<leader>h'] showed
+  // only the direct key in /keybindings and keyHint — the leader sequence
+  // was silently dropped. Both must render, each with its own format.
+  const manager = managerWith({
+    leader: 'ctrl+x',
+    bindings: { 'app.history.search': ['ctrl+z', '<leader>h'] },
+  })
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.history.search')
+  assert.ok(binding !== undefined)
+  assert.deepEqual(binding!.keys, ['ctrl+z'], 'the direct key is carried')
+  assert.deepEqual(binding!.leaderKeys, ['h'], 'the leader completing key is carried separately')
+  assert.equal(manager.keyHint('app.history.search'), 'Ctrl+Z / Leader H', 'the hint shows both forms')
 })

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -54,17 +54,21 @@ test('safe mode restores the advertised defaults for a disabled action', () => {
 
 test('an ambiguous leader sequence is never advertised (review round 3)', () => {
   // Two actions bound to the SAME completing key: neither fires, so
-  // neither may be advertised by keyHint. (app.session.* have no default
-  // keys, so the leader sequence is their ONLY key — a clean probe.)
+  // neither may be advertised by keyHint. (app.transcript.toggleFullscreen
+  // and app.tasks.open are configurable actions whose <leader>n is a
+  // leader-only trigger — a clean probe.)
   const manager = managerWith({
     leader: 'ctrl+x',
     bindings: {
-      'app.session.new': '<leader>n',
-      'app.session.resume': '<leader>n',
+      'app.transcript.toggleFullscreen': '<leader>n',
+      'app.tasks.open': '<leader>n',
     },
   })
-  assert.equal(manager.keyHint('app.session.new'), '')
-  assert.equal(manager.keyHint('app.session.resume'), '')
+  assert.equal(manager.keyHint('app.transcript.toggleFullscreen'), '')
+  // app.tasks.open keeps its SEPARATE down affordance (a composition key,
+  // not the ambiguous leader — convergence §4.5/§6.5: leader bindings are
+  // additive triggers, never a predicate bypass).
+  assert.equal(manager.keyHint('app.tasks.open'), 'Down')
   assert.ok(manager.diagnosticsList().some(message => message.includes('ambiguous leader sequence')))
   // The leader machine itself carries no bindings.
   assert.deepEqual(manager.leaderMachine()?.leaderBindings ?? [], [])
@@ -85,18 +89,18 @@ test('matches() reflects a remap of a configurable action; matchesDefault() stay
 
 test('a leader-only action appears in the snapshot with its leader sequence (review round)', () => {
   // Review finding: an action with NO default keys configured only as
-  // `<leader>X` (e.g. app.session.new) was advertised by keyHint but
-  // absent from the /keybindings table. The snapshot now includes it with
-  // the leader flag so the table renders `Leader N`.
+  // `<leader>X` (e.g. app.transcript.toggleFullscreen) was advertised by
+  // keyHint but absent from the /keybindings table. The snapshot now
+  // includes it with the leader flag so the table renders `Leader N`.
   const manager = managerWith({
     leader: 'ctrl+x',
-    bindings: { 'app.session.new': '<leader>n' },
+    bindings: { 'app.transcript.toggleFullscreen': '<leader>n' },
   })
-  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.session.new')
+  const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.transcript.toggleFullscreen')
   assert.ok(binding !== undefined, 'the leader-only action must appear in the snapshot')
   assert.deepEqual(binding!.keys, [], 'no direct keys')
   assert.deepEqual(binding!.leaderKeys, ['n'], 'the raw completing key is carried')
-  assert.equal(manager.keyHint('app.session.new'), 'Leader N', 'keyHint and snapshot agree')
+  assert.equal(manager.keyHint('app.transcript.toggleFullscreen'), 'Leader N', 'keyHint and snapshot agree')
 })
 
 test('mixed direct + leader keys both appear in the snapshot and the hint (review round)', () => {
@@ -161,7 +165,7 @@ test('duplicate leader bindings of the SAME action are not ambiguous (review rou
     leader: 'ctrl+x',
     bindings: {
       'app.history.search': '<leader>h',
-      'app.session.new': '<leader>h',
+      'app.transcript.toggleFullscreen': '<leader>h',
     },
   })
   assert.ok(ambiguous.diagnosticsList().some(message => message.includes('ambiguous')), 'cross-action same-key stays ambiguous')

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -51,3 +51,21 @@ test('safe mode restores the advertised defaults for a disabled action', () => {
   const snapshot = manager.snapshot()
   assert.ok(snapshot.bindings.some(binding => binding.action === 'app.input.steer'))
 })
+
+test('an ambiguous leader sequence is never advertised (review round 3)', () => {
+  // Two actions bound to the SAME completing key: neither fires, so
+  // neither may be advertised by keyHint. (app.session.* have no default
+  // keys, so the leader sequence is their ONLY key — a clean probe.)
+  const manager = managerWith({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.session.new': '<leader>n',
+      'app.session.resume': '<leader>n',
+    },
+  })
+  assert.equal(manager.keyHint('app.session.new'), '')
+  assert.equal(manager.keyHint('app.session.resume'), '')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('ambiguous leader sequence')))
+  // The leader machine itself carries no bindings.
+  assert.deepEqual(manager.leaderMachine()?.leaderBindings ?? [], [])
+})

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -69,3 +69,16 @@ test('an ambiguous leader sequence is never advertised (review round 3)', () => 
   // The leader machine itself carries no bindings.
   assert.deepEqual(manager.leaderMachine()?.leaderBindings ?? [], [])
 })
+
+test('matches() reflects a remap of a configurable action; matchesDefault() stays on defaults', () => {
+  // Review finding: the search TOGGLE (app.transcript.search) is
+  // configurable, so the overlay handler must match the EFFECTIVE keys
+  // (matches), while the non-configurable overlay keys (close/next/
+  // previous) keep their default matching (matchesDefault).
+  const manager = managerWith({ 'app.transcript.search': 'ctrl+x' })
+  assert.ok(manager.matches('\x18', 'app.transcript.search'), 'the remapped toggle must match')
+  assert.ok(!manager.matches('\x06', 'app.transcript.search'), 'the old default must no longer match')
+  assert.ok(manager.matchesDefault('\x1b', 'app.transcript.search.close'), 'the fixed overlay keys keep their defaults')
+  assert.ok(manager.matchesDefault('\r', 'app.transcript.search.next'), 'the fixed overlay keys keep their defaults')
+  assert.ok(manager.matchesDefault('\x1b[13;2u', 'app.transcript.search.previous'), 'the fixed overlay keys keep their defaults')
+})

--- a/test/keybinding-resolver.test.ts
+++ b/test/keybinding-resolver.test.ts
@@ -1,0 +1,157 @@
+/**
+ * The EffectiveKeymap resolver contract (plan §21): default resolve, user
+ * override, disabled binding, multi-key, context filtering, source
+ * priority.
+ * @module @xmoon76/dsh-pi-tui/keybinding-resolver.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { deriveKeybindingContext } from '../src/keybindings/context.ts'
+import { EffectiveKeymap } from '../src/keybindings/effective-keymap.ts'
+import { APP_KEYBINDINGS } from '../src/keybindings/definitions.ts'
+import type { KeybindingContext } from '../src/keybindings/types.ts'
+
+function keymap(options: Omit<ConstructorParameters<typeof EffectiveKeymap>[0], 'definitions'> = {}): EffectiveKeymap {
+  return new EffectiveKeymap({
+    definitions: APP_KEYBINDINGS,
+    // The HOST keymap resolves the non-capturing scopes only (the manager
+    // wires this); the focused-component actions never resolve here.
+    includeScopes: new Set(['global', 'editor', 'agent-running']),
+    // The empty-editor ↓ affordance (the manager's composition rule).
+    compositionRules: [{
+      action: 'app.tasks.open',
+      key: 'down',
+      predicate: (context) => context.focusedSeat === 'editor' && context.editorEmpty && context.tasksActive,
+    }],
+    ...options,
+  })
+}
+
+const editorContext: KeybindingContext = deriveKeybindingContext({ focusedSeat: 'editor' })
+
+test('default resolve: ctrl+s → app.input.steer', () => {
+  const km = keymap()
+  const resolution = km.resolve('\x13', editorContext) // ctrl+s
+  assert.ok(resolution !== undefined)
+  assert.equal(resolution.action, 'app.input.steer')
+  assert.equal(resolution.source, 'builtin')
+})
+
+test('default resolve: ctrl+o → app.transcript.toggleExpand', () => {
+  const km = keymap()
+  const resolution = km.resolve('\x0f', editorContext) // ctrl+o
+  assert.ok(resolution !== undefined)
+  assert.equal(resolution.action, 'app.transcript.toggleExpand')
+})
+
+test('default resolve: shift+tab → app.permission.cycle', () => {
+  const km = keymap()
+  const resolution = km.resolve('\x1b[Z', editorContext) // shift+tab
+  assert.ok(resolution !== undefined)
+  assert.equal(resolution.action, 'app.permission.cycle')
+})
+
+test('default resolve: alt+up → app.input.dequeue', () => {
+  const km = keymap()
+  const resolution = km.resolve('\x1b[1;3A', editorContext) // alt+up (CSI-u)
+  assert.ok(resolution !== undefined)
+  assert.equal(resolution.action, 'app.input.dequeue')
+})
+
+test('multi-key action: ctrl+c and ctrl+d both resolve to app.exit.request', () => {
+  const km = keymap()
+  assert.equal(km.resolve('\x03', editorContext)?.action, 'app.exit.request') // ctrl+c
+  assert.equal(km.resolve('\x04', editorContext)?.action, 'app.exit.request') // ctrl+d
+})
+
+test('unbound keys resolve to undefined', () => {
+  const km = keymap()
+  assert.equal(km.resolve('a', editorContext), undefined)
+  assert.equal(km.resolve('\x1b[1;5C', editorContext), undefined) // ctrl+right
+})
+
+test('user override replaces the builtin key', () => {
+  const km = keymap({ userBindings: { 'app.input.steer': 'ctrl+x' } })
+  // The new key resolves…
+  assert.equal(km.resolve('\x18', editorContext)?.action, 'app.input.steer') // ctrl+x
+  // …and the old key no longer does.
+  assert.equal(km.resolve('\x13', editorContext), undefined) // ctrl+s
+})
+
+test('user override with multiple keys', () => {
+  const km = keymap({ userBindings: { 'app.input.steer': ['ctrl+s', 'ctrl+shift+s'] } })
+  assert.equal(km.resolve('\x13', editorContext)?.action, 'app.input.steer')
+  assert.equal(km.resolve('\x1b[115;6u', editorContext)?.action, 'app.input.steer') // ctrl+shift+s
+})
+
+test('false disables the action entirely', () => {
+  const km = keymap({ userBindings: { 'app.transcript.toggleThinking': false } })
+  assert.equal(km.resolve('\x1b[1;3t', editorContext), undefined) // alt+t
+  assert.deepEqual(km.keysFor('app.transcript.toggleThinking'), [])
+})
+
+test('user override beats builtin (source priority)', () => {
+  const km = keymap({ userBindings: { 'app.todo.toggle': 'ctrl+shift+t' } })
+  const resolution = km.resolve('\x1b[116;6u', editorContext) // ctrl+shift+t
+  assert.ok(resolution !== undefined)
+  assert.equal(resolution.action, 'app.todo.toggle')
+  assert.equal(resolution.source, 'user')
+})
+
+test('plugin rules resolve last and never beat a host rule', () => {
+  const km = keymap({
+    pluginRules: [{ id: 'plugin-1', action: 'submit-draft', key: 'ctrl+alt+x' }],
+  })
+  // A plugin-only key resolves to the plugin action.
+  assert.equal(km.resolve('\x1b[120;7u', editorContext)?.action, 'submit-draft')
+  // A host key stays host-owned even when a plugin claims it.
+  const km2 = keymap({ pluginRules: [{ id: 'plugin-2', action: 'submit-draft', key: 'ctrl+s' }] })
+  assert.equal(km2.resolve('\x13', editorContext)?.action, 'app.input.steer')
+})
+
+test('context predicate: the empty-editor ↓ affordance', () => {
+  const km = keymap()
+  const idle = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: true, tasksActive: true })
+  const busy = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: false, tasksActive: true })
+  const noTasks = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: true, tasksActive: false })
+  assert.equal(km.resolve('\x1b[B', idle)?.action, 'app.tasks.open') // down
+  assert.equal(km.resolve('\x1b[B', busy), undefined)
+  assert.equal(km.resolve('\x1b[B', noTasks), undefined)
+})
+
+test('focused-component actions never resolve in the host keymap', () => {
+  const km = keymap()
+  // 'down' must resolve to the host affordance, never question.cursorDown.
+  const context = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: true, tasksActive: true })
+  assert.equal(km.resolve('\x1b[B', context)?.action, 'app.tasks.open')
+  // 'e' (question.toggleExpand) and 'i' (tasks.interrupt) stay unbound.
+  assert.equal(km.resolve('e', context), undefined)
+  assert.equal(km.resolve('i', context), undefined)
+})
+
+test('safe mode ignores user overrides', () => {
+  const km = keymap({ userBindings: { 'app.input.steer': 'ctrl+x' }, safeMode: true })
+  assert.equal(km.resolve('\x13', editorContext)?.action, 'app.input.steer') // ctrl+s still steers
+  assert.equal(km.resolve('\x18', editorContext), undefined) // ctrl+x unbound
+})
+
+test('keysFor / primaryKeyFor / keyHint reflect the effective map', () => {
+  const km = keymap({ userBindings: { 'app.permission.cycle': 'alt+p' } })
+  assert.deepEqual(km.keysFor('app.permission.cycle'), ['alt+p'])
+  assert.equal(km.primaryKeyFor('app.permission.cycle'), 'alt+p')
+  assert.equal(km.keyHint('app.permission.cycle'), 'Alt+P')
+  assert.equal(km.keyHint('app.transcript.toggleFullscreen'), '')
+})
+
+test('snapshot lists every action with its effective keys and sources', () => {
+  const km = keymap({ userBindings: { 'app.input.steer': 'ctrl+x' } })
+  const snapshot = km.snapshot()
+  assert.ok(snapshot.revision >= 1)
+  const steer = snapshot.bindings.find(binding => binding.action === 'app.input.steer')
+  assert.ok(steer !== undefined)
+  assert.deepEqual(steer.keys, ['ctrl+x'])
+  assert.equal(steer.source, 'user')
+  assert.equal(steer.scope, 'agent-running')
+  assert.deepEqual(snapshot.conflicts, [])
+})

--- a/test/keybinding-resolver.test.ts
+++ b/test/keybinding-resolver.test.ts
@@ -144,6 +144,32 @@ test('keysFor / primaryKeyFor / keyHint reflect the effective map', () => {
   assert.equal(km.keyHint('app.transcript.toggleFullscreen'), '')
 })
 
+test('a user remap of a conditional action keeps its predicate', () => {
+  // Review round 1: a remap of app.tasks.open must NOT open the task
+  // browser with a non-empty editor or no active tasks — the user rule
+  // inherits the conditional predicate (the ↓ affordance stays too: it is
+  // a builtin conditional binding, and only `false` disables it).
+  const km = keymap({ userBindings: { 'app.tasks.open': 'ctrl+x' } })
+  const idle = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: true, tasksActive: true })
+  const busy = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: false, tasksActive: true })
+  const noTasks = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: true, tasksActive: false })
+  assert.equal(km.resolve('\x18', idle)?.action, 'app.tasks.open') // ctrl+x
+  assert.equal(km.resolve('\x18', busy), undefined, 'a non-empty editor must not open the browser')
+  assert.equal(km.resolve('\x18', noTasks), undefined, 'no active tasks must not open the browser')
+  // The ↓ affordance remains conditional.
+  assert.equal(km.resolve('\x1b[B', idle)?.action, 'app.tasks.open')
+  assert.equal(km.resolve('\x1b[B', busy), undefined)
+})
+
+test('false disables the conditional composition rule too', () => {
+  // Review round 1: `false` disables every source of the action's keys —
+  // including the empty-editor ↓ affordance.
+  const km = keymap({ userBindings: { 'app.tasks.open': false } })
+  const idle = deriveKeybindingContext({ focusedSeat: 'editor', editorEmpty: true, tasksActive: true })
+  assert.equal(km.resolve('\x1b[B', idle), undefined, 'the ↓ affordance must be disabled too')
+  assert.deepEqual(km.keysFor('app.tasks.open'), [])
+})
+
 test('snapshot lists every action with its effective keys and sources', () => {
   const km = keymap({ userBindings: { 'app.input.steer': 'ctrl+x' } })
   const snapshot = km.snapshot()

--- a/test/local-shell-card.test.ts
+++ b/test/local-shell-card.test.ts
@@ -73,14 +73,14 @@ test('empty text previews as empty', () => {
 })
 
 test('the hidden marker carries the expand hint and stays honest', () => {
-  assert.equal(localShellHiddenMarker(0, false), '')
-  assert.equal(localShellHiddenMarker(3, false), '3 more lines (ctrl+o to expand)')
-  assert.equal(localShellHiddenMarker(3, true), '3 more lines (ctrl+o to expand)')
+  assert.equal(localShellHiddenMarker(0, false, false, 'ctrl+o'), '')
+  assert.equal(localShellHiddenMarker(3, false, false, 'ctrl+o'), '3 more lines (ctrl+o to expand)')
+  assert.equal(localShellHiddenMarker(3, true, false, 'ctrl+o'), '3 more lines (ctrl+o to expand)')
   // A PARTIAL cut (the front of the same line hidden) must not claim
   // "1 more line" — that would lie about what is hidden (review P1).
-  assert.equal(localShellHiddenMarker(1, true, true), 'earlier output hidden (ctrl+o to expand)')
-  assert.equal(localShellHiddenMarker(1, false, true), 'earlier output hidden (ctrl+o to expand)')
-  assert.equal(localShellHiddenMarker(0, true, true), '')
+  assert.equal(localShellHiddenMarker(1, true, true, 'ctrl+o'), 'earlier output hidden (ctrl+o to expand)')
+  assert.equal(localShellHiddenMarker(1, false, true, 'ctrl+o'), 'earlier output hidden (ctrl+o to expand)')
+  assert.equal(localShellHiddenMarker(0, true, true, 'ctrl+o'), '')
 })
 
 test('isLocalShellCard recognizes only the unbounded-turn shell card', () => {
@@ -172,7 +172,7 @@ test('a RUNNING gigantic single line is bounded by the visual ceiling, not the l
   assert.equal(hidden, 1, 'the single line is counted hidden')
   assert.equal(partial, true, 'the cut is mid-line: the hidden content is the EARLIER part of the same line')
   // The marker must say so honestly — never "1 more lines".
-  assert.equal(localShellHiddenMarker(hidden, true, partial), 'earlier output hidden (ctrl+o to expand)')
+  assert.equal(localShellHiddenMarker(hidden, true, partial, 'ctrl+o'), 'earlier output hidden (ctrl+o to expand)')
 })
 
 test('a RUNNING preview with many SHORT lines keeps the 5-line budget and is not partial', () => {

--- a/test/pre-push-stages.test.mjs
+++ b/test/pre-push-stages.test.mjs
@@ -102,31 +102,33 @@ test('pre-push-stages: missing verify: prefix is rejected', () => {
   })
 })
 
-test('pre-push-stages: current verify:prepush derives to the expected 7 stages', () => {
+test('pre-push-stages: current verify:prepush derives to the expected 8 stages', () => {
   const r = spawnSync(process.execPath, [STAGES_SCRIPT, 'verify:prepush'], { cwd: ROOT, encoding: 'utf8' })
   assert.equal(r.status, 0)
   const stages = r.stdout.trim().split('\n')
-  assert.equal(stages.length, 7)
+  assert.equal(stages.length, 8)
   assert.deepEqual(stages, [
     'pnpm typecheck:fork',
     'pnpm test:fork',
     'pnpm test:docs',
     'node scripts/naming-gate.mjs',
     'pnpm gate:boundary',
+    'pnpm gate:keybindings',
     'pnpm audit --prod --audit-level high',
     'pnpm pack:release',
   ])
 })
 
-test('pre-push-stages: current verify:prepush:nofork derives to 5 stages', () => {
+test('pre-push-stages: current verify:prepush:nofork derives to 6 stages', () => {
   const r = spawnSync(process.execPath, [STAGES_SCRIPT, 'verify:prepush:nofork'], { cwd: ROOT, encoding: 'utf8' })
   assert.equal(r.status, 0)
   const stages = r.stdout.trim().split('\n')
-  assert.equal(stages.length, 5)
+  assert.equal(stages.length, 6)
   assert.deepEqual(stages, [
     'pnpm test:docs',
     'node scripts/naming-gate.mjs',
     'pnpm gate:boundary',
+    'pnpm gate:keybindings',
     'pnpm audit --prod --audit-level high',
     'pnpm pack:release',
   ])

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -16,6 +16,7 @@ import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { CommandInvocation } from '@deepseek-ai/dsh-commands'
 import { CommandId } from '@deepseek-ai/dsh-commands'
 import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from '../src/commands.ts'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
 import type { CatalogRefreshOutcome, CatalogRefreshRequest } from '../src/skill-catalog-refresh.ts'
 import { SESSIONLESS_COMMANDS } from '../src/index.ts'
 import { createDiag } from '../src/diag.ts'
@@ -605,29 +606,121 @@ test('/reload with a live agent refreshes the AGENT target, never the standing p
   t.app.stop()
 })
 
-test('/keybindings reset awaits the settings write and reports its real outcome', async () => {
+test('/keybindings reload re-reads the settings document LAZILY (the explicit reload seam, no watch)', async () => {
+  // Server/client migration boundary (review finding): the keybinding
+  // reload is EXPLICIT — /keybindings reload calls `settings.get()` at
+  // reload time and rebuilds the keymap. There is deliberately NO settings
+  // `watch` callback: the TuiSettingsConfig port is get/replace only, and
+  // a callback could not cross the process boundary in the future Remote
+  // adapter. This test proves the command reads the CURRENT document at
+  // reload time (a stale cached parse would miss a later settings edit).
+  let settingsDoc = {
+    theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue',
+    localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off',
+    iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' },
+  }
+  let reads = 0
+  const tuiSettings: TuiSettingsLike = {
+    // get/replace ONLY — no watch on the port (the structural type
+    // enforces it: a watch method would not exist on TuiSettingsLike).
+    get: () => { reads += 1; return settingsDoc },
+    replace: async () => {},
+  }
+  const t = setup({ tuiSettings })
+  // The runner applies the startup configuration ONCE at mount (this
+  // command-surface harness mounts only the command layer, so apply the
+  // same parse the runner's applyUserKeybindings performs).
+  t.app.keybindingsManager().setUserConfiguration(parseUserKeybindings(tuiSettings.get().keybindings))
+  const readsAfterSetup = reads
+  // A later settings edit (the user changes the keybindings in the YAML);
+  // the keymap must NOT change until /keybindings reload.
+  settingsDoc = { ...settingsDoc, keybindings: { 'app.input.steer': 'ctrl+y' } }
+  // The app's effective table still shows the startup keys (no watch).
+  const before = t.app.keybindingsManager().keysFor('app.input.steer')
+  assert.deepEqual(before, ['ctrl+x'], 'no watch: the keymap must keep the startup configuration until a reload')
+  const result = await t.runCommand('keybindings', 'reload')
+  assert.equal((result as { kind: string }).kind, 'success', 'the reload must succeed')
+  assert.ok(reads > readsAfterSetup, 'the reload must re-read the settings document')
+  const after = t.app.keybindingsManager().keysFor('app.input.steer')
+  assert.deepEqual(after, ['ctrl+y'], 'the reload must apply the CURRENT settings document')
+  t.app.stop()
+})
+
+test('/keybindings reset awaits the settings write, applies the cleared config, and reports its real outcome', async () => {
   // Review finding: the reset must not report success before the async
   // persistence write resolves — a failed write is an error result.
+  // Review round 28: with the automatic settings watch removed (the reload
+  // seam is explicit), a reset that only persisted would leave the RUNNING
+  // keymap with the old overrides — the reset must also REBUILD from the
+  // now-keybindings-less document.
   let replaced = 0
   const failing: TuiSettingsLike = {
     get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }),
     replace: async () => { replaced += 1; throw new Error('write refused') },
   }
   let t = setup({ tuiSettings: failing })
+  t.app.keybindingsManager().setUserConfiguration(parseUserKeybindings(failing.get().keybindings))
   const failed = await t.runCommand('keybindings', 'reset')
   assert.equal((failed as { kind: string }).kind, 'error', 'a failed write must report an error result')
   assert.ok((failed as { text: string }).text.includes('failed'), `error text missing: ${JSON.stringify(failed)}`)
   assert.equal(replaced, 1, 'the write must be attempted')
+  assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'a failed reset must keep the running keymap')
   t.app.stop()
 
   let okReplaced = 0
+  // The fixture models the storage: after a successful replace the
+  // document has no keybindings field.
+  let okDoc = { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } } as { theme: string; footer: string; fullscreen: string; busyEnter: string; localShellSandbox: string; homeEndKeys: string; focusMode: string; iconStyle: string; keybindings?: unknown }
   const ok: TuiSettingsLike = {
-    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }),
-    replace: async () => { okReplaced += 1 },
+    get: () => okDoc,
+    replace: async (doc) => { okReplaced += 1; okDoc = doc as typeof okDoc },
   }
   t = setup({ tuiSettings: ok })
+  t.app.keybindingsManager().setUserConfiguration(parseUserKeybindings(ok.get().keybindings))
+  assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'the pre-reset keymap must carry the override')
   const succeeded = await t.runCommand('keybindings', 'reset')
   assert.equal((succeeded as { kind: string }).kind, 'success', 'a resolved write must report success')
   assert.equal(okReplaced, 1)
+  assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+s'], 'the reset must REBUILD the running keymap from the cleared document (defaults)')
+  t.app.stop()
+
+  // Round 30: a throwing FIRST read must not escape the handler either —
+  // the reset reports an error and the running keymap stays untouched.
+  let readsFailing = 0
+  const throwingRead: TuiSettingsLike = {
+    get: () => { readsFailing += 1; throw new Error('settings read exploded') },
+    replace: async () => {},
+  }
+  t = setup({ tuiSettings: throwingRead })
+  t.app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.steer': 'ctrl+x' }))
+  const readFailed = await t.runCommand('keybindings', 'reset')
+  assert.equal((readFailed as { kind: string }).kind, 'error', 'a throwing first read must report an error result')
+  assert.ok((readFailed as { text: string }).text.includes('failed'), `error text missing: ${JSON.stringify(readFailed)}`)
+  assert.equal(readsFailing, 1, 'the initial read must be attempted once')
+  assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'a failed reset must keep the running keymap')
+  t.app.stop()
+})
+
+test('/keybindings reload is fail-soft: a throwing settings read keeps the last-known-good keymap', async () => {
+  // Review round 28: reload is now the ONLY reload seam, so its fail-soft
+  // contract must match the startup application — a transient `get()`
+  // failure must not throw out of the handler; the keymap keeps its
+  // last-known-good configuration and the command reports an error.
+  let failing = false
+  const tuiSettings: TuiSettingsLike = {
+    get: () => {
+      if (failing) throw new Error('settings read exploded')
+      return { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }
+    },
+    replace: async () => {},
+  }
+  const t = setup({ tuiSettings })
+  t.app.keybindingsManager().setUserConfiguration(parseUserKeybindings(tuiSettings.get().keybindings))
+  assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'startup configuration')
+  failing = true
+  const result = await t.runCommand('keybindings', 'reload')
+  assert.equal((result as { kind: string }).kind, 'error', 'a throwing settings read must report an error result')
+  assert.ok((result as { text: string }).text.includes('failed'), `error text missing: ${JSON.stringify(result)}`)
+  assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'the keymap must keep the last-known-good configuration')
   t.app.stop()
 })

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -604,3 +604,30 @@ test('/reload with a live agent refreshes the AGENT target, never the standing p
   assert.equal(t.refreshes[0]?.target.kind, 'agent', 'a live session must refresh the agent target')
   t.app.stop()
 })
+
+test('/keybindings reset awaits the settings write and reports its real outcome', async () => {
+  // Review finding: the reset must not report success before the async
+  // persistence write resolves — a failed write is an error result.
+  let replaced = 0
+  const failing: TuiSettingsLike = {
+    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', keybindings: { 'app.input.steer': 'ctrl+x' } }),
+    replace: async () => { replaced += 1; throw new Error('write refused') },
+  }
+  let t = setup({ tuiSettings: failing })
+  const failed = await t.runCommand('keybindings', 'reset')
+  assert.equal((failed as { kind: string }).kind, 'error', 'a failed write must report an error result')
+  assert.ok((failed as { text: string }).text.includes('failed'), `error text missing: ${JSON.stringify(failed)}`)
+  assert.equal(replaced, 1, 'the write must be attempted')
+  t.app.stop()
+
+  let okReplaced = 0
+  const ok: TuiSettingsLike = {
+    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', keybindings: { 'app.input.steer': 'ctrl+x' } }),
+    replace: async () => { okReplaced += 1 },
+  }
+  t = setup({ tuiSettings: ok })
+  const succeeded = await t.runCommand('keybindings', 'reset')
+  assert.equal((succeeded as { kind: string }).kind, 'success', 'a resolved write must report success')
+  assert.equal(okReplaced, 1)
+  t.app.stop()
+})

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -668,19 +668,32 @@ test('/keybindings reset awaits the settings write, applies the cleared config, 
   t.app.stop()
 
   let okReplaced = 0
-  // The fixture models the storage: after a successful replace the
-  // document has no keybindings field.
-  let okDoc = { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } } as { theme: string; footer: string; fullscreen: string; busyEnter: string; localShellSandbox: string; homeEndKeys: string; focusMode: string; iconStyle: string; keybindings?: unknown }
+  // Round 35: the success fixture is the reviewer's regression shape — the
+  // storage may NOT be re-read after a successful write (a post-write read
+  // could fail: disk reset + runtime "reset failed" fork). `get()` throws
+  // on ANY read after the FIRST, so a post-write second read would fail
+  // the test; the reset must project the cleared state locally from the
+  // doc it already holds (`keybindings` deleted above) — write + local
+  // projection, never GET → PUT → GET (the future Remote adapter
+  // contract too). The counter is armed right before the command so the
+  // harness's own setup reads do not trip it.
+  let okReads = 0
   const ok: TuiSettingsLike = {
-    get: () => okDoc,
-    replace: async (doc) => { okReplaced += 1; okDoc = doc as typeof okDoc },
+    get: () => {
+      okReads += 1
+      if (okReads > 1) throw new Error('no second read allowed')
+      return { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }
+    },
+    replace: async () => { okReplaced += 1 },
   }
   t = setup({ tuiSettings: ok })
   t.app.keybindingsManager().setUserConfiguration(parseUserKeybindings(ok.get().keybindings))
   assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'the pre-reset keymap must carry the override')
+  okReads = 0
   const succeeded = await t.runCommand('keybindings', 'reset')
   assert.equal((succeeded as { kind: string }).kind, 'success', 'a resolved write must report success')
   assert.equal(okReplaced, 1)
+  assert.equal(okReads, 1, 'the reset must read the settings document exactly ONCE (no post-write read)')
   assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+s'], 'the reset must REBUILD the running keymap from the cleared document (defaults)')
   t.app.stop()
 
@@ -722,5 +735,17 @@ test('/keybindings reload is fail-soft: a throwing settings read keeps the last-
   assert.equal((result as { kind: string }).kind, 'error', 'a throwing settings read must report an error result')
   assert.ok((result as { text: string }).text.includes('failed'), `error text missing: ${JSON.stringify(result)}`)
   assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'the keymap must keep the last-known-good configuration')
+  t.app.stop()
+})
+
+test('/keybindings reload refuses an absent settings service (no false "reloaded" success)', async () => {
+  // Review round 35 P3: without the settings backend, reload must NOT
+  // misrepresent "reading the defaults" as a success — it mirrors
+  // /keybindings reset's explicit refusal, so a degraded / Remote
+  // backend cannot claim a successful defaults read.
+  const t = setup({ tuiSettings: undefined })
+  const result = await t.runCommand('keybindings', 'reload')
+  assert.equal((result as { kind: string }).kind, 'error', 'an absent settings service must report an error result')
+  assert.ok((result as { text: string }).text.includes('unavailable'), `error text missing: ${JSON.stringify(result)}`)
   t.app.stop()
 })

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -610,7 +610,7 @@ test('/keybindings reset awaits the settings write and reports its real outcome'
   // persistence write resolves — a failed write is an error result.
   let replaced = 0
   const failing: TuiSettingsLike = {
-    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', keybindings: { 'app.input.steer': 'ctrl+x' } }),
+    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }),
     replace: async () => { replaced += 1; throw new Error('write refused') },
   }
   let t = setup({ tuiSettings: failing })
@@ -622,7 +622,7 @@ test('/keybindings reset awaits the settings write and reports its real outcome'
 
   let okReplaced = 0
   const ok: TuiSettingsLike = {
-    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', keybindings: { 'app.input.steer': 'ctrl+x' } }),
+    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }),
     replace: async () => { okReplaced += 1 },
   }
   t = setup({ tuiSettings: ok })

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -464,7 +464,7 @@ function reloadSettings(theme: string, onGet?: (count: number) => void): TuiSett
       onGet?.(reads)
       return { theme: currentTheme, iconStyle: 'emoji', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }
     },
-    replace: doc => { currentTheme = doc.theme },
+    replace: doc => { currentTheme = doc.theme as string },
   }
 }
 

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -18,6 +18,7 @@ import test from 'node:test'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
 
 const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src')
 
@@ -137,5 +138,241 @@ test('no production code listens to the removed credentials/updated event', () =
     violations,
     [],
     'the old credentials/updated event name is removed in dsh 0.1.1-rc.1; listen to credentials/reference-updated and credentials/record-updated',
+  )
+})
+
+test('no keybinding settings watch callback crosses the config port (migration boundary)', () => {
+  // Server/client migration (review rounds 28/30/31): the TUI settings
+  // document surface (`TuiSettingsConfig`/`TuiSettingsLike`) is get/replace
+  // ONLY. A `.watch(callback)` on the settings document in src/ would be a
+  // Direct-only dependency on a Host-side watch — a callback could not map
+  // across the process boundary in the future Remote adapter (migration
+  // rule: no callbacks across the wire). The keybinding reload seam is
+  // EXPLICIT (`/keybindings reload` re-reads the document); this audit
+  // refuses any re-introduction of the watch in production code.
+  // Round 31: the audit is AST-based — it finds every `watch(...)` CALL
+  // whose receiver is (transitively) the settings object: the direct names
+  // `tuiSettings`/`settings` or a simple alias binding
+  // (`const s = tuiSettings`), regardless of whitespace, optional chaining
+  // or LINE BREAKS (a `.watch` split across lines cannot evade it).
+  // Round 32: parenthesized receivers (`(tuiSettings).watch(...)`,
+  // `const s = (settings)`) are unwrapped.
+  // Comment mentions are not call sites and are ignored.
+  const violations: string[] = []
+  for (const path of listSourceFiles(srcDir)) {
+    const file = relative(srcDir, path)
+    const source = readFileSync(path, 'utf8')
+    const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+    // Simple alias bindings of the settings object: name → declaration.
+    // Parenthesized initializers (`const s = (settings)`) are unwrapped.
+    // Round 33: alias collection is a FIXED POINT — a chain
+    // (`const a = tuiSettings; const b = a; b.watch(...)`) resolves
+    // transitively (each pass adds aliases whose initializer names an
+    // already-known settings alias, until no new names appear).
+    const settingsAliases = new Set<string>()
+    const unwrapParens = (expression: ts.Expression): ts.Expression => {
+      let current = expression
+      while (ts.isParenthesizedExpression(current)) current = current.expression
+      return current
+    }
+    const aliasDeclarations: Array<{ name: string; initializerName: string }> = []
+    const collectAliasDeclarations = (node: ts.Node): void => {
+      if (ts.isVariableDeclaration(node)
+        && ts.isIdentifier(node.name)
+        && node.initializer !== undefined) {
+        const initializer = unwrapParens(node.initializer)
+        if (ts.isIdentifier(initializer)) {
+          aliasDeclarations.push({ name: node.name.text, initializerName: initializer.text })
+        }
+      }
+      ts.forEachChild(node, collectAliasDeclarations)
+    }
+    collectAliasDeclarations(sourceFile)
+    for (const declaration of aliasDeclarations) {
+      if (declaration.initializerName === 'tuiSettings' || declaration.initializerName === 'settings') {
+        settingsAliases.add(declaration.name)
+      }
+    }
+    // Fixed point: repeat until no new alias resolves.
+    let grew = true
+    while (grew) {
+      grew = false
+      for (const declaration of aliasDeclarations) {
+        if (settingsAliases.has(declaration.initializerName) && !settingsAliases.has(declaration.name)) {
+          settingsAliases.add(declaration.name)
+          grew = true
+        }
+      }
+    }
+    const findWatch = (node: ts.Node): ts.CallExpression | undefined => {
+      if (ts.isCallExpression(node)) {
+        const callee = node.expression
+        // `x.watch(...)` / `x?.watch(...)` — property-access callee named watch.
+        if (ts.isPropertyAccessExpression(callee) && callee.name.text === 'watch') {
+          const receiver = unwrapParens(callee.expression)
+          if (ts.isIdentifier(receiver)
+            && (receiver.text === 'tuiSettings' || receiver.text === 'settings' || settingsAliases.has(receiver.text))) {
+            return node
+          }
+        }
+      }
+      const found = ts.forEachChild(node, findWatch)
+      return found === undefined ? undefined : found
+    }
+    const call = findWatch(sourceFile)
+    if (call !== undefined) {
+      const line = sourceFile.getLineAndCharacterOfPosition(call.getStart()).line + 1
+      violations.push(`${file}:${line}: ${call.getText().replace(/\s+/g, ' ').slice(0, 80)}`)
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    'no settings watch callback in src/ — the config port is get/replace only; keybinding changes apply via the explicit /keybindings reload seam (migration rule: no callbacks across the wire)',
+  )
+})
+
+test('the runner cleanup closure never references a later-declared binding (TDZ guard)', () => {
+  // Lifecycle regression (review round 28): `cleanup()` is registered into
+  // the Cordis effect BEFORE the app is constructed, so it can run while
+  // later declarations are still in the temporal dead zone — a throwing
+  // subscription registration at startup then turns the teardown into a
+  // SECOND ReferenceError that masks the original failure and skips the
+  // extension detach / diag dispose. Every runner-scope `let`/`const`
+  // identifier the cleanup body touches must be declared BEFORE the
+  // cleanup block. `stopKeybindingWatch` (removed — the settings watch is
+  // gone), `stopPluginKeybindingSync` and `catalogCoordinator` were the
+  // offenders; this audit keeps the whole class out.
+  //
+  // Round 30: the audit is AST-based (typescript's compiler API), so it
+  // handles destructuring (`const { x } = y`, `const [x] = y`), same-line
+  // nested blocks and nested closures precisely — no regex/brace-depth
+  // approximation.
+  const source = readFileSync(join(srcDir, 'index.ts'), 'utf8')
+  const sourceFile = ts.createSourceFile('index.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+
+  // Find the startup lifecycle root's async IIFE:
+  // `void (async () => { ... })().catch(...)` — a void expression nested
+  // inside the apply function. Round 31: NOT simply the first void
+  // statement — the lifecycle root is uniquely identified as the void
+  // statement whose arrow body declares `cleanup` (an earlier unrelated
+  // void expression must not hijack the anchor).
+  const candidates: ts.ExpressionStatement[] = []
+  const findVoidStatements = (node: ts.Node): void => {
+    if (ts.isExpressionStatement(node) && ts.isVoidExpression(node.expression)) candidates.push(node)
+    ts.forEachChild(node, findVoidStatements)
+  }
+  findVoidStatements(sourceFile)
+  const arrowOf = (statement: ts.ExpressionStatement): ts.ArrowFunction | undefined => {
+    let found: ts.ArrowFunction | undefined
+    const walk = (node: ts.Node): void => {
+      if (found !== undefined) return
+      if (ts.isArrowFunction(node)) {
+        found = node
+        return
+      }
+      ts.forEachChild(node, walk)
+    }
+    walk(statement.expression)
+    return found
+  }
+  const hasCleanup = (block: ts.Block): boolean =>
+    block.statements.some(statement =>
+      ts.isVariableStatement(statement)
+      && statement.declarationList.declarations.some(declaration =>
+        ts.isIdentifier(declaration.name) && declaration.name.text === 'cleanup'))
+  const lifecycleRoot = candidates.find(statement => {
+    const arrow = arrowOf(statement)
+    return arrow !== undefined && ts.isBlock(arrow.body) && hasCleanup(arrow.body)
+  })
+  assert.ok(lifecycleRoot !== undefined, 'the startup lifecycle root IIFE (the void expression whose arrow declares cleanup) must exist')
+  const arrow = arrowOf(lifecycleRoot)!
+  const runnerBlock = arrow.body
+  assert.ok(ts.isBlock(runnerBlock), 'the lifecycle root body must be a block')
+
+  // Collect runner-scope `let`/`const` declarations (the arrow body's direct
+  // children): name → declaration line (1-based).
+  const runnerDecls = new Map<string, number>()
+  /** Collect every bound name of a binding pattern (simple identifier,
+   * object/array destructuring, nested patterns incl. aliases). */
+  const boundNames = (pattern: ts.BindingName, out: string[]): void => {
+    if (ts.isIdentifier(pattern)) {
+      out.push(pattern.text)
+      return
+    }
+    for (const element of pattern.elements) {
+      if (ts.isOmittedExpression(element)) continue
+      if (ts.isBindingElement(element)) boundNames(element.name, out)
+      else boundNames(element, out)
+    }
+  }
+  for (const statement of runnerBlock.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    const flags = statement.declarationList.flags
+    if (!(flags & (ts.NodeFlags.Let | ts.NodeFlags.Const))) continue
+    const names: string[] = []
+    for (const declaration of statement.declarationList.declarations) {
+      boundNames(declaration.name, names)
+    }
+    const line = sourceFile.getLineAndCharacterOfPosition(statement.getStart()).line + 1
+    for (const name of names) {
+      if (!runnerDecls.has(name)) runnerDecls.set(name, line)
+    }
+  }
+
+  // The cleanup function declaration (runner-scope).
+  const cleanupDecl = runnerBlock.statements.find(statement =>
+    ts.isVariableStatement(statement)
+    && ts.isIdentifier(statement.declarationList.declarations[0]!.name)
+    && statement.declarationList.declarations[0]!.name.text === 'cleanup'
+  ) as ts.VariableStatement | undefined
+  assert.ok(cleanupDecl !== undefined, 'cleanup must exist in the runner scope')
+  const cleanupInitializer = cleanupDecl.declarationList.declarations[0]!.initializer
+  assert.ok(cleanupInitializer !== undefined && ts.isArrowFunction(cleanupInitializer), 'cleanup must be an arrow function')
+  const cleanupBody = cleanupInitializer.body
+  assert.ok(ts.isBlock(cleanupBody), 'cleanup body must be a block')
+  const cleanupLine = sourceFile.getLineAndCharacterOfPosition(cleanupDecl.getStart()).line + 1
+
+  // Collect the identifiers referenced in the cleanup body (excluding its
+  // own local declarations — e.g. the `for (const file of ...)` loop var).
+  const skip = new Set<string>()
+  const referenced = new Set<string>()
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node)) {
+      const names: string[] = []
+      boundNames(node.name, names)
+      for (const name of names) skip.add(name)
+    }
+    if (ts.isIdentifier(node)) {
+      // Only bare identifiers (not property names / member names) count.
+      const parent = node.parent
+      const isPropertyName = parent !== undefined && (
+        (ts.isPropertyAccessExpression(parent) && parent.name === node)
+        || (ts.isPropertyAssignment(parent) && parent.name === node)
+        || (ts.isShorthandPropertyAssignment(parent) && parent.name === node)
+        || (ts.isBindingElement(parent) && parent.name === node)
+        || (ts.isMethodDeclaration(parent) && parent.name === node)
+        || (ts.isParameter(parent) && parent.name === node)
+        || (ts.isImportClause(parent) || ts.isImportSpecifier(parent) || ts.isNamespaceImport(parent))
+      )
+      if (!isPropertyName) referenced.add(node.text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(cleanupBody)
+  for (const name of [...referenced]) if (skip.has(name)) referenced.delete(name)
+
+  const violations: string[] = []
+  for (const name of referenced) {
+    const declLine = runnerDecls.get(name)
+    if (declLine === undefined) continue
+    if (declLine > cleanupLine) {
+      violations.push(`${name} (runner-scope declaration at line ${declLine}) referenced by cleanup (line ${cleanupLine}) — TDZ ReferenceError on early teardown`)
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    'cleanup must only reference runner-scope bindings declared BEFORE it — a binding declared later is a TDZ ReferenceError when cleanup runs early (effect teardown / startup failure / exit)',
   )
 })

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -348,7 +348,7 @@ test('the queue pane renders pending rows and hides when empty', async () => {
   assert.ok(view.includes('❯ follow up on the audit'), `followup row missing:\n${view}`)
   assert.ok(view.includes('❯ steer a correction'), `steer row missing:\n${view}`)
   assert.ok(view.includes('ctrl+s to steer all'), `steer-all hint missing:\n${view}`)
-  assert.ok(view.includes('alt+↑ to edit all'), `hint row missing:\n${view}`)
+  assert.ok(view.includes('alt+up to edit all'), `hint row missing:\n${view}`)
   app.setQueueItems([])
   await vt.waitForRender()
   view = vt.getViewport().join('\n')


### PR DESCRIPTION
## Summary

User-orchestrable semantic keybindings (M0–M6): every Host shortcut is a semantic action (`app.*`) resolved through a context-aware `EffectiveKeymap`, so the UI (footer hints, `/help`, `/keybindings`) always renders the **effective** keys.

## What's included

- **Semantic action model** (`src/keybindings/`): `APP_KEYBINDINGS` definitions, `EffectiveKeymap` (builtin 100 / composition 100 / user 200 / plugin 10 priorities, conflict detection — never silent last-write-wins), context predicates, per-key rule ids.
- **User configuration** (`keybindings` field in the `dsh-pi-tui` settings namespace, applied via `/keybindings reload` (explicit — the settings watch is intentionally absent: the config port is get/replace only, no callbacks across the process boundary)): string = one key, array = several, `false` = disable, `leader` + `<leader>X` sequences (M6). Fail-soft: a bad entry is a diagnostic, never a startup failure. `DSH_PI_TUI_SAFE_KEYBINDINGS=1` restores builtin defaults.
- **M6 leader / multi-key machine**: pending prefix state, timeout, Esc cancel, paste/typing isolation, focus-transition cancellation, which-key footer hint, ambiguity diagnostics.
- **Effective-key copy convention**: footer hints, `/help` rows, `/settings` rows, fold hints (`(… to expand)`), queue-pane hints, divergence-guard notices and the `/keybindings` table all render the effective keys — a remap updates every copy. Comments name keys only where the semantics are key-specific.
- **Action-based viewer guard**: the continuable subagent viewer blocks PARENT actions by action id (remaps stay blocked); leader sequences cannot bypass it.
- **Semantic component actions**: question/tasks flows route through `question.*` / `tasks.*` component keymaps.
- **Static gate** `scripts/check-host-keybindings.mts` (wired into `verify:prepush`): rejects new physical `matchesKey` chords in the host input path and hard-coded chord labels in user-facing strings, with a documented allowlist.
- **Commands**: `/keybindings` (effective table / conflicts / reload / reset), dynamic `/help`.
- **Docs**: `docs/keybinding-architecture.md` (design + copy convention + review chain), bilingual README/CHANGELOG updates.

## Rebases

Rebased onto the current main twice (M1 semantic ports, shell-editor-mode, thinking-disclosure unify, focus-v2, README/CHANGELOG language flip, focus-viewport policy). All integration conflicts resolved; both sides' behaviors verified by the full suite and the review chain.

## Verification

- 2539 bundle tests, 985 fork tests, 11 docs tests
- typecheck (fork + bundle), `check-host-keybindings` gate, naming gate, client-boundary gate, `git diff --check`
- 39 external review rounds (openai-codex / gpt-5.6-luna) — final round **accepted, zero findings**; unified leader-only override contract (any declaration replaces the builtin; false removes every trigger; a dead leader-only override is inert — no fabricated fallback); the leader-only empty-array marker is written only for a VALID leader — a missing/invalid leader is fail-soft and the action falls back to its builtin default; key-neutral /help and /settings copy after a remap; explicit reload seam (`/keybindings reload` fail-soft, `/keybindings reset` applies immediately); AST-based static gates (settings-watch ban incl. aliases/parens/multi-level chains, cleanup TDZ audit)
