### PR TITLE
fix(sessions): load titles for every picker-visible main session

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -41,7 +41,6 @@ import { ModelSubmenu } from './model-menu.ts'
 import { computeStats, formatStats } from './stats.ts'
 import { renderTranscriptMarkdown, textOf } from './transcript.ts'
 import {
-  MAX_PICKER_SESSIONS,
   TITLE_BATCH_SIZE,
   TITLE_FIRST_BATCH,
   buildSessionTree,
@@ -118,18 +117,20 @@ function metaOf(cwd: string, presetId: string | undefined): Record<string, unkno
  * workspace (the sessionCwd the whole surface follows); `all` lists every
  * main session, grouped by its workspace. Exported so the scope contract
  * is unit-testable without a runner.
- * @param shown - the picker rows, newest first (already capped).
+ * @param rows - the picker rows, newest first (the FULL row set — a main
+ *   session beyond any read-window is still listed here, so the title
+ *   loader must cover every row this function can show).
  * @param currentCwd - the live session's workspace.
  * @param header - the picker header prefix (`sessions` / `resume`).
  * @param itemFor - the row → picker item mapper (titles + current marker).
  */
 export function sessionPickerCategories(
-  shown: readonly SessionPickerRow[],
+  rows: readonly SessionPickerRow[],
   currentCwd: string,
   header: string,
   itemFor: (row: SessionPickerRow, indent?: number) => SessionPickerItem,
 ): PickerCategory[] {
-  const mainRows = shown.filter(row => row.origin !== 'subagent')
+  const mainRows = rows.filter(row => row.origin !== 'subagent')
   return [
     {
       id: 'current',
@@ -1520,11 +1521,9 @@ export function registerTuiCommands(
     if (rows === undefined) return { kind: 'error', text: 'session persistence unavailable' }
     if (rows.length === 0) return { kind: 'error', text: 'no persisted sessions' }
     // The picker opens instantly on the headers; titles land in the
-    // background below. The cap keeps the TITLE read bounded — the category
-    // scopes below still see the FULL row set, so "All directories" really
-    // lists every main session (round-1 review finding: the old code capped
-    // the rows themselves at MAX_PICKER_SESSIONS).
-    const shown = rows.slice(0, MAX_PICKER_SESSIONS)
+    // background below. The category scopes see the FULL row set, so "All
+    // directories" really lists every main session (round-1 review finding:
+    // the old code capped the rows themselves at MAX_PICKER_SESSIONS).
     // Live title map: the background loader fills it, and the category
     // factories re-read it on every activation (Tab cycle, refresh).
     const titlesById = new Map<string, string>()
@@ -1567,6 +1566,14 @@ export function registerTuiCommands(
     // unchanged. Cancellations (TUI quit, the abort signal) are debug-level
     // through the unified entry; a real batch failure lands in diagnostics
     // instead of being swallowed.
+    //
+    // The batches cover MAIN rows only (the categories never show subagents)
+    // and the FULL main-row set — NOT the `shown` window: the category scopes
+    // see every main session (round-1 review finding), so a session beyond
+    // MAX_PICKER_SESSIONS that IS displayed (e.g. an old session in the
+    // "Current directory" scope) would otherwise never get a title read and
+    // would show a bare short id forever.
+    const mainRows = rows.filter(row => row.origin !== 'subagent')
     detach('session titles', async () => {
       const loadBatch = async (batch: SessionPickerRow[]): Promise<void> => {
         const titles = await runner.sessionReader.titles(batch, signal)
@@ -1574,9 +1581,9 @@ export function registerTuiCommands(
         for (const [id, title] of titles) titlesById.set(id, title)
         picker.refresh?.()
       }
-      await loadBatch(shown.slice(0, TITLE_FIRST_BATCH))
-      for (let offset = TITLE_FIRST_BATCH; offset < shown.length; offset += TITLE_BATCH_SIZE) {
-        await loadBatch(shown.slice(offset, offset + TITLE_BATCH_SIZE))
+      await loadBatch(mainRows.slice(0, TITLE_FIRST_BATCH))
+      for (let offset = TITLE_FIRST_BATCH; offset < mainRows.length; offset += TITLE_BATCH_SIZE) {
+        await loadBatch(mainRows.slice(offset, offset + TITLE_BATCH_SIZE))
       }
     })
     return { kind: 'success' }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1448,7 +1448,7 @@ export function apply(ctx: Context, config: Config): void {
     // the Direct session lifecycle can resolve preset compositions.
     const backend = createDirectBackend(
       new DirectSubagentPort(ctx),
-      new DirectSessionReader(ctx, (sessionId) => liveAgent?.session.id === sessionId ? liveAgent : undefined),
+      new DirectSessionReader(ctx, (sessionId) => liveAgent?.session.id === sessionId ? liveAgent : undefined, diag),
       new DirectSessionWriter(ctx, (sessionId) => liveAgent?.session.id === sessionId ? liveAgent as never : undefined),
       new DirectSessionLifecycle(ctx, (presetId) => compose(presetId)),
       new DirectInteractionPort(ctx, (sessionId) => liveAgent?.session.id === sessionId ? liveAgent : undefined),

--- a/src/runtime/direct/session-direct.ts
+++ b/src/runtime/direct/session-direct.ts
@@ -15,7 +15,7 @@
  */
 
 import { dshHome } from '../../diag.ts'
-import { loadSessionTitleBatch, type SessionPickerPersistence, type SessionQueryLike } from '../../sessions.ts'
+import { loadSessionTitleBatch, type SessionPickerPersistence, type SessionQueryLike, type TitleDiagLike } from '../../sessions.ts'
 import { safeErrorMessage } from '../../error-boundary.ts'
 import type { ExportReadResult, SessionSearchHit, SessionReader, SessionSummary } from '../session-reader-port.ts'
 
@@ -48,10 +48,16 @@ export interface LiveAgentLike {
 export class DirectSessionReader implements SessionReader {
   private readonly ctx: HostContextLike
   private readonly agentFor: (sessionId: string) => unknown | undefined
+  private readonly diag: TitleDiagLike | undefined
 
-  constructor(ctx: HostContextLike, agentFor?: (sessionId: string) => unknown | undefined) {
+  constructor(
+    ctx: HostContextLike,
+    agentFor?: (sessionId: string) => unknown | undefined,
+    diag?: TitleDiagLike,
+  ) {
     this.ctx = ctx
     this.agentFor = agentFor ?? (() => undefined)
+    this.diag = diag
   }
 
   private liveAgent(sessionId: string): LiveAgentLike | undefined {
@@ -124,7 +130,7 @@ export class DirectSessionReader implements SessionReader {
   titles(rows: readonly SessionSummary[], signal?: AbortSignal): Promise<Map<string, string>> {
     const query = this.ctx.get('sessionQuery') as SessionQueryLike | undefined
     const persistence = this.ctx.get('sessionPersistence') as SessionPersistenceLike | undefined
-    return loadSessionTitleBatch(query, persistence, dshHome(process.env), rows, signal)
+    return loadSessionTitleBatch(query, persistence, dshHome(process.env), rows, signal, this.diag)
   }
 
   measureContext(sessionId: string): number | undefined {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -11,9 +11,16 @@ import type { SessionEvent, SessionHeader } from '@deepseek-ai/dsh-session'
 import { foldSessionTitle } from '@deepseek-ai/dsh-session-title'
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, normalize } from 'node:path'
+import { safeErrorMessage } from './error-boundary.ts'
 
-/** How many most-recent sessions the picker shows at once (older rows still
- * appear, but only this many get background title reads). */
+/**
+ * Legacy exported window size: how many most-recent sessions the picker's
+ * FIRST title batch used to be capped to, historically. It no longer caps
+ * the title reads — the picker loads titles for every MAIN row it can
+ * display (see commands.ts `openSessionPicker`), so a session beyond this
+ * window still gets its title. Kept exported (and pinned by a test) as a
+ * documented legacy value; do not reintroduce it as a read cap.
+ */
 export const MAX_PICKER_SESSIONS = 200
 /** First-batch size for the progressive session-title loader: the visible
  * picker window fills immediately, then the remaining rows load behind it. */
@@ -47,6 +54,23 @@ export type SessionTitleObservationResultLike =
 /** The persistence surface the fallback title path needs. */
 export interface SessionPickerPersistence {
   inspect(id: SessionId, signal?: AbortSignal): Promise<{ events: readonly SessionEvent[] }>
+}
+
+/** The optional diagnostics sink the title loader reports rejected engine
+ * reads through (a structural subset of the runner's Diag channel — the
+ * pure helper never imports the runner). */
+export interface TitleDiagLike {
+  info(message: string, fields?: Record<string, unknown>): void
+}
+
+/** The engine's rejection `code` when the reason carries one (a
+ * `SessionQueryError`-shaped object), else `UNKNOWN`. */
+function errorCodeOf(reason: unknown): string {
+  if (typeof reason === 'object' && reason !== null) {
+    const code = (reason as { code?: unknown }).code
+    if (typeof code === 'string' && code !== '') return code
+  }
+  return 'UNKNOWN'
 }
 
 /** Strip the `session-` prefix and keep the first 8 characters, like the
@@ -230,13 +254,17 @@ export function headerToPickerRow(header: SessionHeader, live: boolean): Session
 /**
  * Load the latest titles for a batch of sessions, newest-first order
  * preserved. Prefers the session-query engine's batch observation (one
- * cancellable corpus read, failures isolated per session); falls back to
- * bounded sequential persistence inspections folded with `foldSessionTitle`
- * when the engine is absent. Never throws for per-session failures.
+ * cancellable corpus read, failures isolated per session — a rejected
+ * session's id lands an info diagnostic with the engine's code and
+ * reason, never a silent drop and never a behind-the-engine retry);
+ * falls back to bounded sequential persistence inspections folded with
+ * `foldSessionTitle` when the engine is absent. Never throws for
+ * per-session failures.
  * @param query - the mounted session-query engine, when present.
  * @param persistence - the persistence backend for the fallback path.
  * @param ids - session ids to title, in display order.
  * @param signal - optional cancellation for the whole batch.
+ * @param diag - optional diagnostics sink for rejected engine reads.
  * @returns title text by session id; absent ids simply have no entry.
  */
 export async function loadSessionTitles(
@@ -244,8 +272,9 @@ export async function loadSessionTitles(
   persistence: SessionPickerPersistence | undefined,
   ids: readonly string[],
   signal?: AbortSignal,
+  diag?: TitleDiagLike,
 ): Promise<Map<string, string>> {
-  return loadSessionTitleBatch(query, persistence, undefined, ids.map(id => ({ id })), signal)
+  return loadSessionTitleBatch(query, persistence, undefined, ids.map(id => ({ id })), signal, diag)
 }
 
 /**
@@ -257,12 +286,28 @@ export async function loadSessionTitles(
  * session whose log facts cannot be derived (unknown layout, absent file)
  * simply skips the cache and reads directly. `home === undefined` disables
  * the cache entirely (plain `loadSessionTitles` semantics).
+ *
+ * The engine batch isolates failures PER SESSION: a fulfilled result with
+ * a title is final, a fulfilled result WITHOUT a title means the session
+ * genuinely has none, and a REJECTED result is a real per-session read
+ * failure. Rejected reads are NEVER retried behind the engine's back and
+ * NEVER silently dropped: the engine's cold path already performs the
+ * same persistence inspection, so re-running it reproduces the identical
+ * failure for `SESSION_QUERY_PERSISTENCE_FAILED` / `CORRUPT_SESSION` and
+ * would BYPASS the engine's header-identity guard for
+ * `SESSION_QUERY_SOURCE_CONFLICT` (folding a title from a mismatched
+ * header). The engine-present path used to drop rejects silently, leaving
+ * the picker on a bare short id with no explanation; now every rejected
+ * read lands an info diagnostic carrying the engine's original code and
+ * reason, so the failure is visible in the default log file.
  * @param query - the mounted session-query engine, when present.
- * @param persistence - the persistence backend for the fallback path.
+ * @param persistence - the persistence backend for the fallback path
+ *   (used ONLY when no engine is mounted).
  * @param home - `$DSH_HOME` (cache root); undefined disables the cache.
  * @param rows - sessions to title (id + cwd for the log-path derivation),
  *   in display order.
  * @param signal - optional cancellation for the whole batch.
+ * @param diag - optional diagnostics sink for rejected engine reads.
  * @returns title text by session id; absent ids simply have no entry.
  */
 export async function loadSessionTitleBatch(
@@ -271,6 +316,7 @@ export async function loadSessionTitleBatch(
   home: string | undefined,
   rows: readonly { id: string; cwd?: string }[],
   signal?: AbortSignal,
+  diag?: TitleDiagLike,
 ): Promise<Map<string, string>> {
   const titles = new Map<string, string>()
   if (rows.length === 0) return titles
@@ -292,29 +338,27 @@ export async function loadSessionTitleBatch(
   if (toRead.length > 0) {
     if (query !== undefined) {
       const results = await query.readTitleSnapshots(toRead.map(row => SessionId(row.id)), signal)
+      // Cancellation propagates: the engine rethrows an aborted signal, but
+      // re-checking after the await keeps the contract explicit even for a
+      // non-conforming engine, and a cancelled batch must never emit
+      // diagnostics or touch persistence.
+      signal?.throwIfAborted()
       for (const result of results) {
-        if (result.status === 'fulfilled' && result.value.title !== undefined) {
-          found.set(result.sessionId, result.value.title.title)
+        if (result.status === 'fulfilled') {
+          if (result.value.title !== undefined) found.set(result.sessionId, result.value.title.title)
+          continue
         }
+        // A rejected engine read is a real per-session failure: expose the
+        // engine's code + reason at INFO level (visible in the default
+        // diagnostics log file). Never a fallback — see the doc comment.
+        diag?.info('session title unavailable', {
+          session: result.sessionId,
+          code: errorCodeOf(result.reason),
+          reason: safeErrorMessage(result.reason),
+        })
       }
     } else if (persistence !== undefined) {
-      // Fallback: sequential bounded inspections; one failing session must
-      // not starve the rest, so every worker catches per-session failures.
-      const queue = [...toRead]
-      const workers = Array.from({ length: 4 }, async () => {
-        for (;;) {
-          const row = queue.shift()
-          if (row === undefined) return
-          try {
-            const inspection = await persistence.inspect(SessionId(row.id), signal)
-            const title = foldSessionTitle(inspection.events)
-            if (title !== undefined) found.set(row.id, title.title)
-          } catch {
-            // Isolated failure: the row stays untitled.
-          }
-        }
-      })
-      await Promise.all(workers)
+      await inspectTitlesFromPersistence(persistence, toRead, found, signal)
     }
   }
   for (const [id, title] of found) titles.set(id, title)
@@ -332,6 +376,44 @@ export async function loadSessionTitleBatch(
     if (Object.keys(writes).length > 0) cache.write({ ...cached, ...writes })
   }
   return titles
+}
+
+/**
+ * Bounded fallback title reads for deployments WITHOUT a session-query
+ * engine: sequential 4-worker inspections; one failing session must not
+ * starve the rest, so every worker catches per-session failures.
+ * Cancellation propagates — the workers re-check the signal before every
+ * inspection, and each inspection receives it. (Engine-present batches
+ * NEVER reach this path: the engine already performs these same
+ * inspections behind its consistency guards.)
+ * @param persistence - the persistence backend to inspect.
+ * @param rows - the sessions to inspect (the whole batch, no engine).
+ * @param found - the shared title map, filled in place.
+ * @param signal - optional cancellation for the whole fallback.
+ */
+async function inspectTitlesFromPersistence(
+  persistence: SessionPickerPersistence | undefined,
+  rows: readonly { id: string; cwd?: string }[],
+  found: Map<string, string>,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (persistence === undefined) return
+  const queue = [...rows]
+  const workers = Array.from({ length: 4 }, async () => {
+    for (;;) {
+      signal?.throwIfAborted()
+      const row = queue.shift()
+      if (row === undefined) return
+      try {
+        const inspection = await persistence.inspect(SessionId(row.id), signal)
+        const title = foldSessionTitle(inspection.events)
+        if (title !== undefined) found.set(row.id, title.title)
+      } catch {
+        // Isolated failure: the row stays untitled.
+      }
+    }
+  })
+  await Promise.all(workers)
 }
 
 /** One title-cache entry: the title plus the log file facts it was read

--- a/test/session-picker-titles.test.ts
+++ b/test/session-picker-titles.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Orchestration regression for the session-title loader behind the
+ * /sessions and /resume picker: every MAIN row the picker can display must
+ * get a title read — including rows beyond any read window — while
+ * SUBAGENT rows (never shown in the human session picker) must not be read
+ * at all, and each main id must enter `sessionReader.titles()` exactly
+ * once across the progressive batches.
+ *
+ * The regression pins the actual bug shape: the category scopes consume
+ * the FULL row set, but the title loader used to walk only the first
+ * MAX_PICKER_SESSIONS rows, so a displayed session beyond that window
+ * (e.g. an old session in the "Current directory" scope) never got a
+ * title and showed a bare short id forever.
+ * @module @xmoon76/dsh-pi-tui/session-picker-titles.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { Context } from '@deepseek-ai/cordis'
+import { CommandId } from '@deepseek-ai/dsh-commands'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import { registerTuiCommands, type TuiCommandRunner } from '../src/commands.ts'
+import { createDiag } from '../src/diag.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { DraftImageStore } from '../src/image/draft-store.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+import { DirectCatalogPort } from '../src/runtime/direct/catalog-direct.ts'
+import { DirectConfigPort } from '../src/runtime/direct/config-direct.ts'
+import { DirectHostFilePort } from '../src/runtime/direct/host-file-direct.ts'
+
+/** Poll `predicate` until true or the timeout elapses. */
+async function waitUntil(predicate: () => boolean, timeoutMs = 3000, stepMs = 10): Promise<void> {
+  const start = Date.now()
+  for (;;) {
+    if (predicate()) return
+    if (Date.now() - start > timeoutMs) throw new Error(`waitUntil timed out after ${timeoutMs}ms`)
+    await new Promise<void>((resolve) => setTimeout(resolve, stepMs))
+  }
+}
+
+/** A session id with a deterministic createdAt so sort order is stable. */
+function row(id: string, createdAt: number): import('../src/sessions.ts').SessionPickerRow {
+  return { id, createdAt, cwd: '/ws/project-a', live: false }
+}
+
+test('the picker title loader covers EVERY main row beyond the legacy window, and never reads subagents', async (t) => {
+  const ctx = new Context()
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  // Clean up even when an assertion / waitUntil timeout aborts the test.
+  t.after(() => app.stop())
+
+  // 250 main rows + 5 subagent rows; newest-first by createdAt. The
+  // subagents would appear inside the first 200 rows, so a title loader
+  // that (wrongly) capped at MAX_PICKER_SESSIONS would read them AND skip
+  // main rows #201-#249.
+  const rows = [
+    { ...row('session-s000', 1_000_000 - 5), origin: 'subagent' as const },
+    ...Array.from({ length: 250 }, (_, i) => row(`session-m${String(i).padStart(3, '0')}`, 1_000_000 - 6 - i)),
+    { ...row('session-s001', 1_000_000 - 300), origin: 'subagent' as const },
+    { ...row('session-s002', 1_000_000 - 500), origin: 'subagent' as const },
+    { ...row('session-s003', 1_000_000 - 700), origin: 'subagent' as const },
+    { ...row('session-s004', 1_000_000 - 900), origin: 'subagent' as const },
+  ]
+
+  // Record every id handed to sessionReader.titles, across all batches.
+  // A Map counter (not a Set) so a duplicated id fails the exactly-once
+  // assertions below instead of being silently deduped.
+  const counts = new Map<string, number>()
+  const batchLog: number[] = []
+  const sessionReader = {
+    list: async () =>
+      [...rows]
+        .sort((a, b) => b.createdAt - a.createdAt)
+        .map(({ id, createdAt, cwd, origin }) => ({ id, createdAt, cwd, origin, live: false })),
+    search: async () => [],
+    titles: async (batch: readonly { id: string }[]) => {
+      batchLog.push(batch.length)
+      for (const { id } of batch) counts.set(id, (counts.get(id) ?? 0) + 1)
+      // Every requested id gets a title; the relevant assertion is WHICH
+      // ids were requested, not the map contents.
+      return new Map(batch.map(({ id }) => [id, `title-of-${id}`]))
+    },
+    measureContext: () => undefined,
+    readExportData: async () => ({ kind: 'none' }),
+  }
+
+  const defs: { name: string; handler?: unknown }[] = []
+  const commands = {
+    register: (def: { name: string; handler?: unknown }): (() => void) => {
+      defs.push(def)
+      return () => {
+        const i = defs.indexOf(def)
+        if (i !== -1) defs.splice(i, 1)
+      }
+    },
+    list: () => defs.map(({ name }) => ({ name, description: 'registered' })),
+    find: () => undefined,
+    execute: async () => undefined,
+  }
+  ctx.provide('commands', commands as never)
+
+  const state: { agent: Agent | undefined } = { agent: undefined }
+  const runner: TuiCommandRunner = {
+    ctx,
+    app,
+    diag: createDiag({ filePath: undefined, stderrLevel: 'off' }),
+    get liveAgent() { return state.agent },
+    ensureSession: async () => {},
+    get selected() { return { current: undefined, assembled: undefined, saveSelection: async () => {} } },
+    tuiSettings: undefined,
+    agents: {} as never,
+    sessionReader: sessionReader as never,
+    sessionWriter: {
+      followup: () => {},
+      steer: () => {},
+      dequeue: () => {},
+      cancel: () => {},
+      rename: () => true,
+      refreshTitle: async () => ({ kind: 'ok' as const, title: undefined }),
+    },
+    interaction: {
+      registerQuestionProvider: () => true,
+      onApprovalRequest: () => {},
+      setApprovalPolicy: () => true,
+    },
+    catalog: new DirectCatalogPort(ctx as never, () => undefined),
+    config: new DirectConfigPort(ctx as never, undefined, () => undefined),
+    commandRegistry: ctx.get('commands') as never,
+    hostFile: new DirectHostFilePort(() => undefined),
+    requestExit: () => {},
+    cwd: '/ws',
+    sessionCwd: () => '/ws',
+    imageStore: new DraftImageStore(),
+    copyToClipboard: async () => true,
+    imageLimits: () => undefined,
+    insertIntoEditor: () => {},
+    prepareDraftMessage: async (text) => ({ role: 'user', id: `u:${text}`, content: [{ type: 'text', text }], source: { kind: 'user' } }) as never,
+    signal: new AbortController().signal,
+    get sessionGeneration() { return 1 },
+    switchSession: async () => undefined,
+    transitionTo: async <T>(steps: { create: () => Promise<T> }) => ({ ok: true, next: await steps.create() }),
+    currentPreset: () => undefined,
+    pendingPreset: undefined,
+    effectivePresetId: undefined,
+    refreshCatalog: async () => ({ kind: 'failed', error: 'not wired in tests' }),
+    recomposeBlank: async () => ({ kind: 'locked' }),
+    refreshStatus: () => {},
+    focusEnabled: () => false,
+    setFocusMode: () => {},
+    updateWelcomeCard: () => {},
+    openJobView: () => {},
+    openTasksBrowser: () => {},
+    openRewindPicker: () => {},
+    sessionTransitionPending: () => false,
+    withSessionTransition: async <T>(task: () => T | Promise<T>) => task(),
+    withSessionWriter: async <T>(_sessionId: string, task: () => T | Promise<T>) => task(),
+    enterView: async () => {},
+    extensions: undefined,
+    exit: () => {},
+  }
+  registerTuiCommands(runner)
+
+  const def = defs.find(entry => entry.name === 'sessions')
+  assert.ok(def?.handler !== undefined, 'sessions handler missing')
+  await (def!.handler as (inv: { commandId: string; agent: never; rawInput: string; signal: AbortSignal }) => unknown)({
+    commandId: CommandId('cmd-test-1'),
+    agent: undefined as never,
+    rawInput: '',
+    signal: new AbortController().signal,
+  })
+
+  // The title loader runs detached; poll until every main row was handed
+  // to sessionReader.titles (the old impl would block at 200 and time out).
+  await waitUntil(() => counts.size >= 250)
+
+  // Every main row exactly once, across the progressive batches.
+  for (let i = 0; i < 250; i++) {
+    const id = `session-m${String(i).padStart(3, '0')}`
+    assert.equal(counts.get(id), 1, `main row ${id} must be read exactly once (old impl capped at 200)`)
+  }
+  assert.equal(counts.size, 250, 'only the 250 main rows may be read')
+  assert.equal(Array.from(counts.values()).reduce((a, b) => a + b, 0), 250, 'no main id may be read twice')
+  const subagentCounts = Array.from(counts.entries()).filter(([id]) => id.startsWith('session-s'))
+  assert.deepEqual(subagentCounts, [], 'subagent rows must never reach the title reader')
+  // Progressive batching: first batch ≤ TITLE_FIRST_BATCH, later batches ≤
+  // TITLE_BATCH_SIZE, and every batch is non-empty.
+  assert.ok(batchLog.length >= 5, `expected several batches, got ${batchLog.length}`)
+  assert.ok(batchLog[0]! <= 20, `first batch must be ≤ TITLE_FIRST_BATCH, got ${batchLog[0]}`)
+  for (const size of batchLog) assert.ok(size > 0 && size <= 50, `batch size ${size} out of range`)
+  assert.equal(batchLog.reduce((a, b) => a + b, 0), 250, 'the batch sizes must sum to exactly the 250 main rows')
+})

--- a/test/session-reader-port.test.ts
+++ b/test/session-reader-port.test.ts
@@ -10,6 +10,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { SessionId } from '@deepseek-ai/dsh-session'
 import { DirectSessionReader, type HostContextLike, type SessionPersistenceLike } from '../src/runtime/direct/session-direct.ts'
 import type { SessionQueryLike } from '../src/sessions.ts'
 
@@ -122,6 +123,61 @@ test('titles delegates to the title batch loader through the query engine', asyn
   }))
   const titles = await reader.titles([{ id: 'session-a', createdAt: 100, live: false }])
   assert.equal(titles.get('session-a'), 'title-of-session-a')
+})
+
+test('titles never consults persistence behind the engine, even for rejected reads', async () => {
+  // The engine's cold path already performs the same persistence
+  // inspection behind its consistency guards; a rejected read must NOT be
+  // retried by the adapter (port contract — the engine decides).
+  let inspected = 0
+  const reader = new DirectSessionReader(host({
+    sessionQuery: {
+      listSessions: async () => [],
+      readTitleSnapshots: async (ids: readonly SessionId[]) =>
+        ids.map(id => String(id) === 'session-broken'
+          ? { sessionId: String(id), status: 'rejected' as const, reason: new Error('engine boom') }
+          : { sessionId: String(id), status: 'fulfilled' as const, value: { title: { title: `title-of-${id}` } } }),
+    },
+    sessionPersistence: {
+      list: async () => [],
+      readRaw: async () => undefined,
+      inspect: async () => {
+        inspected += 1
+        return { events: [] }
+      },
+    },
+  }))
+  const titles = await reader.titles([
+    { id: 'session-ok', createdAt: 100, live: false },
+    { id: 'session-broken', createdAt: 90, live: false },
+  ])
+  assert.equal(titles.get('session-ok'), 'title-of-session-ok')
+  assert.equal(titles.has('session-broken'), false, 'a rejected read must leave the row untitled')
+  assert.equal(inspected, 0, 'persistence must never be consulted behind the engine')
+})
+
+test('titles reports rejected engine reads at INFO with the engine code and reason', async () => {
+  const diagnostics: Array<{ message: string; fields?: Record<string, unknown> }> = []
+  const reader = new DirectSessionReader(host({
+    sessionQuery: {
+      listSessions: async () => [],
+      readTitleSnapshots: async (ids: readonly SessionId[]) =>
+        ids.map(id => ({
+          sessionId: String(id),
+          status: 'rejected' as const,
+          reason: Object.assign(new Error('corrupt log'), { code: 'SESSION_QUERY_CORRUPT_SESSION' }),
+        })),
+    },
+    sessionPersistence: persistence([header('session-broken', 90)]),
+  }), undefined, {
+    info: (message: string, fields?: Record<string, unknown>) => diagnostics.push({ message, fields }),
+  })
+  const titles = await reader.titles([{ id: 'session-broken', createdAt: 90, live: false }])
+  assert.equal(titles.has('session-broken'), false)
+  assert.equal(diagnostics.length, 1, 'the rejection must land in diagnostics')
+  assert.equal(diagnostics[0]!.message, 'session title unavailable')
+  assert.equal(diagnostics[0]!.fields?.code, 'SESSION_QUERY_CORRUPT_SESSION', 'the engine code must be exposed')
+  assert.match(String(diagnostics[0]!.fields?.reason), /corrupt log/, 'the engine reason must be preserved')
 })
 
 test('readExportData preserves a REJECTED log read as an error with the diagnostic', async () => {

--- a/test/session-titles.test.ts
+++ b/test/session-titles.test.ts
@@ -13,6 +13,8 @@ import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
+// Carries the `session/title` event map augmentation into the test program.
+import type {} from '@deepseek-ai/dsh-session-title'
 import {
   TITLE_BATCH_SIZE,
   TITLE_FIRST_BATCH,
@@ -140,4 +142,144 @@ test('loadSessionTitleBatch honors an aborted signal through the engine path', a
     loadSessionTitleBatch(query as never, undefined, undefined, [{ id: 'session-a' }], controller.signal),
     /abort/i,
   )
+})
+
+// ── per-session failure isolation: rejected engine reads are NEVER
+//    silently dropped AND never retried behind the engine's back — the
+//    engine's cold path already runs the same persistence inspection, so
+//    a fallback would reproduce the identical failure (PERSISTENCE_FAILED
+//    / CORRUPT_SESSION) or bypass its header-identity guard
+//    (SOURCE_CONFLICT). The rejection is surfaced as an info diagnostic
+//    carrying the engine's code and reason instead. ──────────────────────
+
+/** A title event minimal enough for foldSessionTitle. */
+function titleEvent(title: string, seq = 1, time = 1000): SessionEvent<'session/title'> {
+  return {
+    type: 'session/title',
+    seq,
+    time,
+    data: { title, messageSeqs: [seq], source: { kind: 'user' } },
+  } as SessionEvent<'session/title'>
+}
+
+/** A query engine returning fulfilled titles except for the given ids. */
+function mixedQuery(rejectedIds: readonly string[]) {
+  return {
+    readTitleSnapshots: async (ids: readonly string[]) =>
+      ids.map(id => rejectedIds.includes(String(id))
+        ? { sessionId: String(id), status: 'rejected' as const, reason: new Error('engine boom') }
+        : { sessionId: String(id), status: 'fulfilled' as const, value: { session: {}, title: { title: 'alpha title' } } }),
+  }
+}
+
+/** A diag recorder asserting the info channel is used (default-visible). */
+function recordingDiag() {
+  const diagnostics: Array<{ message: string; fields?: Record<string, unknown> }> = []
+  return {
+    diagnostics,
+    diag: {
+      info: (message: string, fields?: Record<string, unknown>) => diagnostics.push({ message, fields }),
+    },
+  }
+}
+
+test('a rejected engine read stays untitled and never touches persistence', async () => {
+  let inspected = 0
+  const persistence = {
+    inspect: async () => {
+      inspected += 1
+      return { events: [titleEvent('beta title')] }
+    },
+  }
+  const { diagnostics, diag } = recordingDiag()
+  const titles = await loadSessionTitleBatch(
+    mixedQuery(['session-b']) as never,
+    persistence as never,
+    undefined,
+    [{ id: 'session-a' }, { id: 'session-b' }],
+    undefined,
+    diag,
+  )
+  assert.equal(titles.get('session-a'), 'alpha title')
+  assert.equal(titles.has('session-b'), false, 'a rejected read must leave the row untitled')
+  assert.equal(inspected, 0, 'persistence must never be consulted behind the engine')
+  assert.equal(diagnostics.length, 1, 'the rejection must land exactly one diagnostic')
+  assert.equal(diagnostics[0]!.message, 'session title unavailable')
+  assert.equal(diagnostics[0]!.fields?.session, 'session-b')
+  assert.equal(diagnostics[0]!.fields?.code, 'UNKNOWN', 'a plain Error reason carries no engine code')
+  assert.match(String(diagnostics[0]!.fields?.reason), /engine boom/, 'the real engine reason must be preserved')
+})
+
+test('a rejected read exposes the engine error code at info level', async () => {
+  const { diagnostics, diag } = recordingDiag()
+  const query = {
+    readTitleSnapshots: async (ids: readonly string[]) =>
+      ids.map(id => ({
+        sessionId: String(id),
+        status: 'rejected' as const,
+        reason: Object.assign(new Error('session source headers conflict'), { code: 'SESSION_QUERY_SOURCE_CONFLICT' }),
+      })),
+  }
+  await loadSessionTitleBatch(query as never, undefined, undefined, [{ id: 'session-a' }], undefined, diag)
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0]!.fields?.code, 'SESSION_QUERY_SOURCE_CONFLICT', 'the engine code must be exposed')
+  assert.match(String(diagnostics[0]!.fields?.reason), /headers conflict/)
+})
+
+test('only rejected reads produce diagnostics (fulfilled rows are silent)', async () => {
+  const { diagnostics, diag } = recordingDiag()
+  const query = {
+    readTitleSnapshots: async (ids: readonly string[]) =>
+      ids.map(id => String(id) === 'session-b'
+        ? { sessionId: String(id), status: 'rejected' as const, reason: new Error('boom') }
+        : String(id) === 'session-c'
+          ? { sessionId: String(id), status: 'fulfilled' as const, value: { session: {} } }
+          : { sessionId: String(id), status: 'fulfilled' as const, value: { session: {}, title: { title: 'alpha title' } } }),
+  }
+  const titles = await loadSessionTitleBatch(
+    query as never,
+    undefined,
+    undefined,
+    [{ id: 'session-a' }, { id: 'session-b' }, { id: 'session-c' }],
+    undefined,
+    diag,
+  )
+  assert.equal(titles.get('session-a'), 'alpha title')
+  assert.equal(titles.has('session-c'), false, 'a genuinely untitled session stays untitled')
+  assert.equal(diagnostics.length, 1, 'only the rejected session may be diagnosed')
+  assert.equal(diagnostics[0]!.fields?.session, 'session-b')
+})
+
+test('a fulfilled read without a title never falls back to persistence', async () => {
+  let inspected = 0
+  const persistence = {
+    inspect: async () => {
+      inspected += 1
+      return { events: [] }
+    },
+  }
+  const query = {
+    readTitleSnapshots: async (ids: readonly string[]) =>
+      ids.map(id => ({ sessionId: String(id), status: 'fulfilled' as const, value: { session: {} } })),
+  }
+  const titles = await loadSessionTitleBatch(query as never, persistence as never, undefined, [{ id: 'session-a' }])
+  assert.equal(titles.has('session-a'), false, 'a genuinely untitled session stays untitled')
+  assert.equal(inspected, 0, 'fulfilled-without-title must not trigger the fallback')
+})
+
+test('an aborted signal never starts the persistence fallback', async () => {
+  const controller = new AbortController()
+  controller.abort()
+  let inspected = 0
+  const persistence = {
+    inspect: async () => {
+      inspected += 1
+      return { events: [] }
+    },
+  }
+  await assert.rejects(
+    loadSessionTitleBatch(mixedQuery(['session-a']) as never, persistence as never, undefined, [{ id: 'session-a' }], controller.signal),
+    /abort/i,
+  )
+  assert.equal(inspected, 0, 'the fallback must never start on an aborted signal')
 })

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -186,8 +186,11 @@ test('loadSessionTitles honors an aborted signal', async () => {
   )
 })
 
-test('MAX_PICKER_SESSIONS keeps the title batch bounded', () => {
-  assert.ok(Number.isInteger(MAX_PICKER_SESSIONS) && MAX_PICKER_SESSIONS > 0)
+test('MAX_PICKER_SESSIONS keeps its legacy exported value', () => {
+  // The constant no longer caps the title reads (the picker loads titles
+  // for every main row it can display), but it stays exported and pinned
+  // as a documented legacy value.
+  assert.equal(MAX_PICKER_SESSIONS, 200)
 })
 
 // ── headless picker behavior through the virtual terminal ────────────────


### PR DESCRIPTION
## Problem

The `/sessions` / `/resume` picker showed a **bare 8-char short id forever** for a batch of older sessions (screenshot's 14h–22h rows), while newer rows in the same view displayed titles. The DSH engine was never the problem — a read-only repro with the **real** `JsonlSessionPersistence` + real `SqliteSessionQueryEngine` + real `~/.dsh` data read a title for every one of those sessions.

## Root cause (reproduced live in tmux with a probe)

The category scopes consume the **FULL** row set — `sessionPickerCategories(rows, ...)` — so "Current directory" and "All directories" list every main session (a deliberate round-1 review outcome). But the progressive title loader only walked `shown = rows.slice(0, MAX_PICKER_SESSIONS)` (the first 200):

```ts
const shown = rows.slice(0, MAX_PICKER_SESSIONS)   // 200
...
await loadBatch(shown.slice(0, TITLE_FIRST_BATCH)) // walks only `shown`
for (let offset = TITLE_FIRST_BATCH; offset < shown.length; ...)
```

A main session **beyond that window that IS displayed** (e.g. an older session in the current-workspace scope, exactly the screenshot's 14h–22h rows) never got a title read → showed its short id forever.

## Fix

- The title loader now batches the **FULL main-row set** (`rows.filter(origin !== 'subagent')` — subagents never appear in the human picker), so every displayed main session gets its title, in the same progressive chunks (first 20, then 50s) as before.
- `MAX_PICKER_SESSIONS` stays exported as a **documented legacy value** (pinned by a test) but no longer caps the reads — its comment, the `sessionPickerCategories` JSDoc (`@param rows`, no longer "already capped"), and the old "keeps the title batch bounded" test semantics were all updated so the cap is not reintroduced by accident.

## Secondary hardening (kept — NOT the incident root cause)

While investigating, a real gap was fixed too: a REJECTED per-session engine read (`SessionQueryError` with a code — `PERSISTENCE_FAILED` / `CORRUPT_SESSION` / `SOURCE_CONFLICT` / …) was silently swallowed, so the picker showed a short id with **no explanation**. Now every rejected read lands an **info diagnostic** (`session title unavailable`) carrying the engine's code and original reason — visible in the default diagnostics log (`$DSH_HOME/logs/pi-tui-*.log`). Rejected reads are deliberately NOT retried behind the engine's back: the engine's cold path already runs the same persistence inspection, so a fallback would reproduce the identical failure or bypass its header-identity guard.

## Verification

- **New orchestration regression** (`test/session-picker-titles.test.ts`): builds 250 main rows + 5 subagent rows and asserts every main row — including #201–#249 beyond the legacy window — enters `sessionReader.titles()` exactly once while subagents never do. Verified it **fails on the old capped loader** (timeout) and passes on the fix.
- tmux real-TUI acceptance on `dsh --profile pi-tui-wt` (this worktree): the screenshot's old sessions now display their real titles; stderr clean.
- Full bundle suite **2350/2350** pass, `tsc --noEmit` clean, client-boundary gate + naming gate + `git diff --check` pass, pre-push gate (typecheck) pass.