### PR TITLE
feat(ui): add emoji/symbols/minimal icon styles with a live /settings switch

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the previous UI; Symbols expresses the same semantics with a small
   set of single-cell Unicode symbols (tool cards, context cards, Focus
   disclosure, Working indicator); Minimal hides ordinary decorative icons
-  and keeps only markers with real status or interaction value (`×` error,
-  `■` interrupted, `?` question, `▸/▾` disclosure, `•/◦` working). All
+  and keeps only markers with real status or interaction value (`⨯` error,
+  `∎` interrupted, `?` question, `▸/▾` disclosure, `∙/◦` working). All
   icons converge on a semantic registry (`src/icons.ts`): fold state
   stores the semantic identity, never the final glyph, so switching in
   `/settings` repaints already-rendered cards immediately in the same

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **An `Icon style` setting switches between Emoji, Symbols and Minimal
+  structural icon palettes.** Emoji is the default and is byte-identical
+  to the previous UI; Symbols expresses the same semantics with a small
+  set of single-cell Unicode symbols (tool cards, context cards, Focus
+  disclosure, Working indicator); Minimal hides ordinary decorative icons
+  and keeps only markers with real status or interaction value (`×` error,
+  `■` interrupted, `?` question, `▸/▾` disclosure, `•/◦` working). All
+  icons converge on a semantic registry (`src/icons.ts`): fold state
+  stores the semantic identity, never the final glyph, so switching in
+  `/settings` repaints already-rendered cards immediately in the same
+  instance — no restart, no session reload. Third-party extensions,
+  user/assistant/tool content and the image attachment marker are
+  untouched.
+
 ## [0.3.4] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
   切换。** Emoji 是默认且与之前完全一致;Symbols 用一套少量、单格
   (1-cell)的 Unicode 符号表达同样的语义(tool card、context card、
   Focus disclosure、Working 指示);Minimal 隐藏普通装饰性图标,只保留
-  真正有状态或交互价值的 marker(`×` error、`■` interrupted、`?`
-  question、`▸/▾` disclosure、`•/◦` working)。图标统一收敛到 semantic
+  真正有状态或交互价值的 marker(`⨯` error、`∎` interrupted、`?`
+  question、`▸/▾` disclosure、`∙/◦` working)。图标统一收敛到 semantic
   registry(`src/icons.ts`):fold 状态只保存 semantic identity,不保存
   最终 glyph,所以 `/settings` 切换后同一运行实例内已渲染的卡片立即换
   图标,无需重启或重新加载会话;第三方扩展、用户/assistant/tool 内容

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
 
 ## [Unreleased]
 
+### 新增
+
+- **`Icon style` 设置:在 Emoji、Symbols 与 Minimal 三种结构图标风格间
+  切换。** Emoji 是默认且与之前完全一致;Symbols 用一套少量、单格
+  (1-cell)的 Unicode 符号表达同样的语义(tool card、context card、
+  Focus disclosure、Working 指示);Minimal 隐藏普通装饰性图标,只保留
+  真正有状态或交互价值的 marker(`×` error、`■` interrupted、`?`
+  question、`▸/▾` disclosure、`•/◦` working)。图标统一收敛到 semantic
+  registry(`src/icons.ts`):fold 状态只保存 semantic identity,不保存
+  最终 glyph,所以 `/settings` 切换后同一运行实例内已渲染的卡片立即换
+  图标,无需重启或重新加载会话;第三方扩展、用户/assistant/tool 内容
+  与图片 attachment marker 均不受影响。
+
 ## [0.3.4] - 2026-08-25
 
 ### 新增

--- a/README.en.md
+++ b/README.en.md
@@ -155,6 +155,11 @@ Common entry points:
 
 Model selection, Reasoning Effort, permission presets, Plan, and Goal all keep the corresponding DSH runtime semantics.
 
+The `Icon style` option in `/settings` switches the TUI's structural icons:
+`Emoji` (default, colorful), `Symbols` (compact single-cell terminal
+symbols), or `Minimal` (decorative icons hidden; only status/interaction
+markers remain). Switching applies immediately and persists.
+
 Slash Commands registered by other plugins through `ctx.commands` are discovered automatically.
 
 ## Common keys

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ TUI 使用 DSH 提供的模型和设置服务。
 
 模型切换、Reasoning Effort、权限 Preset、Plan 和 Goal 都沿用 DSH 对应的运行时语义。
 
+`/settings` 中的 `Icon style` 可切换 TUI 结构图标的风格:`Emoji`(默认,
+彩色)、`Symbols`(紧凑的单格终端符号)、`Minimal`(隐藏装饰性图标,只
+保留状态/交互标记);切换立即生效并持久化。
+
 其他插件注册到 `ctx.commands` 的 Slash Command 也会被自动发现。
 
 ## 常用按键

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,6 +26,7 @@ import { effectiveApprovalPolicy } from '@deepseek-ai/dsh-user-approval'
 import { SettingsList, type SettingItem } from '@xmoon76/pi-tui'
 import { mergeDraft } from './steer.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
+import { iconStyleOf } from './icons.ts'
 import type { TuiApp } from './tui-app.ts'
 import type { PickerCategory, PickerItem } from './tui-app.ts'
 import type { Diag } from './diag.ts'
@@ -1200,6 +1201,15 @@ export function registerTuiCommands(
             values: ['auto', 'dark', 'light', ...customThemeNames(), ...(runner.extensions?.themes.names() ?? [])],
           },
           {
+            id: 'icon-style',
+            label: 'Icon style',
+            description: 'Choose between emoji, compact symbols, or minimal structural markers',
+            // The fallback applies HERE too: an invalid/missing persisted
+            // value must never render as a row outside the values list.
+            currentValue: iconStyleOf(tuiSettings?.get().iconStyle),
+            values: ['emoji', 'symbols', 'minimal'],
+          },
+          {
             id: 'expand',
             label: 'Tool output',
             description: 'Whether recent tool/system entries start expanded',
@@ -1403,6 +1413,19 @@ export function registerTuiCommands(
               const settings = tuiSettings
               if (settings !== undefined) {
                 detach('settings busy enter write', () => settings.replace({ ...settings.get(), busyEnter: value }) as Promise<unknown>, { notify: true })
+              }
+            }
+          } else if (id === 'icon-style') {
+            if (value === 'emoji' || value === 'symbols' || value === 'minimal') {
+              // The visual preference applies FIRST — the UI must not wait
+              // for disk persistence (same policy as theme/focus). A
+              // persistence failure keeps this session's preference and
+              // notifies through the shared error policy; the next start
+              // restores the persisted value.
+              app.setIconStyle(value)
+              const settings = tuiSettings
+              if (settings !== undefined) {
+                detach('settings icon style write', () => settings.replace({ ...settings.get(), iconStyle: value }) as Promise<unknown>, { notify: true })
               }
             }
           } else if (id === 'local-shell-sandbox') {

--- a/src/components/media/image-thumbnail.ts
+++ b/src/components/media/image-thumbnail.ts
@@ -42,11 +42,6 @@ export class ImageThumbnail implements Component {
   private readonly theme: ImageThumbnailTheme
   private readonly ref: ImageAttachmentRefLike
   private readonly collapsedRef: (() => boolean) | undefined
-  /** The attachment marker glyph (the icon-style resolved marker, default
-   * the historical `🖼️`). Resolved by the HOST at construction — the
-   * message cache embeds the icon style, so a live switch rebuilds the
-   * thumbnail with the new marker. */
-  private readonly marker: string
   private unsubscribe: (() => void) | undefined
   private instance: Image | undefined
   private cachedLines: string[] | undefined
@@ -57,14 +52,12 @@ export class ImageThumbnail implements Component {
     loader: ImageLoader,
     theme: ImageThumbnailTheme,
     collapsedRef?: () => boolean,
-    marker = '🖼️',
   ) {
     // Explicit fields (Node strip-only mode rejects parameter properties).
     this.ref = ref
     this.loader = loader
     this.theme = theme
     this.collapsedRef = collapsedRef
-    this.marker = marker
     // Subscribe to THIS attachment's settles only: N thumbnails loading in
     // parallel never invalidate each other (review finding 8 — no O(N²)
     // repaint churn, no kitty image-id churn).
@@ -102,16 +95,14 @@ export class ImageThumbnail implements Component {
   }
 
   /** The constant info line (§17.1): the attachment's identity — name +
-   * dimensions + size — visible in EVERY state. The marker glyph comes
-   * from the icon registry (the emoji `🖼️` carries the U+FE0F variation
-   * selector: U+1F5BC alone has no default emoji presentation, so the
-   * width math measures it as ONE cell while fonts with an emoji face
-   * render it TWO cells wide — the glyph overhang then eats the space and
-   * overlaps the name (font-dependent). VS16 forces the wide 2-cell
-   * rendering the measurement expects; the symbols/minimal markers are
-   * plain 1-cell glyphs with no overhang). */
+   * dimensions + size — visible in EVERY state. The marker is `🖼️` WITH
+   * the U+FE0F variation selector: U+1F5BC alone has no default emoji
+   * presentation, so the width math measures it as ONE cell while fonts
+   * with an emoji face render it TWO cells wide — the glyph overhang then
+   * eats the space and overlaps the name (font-dependent). VS16 forces the
+   * wide 2-cell rendering the measurement expects. */
   private infoLine(): string {
-    return `${this.marker} ${this.label()} · ${this.ref.width}×${this.ref.height} · ${formatBytes(this.ref.bytes)}`
+    return `🖼️ ${this.label()} · ${this.ref.width}×${this.ref.height} · ${formatBytes(this.ref.bytes)}`
   }
 
   invalidate(): void {

--- a/src/components/media/image-thumbnail.ts
+++ b/src/components/media/image-thumbnail.ts
@@ -42,6 +42,11 @@ export class ImageThumbnail implements Component {
   private readonly theme: ImageThumbnailTheme
   private readonly ref: ImageAttachmentRefLike
   private readonly collapsedRef: (() => boolean) | undefined
+  /** The attachment marker glyph (the icon-style resolved marker, default
+   * the historical `🖼️`). Resolved by the HOST at construction — the
+   * message cache embeds the icon style, so a live switch rebuilds the
+   * thumbnail with the new marker. */
+  private readonly marker: string
   private unsubscribe: (() => void) | undefined
   private instance: Image | undefined
   private cachedLines: string[] | undefined
@@ -52,12 +57,14 @@ export class ImageThumbnail implements Component {
     loader: ImageLoader,
     theme: ImageThumbnailTheme,
     collapsedRef?: () => boolean,
+    marker = '🖼️',
   ) {
     // Explicit fields (Node strip-only mode rejects parameter properties).
     this.ref = ref
     this.loader = loader
     this.theme = theme
     this.collapsedRef = collapsedRef
+    this.marker = marker
     // Subscribe to THIS attachment's settles only: N thumbnails loading in
     // parallel never invalidate each other (review finding 8 — no O(N²)
     // repaint churn, no kitty image-id churn).
@@ -95,14 +102,16 @@ export class ImageThumbnail implements Component {
   }
 
   /** The constant info line (§17.1): the attachment's identity — name +
-   * dimensions + size — visible in EVERY state. The marker is `🖼️` WITH
-   * the U+FE0F variation selector: U+1F5BC alone has no default emoji
-   * presentation, so the width math measures it as ONE cell while fonts
-   * with an emoji face render it TWO cells wide — the glyph overhang then
-   * eats the space and overlaps the name (font-dependent). VS16 forces the
-   * wide 2-cell rendering the measurement expects. */
+   * dimensions + size — visible in EVERY state. The marker glyph comes
+   * from the icon registry (the emoji `🖼️` carries the U+FE0F variation
+   * selector: U+1F5BC alone has no default emoji presentation, so the
+   * width math measures it as ONE cell while fonts with an emoji face
+   * render it TWO cells wide — the glyph overhang then eats the space and
+   * overlaps the name (font-dependent). VS16 forces the wide 2-cell
+   * rendering the measurement expects; the symbols/minimal markers are
+   * plain 1-cell glyphs with no overhang). */
   private infoLine(): string {
-    return `🖼️ ${this.label()} · ${this.ref.width}×${this.ref.height} · ${formatBytes(this.ref.bytes)}`
+    return `${this.marker} ${this.label()} · ${this.ref.width}×${this.ref.height} · ${formatBytes(this.ref.bytes)}`
   }
 
   invalidate(): void {

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,6 +9,8 @@
  * @module @xmoon76/dsh-pi-tui/context
  */
 
+import { type IconSemantic } from './icons.ts'
+
 /** One durable source narrowed to the readable-record shape; null for anything else. */
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
@@ -75,25 +77,27 @@ export function contextProvenance(source: unknown): ContextProvenance {
 }
 
 /**
- * The card-header emoji for one context injection, keyed by source kind so a
- * reader can tell an instruction file from a skill catalog or a recalled
- * session at a glance (the Web renders one browse icon for all of them).
+ * The card-header icon SEMANTIC for one context injection, keyed by source
+ * kind so a reader can tell an instruction file from a skill catalog or a
+ * recalled session at a glance (the Web renders one browse icon for all of
+ * them). The glyph itself resolves through src/icons.ts at render time —
+ * fold state stores the semantic, never a concrete emoji/symbol, so an
+ * icon-style switch repaints ALREADY-FOLDED context cards immediately.
  * @param source - the logged user/message source.
- * @returns the emoji for this injection.
  */
-export function contextEmoji(source: unknown): string {
+export function contextIconSemantic(source: unknown): IconSemantic {
   const record = asRecord(source)
   const kind = record === null ? null : readString(record, 'kind')
   switch (kind) {
-    case 'agent-instructions': return '📄'
-    case 'skill-invocation': return '📚'
+    case 'agent-instructions': return 'context-file'
+    case 'skill-invocation': return 'context-skill'
     case 'plugin': {
       // A notice is a one-off account; everything else is payload.
-      return readString(record ?? {}, 'form') === 'notice' ? '📌' : '📦'
+      return readString(record ?? {}, 'form') === 'notice' ? 'context-notice' : 'context-plugin'
     }
-    case 'subagent-settled': return '📌'
-    case 'session-reference': return '🕘'
-    default: return '📎'
+    case 'subagent-settled': return 'context-notice'
+    case 'session-reference': return 'context-recall'
+    default: return 'context-generic'
   }
 }
 

--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -23,6 +23,7 @@
 import { truncateToWidth, visibleWidth } from '@xmoon76/pi-tui'
 import { color } from './theme.ts'
 import { formatTokens } from './token-usage.ts'
+import { iconFor, type IconSemantic, type IconStyle } from './icons.ts'
 import type { TurnActivity } from './transcript.ts'
 import type { TranscriptMessage } from './transcript.ts'
 
@@ -30,8 +31,18 @@ import type { TranscriptMessage } from './transcript.ts'
  * (plan §10.4). */
 export const FOCUS_TOOL_SUMMARY_MAX_TYPES = 3
 
-/** The disclosure icon: 🐋 collapsed, 🐳 expanded — disclosure state ONLY
- * (plan §2.1/§2.2). The execution outcome lives in the header label. */
+/** The disclosure icon SEMANTIC: collapsed / expanded — disclosure state
+ * ONLY (plan §2.1/§2.2). The execution outcome lives in the header label.
+ * The glyph resolves through iconFor(..., iconStyle) at render time. */
+export function focusDisclosureSemantic(expanded: boolean): IconSemantic {
+  return expanded ? 'disclosure-expanded' : 'disclosure-collapsed'
+}
+
+/**
+ * The disclosure icon in the LEGACY emoji style: 🐋 collapsed, 🐳 expanded.
+ * @deprecated internal compatibility — resolve through
+ * `focusDisclosureSemantic` + `iconFor(..., iconStyle)`.
+ */
 export function focusDisclosureIcon(expanded: boolean): '🐋' | '🐳' {
   return expanded ? '🐳' : '🐋'
 }
@@ -98,15 +109,20 @@ export function focusDurationText(activity: TurnActivity, now: () => number): st
  * the header NEVER breaks the terminal (plan §14/§46): full tail → token +
  * tool count → token → bare label (then a hard truncate as the last
  * resort). The per-turn token segment is hidden entirely when the turn has
- * no usage fact (never a fake `0 tok` — plan §13.3). */
+ * no usage fact (never a fake `0 tok` — plan §13.3). The disclosure glyph
+ * resolves against the CURRENT icon style (the disclosure is an
+ * interaction affordance and is never hidden — not even under minimal,
+ * plan §34.7); the single-space lead keeps the historical `🐋 Thought`
+ * layout. */
 export function formatFocusHeaderLine(
   activity: TurnActivity,
   expanded: boolean,
   now: () => number,
   width: number,
+  iconStyle: IconStyle = 'emoji',
 ): string {
   const label = focusStatusLabel(activity, focusDurationText(activity, now))
-  const head = `${focusDisclosureIcon(expanded)} ${label}`
+  const head = `${iconFor(focusDisclosureSemantic(expanded), iconStyle)} ${label}`
   const token = activity.totalTokens === undefined ? undefined : `${formatTokens(activity.totalTokens)} tok`
   const tail = focusToolStatParts(activity.tools, activity.toolCalls)
   const candidates: string[] = []
@@ -189,28 +205,31 @@ export function focusCollapsedBody(
  * The live Thought disclosure. render() re-reads `now()` on EVERY frame, so
  * the WorkingIndicator's 500ms repaint heartbeat refreshes the running
  * duration without a second timer (plan §3.2); the TuiApp component cache
- * (keyed on the activity revision + expansion + theme + tool display) keeps
- * that cheap. The component never mutates Focus state — clicks route through
- * the app's hit map to toggleFocusTurn (plan §17). The Tool line's display
- * text is PRECOMPUTED by the app (presenter-first, plan §38) — the
- * component stays a pure renderer.
+ * (keyed on the activity revision + expansion + theme + tool display +
+ * icon style) keeps that cheap. The component never mutates Focus state —
+ * clicks route through the app's hit map to toggleFocusTurn (plan §17).
+ * The Tool line's display text is PRECOMPUTED by the app (presenter-first,
+ * plan §38) — the component stays a pure renderer.
  */
 export class FocusActivityComponent {
   private readonly activity: TurnActivity
   private readonly expanded: boolean
   private readonly now: () => number
   private readonly toolDisplay: string | undefined
+  private readonly iconStyle: IconStyle
 
   constructor(options: {
     activity: TurnActivity
     expanded: boolean
     now?: () => number
     toolDisplay?: string
+    iconStyle?: IconStyle
   }) {
     this.activity = options.activity
     this.expanded = options.expanded
     this.now = options.now ?? (() => Date.now())
     this.toolDisplay = options.toolDisplay
+    this.iconStyle = options.iconStyle ?? 'emoji'
   }
 
   /** The Component interface requires invalidate(); the component keeps no
@@ -227,7 +246,7 @@ export class FocusActivityComponent {
     // The header formatter budgets the CONTENT width (the indent is added
     // after), so a header that fits never wraps past the terminal — the
     // fullscreen row hit-map depends on that (review fix).
-    lines.push(`${indent}${color.textDim(formatFocusHeaderLine(this.activity, this.expanded, this.now, contentWidth))}`)
+    lines.push(`${indent}${color.textDim(formatFocusHeaderLine(this.activity, this.expanded, this.now, contentWidth, this.iconStyle))}`)
     if (!this.expanded) {
       for (const line of focusCollapsedBody(this.activity, contentWidth, this.toolDisplay)) {
         lines.push(`${indent}${color.textDim(line)}`)

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -26,10 +26,12 @@
  * Deliberate non-goals (see the plan): no global emoji sanitizer, no
  * glyph persistence in session/fold state (fold state carries the
  * SEMANTIC, resolved at render time), no user/assistant/tool-content
- * rewriting, no font dependencies. The assistant whale bullet, the header
- * brand whale, the thinking/compaction markers and the image attachment
- * marker stay emoji-only in this version — they are content-adjacent or
- * brand markers, not registry semantics.
+ * rewriting, no font dependencies. The header brand whale and the
+ * welcome-card brand line stay emoji-only — they are brand identity,
+ * not registry semantics. The image ATTACHMENT marker resolves through
+ * the registry at RENDER time (the folded flat text keeps the emoji
+ * fact for search/export; the marker is TUI-owned text, never a
+ * user-typed emoji).
  * @module @xmoon76/dsh-pi-tui/icons
  */
 
@@ -61,6 +63,11 @@ export type IconSemantic =
   | 'disclosure-expanded'
   | 'working-a'
   | 'working-b'
+  | 'assistant-bullet'
+  | 'thinking'
+  | 'compaction'
+  | 'image-marker'
+  | 'queue-notice'
 
 /** Every semantic, for exhaustive palette/width sweeps. */
 export const ALL_ICON_SEMANTICS: readonly IconSemantic[] = [
@@ -87,6 +94,11 @@ export const ALL_ICON_SEMANTICS: readonly IconSemantic[] = [
   'disclosure-expanded',
   'working-a',
   'working-b',
+  'assistant-bullet',
+  'thinking',
+  'compaction',
+  'image-marker',
+  'queue-notice',
 ]
 
 /** The full palette: semantic × style. The emoji column is the historical
@@ -119,6 +131,11 @@ const ICONS: Record<IconStyle, Record<IconSemantic, string>> = {
     'disclosure-expanded': '🐳',
     'working-a': '🐋',
     'working-b': '🐳',
+    'assistant-bullet': '🐋',
+    thinking: '🌊',
+    compaction: '🗜',
+    'image-marker': '🖼️',
+    'queue-notice': '⏳',
   },
   symbols: {
     'tool-read': '▤',
@@ -144,6 +161,15 @@ const ICONS: Record<IconStyle, Record<IconSemantic, string>> = {
     'disclosure-expanded': '▾',
     'working-a': '•',
     'working-b': '◦',
+    // The markdown bullet (the list-bullet glyph itself), the thinking
+    // wave (U+223F echoes the 🌊 idea), the compaction squeeze (U+21A7),
+    // the attachment marker (U+25A7) and the queued-notice hourglass
+    // (U+29D7) — all verified 1 cell by the width gate.
+    'assistant-bullet': '•',
+    thinking: '∿',
+    compaction: '↧',
+    'image-marker': '▧',
+    'queue-notice': '⧗',
   },
   minimal: {
     // Ordinary decorative icons are HIDDEN — the title + semantic color
@@ -173,6 +199,15 @@ const ICONS: Record<IconStyle, Record<IconSemantic, string>> = {
     // icons, it does not change animation semantics.
     'working-a': '•',
     'working-b': '◦',
+    // Structure anchors survive minimal: the message bullet (the
+    // continuation indent depends on it), the attachment marker (the
+    // image's position in the text flow must stay visible) and the
+    // queued-notice hourglass (a real waiting state).
+    'assistant-bullet': '•',
+    thinking: '',
+    compaction: '',
+    'image-marker': '▧',
+    'queue-notice': '⧗',
   },
 }
 
@@ -192,6 +227,16 @@ export function iconFor(semantic: IconSemantic, style: IconStyle): string {
 export function iconPrefix(semantic: IconSemantic, style: IconStyle): string {
   const icon = iconFor(semantic, style)
   return icon === '' ? '' : `${icon}  `
+}
+
+/** The icon plus its SINGLE-space trailing separator when the style shows
+ * a glyph, '' when hidden — for titles whose historical layout uses one
+ * space (`` `🌊 Thinking` ``, `` `🗜 Context compacted` ``, `` `⏳ notice` ``),
+ * so the emoji default stays byte-identical and minimal never leaves a
+ * dangling space. */
+export function iconLead(semantic: IconSemantic, style: IconStyle): string {
+  const icon = iconFor(semantic, style)
+  return icon === '' ? '' : `${icon} `
 }
 
 /** Normalize any persisted/old value to a valid IconStyle: unknown and

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -7,15 +7,18 @@
  * hard-coded emoji string scattered across renderers. The three palettes:
  *
  * - `emoji` — the legacy colorful set (the default; before == after).
- * - `symbols` — a small, monochrome, terminal-safe set whose glyphs all
- *   measure ONE cell under the fork's `visibleWidth()` (enforced by
- *   test/icons.test.ts). Colors never live here: the renderer's existing
- *   semantic color context (header title, error, textDim, ...) paints the
- *   glyph.
+ * - `symbols` — a small, monochrome, terminal-safe set. EVERY glyph is
+ *   verified by a TWO-LAYER width gate in test/icons.test.ts: it must
+ *   measure ONE cell under the fork's `visibleWidth()` AND carry a
+ *   Unicode East Asian Width class of neutral/narrow/halfwidth —
+ *   EAW-ambiguous glyphs are rejected because CJK-width terminals
+ *   (VTE/WezTerm `cjk-ambiguous-width`) may paint them two cells.
+ *   Colors never live here: the renderer's existing semantic color
+ *   context (header title, error, textDim, ...) paints the glyph.
  * - `minimal` — NOT a third skin: ordinary decorative icons are hidden
  *   (empty glyph) and only state/interaction markers survive (error,
  *   interrupted, question, disclosure, working). The working pair is the
- *   same `• / ◦` as symbols — minimal's calm comes from REMOVING static
+ *   same `∙ / ◦` as symbols — minimal's calm comes from REMOVING static
  *   icons, never from changing animation semantics (a reduced-motion
  *   preference would be its own setting).
  *
@@ -28,10 +31,10 @@
  * SEMANTIC, resolved at render time), no user/assistant/tool-content
  * rewriting, no font dependencies. The header brand whale and the
  * welcome-card brand line stay emoji-only — they are brand identity,
- * not registry semantics. The image ATTACHMENT marker resolves through
- * the registry at RENDER time (the folded flat text keeps the emoji
- * fact for search/export; the marker is TUI-owned text, never a
- * user-typed emoji).
+ * not registry semantics. The image attachment marker is deliberately
+ * NOT part of the registry (the plan defers it): a string-level marker
+ * swap would rewrite user-typed `🖼️` in their own messages, so the
+ * marker stays the constant emoji fact.
  * @module @xmoon76/dsh-pi-tui/icons
  */
 
@@ -102,7 +105,7 @@ export const ALL_ICON_SEMANTICS: readonly IconSemantic[] = [
 /** The full palette: semantic × style. The emoji column is the historical
  * glyph EXACTLY (default behavior must not change); the symbols column is
  * the compact monochrome vocabulary (see the plan for the design notes —
- * ◆/◇ express agent/workflow hierarchy, ▸/▾ disclosure state, •/◦ the
+ * the diamond/flow glyphs express agent/workflow hierarchy, ▸/▾ disclosure state, ∙/◦ the
  * working pair, all mirroring upstream pi/kimi/opencode conventions). */
 const ICONS: Record<IconStyle, Record<IconSemantic, string>> = {
   emoji: {

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -66,7 +66,6 @@ export type IconSemantic =
   | 'assistant-bullet'
   | 'thinking'
   | 'compaction'
-  | 'image-marker'
   | 'queue-notice'
 
 /** Every semantic, for exhaustive palette/width sweeps. */
@@ -97,7 +96,6 @@ export const ALL_ICON_SEMANTICS: readonly IconSemantic[] = [
   'assistant-bullet',
   'thinking',
   'compaction',
-  'image-marker',
   'queue-notice',
 ]
 
@@ -134,41 +132,42 @@ const ICONS: Record<IconStyle, Record<IconSemantic, string>> = {
     'assistant-bullet': '🐋',
     thinking: '🌊',
     compaction: '🗜',
-    'image-marker': '🖼️',
     'queue-notice': '⏳',
   },
   symbols: {
-    'tool-read': '▤',
+    // EVERY glyph here is verified by the width gate to be BOTH 1 cell
+    // under the fork's visibleWidth() AND a Unicode EAW neutral/narrow/
+    // halfwidth class — ambiguous (A) glyphs (▤ ◆ • × ■ · …) were
+    // rejected because CJK-width terminals may paint them 2 cells.
+    'tool-read': '≣',
     'tool-search': '⌕',
     'tool-shell': '›',
     'tool-write': '+',
     'tool-edit': '~',
-    'tool-code': '◆',
-    'tool-generic': '•',
-    subagent: '◆',
-    workflow: '◇',
-    error: '×',
-    interrupted: '■',
+    'tool-code': '⊞',
+    'tool-generic': '∗',
+    subagent: '⋄',
+    workflow: '⇄',
+    error: '⨯',
+    interrupted: '∎',
     question: '?',
     'slash-command': '›',
-    'context-file': '▤',
-    'context-skill': '◆',
-    'context-plugin': '◇',
+    'context-file': '≣',
+    'context-skill': '⋈',
+    'context-plugin': '◻',
     'context-notice': '!',
     'context-recall': '↶',
-    'context-generic': '·',
+    'context-generic': '⋅',
     'disclosure-collapsed': '▸',
     'disclosure-expanded': '▾',
-    'working-a': '•',
+    'working-a': '∙',
     'working-b': '◦',
-    // The markdown bullet (the list-bullet glyph itself), the thinking
-    // wave (U+223F echoes the 🌊 idea), the compaction squeeze (U+21A7),
-    // the attachment marker (U+25A7) and the queued-notice hourglass
-    // (U+29D7) — all verified 1 cell by the width gate.
-    'assistant-bullet': '•',
+    // The markdown bullet (the neutral bullet-operator U+2219), the
+    // thinking wave (U+223F echoes the 🌊 idea), the compaction squeeze
+    // (U+21A7) and the queued-notice hourglass (U+29D7).
+    'assistant-bullet': '∙',
     thinking: '∿',
     compaction: '↧',
-    'image-marker': '▧',
     'queue-notice': '⧗',
   },
   minimal: {
@@ -190,23 +189,21 @@ const ICONS: Record<IconStyle, Record<IconSemantic, string>> = {
     'context-notice': '',
     'context-recall': '',
     'context-generic': '',
-    error: '×',
-    interrupted: '■',
+    error: '⨯',
+    interrupted: '∎',
     question: '?',
     'disclosure-collapsed': '▸',
     'disclosure-expanded': '▾',
     // The working pair is UNIFIED with symbols — minimal removes static
     // icons, it does not change animation semantics.
-    'working-a': '•',
+    'working-a': '∙',
     'working-b': '◦',
     // Structure anchors survive minimal: the message bullet (the
-    // continuation indent depends on it), the attachment marker (the
-    // image's position in the text flow must stay visible) and the
-    // queued-notice hourglass (a real waiting state).
-    'assistant-bullet': '•',
+    // continuation indent depends on it) and the queued-notice hourglass
+    // (a real waiting state).
+    'assistant-bullet': '∙',
     thinking: '',
     compaction: '',
-    'image-marker': '▧',
     'queue-notice': '⧗',
   },
 }

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,0 +1,208 @@
+/**
+ * The first-party structural icon system (plan: icon-style-symbols).
+ *
+ * Every first-party structural glyph the TUI paints — tool-card headers,
+ * context-injection rows, the Focus disclosure, the default working frames —
+ * resolves through ONE registry keyed by SEMANTIC + style, never a
+ * hard-coded emoji string scattered across renderers. The three palettes:
+ *
+ * - `emoji` — the legacy colorful set (the default; before == after).
+ * - `symbols` — a small, monochrome, terminal-safe set whose glyphs all
+ *   measure ONE cell under the fork's `visibleWidth()` (enforced by
+ *   test/icons.test.ts). Colors never live here: the renderer's existing
+ *   semantic color context (header title, error, textDim, ...) paints the
+ *   glyph.
+ * - `minimal` — NOT a third skin: ordinary decorative icons are hidden
+ *   (empty glyph) and only state/interaction markers survive (error,
+ *   interrupted, question, disclosure, working). The working pair is the
+ *   same `• / ◦` as symbols — minimal's calm comes from REMOVING static
+ *   icons, never from changing animation semantics (a reduced-motion
+ *   preference would be its own setting).
+ *
+ * Because `minimal` yields empty glyphs, renderers must never build
+ * `` `${icon} ${title}` `` directly — use {@link iconPrefix}, which returns
+ * the icon plus its two-space separator only when a glyph exists.
+ *
+ * Deliberate non-goals (see the plan): no global emoji sanitizer, no
+ * glyph persistence in session/fold state (fold state carries the
+ * SEMANTIC, resolved at render time), no user/assistant/tool-content
+ * rewriting, no font dependencies. The assistant whale bullet, the header
+ * brand whale, the thinking/compaction markers and the image attachment
+ * marker stay emoji-only in this version — they are content-adjacent or
+ * brand markers, not registry semantics.
+ * @module @xmoon76/dsh-pi-tui/icons
+ */
+
+/** The presentation style for structural icons. */
+export type IconStyle = 'emoji' | 'symbols' | 'minimal'
+
+/** One structural icon identity: WHAT the glyph means, never the glyph. */
+export type IconSemantic =
+  | 'tool-read'
+  | 'tool-search'
+  | 'tool-shell'
+  | 'tool-write'
+  | 'tool-edit'
+  | 'tool-code'
+  | 'tool-generic'
+  | 'subagent'
+  | 'workflow'
+  | 'error'
+  | 'interrupted'
+  | 'question'
+  | 'slash-command'
+  | 'context-file'
+  | 'context-skill'
+  | 'context-plugin'
+  | 'context-notice'
+  | 'context-recall'
+  | 'context-generic'
+  | 'disclosure-collapsed'
+  | 'disclosure-expanded'
+  | 'working-a'
+  | 'working-b'
+
+/** Every semantic, for exhaustive palette/width sweeps. */
+export const ALL_ICON_SEMANTICS: readonly IconSemantic[] = [
+  'tool-read',
+  'tool-search',
+  'tool-shell',
+  'tool-write',
+  'tool-edit',
+  'tool-code',
+  'tool-generic',
+  'subagent',
+  'workflow',
+  'error',
+  'interrupted',
+  'question',
+  'slash-command',
+  'context-file',
+  'context-skill',
+  'context-plugin',
+  'context-notice',
+  'context-recall',
+  'context-generic',
+  'disclosure-collapsed',
+  'disclosure-expanded',
+  'working-a',
+  'working-b',
+]
+
+/** The full palette: semantic × style. The emoji column is the historical
+ * glyph EXACTLY (default behavior must not change); the symbols column is
+ * the compact monochrome vocabulary (see the plan for the design notes —
+ * ◆/◇ express agent/workflow hierarchy, ▸/▾ disclosure state, •/◦ the
+ * working pair, all mirroring upstream pi/kimi/opencode conventions). */
+const ICONS: Record<IconStyle, Record<IconSemantic, string>> = {
+  emoji: {
+    'tool-read': '📖',
+    'tool-search': '🔍',
+    'tool-shell': '🖥️',
+    'tool-write': '📝',
+    'tool-edit': '✏️',
+    'tool-code': '⚙️',
+    'tool-generic': '🛠️',
+    subagent: '🤖',
+    workflow: '🧵',
+    error: '❌',
+    interrupted: '⏹️',
+    question: '❓',
+    'slash-command': '🎛️',
+    'context-file': '📄',
+    'context-skill': '📚',
+    'context-plugin': '📦',
+    'context-notice': '📌',
+    'context-recall': '🕘',
+    'context-generic': '📎',
+    'disclosure-collapsed': '🐋',
+    'disclosure-expanded': '🐳',
+    'working-a': '🐋',
+    'working-b': '🐳',
+  },
+  symbols: {
+    'tool-read': '▤',
+    'tool-search': '⌕',
+    'tool-shell': '›',
+    'tool-write': '+',
+    'tool-edit': '~',
+    'tool-code': '◆',
+    'tool-generic': '•',
+    subagent: '◆',
+    workflow: '◇',
+    error: '×',
+    interrupted: '■',
+    question: '?',
+    'slash-command': '›',
+    'context-file': '▤',
+    'context-skill': '◆',
+    'context-plugin': '◇',
+    'context-notice': '!',
+    'context-recall': '↶',
+    'context-generic': '·',
+    'disclosure-collapsed': '▸',
+    'disclosure-expanded': '▾',
+    'working-a': '•',
+    'working-b': '◦',
+  },
+  minimal: {
+    // Ordinary decorative icons are HIDDEN — the title + semantic color
+    // carry the meaning. Only state/interaction markers survive.
+    'tool-read': '',
+    'tool-search': '',
+    'tool-shell': '',
+    'tool-write': '',
+    'tool-edit': '',
+    'tool-code': '',
+    'tool-generic': '',
+    subagent: '',
+    workflow: '',
+    'slash-command': '',
+    'context-file': '',
+    'context-skill': '',
+    'context-plugin': '',
+    'context-notice': '',
+    'context-recall': '',
+    'context-generic': '',
+    error: '×',
+    interrupted: '■',
+    question: '?',
+    'disclosure-collapsed': '▸',
+    'disclosure-expanded': '▾',
+    // The working pair is UNIFIED with symbols — minimal removes static
+    // icons, it does not change animation semantics.
+    'working-a': '•',
+    'working-b': '◦',
+  },
+}
+
+/** Resolve one semantic icon for a style. Returns a PURE glyph (possibly
+ * EMPTY in `minimal`) — never an ANSI-colored string; the renderer's
+ * semantic color context paints it. */
+export function iconFor(semantic: IconSemantic, style: IconStyle): string {
+  return ICONS[style][semantic]
+}
+
+/** The icon plus its TWO-space trailing separator when the style shows a
+ * glyph, '' when the glyph is hidden (minimal). Renderers MUST compose
+ * headers as `` `${iconPrefix(...)}${title}` `` — the raw `` `${icon} ${title}` ``
+ * form would leave a dangling leading space under minimal. The two-space
+ * trail preserves the historical emoji layout byte-for-byte, so the default
+ * emoji rendering is unchanged. */
+export function iconPrefix(semantic: IconSemantic, style: IconStyle): string {
+  const icon = iconFor(semantic, style)
+  return icon === '' ? '' : `${icon}  `
+}
+
+/** Normalize any persisted/old value to a valid IconStyle: unknown and
+ * missing values fail-safe to `emoji` (backward compatibility — an old
+ * settings file without the field must behave exactly as before). */
+export function iconStyleOf(value: string | undefined | null): IconStyle {
+  switch (value) {
+    case 'symbols':
+    case 'minimal':
+      return value
+    default:
+      return 'emoji'
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ import { ImageInputError } from './image/errors.ts'
 import { clipboardBackendOf, commandOnPath, createClipboardRunner, readClipboardImage, type ClipboardEnvironment } from './image/clipboard.ts'
 import { buildOsc52Sequence, copyToClipboard, type CopyEnvironment, type CopyExecutor } from './clipboard.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
+import { iconStyleOf } from './icons.ts'
 import { checkImageLimits } from './image/intake.ts'
 import { ImageLoadError } from './image/errors.ts'
 import { ImageLoader } from './image/loader.ts'
@@ -1413,12 +1414,16 @@ export function apply(ctx: Context, config: Config): void {
         // Focus Mode: 'on' collapses turn-intermediate activity into a
         // live Thought block (default 'off' — Focus OFF == current UI).
         focusMode: z.string(),
+        // Icon style: 'emoji' (default) or 'symbols' — the first-party
+        // structural icon palette (see src/icons.ts). A persisted invalid
+        // value fails safe to emoji at consumption.
+        iconStyle: z.string(),
       }),
       // `history` used to live here (a per-cwd map in the settings
       // document). It moved to $DSH_HOME/user-history/*.jsonl (see
       // history.ts); the schema deliberately no longer carries it, so the
       // stored section drops the key on the next settings write.
-      { base: { theme: 'auto', footer: 'full', fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' } },
+      { base: { theme: 'auto', iconStyle: 'emoji', footer: 'full', fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' } },
     )
     // The ONE authoritative Focus runtime state (plan §5): restored from
     // the persisted document BEFORE the first compose/resume below, mutated
@@ -4249,6 +4254,10 @@ export function apply(ctx: Context, config: Config): void {
       imageTheme: { fallbackColor: color.textDim },
       present,
       workspaceRoot: cwd,
+      // The structural icon palette: read ONCE at startup from the
+      // persisted document; runtime switches go through app.setIconStyle
+      // (the /settings write path) — never a deep settings read per render.
+      iconStyle: iconStyleOf(tuiSettings?.get().iconStyle),
       extensionHost,
       // Issue #7: the fullscreen drag selection copies through the SAME
       // shared policy as /copy (tmux → platform helper → OSC 52) — a bare

--- a/src/present.ts
+++ b/src/present.ts
@@ -14,6 +14,7 @@ import type { JsonValue } from '@deepseek-ai/dsh-session'
 import type {
   FileDiff, ToolCallView, ToolResult, ToolResultView, WebFetchResultView, WebSearchResultView,
 } from '@deepseek-ai/dsh-tools'
+import { type IconSemantic } from './icons.ts'
 
 /** Figma row titles per variant (design literals, not translatable copy). */
 const VARIANT_TITLES = {
@@ -346,39 +347,43 @@ export function classifyTool(name: string): ToolVariant {
   return TOOL_VARIANTS[name] ?? 'others'
 }
 
-/** Emoji per exact tool name, for synthetic cards without a registry entry. */
-const TOOL_EMOJIS: Record<string, string> = {
-  shell: '🖥️',
-  subagent: '🤖',
-  workflow: '🧵',
-  'workflow-member': '🤖',
-  error: '❌',
-  interrupted: '⏹️',
-  ask_user_question: '❓',
+/** The structural icon semantic per exact tool name, for synthetic cards
+ * without a registry entry (the glyph itself resolves through
+ * src/icons.ts — fold state never stores a concrete emoji/symbol). */
+const TOOL_SEMANTICS: Record<string, IconSemantic> = {
+  shell: 'tool-shell',
+  subagent: 'subagent',
+  workflow: 'workflow',
+  'workflow-member': 'subagent',
+  error: 'error',
+  interrupted: 'interrupted',
+  ask_user_question: 'question',
 }
 
-/** Emoji per row variant, applied to every registered tool of that class. */
-const VARIANT_EMOJIS: Record<ToolVariant, string> = {
-  read: '📖',
-  search: '🔍',
-  bash: '🖥️',
-  write: '📝',
-  edit: '✏️',
-  code: '⚙️',
-  others: '🛠️',
+/** The icon semantic per row variant, applied to every registered tool of
+ * that class. */
+const VARIANT_SEMANTICS: Record<ToolVariant, IconSemantic> = {
+  read: 'tool-read',
+  search: 'tool-search',
+  bash: 'tool-shell',
+  write: 'tool-write',
+  edit: 'tool-edit',
+  code: 'tool-code',
+  others: 'tool-generic',
 }
 
 /**
- * The card header's leading emoji: exact-name entries first (synthetic
- * cards), then slash commands (a control action, not a tool), then the
- * tool's row-variant icon, then the generic wrench.
+ * The card header's leading icon semantic: exact-name entries first
+ * (synthetic cards), then slash commands (a control action, not a tool),
+ * then the tool's row-variant semantic, then the generic tool. The renderer
+ * resolves the glyph through `iconFor(semantic, iconStyle)`.
  * @param name - the tool name.
  */
-export function toolEmoji(name: string): string {
-  const exact = TOOL_EMOJIS[name]
+export function toolIconSemantic(name: string): IconSemantic {
+  const exact = TOOL_SEMANTICS[name]
   if (exact !== undefined) return exact
-  if (name.startsWith('/')) return '🎛️'
-  return VARIANT_EMOJIS[classifyTool(name)]
+  if (name.startsWith('/')) return 'slash-command'
+  return VARIANT_SEMANTICS[classifyTool(name)]
 }
 
 /** The rendered card header: design title plus the relativized args summary. */

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -27,12 +27,13 @@
 
 import type { AuthorizationTarget } from '../authorization.ts'
 
-/** The TUI settings document (theme/footer/fullscreen/busyEnter/
+/** The TUI settings document (theme/iconStyle/footer/fullscreen/busyEnter/
  * localShellSandbox/homeEndKeys/focusMode). The old `history` field moved
  * to $DSH_HOME/user-history/*.jsonl and is deliberately NOT part of the
  * document anymore. */
 export interface TuiSettingsDoc {
   theme: string
+  iconStyle: string
   footer: string
   fullscreen: string
   busyEnter: string

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -18,7 +18,8 @@
 
 import type { SessionEvent, SessionHeader, JsonValue } from '@deepseek-ai/dsh-session'
 import type { ContentBlock } from '@deepseek-ai/dsh-llm'
-import { contextEmoji, contextProvenance, contextSummary } from './context.ts'
+import { contextIconSemantic, contextProvenance, contextSummary } from './context.ts'
+import type { IconSemantic } from './icons.ts'
 import { firstLine, latestLine } from './present.ts'
 import { StepUsageAccumulator, totalTokens, type TokenUsageTotals } from './token-usage.ts'
 // The command/run + command/done event merge (SessionEventMap extension).
@@ -48,10 +49,11 @@ export type TranscriptMessage =
   /**
    * Injected context (system reminders, skill content) from non-user sources.
    * Labeled entries carry the Web-provenance producer name (e.g. AGENTS.md,
-   * @deepseek-ai/dsh-system-prompt, skill-catalog), a source-kind emoji, and,
-   * for notice forms, the producer's one-line summary.
+   * @deepseek-ai/dsh-system-prompt, skill-catalog), a source-kind icon
+   * SEMANTIC (never a concrete glyph — the renderer resolves the palette),
+   * and, for notice forms, the producer's one-line summary.
    */
-  | { kind: 'system'; turn: number; text: string; label?: string; summary?: string; emoji?: string }
+  | { kind: 'system'; turn: number; text: string; label?: string; summary?: string; icon?: IconSemantic }
   | {
     kind: 'tool'
     turn: number
@@ -986,17 +988,18 @@ export class TranscriptFolder {
           this.appendItem({ kind: 'user', turn: this.currentTurn, text, content: blocks })
         } else {
           // Injected context: name the producer the way the Web row does
-          // (contextProvenance), plus a notice form's one-line account.
+          // (contextProvenance), plus a notice form's one-line account. The
+          // fold stores the icon SEMANTIC (never the concrete glyph), so a
+          // live icon-style switch repaints already-folded cards.
           const provenance = contextProvenance(event.data.source)
           const summary = contextSummary(event.data.source)
-          const emoji = contextEmoji(event.data.source)
           this.appendItem({
             kind: 'system',
             turn: this.currentTurn,
             text,
             ...provenance.label === null ? {} : { label: provenance.label },
             ...summary === null ? {} : { summary },
-            emoji,
+            icon: contextIconSemantic(event.data.source),
           })
           // Focus aggregation: injected context (skill-invocation,
           // skill-catalog, system reminders) is orchestration, NOT one of

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -517,17 +517,6 @@ export class TranscriptGutterComponent implements Component {
   }
 }
 
-/** Swap the TUI-generated image-attachment marker (`🖼️` with or without
- * its U+FE0F variation selector) inside RENDERED user-message text for the
- * CURRENT icon style's marker. This is a CONTROLLED substitution of the
- * TUI's own attachment fact — never a global emoji sanitizer: the folded
- * `message.text` keeps the emoji for search/export, and user-typed emoji
- * are untouched. No marker → no work (the fast path). */
-function renderImageMarkers(text: string, marker: string): string {
-  if (!text.includes('\u{1F5BC}')) return text
-  return text.replace(/\u{1F5BC}\uFE0F?/gu, marker)
-}
-
 /**
  * Bullet + continuation-indent wrapper that keeps its child LIVE, so a
  * terminal resize re-renders the child at the new width instead of
@@ -6622,10 +6611,10 @@ export class TuiApp {
   ): Component {
     const container = new Container()
     container.addChild(new UserBubbleComponent(
-      // The folded flat text keeps the emoji marker (search/export fact);
-      // the RENDER swaps in the current icon style's marker — the marker
-      // is TUI-owned text, never a user-typed emoji.
-      new Text(renderImageMarkers(textWithImageMarkers(content), iconFor('image-marker', this.iconStyle)), 0, 0),
+      // The attachment marker is deliberately NOT style-swapped (the plan
+      // defers it): the flat text keeps the constant 🖼️ fact, so a
+      // user-typed 🖼️ in their own words is never rewritten.
+      new Text(textWithImageMarkers(content), 0, 0),
       `${color.roleUser('❯')} `,
       color.roleUserBg,
     ))
@@ -6637,7 +6626,6 @@ export class TuiApp {
           this.imageLoader!,
           this.imageTheme!,
           this.occurrenceCollapsedRef(message, imageIndex),
-          iconFor('image-marker', this.iconStyle),
         ))
         imageIndex += 1
       }
@@ -6657,7 +6645,7 @@ export class TuiApp {
         return this.renderUserBlocks(message.content, message)
       }
       return new UserBubbleComponent(
-        new Text(renderImageMarkers(message.text, iconFor('image-marker', this.iconStyle)), 0, 0),
+        new Text(message.text, 0, 0),
         `${color.roleUser('❯')} `,
         color.roleUserBg,
       )
@@ -7338,8 +7326,6 @@ export class TuiApp {
                     block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
                     this.imageLoader,
                     this.imageTheme,
-                    undefined,
-                    iconFor('image-marker', this.iconStyle),
                   ))
                 } else {
                   // Non-text/non-image blocks keep the legacy JSON form,
@@ -7483,8 +7469,6 @@ export class TuiApp {
               block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
               this.imageLoader,
               this.imageTheme,
-              undefined,
-              iconFor('image-marker', this.iconStyle),
             ))
           } else {
             // Non-text/non-image blocks keep the legacy JSON form, in order
@@ -7531,8 +7515,6 @@ export class TuiApp {
           block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
           this.imageLoader,
           this.imageTheme,
-          undefined,
-          iconFor('image-marker', this.iconStyle),
         ))
       }
     }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -100,7 +100,7 @@ import { MentionProvider } from './mentions.ts'
 import { recentTurnThreshold, textWithImageMarkers, type TranscriptMessage, type TurnActivity } from './transcript.ts'
 import { FocusActivityComponent, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
 import { WorkingIndicator, workingFramesFor } from './working.ts'
-import { iconPrefix, type IconStyle } from './icons.ts'
+import { iconFor, iconLead, iconPrefix, type IconStyle } from './icons.ts'
 import { indeterminateProgressFrames } from './progress.ts'
 import { cancellationError, type OwnedTaskOptions } from './detached.ts'
 import { safeErrorMessage } from './error-boundary.ts'
@@ -517,6 +517,17 @@ export class TranscriptGutterComponent implements Component {
   }
 }
 
+/** Swap the TUI-generated image-attachment marker (`🖼️` with or without
+ * its U+FE0F variation selector) inside RENDERED user-message text for the
+ * CURRENT icon style's marker. This is a CONTROLLED substitution of the
+ * TUI's own attachment fact — never a global emoji sanitizer: the folded
+ * `message.text` keeps the emoji for search/export, and user-typed emoji
+ * are untouched. No marker → no work (the fast path). */
+function renderImageMarkers(text: string, marker: string): string {
+  if (!text.includes('\u{1F5BC}')) return text
+  return text.replace(/\u{1F5BC}\uFE0F?/gu, marker)
+}
+
 /**
  * Bullet + continuation-indent wrapper that keeps its child LIVE, so a
  * terminal resize re-renders the child at the new width instead of
@@ -591,15 +602,17 @@ export class BulletedComponent implements Component {
 export class ThinkingCompactComponent implements Component {
   private readonly message: Extract<TranscriptMessage, { kind: 'thinking' }>
   private readonly hint: ExpandHint
+  private readonly iconStyle: IconStyle
   /** TRUE per-width cache: the same component + same width returns the
    * same array instance even after intermediate widths (a single
    * last-width slot would re-create the array on a width A → B → A
    * sequence and break the reference-stable contract). */
   private readonly cached = new Map<number, string[]>()
 
-  constructor(message: Extract<TranscriptMessage, { kind: 'thinking' }>, hint: ExpandHint) {
+  constructor(message: Extract<TranscriptMessage, { kind: 'thinking' }>, hint: ExpandHint, iconStyle: IconStyle = 'emoji') {
     this.message = message
     this.hint = hint
+    this.iconStyle = iconStyle
   }
 
   invalidate(): void {
@@ -610,15 +623,16 @@ export class ThinkingCompactComponent implements Component {
     const existing = this.cached.get(width)
     if (existing !== undefined) return existing
     const previewLine = latestLine(this.message.text)
+    const title = color.textDim(`${iconLead('thinking', this.iconStyle)}Thinking`)
     let lines: string[]
     if (previewLine === '') {
       // An existing block with no text yet (a very short streaming /
       // replay edge): the bare title — never a fake "No reasoning" row.
-      lines = [truncateToWidth(color.textDim('🌊 Thinking'), Math.max(1, width), '…')]
+      lines = [truncateToWidth(title, Math.max(1, width), '…')]
     } else {
       const hintVerb = this.hint ?? 'ctrl+o'
       lines = [
-        truncateToWidth(color.textDim('🌊 Thinking'), Math.max(1, width), '…'),
+        truncateToWidth(title, Math.max(1, width), '…'),
         truncateToWidth(color.textDimItalic(`  ${previewLine}`), Math.max(1, width), '…'),
         truncateToWidth(color.textDim(`  (${hintVerb} to expand)`), Math.max(1, width), '…'),
       ]
@@ -6608,7 +6622,10 @@ export class TuiApp {
   ): Component {
     const container = new Container()
     container.addChild(new UserBubbleComponent(
-      new Text(textWithImageMarkers(content), 0, 0),
+      // The folded flat text keeps the emoji marker (search/export fact);
+      // the RENDER swaps in the current icon style's marker — the marker
+      // is TUI-owned text, never a user-typed emoji.
+      new Text(renderImageMarkers(textWithImageMarkers(content), iconFor('image-marker', this.iconStyle)), 0, 0),
       `${color.roleUser('❯')} `,
       color.roleUserBg,
     ))
@@ -6620,6 +6637,7 @@ export class TuiApp {
           this.imageLoader!,
           this.imageTheme!,
           this.occurrenceCollapsedRef(message, imageIndex),
+          iconFor('image-marker', this.iconStyle),
         ))
         imageIndex += 1
       }
@@ -6639,22 +6657,26 @@ export class TuiApp {
         return this.renderUserBlocks(message.content, message)
       }
       return new UserBubbleComponent(
-        new Text(message.text, 0, 0),
+        new Text(renderImageMarkers(message.text, iconFor('image-marker', this.iconStyle)), 0, 0),
         `${color.roleUser('❯')} `,
         color.roleUserBg,
       )
     }
     if (message.kind === 'assistant') {
-      // The whale bullet leads the FIRST markdown line; wrapped continuation
-      // lines indent under it (kimi prefix+indent parity), so the bullet
-      // never floats alone on its own row. The markdown stays a LIVE child:
-      // a terminal resize re-renders it at the new width, so tables reflow
-      // instead of re-wrapping a frozen render (the 5a76526 regression).
+      // The leading bullet marks the FIRST markdown line; wrapped
+      // continuation lines indent under it (kimi prefix+indent parity), so
+      // the bullet never floats alone on its own row. The bullet follows
+      // the icon style (the whale under emoji, the list bullet under
+      // symbols/minimal — the continuation indent depends on it, so it is
+      // never hidden). The markdown stays a LIVE child: a terminal resize
+      // re-renders it at the new width, so tables reflow instead of
+      // re-wrapping a frozen render (the 5a76526 regression).
+      const bullet = color.primary(iconPrefix('assistant-bullet', this.iconStyle))
       if (message.content !== undefined && this.imageLoader !== undefined && this.imageTheme !== undefined) {
         return this.renderBlockSequence(message.content, (text) =>
-          new BulletedComponent(new Markdown(text, 0, 0, markdownTheme), `${color.primary('🐋')}  `), message)
+          new BulletedComponent(new Markdown(text, 0, 0, markdownTheme), bullet), message)
       }
-      return new BulletedComponent(new Markdown(message.text, 0, 0, markdownTheme), `${color.primary('🐋')}  `)
+      return new BulletedComponent(new Markdown(message.text, 0, 0, markdownTheme), bullet)
     }
     if (message.kind === 'thinking') {
       // The unified Thinking disclosure card (plan §4/§13): COMPACT is
@@ -6667,9 +6689,9 @@ export class TuiApp {
       // output), wrapping normally per the Text/Markdown policy; the
       // compact preview is never repeated next to the full body.
       if (!expanded) {
-        return new ThinkingCompactComponent(message, expandHint)
+        return new ThinkingCompactComponent(message, expandHint, this.iconStyle)
       }
-      const head = color.textDim('🌊 Thinking')
+      const head = color.textDim(`${iconLead('thinking', this.iconStyle)}Thinking`)
       const body = message.text === '' ? '' : message.text.split('\n').map(line => `  ${line}`).join('\n')
       return new Text([head, color.textDimItalic(body)].filter(line => line !== '').join('\n'), 0, 0)
     }
@@ -6739,11 +6761,14 @@ export class TuiApp {
       // Compaction card (web CompactionItem parity): a title row with the
       // shadowed item/token counts, expandable to the summary body. The
       // running card shows "Compacting context…" until the summary lands.
+      // The title icon follows the icon style (hidden under minimal — the
+      // text and the error colour carry the state).
+      const lead = iconLead('compaction', this.iconStyle)
       const title = message.error !== undefined
-        ? color.error('🗜 Compaction failed')
+        ? color.error(`${lead}Compaction failed`)
         : message.running === true
-          ? color.textMuted('🗜 Compacting context…')
-          : color.text('🗜 Context compacted')
+          ? color.textMuted(`${lead}Compacting context…`)
+          : color.text(`${lead}Context compacted`)
       const counts = (message.items > 0 || message.tokens > 0)
         ? `Compacted ${message.items} history item${message.items === 1 ? '' : 's'} (~${message.tokens} tokens)`
         : ''
@@ -7313,6 +7338,8 @@ export class TuiApp {
                     block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
                     this.imageLoader,
                     this.imageTheme,
+                    undefined,
+                    iconFor('image-marker', this.iconStyle),
                   ))
                 } else {
                   // Non-text/non-image blocks keep the legacy JSON form,
@@ -7456,6 +7483,8 @@ export class TuiApp {
               block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
               this.imageLoader,
               this.imageTheme,
+              undefined,
+              iconFor('image-marker', this.iconStyle),
             ))
           } else {
             // Non-text/non-image blocks keep the legacy JSON form, in order
@@ -7502,6 +7531,8 @@ export class TuiApp {
           block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
           this.imageLoader,
           this.imageTheme,
+          undefined,
+          iconFor('image-marker', this.iconStyle),
         ))
       }
     }
@@ -8006,12 +8037,14 @@ export class TuiApp {
       lines.push(`${color.roleUser('❯')} ${truncated}`)
     }
     for (const item of shownNotices) {
-      // Notices are NOT steerable: they carry their own ⏳ marker so they
-      // never read as user input, and the hint below drops the steer/edit
-      // verbs when nothing else is queued.
+      // Notices are NOT steerable: they carry their own waiting-state
+      // marker (the ⏳ under emoji, the ⧗ hourglass under symbols/minimal)
+      // so they never read as user input, and the hint below drops the
+      // steer/edit verbs when nothing else is queued.
       const text = item.text.replace(/\s+/g, ' ').trim()
-      const truncated = truncateToWidth(text, Math.max(1, width - visibleWidth('⏳ ')), '…')
-      lines.push(`${color.textDim('⏳')} ${color.textDim(truncated)}`)
+      const lead = iconLead('queue-notice', this.iconStyle)
+      const truncated = truncateToWidth(text, Math.max(1, width - visibleWidth(lead)), '…')
+      lines.push(`${color.textDim(lead)}${color.textDim(truncated)}`)
     }
     const folded = noticeRows.length - shownNotices.length
     if (folded > 0) {

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -88,7 +88,7 @@ import {
   focusToolDisplay,
   systemContextBody,
   toolCardHeader,
-  toolEmoji,
+  toolIconSemantic,
   webCardLines,
   type ToolPresenter,
 } from './present.ts'
@@ -99,7 +99,8 @@ import { QuestionFlow } from './question.ts'
 import { MentionProvider } from './mentions.ts'
 import { recentTurnThreshold, textWithImageMarkers, type TranscriptMessage, type TurnActivity } from './transcript.ts'
 import { FocusActivityComponent, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
-import { WorkingIndicator } from './working.ts'
+import { WorkingIndicator, workingFramesFor } from './working.ts'
+import { iconPrefix, type IconStyle } from './icons.ts'
 import { indeterminateProgressFrames } from './progress.ts'
 import { cancellationError, type OwnedTaskOptions } from './detached.ts'
 import { safeErrorMessage } from './error-boundary.ts'
@@ -1272,6 +1273,13 @@ export interface TuiAppOptions {
   /** Working-indicator frame interval in ms; injectable so tests stay fast. */
   workingIntervalMs?: number
   /**
+   * The structural icon palette (emoji | symbols | minimal), read once at
+   * startup from the persisted settings. Runtime switches go through
+   * {@link TuiApp.setIconStyle} — renderers NEVER deep-read a settings
+   * service per frame.
+   */
+  iconStyle?: IconStyle
+  /**
    * The extension surface host (M2). When attached, the header/dock/footer
    * renders merge the extension outlets' content (header badges, dock
    * items, footer segments) into the host chrome. Optional — the surface
@@ -1439,6 +1447,10 @@ interface MessageComponentEntry {
   builtWidth?: number
   /** The theme revision at build time (colors are baked into the ANSI). */
   themeRev: number
+  /** The icon style at build time (glyphs are baked into the header). An
+   * icon-style switch must rebuild the entry — the cache never serves a
+   * frame painted in the old palette (plan §34.9). */
+  iconStyle: IconStyle
   /** Whether the entry renders expanded (boundary + click override). */
   expanded: boolean
   /** The full-reveal flag (tool bodies / large diffs): per-card override
@@ -1788,6 +1800,10 @@ export class TuiApp {
   private readonly imageTheme: import('./components/media/image-thumbnail.ts').ImageThumbnailTheme | undefined
   /** The busy indicator row directly above the editor border; idle renders nothing. */
   private readonly working: WorkingIndicator
+  /** The structural icon palette (emoji | symbols | minimal). The runtime
+   * source of truth — mutated ONLY through {@link setIconStyle}, never a
+   * per-render settings read. */
+  private iconStyle: IconStyle
   /** The fullscreen transcript ScrollView, for click hit-testing offsets. */
   private fullscreenScroll: ScrollView | undefined
   /**
@@ -1819,10 +1835,10 @@ export class TuiApp {
   /** The folder's per-turn activities (same fold state as `messages`). */
   private turnActivities: ReadonlyMap<number, TurnActivity> = new Map()
   /** The FocusActivityComponent cache, keyed by turn: rebuilds on the
-   * activity revision, the expansion state, the theme revision, or the
-   * precomputed Tool display (plan §39). render() still re-reads
-   * Date.now() per frame, so the running duration refreshes on the
-   * WorkingIndicator's repaint heartbeat. */
+   * activity revision, the expansion state, the theme revision, the icon
+   * style, or the precomputed Tool display (plan §39 + §34.9). render()
+   * still re-reads Date.now() per frame, so the running duration refreshes
+   * on the WorkingIndicator's repaint heartbeat. */
   private readonly focusActivityComponents = new Map<number, {
     /** The activity object the component was built from (identity key). */
     activity: TurnActivity
@@ -1830,6 +1846,7 @@ export class TuiApp {
     revision: number
     expanded: boolean
     themeRev: number
+    iconStyle: IconStyle
     toolDisplay?: string
   }>()
   /** The parent session's expansion set while the subagent viewer covers
@@ -1961,6 +1978,7 @@ export class TuiApp {
     })
     this.terminal = resizeAware
     this.events = events
+    this.iconStyle = options.iconStyle ?? 'emoji'
     this.extensionHost = options.extensionHost
     // F-17: an invalidation batch re-bakes the outlets; the host then
     // re-merges its chrome rows so the new content reaches the screen.
@@ -2156,6 +2174,9 @@ export class TuiApp {
     this.working = new WorkingIndicator(() => this.requestRender(), options.workingIntervalMs === undefined
       ? {}
       : { intervalMs: options.workingIntervalMs })
+    // The startup icon style decides the default animation frames (the
+    // guard keeps any explicit custom frames untouched).
+    this.working.setIconStyleFrames(workingFramesFor(this.iconStyle))
     this.footer = new Text('', 0, 0)
     // The M4 widget zones: bounded rows above and below the editor seat,
     // fed by the extension widget outlets. Host-owned Text components — a
@@ -3536,6 +3557,28 @@ export class TuiApp {
     this.requestRender()
   }
 
+  /** Switch the structural icon palette at runtime (the /settings write
+   * path). Applies IMMEDIATELY — no restart, no session reload: the
+   * working frames follow the new style, the message/focus component
+   * caches detect the stale `iconStyle` on the next rebuild and re-resolve
+   * every glyph, and the frame repaints. A persistence failure leaves this
+   * session's preference live (the next start restores the persisted
+   * value) — same policy as theme/focus. */
+  setIconStyle(style: IconStyle): void {
+    if (this.iconStyle === style) return
+    this.iconStyle = style
+    // Default working frames follow the style; an explicit custom frame
+    // set (extension/advanced indicator) is never overwritten.
+    this.working.setIconStyleFrames(workingFramesFor(style))
+    this.rebuildMessages()
+    this.requestRender()
+  }
+
+  /** The current icon style (diagnostics / test hook). */
+  currentIconStyle(): IconStyle {
+    return this.iconStyle
+  }
+
   /** Toggle one turn's Thought disclosure (click on the header — plan
    * §16.1). Running turns are toggleable; turn/end never reverts the
    * choice. Closing is a COLLAPSE ALL: the turn's secondary expansions
@@ -3997,16 +4040,18 @@ export class TuiApp {
     if (entry !== undefined && entry.activity === activity
       && entry.revision === activity.revision
       && entry.expanded === expanded && entry.themeRev === this.themeRevision
+      && entry.iconStyle === this.iconStyle
       && entry.toolDisplay === toolDisplay) {
       return entry.component
     }
-    const component = new FocusActivityComponent({ activity, expanded, toolDisplay })
+    const component = new FocusActivityComponent({ activity, expanded, toolDisplay, iconStyle: this.iconStyle })
     this.focusActivityComponents.set(activity.turn, {
       activity,
       component,
       revision: activity.revision,
       expanded,
       themeRev: this.themeRevision,
+      iconStyle: this.iconStyle,
       toolDisplay,
     })
     return component
@@ -6349,6 +6394,7 @@ export class TuiApp {
     if (entry.boundary !== boundary
       || (entry.builtWidth !== undefined && entry.builtWidth !== width)
       || entry.themeRev !== this.themeRevision
+      || entry.iconStyle !== this.iconStyle
       || entry.expanded !== state.expanded
       || entry.fullReveal !== state.fullReveal
       || entry.expandHint !== state.expandHint
@@ -6369,6 +6415,7 @@ export class TuiApp {
       entry.boundary = rebuilt.boundary
       entry.builtWidth = rebuilt.builtWidth
       entry.themeRev = rebuilt.themeRev
+      entry.iconStyle = rebuilt.iconStyle
       entry.expanded = rebuilt.expanded
       entry.fullReveal = rebuilt.fullReveal
       entry.expandHint = rebuilt.expandHint
@@ -6428,6 +6475,7 @@ export class TuiApp {
       boundary,
       builtWidth: hostBuilt && this.bakesFoldedWidth(message, state.expanded) ? width : undefined,
       themeRev: this.themeRevision,
+      iconStyle: this.iconStyle,
       expanded: state.expanded,
       fullReveal: state.fullReveal,
       expandHint: state.expandHint,
@@ -6632,9 +6680,13 @@ export class TuiApp {
       // the generic section marker.
       if (message.label !== undefined) {
         const row = new Container()
-        const emoji = message.emoji ?? '📎'
+        // The fold stores the icon SEMANTIC; the glyph resolves against the
+        // CURRENT icon style, so a live switch repaints already-folded rows.
+        // iconPrefix hides the separator entirely when the style hides the
+        // icon (minimal) — never a dangling leading space.
+        const icon = iconPrefix(message.icon ?? 'context-generic', this.iconStyle)
         if (expanded) {
-          row.addChild(new Text(color.textMuted(`${emoji}  Context injection ${message.label}`), 0, 0))
+          row.addChild(new Text(color.textMuted(`${icon}Context injection ${message.label}`), 0, 0))
           // Injected content stays dimmed like tool-card bodies: context is
           // never mistaken for the assistant's actual output. XML-framed
           // envelopes (the skill loader's `<skill_content>` body, the skill
@@ -6666,7 +6718,7 @@ export class TuiApp {
           // contract), so the baked line fits the paint width exactly and
           // the row can never wrap.
           row.addChild(new Text(truncateToWidth(
-            color.textMuted(`${emoji}  Context injection ${message.label}${summary} (${expandHint ?? 'ctrl+o'} to expand)`),
+            color.textMuted(`${icon}Context injection ${message.label}${summary} (${expandHint ?? 'ctrl+o'} to expand)`),
             width,
             '…',
           ), 0, 0))
@@ -6721,13 +6773,16 @@ export class TuiApp {
     const card = new Container()
     const header = toolCardHeader(message.name, message.args, this.workspaceRoot)
     const summary = header.summary === '' ? '' : ` ${header.summary}`
-    const emoji = toolEmoji(message.name)
+    // The glyph resolves through the icon registry against the CURRENT
+    // style; iconPrefix drops the separator when the style hides the icon
+    // (minimal) — the header starts directly with the title.
+    const icon = iconPrefix(toolIconSemantic(message.name), this.iconStyle)
     const pill = message.status === 'ok'
       ? color.success('[ok]')
       : message.status === 'error'
         ? color.error('[error]')
         : color.textDim('[running]')
-    const head = `${color.textDim(`${emoji}  ${header.title}${summary}`)} ${pill}`
+    const head = `${color.textDim(`${icon}${header.title}${summary}`)} ${pill}`
     // LOCAL `!`/`!!` shell cards read the master Ctrl+O switch (plan §5.3),
     // never the unbounded turn marker: collapsed by default so a long log
     // cannot fill the TUI, expanded only while Ctrl+O is on.

--- a/src/working.ts
+++ b/src/working.ts
@@ -10,23 +10,33 @@
  * active, so a captured `TuiMainScreen` would freeze the animation at the
  * first frame. The callback routes to whichever screen is active.
  *
- * Frames follow the icon style through {@link workingFramesFor}: the whale
- * pair under `emoji`, the `• / ◦` pair under `symbols` AND `minimal`
- * (minimal removes static icons — it does not change animation semantics).
- * An EXPLICIT `frames` option (an extension/advanced custom indicator) is
- * never overwritten by an icon-style change.
+ * Frames follow the icon style through {@link workingFramesFor}, which
+ * DERIVES them from the icon registry (`working-a` / `working-b`): the
+ * whale pair under `emoji`, the `∙ / ◦` pair under `symbols` AND
+ * `minimal` (minimal removes static icons — it does not change animation
+ * semantics). Deriving from the registry keeps the EAW-safe width gate
+ * covering the ACTUAL running glyphs — a hard-coded frame literal here
+ * would silently bypass it. An EXPLICIT `frames` option (an
+ * extension/advanced custom indicator) is never overwritten by an
+ * icon-style change.
  * @module @xmoon76/dsh-pi-tui/working
  */
 
 import { Text } from '@xmoon76/pi-tui'
-import type { IconStyle } from './icons.ts'
+import { iconFor, type IconStyle } from './icons.ts'
 import { color } from './theme.ts'
 
-/** The DEFAULT animation frames for one icon style. `symbols` and
- * `minimal` share the low-noise pair — a reduced-motion preference would
- * be its own setting, never smuggled into the icon style. */
+/** The DEFAULT animation frames for one icon style, DERIVED from the icon
+ * registry — the single source of truth, so the palette's width gate also
+ * guards the running indicator glyphs (a drift between this and the
+ * registry is impossible by construction). `symbols` and `minimal` share
+ * the low-noise pair — a reduced-motion preference would be its own
+ * setting, never smuggled into the icon style. */
 export function workingFramesFor(style: IconStyle): readonly string[] {
-  return style === 'emoji' ? ['🐋', '🐳'] : ['•', '◦']
+  return [
+    iconFor('working-a', style),
+    iconFor('working-b', style),
+  ]
 }
 
 export interface WorkingIndicatorOptions {

--- a/src/working.ts
+++ b/src/working.ts
@@ -79,11 +79,18 @@ export class WorkingIndicator extends Text {
   /** Replace the animation frames at runtime (an active indicator repaints
    * with the new set immediately; the frame position is clamped). This is
    * the generic setter — extension/advanced custom indicators can keep
-   * swapping frames through it. */
+   * swapping frames through it. A frame-COUNT change re-arms the timer:
+   * shrinking to ≤1 frame clears the interval, growing re-arms it — an
+   * active indicator never keeps ticking a stale interval (and never
+   * modulo-zeros on an empty set). */
   setFrames(frames: readonly string[]): void {
     this.frames = [...frames]
     if (this.currentFrame >= this.frames.length) this.currentFrame = 0
-    if (this.active) this.updateDisplay()
+    if (!this.active) return
+    // restartAnimation clears the old interval and re-arms (or clears)
+    // per the NEW length; updateDisplay paints the first frame.
+    this.restartAnimation()
+    this.updateDisplay()
   }
 
   /** Follow an icon-style frame set ONLY when no explicit custom frames

--- a/src/working.ts
+++ b/src/working.ts
@@ -1,7 +1,7 @@
 /**
  * The animated busy indicator shown on the row directly above the editor
  * while the agent works (a turn is streaming or a tool is running): two
- * whale emojis alternate before a dim Working label, mirroring pi's
+ * frames alternate before a dim Working label, mirroring pi's
  * WorkingStatusIndicator placement. A Text subclass whose idle text renders
  * zero rows, so the row disappears entirely when idle.
  *
@@ -9,14 +9,30 @@
  * the main screen stops rendering while the alt screen (fullscreen) is
  * active, so a captured `TuiMainScreen` would freeze the animation at the
  * first frame. The callback routes to whichever screen is active.
+ *
+ * Frames follow the icon style through {@link workingFramesFor}: the whale
+ * pair under `emoji`, the `• / ◦` pair under `symbols` AND `minimal`
+ * (minimal removes static icons — it does not change animation semantics).
+ * An EXPLICIT `frames` option (an extension/advanced custom indicator) is
+ * never overwritten by an icon-style change.
  * @module @xmoon76/dsh-pi-tui/working
  */
 
 import { Text } from '@xmoon76/pi-tui'
+import type { IconStyle } from './icons.ts'
 import { color } from './theme.ts'
 
+/** The DEFAULT animation frames for one icon style. `symbols` and
+ * `minimal` share the low-noise pair — a reduced-motion preference would
+ * be its own setting, never smuggled into the icon style. */
+export function workingFramesFor(style: IconStyle): readonly string[] {
+  return style === 'emoji' ? ['🐋', '🐳'] : ['•', '◦']
+}
+
 export interface WorkingIndicatorOptions {
-  /** Animation frames, alternated in order; defaults to the whale pair. */
+  /** Animation frames, alternated in order; defaults to the icon-style
+   * pair. An EXPLICIT value is a custom indicator and is preserved across
+   * icon-style switches (setIconStyleFrames never overwrites it). */
   frames?: string[]
   /** Frame interval in milliseconds; injectable so tests stay fast. */
   intervalMs?: number
@@ -39,7 +55,10 @@ export interface WorkingIndicatorAnimation {
  */
 export class WorkingIndicator extends Text {
   private readonly requestRender: () => void
-  private readonly frames: string[]
+  private frames: string[]
+  /** An EXPLICIT caller-provided frame set — icon-style switches must never
+   * overwrite a custom indicator (plan §13.2). */
+  private readonly customFrames: readonly string[] | undefined
   private readonly intervalMs: number
   private message: string
   private currentFrame = 0
@@ -51,9 +70,28 @@ export class WorkingIndicator extends Text {
   constructor(requestRender: () => void, options: WorkingIndicatorOptions = {}) {
     super('', 0, 0)
     this.requestRender = requestRender
-    this.frames = options.frames ?? ['🐋', '🐳']
+    this.customFrames = options.frames
+    this.frames = [...(options.frames ?? workingFramesFor('emoji'))]
     this.intervalMs = options.intervalMs ?? 500
     this.message = options.message ?? 'Working...'
+  }
+
+  /** Replace the animation frames at runtime (an active indicator repaints
+   * with the new set immediately; the frame position is clamped). This is
+   * the generic setter — extension/advanced custom indicators can keep
+   * swapping frames through it. */
+  setFrames(frames: readonly string[]): void {
+    this.frames = [...frames]
+    if (this.currentFrame >= this.frames.length) this.currentFrame = 0
+    if (this.active) this.updateDisplay()
+  }
+
+  /** Follow an icon-style frame set ONLY when no explicit custom frames
+   * were provided — the user's iconStyle must never overwrite a
+   * third-party/explicit custom working indicator (plan §13.2). */
+  setIconStyleFrames(frames: readonly string[]): void {
+    if (this.customFrames !== undefined) return
+    this.setFrames(frames)
   }
 
   /** Override the label after the animated frame (Phase 4: the advanced

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -229,9 +229,11 @@ test('the busy-enter row Enter toggle persists the other behavior', async () => 
   const t = setup({ busyEnter: 'steer' })
   await t.run('')
   await t.view()
-  // Rows without a session: theme, expand, thinking, footer, busy-enter,
-  // fullscreen, separator, cwd — the busy-enter row is the 5th.
-  t.vt.sendInput('\x1b[B') // down × 4
+  // Rows without a session: theme, icon-style, expand, thinking, footer,
+  // busy-enter, fullscreen, separator, cwd — the busy-enter row is the
+  // 6th.
+  t.vt.sendInput('\x1b[B') // down × 5
+  t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')
@@ -254,6 +256,10 @@ test('the busy-enter row defaults to queue', async () => {
 test('/settings shows the local-shell-sandbox row with the persisted value', async () => {
   const t = setup({ localShellSandbox: 'sandbox' })
   await t.run('')
+  await t.view()
+  // The row sits below the initial fold (theme, icon-style, expand,
+  // thinking, footer, busy-enter, then sandbox).
+  for (let i = 0; i < 6; i += 1) t.vt.sendInput('\x1b[B')
   const view = await t.view()
   assert.ok(view.includes('Local shell sandbox'), `local-shell-sandbox row missing:\n${view}`)
   assert.ok(view.includes('sandbox'), `persisted value missing:\n${view}`)
@@ -263,6 +269,8 @@ test('/settings shows the local-shell-sandbox row with the persisted value', asy
 test('the local-shell-sandbox row defaults to bypass', async () => {
   const t = setup()
   await t.run('')
+  await t.view()
+  for (let i = 0; i < 6; i += 1) t.vt.sendInput('\x1b[B')
   const view = await t.view()
   assert.ok(view.includes('bypass'), `default bypass value missing:\n${view}`)
   t.app.stop()
@@ -272,10 +280,11 @@ test('the local-shell-sandbox row Enter toggle persists the other behavior', asy
   const t = setup({ localShellSandbox: 'bypass' })
   await t.run('')
   await t.view()
-  // Rows without a session: theme, expand, thinking, footer, busy-enter,
-  // local-shell-sandbox, fullscreen, separator, cwd — the sandbox row is
-  // the 6th.
-  t.vt.sendInput('\x1b[B') // down × 5
+  // Rows without a session: theme, icon-style, expand, thinking, footer,
+  // busy-enter, local-shell-sandbox, fullscreen, separator, cwd — the
+  // sandbox row is the 7th.
+  t.vt.sendInput('\x1b[B') // down × 6
+  t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -24,6 +24,7 @@ import {
   FocusActivityComponent,
   focusCollapsedBody,
   focusDisclosureIcon,
+  focusDisclosureSemantic,
   focusDurationText,
   focusStatusLabel,
   focusToolStatParts,
@@ -1263,6 +1264,23 @@ test('the whale icon encodes ONLY the disclosure state (plan §2/§39)', () => {
   assert.ok(!header.includes('◐') && !header.includes('▸') && !header.includes('▾') && !header.includes('⚠'), header)
 })
 
+test('the disclosure resolves per icon style and is NEVER hidden under minimal (plan §34.7)', () => {
+  // Semantic resolution is separate from the glyph.
+  assert.equal(focusDisclosureSemantic(false), 'disclosure-collapsed')
+  assert.equal(focusDisclosureSemantic(true), 'disclosure-expanded')
+  const failed = activityOf(0, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'error', error: { code: 'E', message: 'boom' } } }, 2000, 1),
+  ])!
+  assert.equal(formatFocusHeaderLine(failed, false, () => 3000, 120, 'emoji'), '🐋 Failed after 1s')
+  assert.equal(formatFocusHeaderLine(failed, true, () => 3000, 120, 'emoji'), '🐳 Failed after 1s')
+  assert.equal(formatFocusHeaderLine(failed, false, () => 3000, 120, 'symbols'), '▸ Failed after 1s')
+  assert.equal(formatFocusHeaderLine(failed, true, () => 3000, 120, 'symbols'), '▾ Failed after 1s')
+  // Minimal is an interaction affordance, never a decorative icon.
+  assert.equal(formatFocusHeaderLine(failed, false, () => 3000, 120, 'minimal'), '▸ Failed after 1s')
+  assert.equal(formatFocusHeaderLine(failed, true, () => 3000, 120, 'minimal'), '▾ Failed after 1s')
+})
+
 test('tool stats sort count-desc/name-asc, cap at 3 types, +N counts TYPES', () => {
   const tools = new Map<string, number>([['read', 7], ['search', 4], ['bash', 3], ['grep', 2]])
   const parts = focusToolStatParts(tools, 16)
@@ -1387,6 +1405,22 @@ test('the component renders an indented muted card and refreshes duration live',
   assert.ok(live.render(80)[0]!.includes('🐋 Thought 11s'))
   const later = new FocusActivityComponent({ activity: running, expanded: false, now: () => 14000 })
   assert.ok(later.render(80)[0]!.includes('🐋 Thought 13s'))
+})
+
+test('the symbols/minimal disclosure keeps every narrow width inside the terminal', () => {
+  const folder = new TranscriptFolder()
+  folder.apply(completedTurn(0, 0, 1000))
+  const activity = folder.turnActivity(0)!
+  for (const iconStyle of ['symbols', 'minimal'] as const) {
+    for (const width of [1, 2, 3, 4, 8]) {
+      for (const expanded of [false, true]) {
+        const component = new FocusActivityComponent({ activity, expanded, now: () => 35000, iconStyle })
+        for (const line of component.render(width)) {
+          assert.ok(visibleWidth(line) <= width, `row wider than ${width} cols under ${iconStyle} (${expanded ? 'expanded' : 'collapsed'}): ${JSON.stringify(line)}`)
+        }
+      }
+    }
+  }
 })
 
 test('the Tool display is presenter-first with a static fallback (plan §9/§43)', () => {

--- a/test/home-end-keys.test.ts
+++ b/test/home-end-keys.test.ts
@@ -320,10 +320,11 @@ test('/settings shows the Home/End keys row; an invalid persisted value falls ba
   const t = setupSettings({ homeEndKeys: 'garbage' })
   await t.run()
   await t.view()
-  // Rows without a session: theme, expand, thinking, footer, busy-enter,
-  // local-shell-sandbox, home-end-keys, fullscreen, separator, cwd — the
-  // home-end-keys row is the 7th, below the panel's visible fold.
-  for (let i = 0; i < 6; i += 1) t.vt.sendInput('\x1b[B')
+  // Rows without a session: theme, icon-style, expand, thinking, footer,
+  // busy-enter, local-shell-sandbox, home-end-keys, fullscreen,
+  // separator, cwd — the home-end-keys row is the 8th, below the panel's
+  // visible fold.
+  for (let i = 0; i < 7; i += 1) t.vt.sendInput('\x1b[B')
   const view = await t.view()
   assert.ok(view.includes('Home/End keys'), `row missing:\n${view}`)
   assert.ok(view.includes('viewport'), `an invalid persisted value must fall back to viewport:\n${view}`)
@@ -336,10 +337,10 @@ test('the Home/End keys row toggle applies the preset immediately and persists',
   const t = setupSettings({ homeEndKeys: 'viewport' })
   await t.run()
   await t.view()
-  // Rows without a session: theme, expand, thinking, footer, busy-enter,
-  // local-shell-sandbox, home-end-keys, fullscreen, separator, cwd — the
-  // home-end-keys row is the 7th.
-  for (let i = 0; i < 6; i += 1) t.vt.sendInput('\x1b[B')
+  // Rows without a session: theme, icon-style, expand, thinking, footer,
+  // busy-enter, local-shell-sandbox, home-end-keys, fullscreen, separator,
+  // cwd — the home-end-keys row is the 8th.
+  for (let i = 0; i < 7; i += 1) t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\r') // toggle viewport -> input
   await t.view()
   const resolved = getKeybindings().getResolvedBindings()

--- a/test/icon-style-settings.test.ts
+++ b/test/icon-style-settings.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Icon-style /settings tests (plan §17 + §34.8): the row lists all three
+ * styles, missing/invalid persisted values fall back to emoji, the toggle
+ * applies to the app IMMEDIATELY (no restart, no session reload) and
+ * persists a replace that preserves the other fields.
+ * @module @xmoon76/dsh-pi-tui/icon-style-settings.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { CommandId } from '@deepseek-ai/dsh-commands'
+import { Context } from '@deepseek-ai/cordis'
+import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from '../src/commands.ts'
+import type { TuiSettingsDoc } from '../src/runtime/config-port.ts'
+import { createDiag } from '../src/diag.ts'
+import { DraftImageStore } from '../src/image/draft-store.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { stripTerminalSequences } from '@xmoon76/pi-tui'
+import { VirtualTerminal } from './virtual-terminal.ts'
+import { DirectCatalogPort } from '../src/runtime/direct/catalog-direct.ts'
+import { DirectConfigPort } from '../src/runtime/direct/config-direct.ts'
+import { DirectHostFilePort } from '../src/runtime/direct/host-file-direct.ts'
+
+/** A fake TuiSettingsLike recording every replace (the TUI settings
+ * document surface; the writes array lets tests assert persistence). */
+function fakeSettings(doc: Record<string, unknown>) {
+  const writes: Array<Record<string, unknown>> = []
+  return {
+    writes,
+    value: {
+      get: () => ({ ...doc }) as unknown as TuiSettingsLike['get'] extends () => infer R ? R : never,
+      replace: (next: TuiSettingsDoc) => {
+        writes.push({ ...next })
+        Object.assign(doc, next)
+        return undefined as unknown
+      },
+    },
+  }
+}
+
+/** Register the TUI commands with a stubbed runner and return /settings. */
+function setupSettings(options: { iconStyle?: string } = {}) {
+  const ctx = new Context()
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const defs: { name: string; handler?: unknown }[] = []
+  ctx.provide('commands', {
+    register: (def: { name: string; handler?: unknown }): (() => void) => {
+      defs.push(def)
+      return () => {}
+    },
+    list: () => [],
+    find: () => undefined,
+    execute: async () => undefined,
+  } as never)
+  // The fake document starts from the FULL default shape (an old
+  // settings file may lack iconStyle — that case is tested separately).
+  const settings = fakeSettings({ theme: 'auto', iconStyle: options.iconStyle ?? 'emoji', footer: 'full', fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' })
+  const runner: TuiCommandRunner = {
+    ctx,
+    app,
+    diag: createDiag({ filePath: undefined, stderrLevel: 'off' }),
+    get liveAgent() { return undefined },
+    ensureSession: async () => {},
+    get selected() { return { current: undefined, assembled: undefined, saveSelection: async () => {} } },
+    tuiSettings: settings.value,
+    agents: {} as never,
+    sessionReader: {
+      list: async () => [],
+      search: async () => [],
+      titles: async () => new Map(),
+      measureContext: () => undefined,
+      readExportData: async () => ({ kind: 'none' }),
+    },
+    catalog: new DirectCatalogPort(ctx as never, () => undefined),
+    config: new DirectConfigPort(ctx as never, undefined, () => undefined),
+    commandRegistry: ctx.get('commands') as import('../src/commands.ts').CommandRegistryLike | undefined,
+    hostFile: new DirectHostFilePort(() => undefined),
+    interaction: {
+      registerQuestionProvider: () => true,
+      onApprovalRequest: () => {},
+      setApprovalPolicy: () => true,
+    },
+    sessionWriter: {
+      followup: () => {},
+      steer: () => {},
+      dequeue: () => {},
+      cancel: () => {},
+      rename: () => true,
+      refreshTitle: async () => ({ kind: 'ok' as const, title: undefined }),
+    },
+    cwd: '/ws',
+    sessionCwd: () => '/ws',
+    imageStore: new DraftImageStore(),
+    copyToClipboard: async () => true,
+    imageLimits: () => undefined,
+    insertIntoEditor: () => {},
+    prepareDraftMessage: async (text) => ({ role: 'user', id: `u:${text}`, content: [{ type: 'text', text }], source: { kind: 'user' } }) as never,
+    signal: new AbortController().signal,
+    get sessionGeneration() { return 0 },
+    switchSession: async () => undefined,
+    transitionTo: async <T>(steps: { target?: { id: string; header?: { cwd?: string } }; prepare?: () => Promise<void> | void; create: () => Promise<T> }) => {
+      await steps.prepare?.()
+      return { ok: true, next: await steps.create() }
+    },
+    currentPreset: () => undefined,
+    get pendingPreset() { return undefined },
+    set pendingPreset(_id: string | undefined) {},
+    get effectivePresetId() { return undefined },
+    refreshCatalog: async () => ({ kind: 'failed', error: 'not wired in tests' }),
+    recomposeBlank: async () => ({ kind: 'switched', preset: 'standard' }),
+    refreshStatus: () => {},
+    focusEnabled: () => false,
+    setFocusMode: () => {},
+    updateWelcomeCard: () => {},
+    openJobView: () => {},
+    openTasksBrowser: () => {},
+    openRewindPicker: () => {},
+    sessionTransitionPending: () => false,
+    withSessionTransition: async <T>(task: () => T | Promise<T>) => task(),
+    withSessionWriter: async <T>(_sessionId: string, task: () => T | Promise<T>) => task(),
+    enterView: async () => {},
+    requestExit: () => {},
+    extensions: undefined,
+    exit: () => {},
+  }
+  registerTuiCommands(runner)
+  const def = defs.find(entry => entry.name === 'settings')
+  assert.ok(def?.handler !== undefined, 'settings handler missing')
+  const run = async (): Promise<void> => {
+    await (def!.handler as (inv: { commandId: string; agent: never; rawInput: string; signal: AbortSignal }) => unknown)({
+      commandId: CommandId('cmd-icon-test'),
+      agent: undefined as never,
+      rawInput: '',
+      signal: new AbortController().signal,
+    })
+  }
+  const view = async (): Promise<string> => {
+    await vt.waitForRender()
+    return vt.getViewport().join('\n')
+  }
+  return { vt, app, settings, run, view }
+}
+
+test('/settings lists the Icon style row; missing and invalid persisted values fall back to emoji', async () => {
+  // Missing field (old settings file): the row reads emoji.
+  const t = setupSettings({})
+  await t.run()
+  await t.view()
+  // Rows without a session: theme, icon-style, expand, thinking, footer,
+  // busy-enter, local-shell-sandbox, home-end-keys, fullscreen — the
+  // icon-style row is the 2nd.
+  t.vt.sendInput('\x1b[B')
+  const view = await t.view()
+  assert.ok(view.includes('Icon style'), `row missing:\n${view}`)
+  // The selected row's VALUE sits on the label's line (the description
+  // below also names the styles, so assert on the row line specifically).
+  const row = stripTerminalSequences(view).split('\n').find(line => line.includes('Icon style'))
+  assert.ok(row !== undefined && row.includes('Icon style') && row.includes('emoji'),
+    `missing persisted value must fall back to emoji (row: ${row}):\n${view}`)
+  t.app.stop()
+
+  // An invalid persisted value never renders outside the values list.
+  const t2 = setupSettings({ iconStyle: 'garbage' })
+  await t2.run()
+  await t2.view()
+  t2.vt.sendInput('\x1b[B')
+  const view2 = await t2.view()
+  assert.ok(stripTerminalSequences(view2).split('\n').some(line => line.includes('Icon style') && line.includes('emoji')),
+    `invalid persisted value must fall back to emoji:\n${view2}`)
+  assert.ok(!view2.includes('garbage'), `the raw invalid value must never render:\n${view2}`)
+  t2.app.stop()
+
+  // A persisted minimal value renders as minimal.
+  const t3 = setupSettings({ iconStyle: 'minimal' })
+  await t3.run()
+  await t3.view()
+  t3.vt.sendInput('\x1b[B')
+  const view3 = await t3.view()
+  assert.ok(stripTerminalSequences(view3).split('\n').some(line => line.includes('Icon style') && line.includes('minimal')),
+    `persisted minimal must render on the row:\n${view3}`)
+  t3.app.stop()
+})
+
+test('the Icon style row toggle applies immediately and persists without dropping other fields', async () => {
+  const t = setupSettings({ iconStyle: 'emoji' })
+  await t.run()
+  await t.view()
+  t.vt.sendInput('\x1b[B') // move to the icon-style row
+  await t.view()
+  t.vt.sendInput('\r') // toggle emoji -> symbols
+  await t.view()
+  // The app runtime switched IMMEDIATELY (no restart, no reload).
+  assert.equal(t.app.currentIconStyle(), 'symbols', 'the app runtime must switch before persistence settles')
+  assert.ok(t.settings.writes.length >= 1, 'the toggle must persist a write')
+  const last = t.settings.writes[t.settings.writes.length - 1]
+  assert.equal(last?.iconStyle, 'symbols', `wrote: ${JSON.stringify(last)}`)
+  // A replace is wholesale: every other field rides along untouched.
+  assert.equal(last?.theme, 'auto')
+  assert.equal(last?.footer, 'full')
+  assert.equal(last?.fullscreen, 'on')
+  t.app.stop()
+})
+
+test('the toggle cycles through all three styles in one open panel', async () => {
+  const t = setupSettings({ iconStyle: 'emoji' })
+  await t.run()
+  await t.view()
+  t.vt.sendInput('\x1b[B') // icon-style row
+  await t.view()
+  t.vt.sendInput('\r') // -> symbols
+  await t.view()
+  assert.equal(t.app.currentIconStyle(), 'symbols')
+  t.vt.sendInput('\r') // -> minimal
+  await t.view()
+  assert.equal(t.app.currentIconStyle(), 'minimal', 'minimal must be reachable in the same panel')
+  t.vt.sendInput('\r') // -> emoji (wraps)
+  await t.view()
+  assert.equal(t.app.currentIconStyle(), 'emoji', 'the cycle wraps back to emoji')
+  t.app.stop()
+})

--- a/test/icon-style-settings.test.ts
+++ b/test/icon-style-settings.test.ts
@@ -54,9 +54,19 @@ function setupSettings(options: { iconStyle?: string } = {}) {
     find: () => undefined,
     execute: async () => undefined,
   } as never)
-  // The fake document starts from the FULL default shape (an old
-  // settings file may lack iconStyle — that case is tested separately).
-  const settings = fakeSettings({ theme: 'auto', iconStyle: options.iconStyle ?? 'emoji', footer: 'full', fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' })
+  // The fake document starts from the FULL default shape. When no
+  // iconStyle is passed, the field is OMITTED entirely — the exact shape
+  // of an old settings file written before the preference existed.
+  const settings = fakeSettings({
+    theme: 'auto',
+    footer: 'full',
+    fullscreen: 'on',
+    busyEnter: 'queue',
+    localShellSandbox: 'bypass',
+    homeEndKeys: 'viewport',
+    focusMode: 'off',
+    ...(options.iconStyle === undefined ? {} : { iconStyle: options.iconStyle }),
+  })
   const runner: TuiCommandRunner = {
     ctx,
     app,

--- a/test/icons.test.ts
+++ b/test/icons.test.ts
@@ -11,7 +11,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { visibleWidth } from '@xmoon76/pi-tui'
-import { ALL_ICON_SEMANTICS, iconFor, iconPrefix, iconStyleOf } from '../src/icons.ts'
+import { ALL_ICON_SEMANTICS, iconFor, iconLead, iconPrefix, iconStyleOf } from '../src/icons.ts'
 
 /** The ONLY semantics allowed to show a glyph under minimal (the plan §34
  * visibility set — guards against someone silently stuffing decorative
@@ -24,6 +24,11 @@ const MINIMAL_VISIBLE: ReadonlySet<string> = new Set([
   'disclosure-expanded',
   'working-a',
   'working-b',
+  // Structure anchors survive minimal: the message bullet, the attachment
+  // marker and the queued-notice hourglass (plan §34 addendum).
+  'assistant-bullet',
+  'image-marker',
+  'queue-notice',
 ])
 
 test('every symbols glyph measures exactly ONE terminal cell', () => {
@@ -57,6 +62,31 @@ test('iconPrefix never emits a dangling separator for hidden icons', () => {
   assert.equal(`${iconPrefix('error', 'minimal')}Error`, '×  Error')
 })
 
+test('iconLead composes SINGLE-space titles and never dangles under minimal', () => {
+  // Historical single-space titles stay byte-identical under emoji.
+  assert.equal(`${iconLead('thinking', 'emoji')}Thinking`, '🌊 Thinking')
+  assert.equal(`${iconLead('compaction', 'emoji')}Context compacted`, '🗜 Context compacted')
+  assert.equal(`${iconLead('queue-notice', 'emoji')}notice text`, '⏳ notice text')
+  // Symbols swaps the glyphs.
+  assert.equal(`${iconLead('thinking', 'symbols')}Thinking`, '∿ Thinking')
+  assert.equal(`${iconLead('compaction', 'symbols')}Context compacted`, '↧ Context compacted')
+  assert.equal(`${iconLead('queue-notice', 'symbols')}notice text`, '⧗ notice text')
+  // Minimal hides thinking/compaction with NO leading space...
+  assert.equal(`${iconLead('thinking', 'minimal')}Thinking`, 'Thinking')
+  assert.equal(`${iconLead('compaction', 'minimal')}Context compacted`, 'Context compacted')
+  // ...but keeps the queued-notice hourglass (a real waiting state).
+  assert.equal(`${iconLead('queue-notice', 'minimal')}notice text`, '⧗ notice text')
+  // The assistant bullet keeps its TWO-space prefix in every style (the
+  // continuation indent depends on it).
+  assert.equal(`${iconPrefix('assistant-bullet', 'emoji')}line`, '🐋  line')
+  assert.equal(`${iconPrefix('assistant-bullet', 'symbols')}line`, '•  line')
+  assert.equal(`${iconPrefix('assistant-bullet', 'minimal')}line`, '•  line')
+  // The attachment marker follows the style too.
+  assert.equal(`${iconPrefix('image-marker', 'emoji')}shot.png`, '🖼️  shot.png')
+  assert.equal(`${iconPrefix('image-marker', 'symbols')}shot.png`, '▧  shot.png')
+  assert.equal(`${iconPrefix('image-marker', 'minimal')}shot.png`, '▧  shot.png')
+})
+
 test('the emoji palette preserves the historical glyphs', () => {
   // The default style must be pixel-identical to the pre-feature UI: these
   // are the exact glyphs the old hard-coded maps returned.
@@ -84,6 +114,11 @@ test('the emoji palette preserves the historical glyphs', () => {
     'disclosure-expanded': '🐳',
     'working-a': '🐋',
     'working-b': '🐳',
+    'assistant-bullet': '🐋',
+    thinking: '🌊',
+    compaction: '🗜',
+    'image-marker': '🖼️',
+    'queue-notice': '⏳',
   }
   for (const semantic of ALL_ICON_SEMANTICS) {
     assert.equal(iconFor(semantic, 'emoji'), expected[semantic], `emoji glyph for ${semantic}`)
@@ -115,6 +150,11 @@ test('the symbols palette is the documented compact vocabulary', () => {
     'disclosure-expanded': '▾',
     'working-a': '•',
     'working-b': '◦',
+    'assistant-bullet': '•',
+    thinking: '∿',
+    compaction: '↧',
+    'image-marker': '▧',
+    'queue-notice': '⧗',
   }
   for (const semantic of ALL_ICON_SEMANTICS) {
     assert.equal(iconFor(semantic, 'symbols'), expected[semantic], `symbols glyph for ${semantic}`)

--- a/test/icons.test.ts
+++ b/test/icons.test.ts
@@ -57,13 +57,6 @@ test('iconPrefix never emits a dangling separator for hidden icons', () => {
   assert.equal(`${iconPrefix('error', 'minimal')}Error`, '×  Error')
 })
 
-test('every symbols glyph measures exactly ONE terminal cell', () => {
-  for (const semantic of ALL_ICON_SEMANTICS) {
-    const glyph = iconFor(semantic, 'symbols')
-    assert.equal(visibleWidth(glyph), 1, `symbols glyph for ${semantic} must be 1 cell (got ${JSON.stringify(glyph)})`)
-  }
-})
-
 test('the emoji palette preserves the historical glyphs', () => {
   // The default style must be pixel-identical to the pre-feature UI: these
   // are the exact glyphs the old hard-coded maps returned.

--- a/test/icons.test.ts
+++ b/test/icons.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Icon registry tests: the symbols palette MUST stay one terminal cell per
+ * glyph (the plan's width safety gate — a wider symbol would drift every
+ * layout that measures by visible width); the minimal palette hides every
+ * decorative icon and keeps only 1-cell state/interaction markers; the
+ * emoji palette preserves the historical glyphs exactly; and unknown/
+ * missing persisted values fail safe to emoji.
+ * @module @xmoon76/dsh-pi-tui/icons.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { visibleWidth } from '@xmoon76/pi-tui'
+import { ALL_ICON_SEMANTICS, iconFor, iconPrefix, iconStyleOf } from '../src/icons.ts'
+
+/** The ONLY semantics allowed to show a glyph under minimal (the plan §34
+ * visibility set — guards against someone silently stuffing decorative
+ * icons back into minimal). */
+const MINIMAL_VISIBLE: ReadonlySet<string> = new Set([
+  'error',
+  'interrupted',
+  'question',
+  'disclosure-collapsed',
+  'disclosure-expanded',
+  'working-a',
+  'working-b',
+])
+
+test('every symbols glyph measures exactly ONE terminal cell', () => {
+  for (const semantic of ALL_ICON_SEMANTICS) {
+    const glyph = iconFor(semantic, 'symbols')
+    assert.equal(visibleWidth(glyph), 1, `symbols glyph for ${semantic} must be 1 cell (got ${JSON.stringify(glyph)})`)
+  }
+})
+
+test('minimal hides every decorative icon and keeps 1-cell state markers', () => {
+  for (const semantic of ALL_ICON_SEMANTICS) {
+    const glyph = iconFor(semantic, 'minimal')
+    if (MINIMAL_VISIBLE.has(semantic)) {
+      assert.equal(visibleWidth(glyph), 1, `minimal marker for ${semantic} must be 1 cell (got ${JSON.stringify(glyph)})`)
+    } else {
+      assert.equal(glyph, '', `minimal must hide the decorative icon for ${semantic} (got ${JSON.stringify(glyph)})`)
+    }
+  }
+})
+
+test('iconPrefix never emits a dangling separator for hidden icons', () => {
+  // A hidden (minimal) icon contributes NOTHING — no leading space, no
+  // double space: `${iconPrefix(...)}Read` must equal `Read`.
+  assert.equal(`${iconPrefix('tool-read', 'minimal')}Read`, 'Read')
+  assert.equal(`${iconPrefix('context-file', 'minimal')}AGENTS.md`, 'AGENTS.md')
+  assert.equal(`${iconPrefix('slash-command', 'minimal')}/settings`, '/settings')
+  // Visible icons keep their historical two-space trail (byte-identical
+  // emoji default rendering).
+  assert.equal(`${iconPrefix('tool-read', 'emoji')}Read`, '📖  Read')
+  assert.equal(`${iconPrefix('tool-read', 'symbols')}Read`, '▤  Read')
+  assert.equal(`${iconPrefix('error', 'minimal')}Error`, '×  Error')
+})
+
+test('every symbols glyph measures exactly ONE terminal cell', () => {
+  for (const semantic of ALL_ICON_SEMANTICS) {
+    const glyph = iconFor(semantic, 'symbols')
+    assert.equal(visibleWidth(glyph), 1, `symbols glyph for ${semantic} must be 1 cell (got ${JSON.stringify(glyph)})`)
+  }
+})
+
+test('the emoji palette preserves the historical glyphs', () => {
+  // The default style must be pixel-identical to the pre-feature UI: these
+  // are the exact glyphs the old hard-coded maps returned.
+  const expected: Record<string, string> = {
+    'tool-read': '📖',
+    'tool-search': '🔍',
+    'tool-shell': '🖥️',
+    'tool-write': '📝',
+    'tool-edit': '✏️',
+    'tool-code': '⚙️',
+    'tool-generic': '🛠️',
+    subagent: '🤖',
+    workflow: '🧵',
+    error: '❌',
+    interrupted: '⏹️',
+    question: '❓',
+    'slash-command': '🎛️',
+    'context-file': '📄',
+    'context-skill': '📚',
+    'context-plugin': '📦',
+    'context-notice': '📌',
+    'context-recall': '🕘',
+    'context-generic': '📎',
+    'disclosure-collapsed': '🐋',
+    'disclosure-expanded': '🐳',
+    'working-a': '🐋',
+    'working-b': '🐳',
+  }
+  for (const semantic of ALL_ICON_SEMANTICS) {
+    assert.equal(iconFor(semantic, 'emoji'), expected[semantic], `emoji glyph for ${semantic}`)
+  }
+})
+
+test('the symbols palette is the documented compact vocabulary', () => {
+  const expected: Record<string, string> = {
+    'tool-read': '▤',
+    'tool-search': '⌕',
+    'tool-shell': '›',
+    'tool-write': '+',
+    'tool-edit': '~',
+    'tool-code': '◆',
+    'tool-generic': '•',
+    subagent: '◆',
+    workflow: '◇',
+    error: '×',
+    interrupted: '■',
+    question: '?',
+    'slash-command': '›',
+    'context-file': '▤',
+    'context-skill': '◆',
+    'context-plugin': '◇',
+    'context-notice': '!',
+    'context-recall': '↶',
+    'context-generic': '·',
+    'disclosure-collapsed': '▸',
+    'disclosure-expanded': '▾',
+    'working-a': '•',
+    'working-b': '◦',
+  }
+  for (const semantic of ALL_ICON_SEMANTICS) {
+    assert.equal(iconFor(semantic, 'symbols'), expected[semantic], `symbols glyph for ${semantic}`)
+  }
+})
+
+test('iconStyleOf normalizes every persisted value', () => {
+  // Missing field (old settings file): emoji.
+  assert.equal(iconStyleOf(undefined), 'emoji')
+  assert.equal(iconStyleOf(null), 'emoji')
+  assert.equal(iconStyleOf(''), 'emoji')
+  // Valid values pass through.
+  assert.equal(iconStyleOf('emoji'), 'emoji')
+  assert.equal(iconStyleOf('symbols'), 'symbols')
+  assert.equal(iconStyleOf('minimal'), 'minimal')
+  // Unknown/legacy values fail safe to emoji.
+  assert.equal(iconStyleOf('hello'), 'emoji')
+  assert.equal(iconStyleOf('1'), 'emoji')
+})

--- a/test/icons.test.ts
+++ b/test/icons.test.ts
@@ -11,6 +11,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { visibleWidth } from '@xmoon76/pi-tui'
+import { eastAsianWidthType } from 'get-east-asian-width'
 import { ALL_ICON_SEMANTICS, iconFor, iconLead, iconPrefix, iconStyleOf } from '../src/icons.ts'
 
 /** The ONLY semantics allowed to show a glyph under minimal (the plan §34
@@ -24,17 +25,41 @@ const MINIMAL_VISIBLE: ReadonlySet<string> = new Set([
   'disclosure-expanded',
   'working-a',
   'working-b',
-  // Structure anchors survive minimal: the message bullet, the attachment
-  // marker and the queued-notice hourglass (plan §34 addendum).
+  // Structure anchors survive minimal: the message bullet and the
+  // queued-notice hourglass (plan §34 addendum).
   'assistant-bullet',
-  'image-marker',
   'queue-notice',
 ])
 
-test('every symbols glyph measures exactly ONE terminal cell', () => {
+/** The EAW classes that are safe under CJK-width terminals: ambiguous
+ * (A) glyphs are REJECTED because VTE/WezTerm-style cjk-ambiguous-width
+ * handling may paint them two cells, which would drift truncation, table
+ * borders and the fullscreen hit-map. */
+const SAFE_EAW = new Set(['neutral', 'narrow', 'halfwidth'])
+
+function assertEawSafe(glyph: string, semantic: string, style: string): void {
+  for (const char of glyph) {
+    const cp = char.codePointAt(0)!
+    const type = eastAsianWidthType(cp)
+    assert.ok(SAFE_EAW.has(type),
+      `${style} glyph for ${semantic} (${JSON.stringify(char)} U+${cp.toString(16).toUpperCase()}) is EAW ${type} — ambiguous/wide glyphs drift on CJK terminals`)
+  }
+}
+
+test('every symbols glyph measures exactly ONE cell AND is EAW-safe', () => {
   for (const semantic of ALL_ICON_SEMANTICS) {
     const glyph = iconFor(semantic, 'symbols')
     assert.equal(visibleWidth(glyph), 1, `symbols glyph for ${semantic} must be 1 cell (got ${JSON.stringify(glyph)})`)
+    assertEawSafe(glyph, semantic, 'symbols')
+  }
+})
+
+test('every visible minimal marker is also EAW-safe', () => {
+  for (const semantic of ALL_ICON_SEMANTICS) {
+    const glyph = iconFor(semantic, 'minimal')
+    if (glyph === '') continue
+    assert.equal(visibleWidth(glyph), 1, `minimal marker for ${semantic} must be 1 cell (got ${JSON.stringify(glyph)})`)
+    assertEawSafe(glyph, semantic, 'minimal')
   }
 })
 
@@ -58,8 +83,8 @@ test('iconPrefix never emits a dangling separator for hidden icons', () => {
   // Visible icons keep their historical two-space trail (byte-identical
   // emoji default rendering).
   assert.equal(`${iconPrefix('tool-read', 'emoji')}Read`, '📖  Read')
-  assert.equal(`${iconPrefix('tool-read', 'symbols')}Read`, '▤  Read')
-  assert.equal(`${iconPrefix('error', 'minimal')}Error`, '×  Error')
+  assert.equal(`${iconPrefix('tool-read', 'symbols')}Read`, '≣  Read')
+  assert.equal(`${iconPrefix('error', 'minimal')}Error`, '⨯  Error')
 })
 
 test('iconLead composes SINGLE-space titles and never dangles under minimal', () => {
@@ -79,12 +104,8 @@ test('iconLead composes SINGLE-space titles and never dangles under minimal', ()
   // The assistant bullet keeps its TWO-space prefix in every style (the
   // continuation indent depends on it).
   assert.equal(`${iconPrefix('assistant-bullet', 'emoji')}line`, '🐋  line')
-  assert.equal(`${iconPrefix('assistant-bullet', 'symbols')}line`, '•  line')
-  assert.equal(`${iconPrefix('assistant-bullet', 'minimal')}line`, '•  line')
-  // The attachment marker follows the style too.
-  assert.equal(`${iconPrefix('image-marker', 'emoji')}shot.png`, '🖼️  shot.png')
-  assert.equal(`${iconPrefix('image-marker', 'symbols')}shot.png`, '▧  shot.png')
-  assert.equal(`${iconPrefix('image-marker', 'minimal')}shot.png`, '▧  shot.png')
+  assert.equal(`${iconPrefix('assistant-bullet', 'symbols')}line`, '∙  line')
+  assert.equal(`${iconPrefix('assistant-bullet', 'minimal')}line`, '∙  line')
 })
 
 test('the emoji palette preserves the historical glyphs', () => {
@@ -117,7 +138,6 @@ test('the emoji palette preserves the historical glyphs', () => {
     'assistant-bullet': '🐋',
     thinking: '🌊',
     compaction: '🗜',
-    'image-marker': '🖼️',
     'queue-notice': '⏳',
   }
   for (const semantic of ALL_ICON_SEMANTICS) {
@@ -127,33 +147,32 @@ test('the emoji palette preserves the historical glyphs', () => {
 
 test('the symbols palette is the documented compact vocabulary', () => {
   const expected: Record<string, string> = {
-    'tool-read': '▤',
+    'tool-read': '≣',
     'tool-search': '⌕',
     'tool-shell': '›',
     'tool-write': '+',
     'tool-edit': '~',
-    'tool-code': '◆',
-    'tool-generic': '•',
-    subagent: '◆',
-    workflow: '◇',
-    error: '×',
-    interrupted: '■',
+    'tool-code': '⊞',
+    'tool-generic': '∗',
+    subagent: '⋄',
+    workflow: '⇄',
+    error: '⨯',
+    interrupted: '∎',
     question: '?',
     'slash-command': '›',
-    'context-file': '▤',
-    'context-skill': '◆',
-    'context-plugin': '◇',
+    'context-file': '≣',
+    'context-skill': '⋈',
+    'context-plugin': '◻',
     'context-notice': '!',
     'context-recall': '↶',
-    'context-generic': '·',
+    'context-generic': '⋅',
     'disclosure-collapsed': '▸',
     'disclosure-expanded': '▾',
-    'working-a': '•',
+    'working-a': '∙',
     'working-b': '◦',
-    'assistant-bullet': '•',
+    'assistant-bullet': '∙',
     thinking: '∿',
     compaction: '↧',
-    'image-marker': '▧',
     'queue-notice': '⧗',
   }
   for (const semantic of ALL_ICON_SEMANTICS) {

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -462,7 +462,7 @@ function reloadSettings(theme: string, onGet?: (count: number) => void): TuiSett
     get: () => {
       reads += 1
       onGet?.(reads)
-      return { theme: currentTheme, footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }
+      return { theme: currentTheme, iconStyle: 'emoji', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }
     },
     replace: doc => { currentTheme = doc.theme },
   }

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -2100,23 +2100,27 @@ test('setIconStyleFrames never overwrites an explicit custom frame set', () => {
   indicator.dispose()
 })
 
-test('setFrames to an empty set clears the running interval (no stale tick, no modulo-zero)', async () => {
+test('setFrames to an empty set clears the running interval (no stale tick, no modulo-zero)', (t) => {
+  // Deterministic clock: the node:test mock timers drive the indicator's
+  // setInterval — no fixed real-time sleeps (the repo's timing rule).
+  t.mock.timers.enable({ apis: ['setInterval'] })
   const renders: string[] = []
   const capture = (): void => { renders.push(indicator.render(80).join('')) }
   const indicator = new WorkingIndicator(capture, { frames: ['🐋', '🐳'], intervalMs: 10 })
   indicator.start()
   const afterStart = renders.length
   // Shrink the ACTIVE indicator to zero frames: it repaints once with the
-  // new (empty) set, and the interval MUST be cleared — no ticks after.
+  // new (empty) set, and the interval MUST be cleared — tick() must not
+  // produce further renders (and never modulo-zeros the frame index).
   indicator.setFrames([])
   const afterSet = renders.length
   assert.ok(afterSet > afterStart, 'an active indicator must repaint with the new frame set')
-  await new Promise(resolve => setTimeout(resolve, 40))
+  t.mock.timers.tick(100)
   assert.equal(renders.length, afterSet, `the interval must be cleared for a zero-frame set:\n${renders.join('\n')}`)
-  // Growing back re-arms the animation.
-  indicator.setFrames(['🐋', '🐳'])
+  // Growing back re-arms the animation deterministically.
+  indicator.setFrames(['😊', '🙂'])
   const afterGrow = renders.length
-  await new Promise(resolve => setTimeout(resolve, 40))
+  t.mock.timers.tick(100)
   assert.ok(renders.length > afterGrow, 'the interval must re-arm when frames grow back')
   indicator.dispose()
 })

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -13,8 +13,8 @@ import {
 } from '../src/present.ts'
 import { color, currentPalette, darkColors, lightColors, setTheme } from '../src/theme.ts'
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent } from '../src/tui-app.ts'
-import { WorkingIndicator } from '../src/working.ts'
-import { Text, visibleWidth, type Terminal } from '@xmoon76/pi-tui'
+import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
+import { Text, visibleWidth, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 // CI/tooling environments export NO_COLOR, FORCE_COLOR=0 and CI=true, which
@@ -1925,12 +1925,12 @@ test('injected context rows show their emoji in the viewport', async () => {
     kind: 'system', turn: 0,
     text: '# AGENTS.md\nRead me first.',
     label: 'AGENTS.md',
-    emoji: '📄',
+    icon: 'context-file',
   }, {
     kind: 'system', turn: 0,
     text: 'catalog',
     label: 'skill-catalog',
-    emoji: '📚',
+    icon: 'context-skill',
   }])
   const view = await viewport(vt)
   assert.ok(view.includes('📄  Context injection AGENTS.md'), `instruction emoji missing:\n${view}`)
@@ -1944,6 +1944,159 @@ test('slash command cards carry a control-panel emoji', async () => {
   ])
   const view = await viewport(vt)
   assert.ok(view.includes('🎛️  compact [ok]'), `slash emoji missing:\n${view}`)
+})
+
+test('tool and context cards render the symbols palette', async (t) => {
+  const vt = new VirtualTerminal(100, 40)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { iconStyle: 'symbols' })
+  t.after(() => app.stop())
+  app.start()
+  app.setTranscript([
+    { kind: 'tool', turn: 0, name: 'read', args: JSON.stringify({ path: '/ws/src/foo.ts' }), result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'bash', args: JSON.stringify({ command: 'ls' }), result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'grep', args: '', result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'edit', args: '', result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'unknown-thing', args: '', result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'subagent', args: '', result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'workflow', args: '', result: '', status: 'ok' },
+    // The ERROR semantic belongs to the synthetic error card (the
+    // `error`-named tool); an ordinary tool that FAILED keeps its own
+    // variant icon — the status pill carries the failure.
+    { kind: 'tool', turn: 0, name: 'some-tool', args: '', result: 'boom', status: 'error' },
+    { kind: 'tool', turn: 0, name: 'error', args: '', result: '', status: 'error' },
+    { kind: 'tool', turn: 0, name: 'ask_user_question', args: '', result: '', status: 'error' },
+    { kind: 'tool', turn: 0, name: '/compact', args: '', result: 'executed', status: 'ok' },
+    { kind: 'system', turn: 0, text: '# AGENTS.md', label: 'AGENTS.md', icon: 'context-file' },
+  ])
+  const view = await viewport(vt)
+  assert.ok(view.includes('▤  Read /ws/src/foo.ts'), `symbols read icon missing:\n${view}`)
+  assert.ok(view.includes('›  Bash'), `symbols bash icon missing:\n${view}`)
+  assert.ok(view.includes('⌕  Search'), `symbols search icon missing:\n${view}`)
+  assert.ok(view.includes('~  Edit'), `symbols edit icon missing:\n${view}`)
+  assert.ok(view.includes('•  Tool call'), `symbols generic icon missing:\n${view}`)
+  assert.ok(view.includes('◆  Subagent'), `symbols subagent icon missing:\n${view}`)
+  assert.ok(view.includes('◇  Workflow'), `symbols workflow icon missing:\n${view}`)
+  assert.ok(view.includes('×  Error'), `symbols error icon missing:\n${view}`)
+  assert.ok(view.includes('?  Question'), `symbols question icon missing:\n${view}`)
+  assert.ok(view.includes('›  compact [ok]'), `symbols slash icon missing:\n${view}`)
+  assert.ok(view.includes('▤  Context injection AGENTS.md'), `symbols context icon missing:\n${view}`)
+})
+
+test('minimal hides decorative icons with no dangling whitespace', async (t) => {
+  const vt = new VirtualTerminal(100, 40)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { iconStyle: 'minimal' })
+  t.after(() => app.stop())
+  app.start()
+  app.setTranscript([
+    { kind: 'tool', turn: 0, name: 'read', args: JSON.stringify({ path: '/ws/src/foo.ts' }), result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'subagent', args: '', result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'workflow', args: '', result: '', status: 'ok' },
+    { kind: 'tool', turn: 0, name: 'some-tool', args: '', result: 'boom', status: 'error' },
+    { kind: 'tool', turn: 0, name: 'error', args: '', result: '', status: 'error' },
+    { kind: 'tool', turn: 0, name: '/compact', args: '', result: 'executed', status: 'ok' },
+    { kind: 'system', turn: 0, text: '# AGENTS.md', label: 'AGENTS.md', icon: 'context-file' },
+  ])
+  const view = await viewport(vt)
+  const lines = view.split('\n').map(stripTerminalSequences)
+  // Decorative icons are gone AND no leading space remains where the icon
+  // used to sit — the header starts directly with the title.
+  const read = lines.find(line => line.startsWith('Read /ws/src/foo.ts'))
+  assert.ok(read !== undefined, `minimal read header missing or space-prefixed:\n${view}`)
+  const subagent = lines.find(line => line.startsWith('Subagent'))
+  assert.ok(subagent !== undefined, `minimal subagent header missing or space-prefixed:\n${view}`)
+  const workflow = lines.find(line => line.startsWith('Workflow'))
+  assert.ok(workflow !== undefined, `minimal workflow header missing or space-prefixed:\n${view}`)
+  const slash = lines.find(line => line.startsWith('compact [ok]'))
+  assert.ok(slash !== undefined, `minimal slash header missing or space-prefixed:\n${view}`)
+  const context = lines.find(line => line.startsWith('Context injection AGENTS.md'))
+  assert.ok(context !== undefined, `minimal context row missing or space-prefixed:\n${view}`)
+  // No decorative glyphs survived anywhere.
+  assert.ok(!view.includes('📖') && !view.includes('▤') && !view.includes('🤖') && !view.includes('◆')
+    && !view.includes('🎛️') && !view.includes('›  '), `decorative icons leaked into minimal:\n${view}`)
+  // The important state markers survive — the synthetic error card keeps
+  // its `×` while an ordinary failed tool stays icon-free (the [error]
+  // pill carries it).
+  assert.ok(lines.some(line => line.startsWith('×  Error')), `minimal error marker missing:\n${view}`)
+  assert.ok(lines.some(line => line.startsWith('Tool call [error]')), `a failed ordinary tool must not gain a marker:\n${view}`)
+})
+
+test('the same folded messages repaint across emoji → symbols → minimal → emoji', async (t) => {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  t.after(() => app.stop())
+  app.start()
+  const messages = [
+    { kind: 'tool' as const, turn: 0, name: 'read', args: JSON.stringify({ path: '/ws/src/foo.ts' }), result: '', status: 'ok' as const },
+    { kind: 'system' as const, turn: 0, text: '# AGENTS.md', label: 'AGENTS.md', icon: 'context-file' as const },
+  ]
+  app.setTranscript(messages)
+  // Emoji (the default).
+  let view = await viewport(vt)
+  assert.ok(view.includes('📖  Read /ws/src/foo.ts'), `emoji read icon missing:\n${view}`)
+  assert.ok(view.includes('📄  Context injection AGENTS.md'), `emoji context icon missing:\n${view}`)
+  // Symbols: the SAME folded messages, no reload, no re-fold.
+  app.setIconStyle('symbols')
+  view = await viewport(vt)
+  assert.ok(view.includes('▤  Read /ws/src/foo.ts'), `symbols read icon missing after switch:\n${view}`)
+  assert.ok(view.includes('▤  Context injection AGENTS.md'), `symbols context icon missing after switch:\n${view}`)
+  // Minimal: icons disappear, no dangling whitespace.
+  app.setIconStyle('minimal')
+  view = await viewport(vt)
+  const lines = view.split('\n').map(stripTerminalSequences)
+  assert.ok(lines.some(line => line.startsWith('Read /ws/src/foo.ts')), `minimal read header missing:\n${view}`)
+  assert.ok(lines.some(line => line.startsWith('Context injection AGENTS.md')), `minimal context row missing:\n${view}`)
+  // Back to emoji: the fold state never baked a glyph, so the original
+  // palette returns exactly.
+  app.setIconStyle('emoji')
+  view = await viewport(vt)
+  assert.ok(view.includes('📖  Read /ws/src/foo.ts'), `emoji read icon missing after round-trip:\n${view}`)
+  assert.ok(view.includes('📄  Context injection AGENTS.md'), `emoji context icon missing after round-trip:\n${view}`)
+  app.stop()
+})
+
+test('working indicator frames follow the icon style; custom frames survive switches', async (t) => {
+  // The default frame pairs per style (emoji keeps the whale pair;
+  // symbols and minimal share the low-noise pair — minimal removes static
+  // icons, not animation semantics).
+  assert.deepEqual(workingFramesFor('emoji'), ['🐋', '🐳'])
+  assert.deepEqual(workingFramesFor('symbols'), ['•', '◦'])
+  assert.deepEqual(workingFramesFor('minimal'), ['•', '◦'])
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { workingIntervalMs: 20 })
+  t.after(() => app.stop())
+  app.start()
+  app.setWorking(true)
+  await vt.waitForRender()
+  const workingLine = (): string | undefined =>
+    vt.getViewport().join('\n').split('\n').find(line => line.includes('Working'))
+  // Default frames are the whale pair under emoji (either frame may be
+  // live at sample time — the 20ms interval cycles fast).
+  let line = workingLine()
+  assert.ok(line !== undefined && (line.includes('🐋') || line.includes('🐳')),
+    `emoji whale frame missing:\n${vt.getViewport().join('\n')}`)
+  // A runtime switch swaps the frames to the low-noise pair.
+  app.setIconStyle('symbols')
+  await vt.waitForRender()
+  line = workingLine()
+  assert.ok(line !== undefined && (line.includes('•') || line.includes('◦')), `symbols frame missing:\n${vt.getViewport().join('\n')}`)
+  assert.ok(!line.includes('🐋') && !line.includes('🐳'), `whale frames survived the switch:\n${line}`)
+  // Minimal shares the same animation pair.
+  app.setIconStyle('minimal')
+  await vt.waitForRender()
+  line = workingLine()
+  assert.ok(line !== undefined && (line.includes('•') || line.includes('◦')), `minimal frame missing:\n${line}`)
+  app.setWorking(false)
+  app.stop()
+})
+
+test('setIconStyleFrames never overwrites an explicit custom frame set', () => {
+  const renders: string[] = []
+  const capture = (): void => { renders.push(indicator.render(80).join('')) }
+  const indicator = new WorkingIndicator(capture, { frames: ['❄️'], intervalMs: 1000 })
+  indicator.setIconStyleFrames(['•', '◦'])
+  indicator.start()
+  assert.ok(renders[renders.length - 1]!.includes('❄️'), `custom frames must survive an icon-style switch:\n${renders.join('\n')}`)
+  indicator.dispose()
 })
 
 
@@ -2323,7 +2476,7 @@ test('injected skill rows fold with the instruction count and expand to the pars
   ].join('\n')
   // Folded (old turn): the row names the skill and the instruction count,
   // never a single envelope tag.
-  app.setTranscript([{ kind: 'system', turn: 99, text: envelope, label: 'review-fix-loop', emoji: '📚' }])
+  app.setTranscript([{ kind: 'system', turn: 99, text: envelope, label: 'review-fix-loop', icon: 'context-skill' }])
   let view = await viewport(vt)
   assert.ok(view.includes('Context injection review-fix-loop — 2 lines of instructions'), `skill count missing:\n${view}`)
   assert.ok(!view.includes('<skill_content'), `raw skill envelope leaked into the folded row:\n${view}`)
@@ -2331,7 +2484,7 @@ test('injected skill rows fold with the instruction count and expand to the pars
   // Expanded (Ctrl+O, recent turn): the instructions body renders, the
   // envelope stays out — the same no-XML rule as the skill tool card.
   app.setToolOutputExpanded(true)
-  app.setTranscript([{ kind: 'system', turn: 0, text: envelope, label: 'review-fix-loop', emoji: '📚' }])
+  app.setTranscript([{ kind: 'system', turn: 0, text: envelope, label: 'review-fix-loop', icon: 'context-skill' }])
   view = await viewport(vt)
   assert.ok(view.includes('Context injection review-fix-loop'), `labeled header missing:\n${view}`)
   assert.ok(view.includes('Follow these instructions.'), `instructions body missing:\n${view}`)
@@ -2341,7 +2494,7 @@ test('injected skill rows fold with the instruction count and expand to the pars
   assert.ok(!view.includes('<skill_resources'), `raw skill envelope leaked into the expanded row:\n${view}`)
   assert.ok(!view.includes('Base directory'), `resource chrome leaked into the expanded row:\n${view}`)
   // A malformed skill envelope in a system row renders the header only.
-  app.setTranscript([{ kind: 'system', turn: 0, text: '<skill_content name="">broken', label: 'x', emoji: '📚' }])
+  app.setTranscript([{ kind: 'system', turn: 0, text: '<skill_content name="">broken', label: 'x', icon: 'context-skill' }])
   view = await viewport(vt)
   assert.ok(view.includes('Context injection x'), `malformed header missing:\n${view}`)
   assert.ok(!view.includes('<skill'), `malformed skill envelope leaked:\n${view}`)
@@ -2362,7 +2515,7 @@ test('injected catalog and instruction rows strip their reminder framing when ex
     'If the user names a skill, call the `skill` tool.',
     '</system-reminder>',
   ].join('\n')
-  app.setTranscript([{ kind: 'system', turn: 0, text: catalog, label: 'skill-catalog', emoji: '📚' }])
+  app.setTranscript([{ kind: 'system', turn: 0, text: catalog, label: 'skill-catalog', icon: 'context-skill' }])
   let view = await viewport(vt)
   assert.ok(view.includes('Context injection skill-catalog'), `catalog header missing:\n${view}`)
   assert.ok(view.includes('- `glab`: GitLab helper'), `catalog entry missing:\n${view}`)
@@ -2378,7 +2531,7 @@ test('injected catalog and instruction rows strip their reminder framing when ex
     'Do the thing carefully.',
     '</system-reminder>',
   ].join('\n')
-  app.setTranscript([{ kind: 'system', turn: 0, text: instructions, label: 'AGENTS.md', emoji: '📄' }])
+  app.setTranscript([{ kind: 'system', turn: 0, text: instructions, label: 'AGENTS.md', icon: 'context-file' }])
   view = await viewport(vt)
   assert.ok(view.includes('Context injection AGENTS.md'), `instruction header missing:\n${view}`)
   assert.ok(view.includes('Do the thing carefully.'), `instruction body missing:\n${view}`)

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -15,6 +15,9 @@ import { color, currentPalette, darkColors, lightColors, setTheme } from '../src
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent } from '../src/tui-app.ts'
 import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
 import type { TurnActivity } from '../src/transcript.ts'
+import { TranscriptFolder } from '../src/transcript.ts'
+import { ImageLoader } from '../src/image/loader.ts'
+import type { ImageAttachmentRefLike } from '../src/image/admission.ts'
 import { Text, visibleWidth, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
@@ -3656,4 +3659,83 @@ test('a terminal resize re-bakes the folded rows at the new content width (never
   assert.ok(visibleWidth(lines[sysIdx]!) <= transcriptContentWidth(20),
     `the re-baked fold must fit the 18-col content width: ${JSON.stringify(lines[sysIdx])}`)
   app.stop()
+})
+
+test('assistant bullet, thinking and compaction follow the symbols palette', async (t) => {
+  const vt = new VirtualTerminal(100, 40)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { iconStyle: 'symbols' })
+  t.after(() => app.stop())
+  app.start()
+  app.setTranscript([
+    { kind: 'assistant', turn: 0, text: 'para one\n\npara two' },
+    { kind: 'thinking', turn: 0, text: 'reasoning preview line' },
+    { kind: 'compaction', turn: 0, text: 'summary', items: 3, tokens: 100 },
+  ])
+  const view = await viewport(vt)
+  assert.ok(view.includes('•  para one'), `symbols bullet missing:\n${view}`)
+  assert.ok(view.includes('∿ Thinking'), `symbols thinking title missing:\n${view}`)
+  assert.ok(view.includes('↧ Context compacted'), `symbols compaction title missing:\n${view}`)
+  // The header brand whale stays by design; the content-area glyphs must all be symbols.
+  assert.ok(!view.includes('🌊') && !view.includes('🗜') && !view.includes('🐋  para'), `emoji glyphs leaked into symbols:\n${view}`)
+})
+
+test('minimal keeps the bullet and notice hourglass; thinking/compaction titles go bare', async (t) => {
+  const vt = new VirtualTerminal(100, 40)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { iconStyle: 'minimal' })
+  t.after(() => app.stop())
+  app.start()
+  app.setTranscript([
+    { kind: 'assistant', turn: 0, text: 'para one' },
+    { kind: 'thinking', turn: 0, text: 'reasoning preview line' },
+    { kind: 'compaction', turn: 0, text: 'summary', items: 3, tokens: 2 },
+  ])
+  app.setQueueItems([{ id: 'j-1', text: 'job done: exit 0', mode: 'steer', notice: true }])
+  const view = await viewport(vt)
+  const lines = view.split('\n').map(stripTerminalSequences)
+  assert.ok(lines.some(line => line.startsWith('•  para one')), `the bullet must survive minimal:\n${view}`)
+  assert.ok(lines.some(line => line.startsWith('Thinking')), `thinking title must go bare (no leading space):\n${view}`)
+  assert.ok(lines.some(line => line.startsWith('Context compacted')), `compaction title must go bare:\n${view}`)
+  assert.ok(view.includes('⧗ job done: exit 0'), `the queue-notice hourglass must survive minimal:\n${view}`)
+})
+
+test('the image attachment marker follows the icon style in bubbles and info bars', async (t) => {
+  const ref: ImageAttachmentRefLike = {
+    attachmentId: 'att-img-1',
+    mediaType: 'image/png',
+    bytes: 4,
+    width: 800,
+    height: 600,
+    name: 'shot.png',
+  }
+  const mkApp = (iconStyle: 'symbols' | 'minimal'): { vt: VirtualTerminal; app: TuiApp } => {
+    const vt = new VirtualTerminal(100, 24)
+    const loader = new ImageLoader(async () => ({ ref: {}, data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) }))
+    const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+      iconStyle,
+      imageLoader: loader,
+      imageTheme: { fallbackColor: (text) => text },
+    })
+    t.after(() => app.stop())
+    app.start()
+    return { vt, app }
+  }
+  for (const style of ['symbols', 'minimal'] as const) {
+    const { vt, app } = mkApp(style)
+    const folder = new TranscriptFolder()
+    folder.apply([{
+      type: 'user/message', seq: 1, time: 1,
+      data: {
+        content: [
+          { type: 'text', text: 'check ' },
+          { type: 'image', attachment: ref },
+        ],
+        source: { kind: 'user' },
+      },
+    }] as never)
+    app.setTranscript(folder.messages())
+    const view = await viewport(vt)
+    assert.ok(view.includes('▧ shot.png · 800×600'), `${style} info-bar marker missing:\n${view}`)
+    assert.ok(view.includes('check ▧ shot.png'), `${style} bubble marker missing:\n${view}`)
+    assert.ok(!view.includes('🖼️'), `emoji marker leaked into ${style}:\n${view}`)
+  }
 })

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -15,9 +15,6 @@ import { color, currentPalette, darkColors, lightColors, setTheme } from '../src
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent } from '../src/tui-app.ts'
 import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
 import type { TurnActivity } from '../src/transcript.ts'
-import { TranscriptFolder } from '../src/transcript.ts'
-import { ImageLoader } from '../src/image/loader.ts'
-import type { ImageAttachmentRefLike } from '../src/image/admission.ts'
 import { Text, visibleWidth, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
@@ -1973,17 +1970,17 @@ test('tool and context cards render the symbols palette', async (t) => {
     { kind: 'system', turn: 0, text: '# AGENTS.md', label: 'AGENTS.md', icon: 'context-file' },
   ])
   const view = await viewport(vt)
-  assert.ok(view.includes('▤  Read /ws/src/foo.ts'), `symbols read icon missing:\n${view}`)
+  assert.ok(view.includes('≣  Read /ws/src/foo.ts'), `symbols read icon missing:\n${view}`)
   assert.ok(view.includes('›  Bash'), `symbols bash icon missing:\n${view}`)
   assert.ok(view.includes('⌕  Search'), `symbols search icon missing:\n${view}`)
   assert.ok(view.includes('~  Edit'), `symbols edit icon missing:\n${view}`)
-  assert.ok(view.includes('•  Tool call'), `symbols generic icon missing:\n${view}`)
-  assert.ok(view.includes('◆  Subagent'), `symbols subagent icon missing:\n${view}`)
-  assert.ok(view.includes('◇  Workflow'), `symbols workflow icon missing:\n${view}`)
-  assert.ok(view.includes('×  Error'), `symbols error icon missing:\n${view}`)
+  assert.ok(view.includes('∗  Tool call'), `symbols generic icon missing:\n${view}`)
+  assert.ok(view.includes('⋄  Subagent'), `symbols subagent icon missing:\n${view}`)
+  assert.ok(view.includes('⇄  Workflow'), `symbols workflow icon missing:\n${view}`)
+  assert.ok(view.includes('⨯  Error'), `symbols error icon missing:\n${view}`)
   assert.ok(view.includes('?  Question'), `symbols question icon missing:\n${view}`)
   assert.ok(view.includes('›  compact [ok]'), `symbols slash icon missing:\n${view}`)
-  assert.ok(view.includes('▤  Context injection AGENTS.md'), `symbols context icon missing:\n${view}`)
+  assert.ok(view.includes('≣  Context injection AGENTS.md'), `symbols context icon missing:\n${view}`)
 })
 
 test('minimal hides decorative icons with no dangling whitespace', async (t) => {
@@ -2015,12 +2012,12 @@ test('minimal hides decorative icons with no dangling whitespace', async (t) => 
   const context = lines.find(line => line.startsWith('Context injection AGENTS.md'))
   assert.ok(context !== undefined, `minimal context row missing or space-prefixed:\n${view}`)
   // No decorative glyphs survived anywhere.
-  assert.ok(!view.includes('📖') && !view.includes('▤') && !view.includes('🤖') && !view.includes('◆')
+  assert.ok(!view.includes('📖') && !view.includes('≣') && !view.includes('🤖') && !view.includes('⋄')
     && !view.includes('🎛️') && !view.includes('›  '), `decorative icons leaked into minimal:\n${view}`)
   // The important state markers survive — the synthetic error card keeps
   // its `×` while an ordinary failed tool stays icon-free (the [error]
   // pill carries it).
-  assert.ok(lines.some(line => line.startsWith('×  Error')), `minimal error marker missing:\n${view}`)
+  assert.ok(lines.some(line => line.startsWith('⨯  Error')), `minimal error marker missing:\n${view}`)
   assert.ok(lines.some(line => line.startsWith('Tool call [error]')), `a failed ordinary tool must not gain a marker:\n${view}`)
 })
 
@@ -2041,8 +2038,8 @@ test('the same folded messages repaint across emoji → symbols → minimal → 
   // Symbols: the SAME folded messages, no reload, no re-fold.
   app.setIconStyle('symbols')
   view = await viewport(vt)
-  assert.ok(view.includes('▤  Read /ws/src/foo.ts'), `symbols read icon missing after switch:\n${view}`)
-  assert.ok(view.includes('▤  Context injection AGENTS.md'), `symbols context icon missing after switch:\n${view}`)
+  assert.ok(view.includes('≣  Read /ws/src/foo.ts'), `symbols read icon missing after switch:\n${view}`)
+  assert.ok(view.includes('≣  Context injection AGENTS.md'), `symbols context icon missing after switch:\n${view}`)
   // Minimal: icons disappear, no dangling whitespace.
   app.setIconStyle('minimal')
   view = await viewport(vt)
@@ -2171,8 +2168,8 @@ test('fullscreen cards and the Focus disclosure repaint across an icon style swi
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('▾ Thought'), `symbols disclosure missing after fullscreen switch:\n${view}`)
-  assert.ok(view.includes('▤  Read /ws/src/foo.ts'), `symbols read icon missing after fullscreen switch:\n${view}`)
-  assert.ok(view.includes('▤  Context injection AGENTS.md'), `symbols context icon missing after fullscreen switch:\n${view}`)
+  assert.ok(view.includes('≣  Read /ws/src/foo.ts'), `symbols read icon missing after fullscreen switch:\n${view}`)
+  assert.ok(view.includes('≣  Context injection AGENTS.md'), `symbols context icon missing after fullscreen switch:\n${view}`)
   // Minimal: decorative icons vanish (no dangling space), the disclosure
   // affordance survives.
   app.setIconStyle('minimal')
@@ -3672,7 +3669,7 @@ test('assistant bullet, thinking and compaction follow the symbols palette', asy
     { kind: 'compaction', turn: 0, text: 'summary', items: 3, tokens: 100 },
   ])
   const view = await viewport(vt)
-  assert.ok(view.includes('•  para one'), `symbols bullet missing:\n${view}`)
+  assert.ok(view.includes('∙  para one'), `symbols bullet missing:\n${view}`)
   assert.ok(view.includes('∿ Thinking'), `symbols thinking title missing:\n${view}`)
   assert.ok(view.includes('↧ Context compacted'), `symbols compaction title missing:\n${view}`)
   // The header brand whale stays by design; the content-area glyphs must all be symbols.
@@ -3692,50 +3689,8 @@ test('minimal keeps the bullet and notice hourglass; thinking/compaction titles 
   app.setQueueItems([{ id: 'j-1', text: 'job done: exit 0', mode: 'steer', notice: true }])
   const view = await viewport(vt)
   const lines = view.split('\n').map(stripTerminalSequences)
-  assert.ok(lines.some(line => line.startsWith('•  para one')), `the bullet must survive minimal:\n${view}`)
+  assert.ok(lines.some(line => line.startsWith('∙  para one')), `the bullet must survive minimal:\n${view}`)
   assert.ok(lines.some(line => line.startsWith('Thinking')), `thinking title must go bare (no leading space):\n${view}`)
   assert.ok(lines.some(line => line.startsWith('Context compacted')), `compaction title must go bare:\n${view}`)
   assert.ok(view.includes('⧗ job done: exit 0'), `the queue-notice hourglass must survive minimal:\n${view}`)
-})
-
-test('the image attachment marker follows the icon style in bubbles and info bars', async (t) => {
-  const ref: ImageAttachmentRefLike = {
-    attachmentId: 'att-img-1',
-    mediaType: 'image/png',
-    bytes: 4,
-    width: 800,
-    height: 600,
-    name: 'shot.png',
-  }
-  const mkApp = (iconStyle: 'symbols' | 'minimal'): { vt: VirtualTerminal; app: TuiApp } => {
-    const vt = new VirtualTerminal(100, 24)
-    const loader = new ImageLoader(async () => ({ ref: {}, data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) }))
-    const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
-      iconStyle,
-      imageLoader: loader,
-      imageTheme: { fallbackColor: (text) => text },
-    })
-    t.after(() => app.stop())
-    app.start()
-    return { vt, app }
-  }
-  for (const style of ['symbols', 'minimal'] as const) {
-    const { vt, app } = mkApp(style)
-    const folder = new TranscriptFolder()
-    folder.apply([{
-      type: 'user/message', seq: 1, time: 1,
-      data: {
-        content: [
-          { type: 'text', text: 'check ' },
-          { type: 'image', attachment: ref },
-        ],
-        source: { kind: 'user' },
-      },
-    }] as never)
-    app.setTranscript(folder.messages())
-    const view = await viewport(vt)
-    assert.ok(view.includes('▧ shot.png · 800×600'), `${style} info-bar marker missing:\n${view}`)
-    assert.ok(view.includes('check ▧ shot.png'), `${style} bubble marker missing:\n${view}`)
-    assert.ok(!view.includes('🖼️'), `emoji marker leaked into ${style}:\n${view}`)
-  }
 })

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -12,6 +12,7 @@ import {
   foldedCallPreview, genericRawInputLines, parseReadEnvelopes, parseSkillEnvelope, resultTextLines, subagentModelDisplay, systemContextBody, toolPresenterFrom, webCardLines,
 } from '../src/present.ts'
 import { color, currentPalette, darkColors, lightColors, setTheme } from '../src/theme.ts'
+import { iconFor } from '../src/icons.ts'
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent } from '../src/tui-app.ts'
 import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
 import type { TurnActivity } from '../src/transcript.ts'
@@ -2056,12 +2057,15 @@ test('the same folded messages repaint across emoji → symbols → minimal → 
 })
 
 test('working indicator frames follow the icon style; custom frames survive switches', async (t) => {
-  // The default frame pairs per style (emoji keeps the whale pair;
-  // symbols and minimal share the low-noise pair — minimal removes static
-  // icons, not animation semantics).
-  assert.deepEqual(workingFramesFor('emoji'), ['🐋', '🐳'])
-  assert.deepEqual(workingFramesFor('symbols'), ['•', '◦'])
-  assert.deepEqual(workingFramesFor('minimal'), ['•', '◦'])
+  // The default frames DERIVE from the icon registry — a drift between
+  // workingFramesFor and the palette is impossible by construction (the
+  // registry's EAW-safe gate therefore also guards the running glyphs).
+  for (const style of ['emoji', 'symbols', 'minimal'] as const) {
+    assert.deepEqual(workingFramesFor(style), [
+      iconFor('working-a', style),
+      iconFor('working-b', style),
+    ], `frames for ${style}`)
+  }
   const vt = new VirtualTerminal(100, 24)
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { workingIntervalMs: 20 })
   t.after(() => app.stop())
@@ -2079,13 +2083,13 @@ test('working indicator frames follow the icon style; custom frames survive swit
   app.setIconStyle('symbols')
   await vt.waitForRender()
   line = workingLine()
-  assert.ok(line !== undefined && (line.includes('•') || line.includes('◦')), `symbols frame missing:\n${vt.getViewport().join('\n')}`)
+  assert.ok(line !== undefined && (line.includes('∙') || line.includes('◦')), `symbols frame missing:\n${vt.getViewport().join('\n')}`)
   assert.ok(!line.includes('🐋') && !line.includes('🐳'), `whale frames survived the switch:\n${line}`)
   // Minimal shares the same animation pair.
   app.setIconStyle('minimal')
   await vt.waitForRender()
   line = workingLine()
-  assert.ok(line !== undefined && (line.includes('•') || line.includes('◦')), `minimal frame missing:\n${line}`)
+  assert.ok(line !== undefined && (line.includes('∙') || line.includes('◦')), `minimal frame missing:\n${line}`)
   app.setWorking(false)
   app.stop()
 })

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -14,6 +14,7 @@ import {
 import { color, currentPalette, darkColors, lightColors, setTheme } from '../src/theme.ts'
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent } from '../src/tui-app.ts'
 import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
+import type { TurnActivity } from '../src/transcript.ts'
 import { Text, visibleWidth, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
@@ -2097,6 +2098,82 @@ test('setIconStyleFrames never overwrites an explicit custom frame set', () => {
   indicator.start()
   assert.ok(renders[renders.length - 1]!.includes('❄️'), `custom frames must survive an icon-style switch:\n${renders.join('\n')}`)
   indicator.dispose()
+})
+
+test('setFrames to an empty set clears the running interval (no stale tick, no modulo-zero)', async () => {
+  const renders: string[] = []
+  const capture = (): void => { renders.push(indicator.render(80).join('')) }
+  const indicator = new WorkingIndicator(capture, { frames: ['🐋', '🐳'], intervalMs: 10 })
+  indicator.start()
+  const afterStart = renders.length
+  // Shrink the ACTIVE indicator to zero frames: it repaints once with the
+  // new (empty) set, and the interval MUST be cleared — no ticks after.
+  indicator.setFrames([])
+  const afterSet = renders.length
+  assert.ok(afterSet > afterStart, 'an active indicator must repaint with the new frame set')
+  await new Promise(resolve => setTimeout(resolve, 40))
+  assert.equal(renders.length, afterSet, `the interval must be cleared for a zero-frame set:\n${renders.join('\n')}`)
+  // Growing back re-arms the animation.
+  indicator.setFrames(['🐋', '🐳'])
+  const afterGrow = renders.length
+  await new Promise(resolve => setTimeout(resolve, 40))
+  assert.ok(renders.length > afterGrow, 'the interval must re-arm when frames grow back')
+  indicator.dispose()
+})
+
+test('fullscreen cards and the Focus disclosure repaint across an icon style switch', async (t) => {
+  const vt = new VirtualTerminal(100, 40)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  t.after(() => app.stop())
+  app.start()
+  const activity: TurnActivity = {
+    turn: 0,
+    startedAt: 1000,
+    endedAt: 6000,
+    completed: true,
+    reason: { kind: 'completed' },
+    tools: new Map(),
+    toolCalls: 0,
+    assistantMessages: 0,
+    revision: 0,
+  }
+  app.setTranscript(
+    [
+      { kind: 'user', turn: 0, text: 'hello' },
+      { kind: 'tool', turn: 0, name: 'read', args: JSON.stringify({ path: '/ws/src/foo.ts' }), result: '', status: 'ok' },
+      { kind: 'system', turn: 0, text: '# AGENTS.md', label: 'AGENTS.md', icon: 'context-file' },
+    ],
+    new Map([[0, activity]]),
+  )
+  app.setFocusMode(true)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('🐋 Thought'), `emoji collapsed disclosure missing in fullscreen:\n${view}`)
+  // Open the Thought: the fullscreen secondaries default compact, so the
+  // tool/context headers are visible in the same frame.
+  app.toggleFocusTurn(0)
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('🐳 Thought'), `emoji expanded disclosure missing in fullscreen:\n${view}`)
+  assert.ok(view.includes('📖  Read /ws/src/foo.ts'), `emoji read icon missing in fullscreen:\n${view}`)
+  assert.ok(view.includes('📄  Context injection AGENTS.md'), `emoji context icon missing in fullscreen:\n${view}`)
+  // Symbols: the SAME fullscreen session repaints with the new palette —
+  // no stale frame, no reload.
+  app.setIconStyle('symbols')
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('▾ Thought'), `symbols disclosure missing after fullscreen switch:\n${view}`)
+  assert.ok(view.includes('▤  Read /ws/src/foo.ts'), `symbols read icon missing after fullscreen switch:\n${view}`)
+  assert.ok(view.includes('▤  Context injection AGENTS.md'), `symbols context icon missing after fullscreen switch:\n${view}`)
+  // Minimal: decorative icons vanish (no dangling space), the disclosure
+  // affordance survives.
+  app.setIconStyle('minimal')
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  const lines = view.split('\n').map(stripTerminalSequences)
+  assert.ok(lines.some(line => line.startsWith('Read /ws/src/foo.ts')), `minimal read header missing in fullscreen:\n${view}`)
+  assert.ok(view.includes('▾ Thought'), `minimal disclosure must survive in fullscreen:\n${view}`)
 })
 
 

--- a/test/session-state.test.ts
+++ b/test/session-state.test.ts
@@ -222,8 +222,8 @@ test('/settings working-directory row follows the live session cwd', async () =>
   ;(settingsDef!.handler as () => unknown)()
   await vt.waitForRender()
   // The working-directory row sits at the end of the scrolling list (the
-  // sandbox row joined the panel, so the list is one row longer).
-  for (let index = 0; index < 8; index += 1) vt.sendInput('\x1b[B')
+  // icon-style and sandbox rows joined the panel, so the list is longer).
+  for (let index = 0; index < 10; index += 1) vt.sendInput('\x1b[B')
   await vt.waitForRender()
   let view = vt.getViewport().join('\n')
   assert.ok(view.includes('/ws/alpha'), `session cwd row missing:\n${view}`)
@@ -233,7 +233,7 @@ test('/settings working-directory row follows the live session cwd', async () =>
   await vt.waitForRender()
   ;(settingsDef!.handler as () => unknown)()
   await vt.waitForRender()
-  for (let index = 0; index < 8; index += 1) vt.sendInput('\x1b[B')
+  for (let index = 0; index < 10; index += 1) vt.sendInput('\x1b[B')
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('/ws/beta'), `updated session cwd missing:\n${view}`)

--- a/test/thinking-disclosure.test.ts
+++ b/test/thinking-disclosure.test.ts
@@ -610,7 +610,9 @@ test('I1–I6: the /settings Thinking row is the SAME state as Alt+T (detail sem
   assert.ok(view.includes('Thinking detail'), `the row must render:\n${view}`)
   assert.ok(view.includes('collapsed'), `the default value must be collapsed:\n${view}`)
   // I2: the value list is exactly collapsed / expanded (cycle once).
-  // Select the row (rows without a session: theme, expand, thinking).
+  // Select the row (rows without a session: theme, icon-style, expand,
+  // thinking).
+  t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')
   t.vt.sendInput('\x1b[B')
   view = await t.view()

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -890,15 +890,19 @@ test('an unreadable injection source degrades to its kind as the label', () => {
   assert.equal(system.label, 'mystery-producer')
 })
 
-test('injected context rows carry a source-kind emoji', () => {
-  const cases: { source: Record<string, unknown>; emoji: string }[] = [
-    { source: { kind: 'agent-instructions', form: 'instructions', changes: [{ path: 'AGENTS.md' }] }, emoji: '📄' },
-    { source: { kind: 'skill-invocation', form: 'instructions', name: 'skill-catalog' }, emoji: '📚' },
-    { source: { kind: 'plugin', plugin: '@deepseek-ai/dsh-system-prompt' }, emoji: '📦' },
-    { source: { kind: 'plugin', plugin: 'todo', form: 'notice', summary: 'saved' }, emoji: '📌' },
+test('injected context rows carry a source-kind icon SEMANTIC (never a glyph)', () => {
+  // The fold must store the semantic identity, not the concrete emoji:
+  // an icon-style switch repaints already-folded cards (plan §11).
+  const cases: { source: Record<string, unknown>; icon: string }[] = [
+    { source: { kind: 'agent-instructions', form: 'instructions', changes: [{ path: 'AGENTS.md' }] }, icon: 'context-file' },
+    { source: { kind: 'skill-invocation', form: 'instructions', name: 'skill-catalog' }, icon: 'context-skill' },
+    { source: { kind: 'plugin', plugin: '@deepseek-ai/dsh-system-prompt' }, icon: 'context-plugin' },
+    { source: { kind: 'plugin', plugin: 'todo', form: 'notice', summary: 'saved' }, icon: 'context-notice' },
+    { source: { kind: 'session-reference', references: [{ label: 'yesterday' }] }, icon: 'context-recall' },
+    { source: { kind: 'mystery-producer' } as never, icon: 'context-generic' },
   ]
   const events: SessionEvent[] = cases.map((entry, index) => event('user/message', {
-    id: MessageId(`msg-emoji-${index}`),
+    id: MessageId(`msg-icon-${index}`),
     role: 'user',
     content: [{ type: 'text', text: 'body' }],
     source: entry.source as never,
@@ -906,7 +910,9 @@ test('injected context rows carry a source-kind emoji', () => {
   const messages = foldTranscript(events)
   messages.forEach((message, index) => {
     assert.ok(message !== undefined && message.kind === 'system')
-    assert.equal(message.emoji, cases[index]?.emoji, `emoji for injection ${index}`)
+    assert.equal(message.icon, cases[index]?.icon, `icon semantic for injection ${index}`)
+    // The fold NEVER stores a concrete glyph.
+    assert.equal('emoji' in (message as Record<string, unknown>), false, `folded system rows must not carry a glyph field:\n${JSON.stringify(message)}`)
   })
 })
 


### PR DESCRIPTION
## Summary

Adds a persistent `Icon style` setting (`/settings` → Icon style) with three palettes for **first-party structural icons only**:

- **Emoji** (default) — byte-identical to the previous UI.
- **Symbols** — a small, monochrome, terminal-safe vocabulary. Every glyph is verified by a **two-layer width gate**: `visibleWidth() === 1` **and** Unicode East Asian Width ∈ {neutral, narrow, halfwidth} — EAW-ambiguous glyphs are rejected (VTE/WezTerm `cjk-ambiguous-width` would paint them 2 cells and re-create the width drift this feature exists to prevent).
- **Minimal** — hides ordinary decorative icons, keeps only state/interaction markers (`⨯` error, `∎` interrupted, `?` question, `▸/▾` disclosure, `∙/◦` working, `∙` message bullet, `⧗` queued-notice hourglass).

All first-party structural icons converge on a semantic registry (`src/icons.ts`): tool/context/slash cards, Focus disclosure, working indicator frames, the assistant markdown bullet, thinking/compaction titles, and queue-pane notices. Fold state stores the icon **semantic**, never a glyph, so switching in `/settings` repaints already-rendered cards immediately — no restart, no session reload, no Host changes. Third-party extensions, user/assistant/tool content, the image attachment marker, the header brand whale and the welcome brand line are untouched (the image marker stays the constant `🖼️` fact — a string-level swap would rewrite user-typed `🖼️`).

## Key points

- `iconFor`/`iconPrefix` (two-space trail) / `iconLead` (single-space trail) — minimal never leaves dangling whitespace.
- WorkingIndicator frames follow the style; explicit custom frames are never overwritten (`setIconStyleFrames` guard).
- Message render cache and Focus activity cache embed `iconStyle` in their identity.
- `iconStyleOf()` fails unknown/missing persisted values safe to `emoji`.

## Verification

- `pnpm typecheck` ✅
- `pnpm test:bundle` — 2342/2342 ✅
- 3-round external review loop (holistic diff sweep) + PR review follow-ups: 6 findings fixed (working-timer lifecycle, missing-field settings test, fullscreen live-switch coverage, deterministic mock-timer test, user-`🖼️` rewrite bug, EAW-ambiguous palette).
- Plan: `temp/dsh-pi-tui-icon-style-symbols-implementation-plan.md` (incl. §34 Minimal supplement and §34.11b EAW-safety revision).