### PR TITLE
feat(footer): add meaningful builtin item styles

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -48,9 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   items gain useful variants: model and permission badges can be plain or
   compact, directories can be short/basename/full, context can be a bar,
   percent or full value, token usage can be input/output, total or compact,
-  performance can show full timing, speed or latency, and turn/step counters
-  can show both or either counter. Cache-hit compact output now differs from
-  full output, and omitted formats keep every legacy default unchanged.
+  performance can show full timing, speed or average time-to-first-token
+  latency, and turn/step counters can show both or either counter. Cache-hit
+  compact output now differs from full output, and omitted formats keep every
+  legacy default unchanged.
 - **Plugin theme selections are now SOURCE-QUALIFIED (`plugin:<owner>/<id>`).**
   Previously a plugin theme and a local custom theme file shared one bare
   name namespace: `Foo.json` and a plugin's `name: "Foo"` produced two

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enforces the persisted-layout parser's 32-items-per-row cap — the
   picker shows an explicit notice when the row is full instead of
   letting a 33rd item make every future save fail to parse.
+- **Builtin footer items now expose meaningful finite styles.** Existing
+  `format` references remain the only persisted style field, while common
+  items gain useful variants: model and permission badges can be plain or
+  compact, directories can be short/basename/full, context can be a bar,
+  percent or full value, token usage can be input/output, total or compact,
+  performance can show full timing, speed or latency, and turn/step counters
+  can show both or either counter. Cache-hit compact output now differs from
+  full output, and omitted formats keep every legacy default unchanged.
 - **Plugin theme selections are now SOURCE-QUALIFIED (`plugin:<owner>/<id>`).**
   Previously a plugin theme and a local custom theme file shared one bare
   name namespace: `Foo.json` and a plugin's `name: "Foo"` produced two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@
   扩展条目能力、默认布局输出与无迁移契约均不变。Add 路径同时执行
   持久化解析的每行 32 条上限——满行时 picker 显示明确提示,拒绝第
   33 条而不是让之后的保存永远失败。
+- **内置 Footer 条目现在提供有意义的有限 Style。** 持久化仍只使用既有的
+  `format` 字段,常用条目新增了可区分的变体:Model 与 Permission preset
+  支持 badge/plain/compact,Working directory 支持 short/basename/full,
+  Context 支持 bar/percent/full,Token usage 支持 io/total/compact,
+  Performance 支持 full/speed/latency,Turns/steps 支持 both 或单独计数器。
+  Cache hit 的 compact 输出也不再与 full 相同;省略 format 时所有旧默认输出
+  保持不变。
 - **插件主题的选择身份改为 SOURCE-QUALIFIED(`plugin:<owner>/<id>`)。**
   之前插件主题与本地自定义主题文件共享同一个裸名字空间:`Foo.json` 与
   插件注册的 `name: "Foo"` 会在 picker 里出现两个完全相同的值,真正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   `format` 字段,常用条目新增了可区分的变体:Model 与 Permission preset
   支持 badge/plain/compact,Working directory 支持 short/basename/full,
   Context 支持 bar/percent/full,Token usage 支持 io/total/compact,
-  Performance 支持 full/speed/latency,Turns/steps 支持 both 或单独计数器。
+  Performance 支持 full/speed/平均首 token latency,Turns/steps 支持 both 或单独计数器。
   Cache hit 的 compact 输出也不再与 full 相同;省略 format 时所有旧默认输出
   保持不变。
 - **插件主题的选择身份改为 SOURCE-QUALIFIED(`plugin:<owner>/<id>`)。**

--- a/README.en.md
+++ b/README.en.md
@@ -234,9 +234,9 @@ second style schema): Model `badge` / `plain` / `compact`; Permission preset
 `badge` / `plain` / `compact`; Plan state `badge` / `plain`; Working directory
 `short` / `basename` / `full`; Git branch `plain` / `label`; Context `bar` /
 `percent` / `full`; Token usage `io` / `total` / `compact`; Cache hit `full` /
-`compact`; Performance `full` / `speed` / `latency`; Turns/steps `both` /
-`turns` / `steps`; Version keeps `tui` / `dsh` / `both`. Omitting `format`
-continues to use each item's legacy default.
+`compact`; Performance `full` / `speed` / `latency` measures average time
+to first token; Turns/steps `both` / `turns` / `steps`; Version keeps `tui` / `dsh` /
+`both`. Omitting `format` continues to use each item's legacy default.
 
 Builtin item ids: `agent-preset`, `model`, `reasoning`,
 `permission-preset`, `sandbox-mode`, `approval-policy`, `plan-state`,

--- a/README.en.md
+++ b/README.en.md
@@ -219,7 +219,7 @@ footerLayout:
         - id: token-usage
           format: io
         - id: performance
-          format: compact
+          format: speed
         - id: version
           format: tui
       right:
@@ -228,6 +228,15 @@ footerLayout:
         text: " │ "
         tone: textDim
 ```
+
+Builtin format choices are finite and use the existing `format` field (no
+second style schema): Model `badge` / `plain` / `compact`; Permission preset
+`badge` / `plain` / `compact`; Plan state `badge` / `plain`; Working directory
+`short` / `basename` / `full`; Git branch `plain` / `label`; Context `bar` /
+`percent` / `full`; Token usage `io` / `total` / `compact`; Cache hit `full` /
+`compact`; Performance `full` / `speed` / `latency`; Turns/steps `both` /
+`turns` / `steps`; Version keeps `tui` / `dsh` / `both`. Omitting `format`
+continues to use each item's legacy default.
 
 Builtin item ids: `agent-preset`, `model`, `reasoning`,
 `permission-preset`, `sandbox-mode`, `approval-policy`, `plan-state`,

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ footerLayout:
         - id: token-usage
           format: io
         - id: performance
-          format: compact
+          format: speed
         - id: version
           format: tui
       right:
@@ -221,6 +221,15 @@ footerLayout:
         text: " │ "
         tone: textDim
 ```
+
+内置 format 是有限集合,继续使用现有的 `format` 字段(不新增第二套
+style schema):Model 为 `badge` / `plain` / `compact`;Permission preset
+为 `badge` / `plain` / `compact`;Plan state 为 `badge` / `plain`;Working
+directory 为 `short` / `basename` / `full`;Git branch 为 `plain` / `label`;
+Context 为 `bar` / `percent` / `full`;Token usage 为 `io` / `total` /
+`compact`;Cache hit 为 `full` / `compact`;Performance 为 `full` / `speed` /
+`latency`;Turns/steps 为 `both` / `turns` / `steps`;Version 保留 `tui` /
+`dsh` / `both`。省略 `format` 时仍使用各条目的旧默认值。
 
 内置条目 id:`agent-preset`、`model`、`reasoning`、
 `permission-preset`、`sandbox-mode`、`approval-policy`、`plan-state`、

--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ style schema):Model 为 `badge` / `plain` / `compact`;Permission preset
 directory 为 `short` / `basename` / `full`;Git branch 为 `plain` / `label`;
 Context 为 `bar` / `percent` / `full`;Token usage 为 `io` / `total` /
 `compact`;Cache hit 为 `full` / `compact`;Performance 为 `full` / `speed` /
-`latency`;Turns/steps 为 `both` / `turns` / `steps`;Version 保留 `tui` /
-`dsh` / `both`。省略 `format` 时仍使用各条目的旧默认值。
+`latency`(平均首 token 时间);Turns/steps 为 `both` / `turns` / `steps`;
+Version 保留 `tui` / `dsh` / `both`。省略 `format` 时仍使用各条目的旧默认值。
 
 内置条目 id:`agent-preset`、`model`、`reasoning`、
 `permission-preset`、`sandbox-mode`、`approval-policy`、`plan-state`、

--- a/src/footer/builtin-items.ts
+++ b/src/footer/builtin-items.ts
@@ -16,13 +16,23 @@
 import type { StatusSnapshot } from '../status/types.ts'
 import {
   formatCacheHit,
+  formatCacheHitCompact,
   formatContextFull,
+  formatContextPercent,
+  formatGitBranch,
+  formatModel,
   formatPerformanceFull,
+  formatPerformanceLatency,
+  formatPerformanceSpeed,
+  formatPermissionPreset,
+  formatPlanState,
   formatStatsLine,
+  formatTokenUsageCompact,
   formatTokenUsageIo,
+  formatTokenUsageTotal,
   formatTurnsSteps,
   formatVersion,
-  shortCwd,
+  formatWorkingDirectory,
 } from './formatters.ts'
 import type { FooterItemDefinition } from './types.ts'
 import { FooterItemRegistry } from './item-registry.ts'
@@ -32,60 +42,59 @@ import { FooterItemRegistry } from './item-registry.ts'
 const permissionPresetItem: FooterItemDefinition = {
   id: 'permission-preset',
   label: 'Permission preset',
-  description: 'The effective permission preset badge ([yolo]/[read-only]/[workspace-write]/[custom]).',
+  description: 'The effective permission preset as a badge, plain label, or compact code.',
   defaultZone: 'left',
   defaultImportance: 110,
-  formats: ['badge'],
+  formats: ['badge', 'plain', 'compact'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     if (snapshot.view.subject.kind !== 'main') return null
-    switch (snapshot.access.permissionPreset?.id) {
-      case 'danger-full-access': return { spans: [{ text: '[yolo]', tone: 'warning' }] }
-      case 'read-only': return { spans: [{ text: '[read-only]', tone: 'textMuted' }] }
-      case 'workspace-write': return { spans: [{ text: '[workspace-write]', tone: 'text' }] }
-      case 'custom': return { spans: [{ text: '[custom]', tone: 'warning' }] }
-      default: return null
-    }
+    const preset = snapshot.access.permissionPreset
+    if (preset === undefined) return null
+    const text = formatPermissionPreset(preset.id, ref.format ?? 'badge')
+    if (text === undefined) return null
+    const tone = preset.id === 'danger-full-access' || preset.id === 'custom'
+      ? 'warning'
+      : preset.id === 'read-only' ? 'textMuted' : 'text'
+    return { spans: [{ text, tone }] }
   },
 }
 
-/** The plan badge: `[plan]` while plan mode is effective, `[plan pending]`
- * while a plan-mode switch is pending (plan §4.3 — BOTH pending-enter and
- * pending-exit render the pending badge; the derive never guesses it). */
+/** The plan styles: a badge or a plain status label. Pending enter and
+ * pending exit both keep the pending state visible (plan §4.3). */
 const planStateItem: FooterItemDefinition = {
   id: 'plan-state',
   label: 'Plan state',
-  description: 'The plan-mode badge ([plan] while effective, [plan pending] while a switch is pending).',
+  description: 'The plan-mode badge or plain status label.',
   defaultZone: 'left',
   defaultImportance: 115,
-  formats: ['badge'],
+  formats: ['badge', 'plain'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     if (snapshot.view.subject.kind !== 'main') return null
-    if (snapshot.collaboration.plan.pending !== undefined) {
-      return { spans: [{ text: '[plan pending]', tone: 'warning' }] }
-    }
-    if (!snapshot.collaboration.plan.effective) return null
-    return { spans: [{ text: '[plan]', tone: 'warning' }] }
+    const text = formatPlanState(
+      snapshot.collaboration.plan.effective,
+      snapshot.collaboration.plan.pending,
+      ref.format ?? 'badge',
+    )
+    return text === undefined ? null : { spans: [{ text, tone: 'warning' }] }
   },
 }
 
-/** The model badge: `[provider/model @effort]` (legacy label form). */
+/** The model styles: badge, provider/model plain text, or model id only. */
 const modelItem: FooterItemDefinition = {
   id: 'model',
   label: 'Model',
-  description: 'The provider/model badge with the reasoning effort.',
+  description: 'The provider/model identity as a badge, plain label, or model id.',
   defaultZone: 'left',
   defaultImportance: 100,
-  formats: ['badge'],
+  formats: ['badge', 'plain', 'compact'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     if (snapshot.view.subject.kind !== 'main') return null
     const model = snapshot.composition.model
     if (model === undefined) return null
-    const label = `${model.provider === undefined ? '' : `${model.provider}/`}${model.id}`
-      + (model.reasoningEffort === undefined ? '' : ` @${model.reasoningEffort}`)
-    return { spans: [{ text: `[${label}]` }] }
+    return { spans: [{ text: formatModel(model.provider, model.id, model.reasoningEffort, ref.format ?? 'badge') }] }
   },
 }
 
@@ -118,48 +127,48 @@ const tasksItem: FooterItemDefinition = {
   },
 }
 
-/** The working directory (shortened for display). */
+/** The working directory (short, basename, or full path). */
 const cwdItem: FooterItemDefinition = {
   id: 'cwd',
   label: 'Working directory',
-  description: 'The display subject\'s workspace, shortened to the last two segments.',
+  description: 'The display subject\'s workspace in short, basename, or full form.',
   defaultZone: 'left',
   defaultImportance: 80,
-  formats: ['short'],
+  formats: ['short', 'basename', 'full'],
   defaultFormat: 'short',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     const cwd = snapshot.workspace.cwd
     if (cwd === '') return null
-    return { spans: [{ text: shortCwd(cwd) }] }
+    return { spans: [{ text: formatWorkingDirectory(cwd, ref.format ?? 'short') }] }
   },
 }
 
-/** The git branch. */
+/** The git branch, either plainly or with a visible label. */
 const gitBranchItem: FooterItemDefinition = {
   id: 'git-branch',
   label: 'Git branch',
-  description: 'The display subject\'s git branch.',
+  description: 'The display subject\'s git branch, plainly or with a label.',
   defaultZone: 'left',
   defaultImportance: 70,
-  formats: ['plain'],
+  formats: ['plain', 'label'],
   defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     if (snapshot.view.subject.kind !== 'main') return null
     const branch = snapshot.workspace.branch
     if (branch === undefined || branch === '') return null
-    return { spans: [{ text: branch }] }
+    return { spans: [{ text: formatGitBranch(branch, ref.format ?? 'plain') }] }
   },
 }
 
-/** The context pressure bar (legacy form) or the full `used/window (pct)`
- * formatter. */
+/** The context pressure styles: legacy bar, percent, or full
+ * used/window output. */
 const contextItem: FooterItemDefinition = {
   id: 'context',
   label: 'Context',
-  description: 'Context pressure: the progress bar (bar) or used/window (full).',
+  description: 'Context pressure: a progress bar, percent, or used/window value.',
   defaultZone: 'left',
   defaultImportance: 100,
-  formats: ['bar', 'full'],
+  formats: ['bar', 'percent', 'full'],
   defaultFormat: 'bar',
   render(snapshot: StatusSnapshot, ref) {
     if (snapshot.view.subject.kind !== 'main') return null
@@ -168,37 +177,40 @@ const contextItem: FooterItemDefinition = {
     const used = context.usedTokens ?? 0
     const window = context.windowTokens
     const format = ref.format ?? 'bar'
+    const percent = context.percent ?? Math.min(100, Math.max(0, Math.ceil((used * 100) / window)))
     if (format === 'full') {
-      const percent = context.percent ?? Math.min(100, Math.max(0, Math.ceil((used * 100) / window)))
       return { spans: [{ text: formatContextFull(used, window, percent), tone: 'primary' }] }
+    }
+    if (format === 'percent') {
+      return { spans: [{ text: formatContextPercent(percent), tone: 'primary' }] }
     }
     // The legacy bar: 12 cells, rounded fill, ceiling percent. The bar is
     // primary; the percent rides OUTSIDE the color (the legacy string
     // concatenation — the outer dim pass colors it).
     const ratio = Math.min(1, Math.max(0, used / window))
     const filled = Math.round(ratio * CONTEXT_BAR_WIDTH)
-    const pct = Math.min(100, Math.max(0, Math.ceil(ratio * 100)))
+    const barPercent = Math.min(100, Math.max(0, Math.ceil(ratio * 100)))
     const bar = '█'.repeat(filled) + '░'.repeat(CONTEXT_BAR_WIDTH - filled)
-    return { spans: [{ text: `[${bar}]`, tone: 'primary' }, { text: ` ${pct}%` }] }
+    return { spans: [{ text: `[${bar}]`, tone: 'primary' }, { text: ` ${barPercent}%` }] }
   },
 }
 
 /** The legacy bar width (moved from tui-app.ts). */
 const CONTEXT_BAR_WIDTH = 12
 
-/** The turn/step counters: `t3/s7` (host-native since M1 — the first-party
- * builtin extension segment was removed; the host core state no longer
- * depends on plugin loading). */
+/** The turn/step counters: both counters, turns only, or steps only
+ * (host-native since M1 — the first-party builtin extension segment was
+ * removed; the host core state no longer depends on plugin loading). */
 const turnsStepsItem: FooterItemDefinition = {
   id: 'turns-steps',
   label: 'Turns/steps',
-  description: 'The completed turn/step counters.',
+  description: 'The completed turn/step counters, together or separately.',
   defaultZone: 'left',
   defaultImportance: 45,
-  formats: ['plain'],
-  defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot) {
-    return { spans: [{ text: formatTurnsSteps(snapshot.usage.turns, snapshot.usage.steps) }] }
+  formats: ['both', 'turns', 'steps'],
+  defaultFormat: 'both',
+  render(snapshot: StatusSnapshot, ref) {
+    return { spans: [{ text: formatTurnsSteps(snapshot.usage.turns, snapshot.usage.steps, ref.format ?? 'both') }] }
   },
 }
 
@@ -290,12 +302,23 @@ export function registerBuiltinFooterItems(registry: FooterItemRegistry): void {
   registry.register(versionItem)
 }
 
+/** Derive a deterministic compact preset label when the host does not
+ * provide one. The final first-character fallback also keeps compact output
+ * distinct from the badge for one-word or one-character labels. */
+function compactPresetLabel(label: string): string {
+  const trimmed = label.trim()
+  const words = trimmed.split(/\s+/u).filter(Boolean)
+  const initials = words.map(word => [...word][0] ?? '').join('').toUpperCase()
+  if (initials !== '' && initials.length < trimmed.length) return initials
+  return [...trimmed][0] ?? ''
+}
+
 /** The agent-preset badge: `[CM]`-style from the composition preset
  * (shortLabel when provided — the state layer never hardcodes it). */
 const agentPresetItem: FooterItemDefinition = {
   id: 'agent-preset',
   label: 'Agent preset',
-  description: 'The agent composition preset badge.',
+  description: 'The agent composition preset badge or compact short label.',
   defaultZone: 'left',
   defaultImportance: 90,
   formats: ['badge', 'compact'],
@@ -304,10 +327,16 @@ const agentPresetItem: FooterItemDefinition = {
     if (snapshot.view.subject.kind !== 'main') return null
     const preset = snapshot.composition.agentPreset
     if (preset === undefined) return null
-    const text = ref.format === 'compact' && preset.shortLabel !== undefined
-      ? preset.shortLabel
-      : preset.label
-    return { spans: [{ text: `[${text}]`, tone: 'accent' }] }
+    if (ref.format !== 'compact') {
+      return { spans: [{ text: `[${preset.label}]`, tone: 'accent' }] }
+    }
+    const compact = preset.shortLabel ?? compactPresetLabel(preset.label)
+    const compactBadge = `[${compact}]`
+    // A host may explicitly set a shortLabel equal to the full label. Drop
+    // the badge chrome in that degenerate case so the declared styles still
+    // have different, useful output rather than silently duplicating badge.
+    const text = compactBadge === `[${preset.label}]` ? compact : compactBadge
+    return { spans: [{ text, tone: 'accent' }] }
   },
 }
 
@@ -478,49 +507,62 @@ const todoItem: FooterItemDefinition = {
   },
 }
 
-/** The cache-hit share: `C 91.9%`. */
+/** The cache-hit share: full `C 91.9%` or compact `91.9%`. */
 const cacheHitItem: FooterItemDefinition = {
   id: 'cache-hit',
   label: 'Cache hit',
-  description: 'The cache-hit share of billed input tokens.',
+  description: 'The cache-hit share of billed input tokens, full or compact.',
   defaultZone: 'left',
   defaultImportance: 55,
   formats: ['full', 'compact'],
   defaultFormat: 'full',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     const pct = snapshot.usage.cacheHitPct
     if (pct === undefined) return null
-    return { spans: [{ text: formatCacheHit(pct), tone: 'success' }] }
+    const text = ref.format === 'compact' ? formatCacheHitCompact(pct) : formatCacheHit(pct)
+    return { spans: [{ text, tone: 'success' }] }
   },
 }
 
-/** The token usage: `2579/5507` (io). */
+/** The token usage: input/output, all billed tokens, or compact total. */
 const tokenUsageItem: FooterItemDefinition = {
   id: 'token-usage',
   label: 'Token usage',
-  description: 'The input/output token totals.',
+  description: 'The input/output totals, billed total, or compact total.',
   defaultZone: 'left',
   defaultImportance: 50,
-  formats: ['io'],
+  formats: ['io', 'total', 'compact'],
   defaultFormat: 'io',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     const tokens = snapshot.usage.tokens
-    return { spans: [{ text: formatTokenUsageIo(tokens.input, tokens.output), tone: 'success' }] }
+    const format = ref.format ?? 'io'
+    const text = format === 'total'
+      ? formatTokenUsageTotal(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
+      : format === 'compact'
+        ? formatTokenUsageCompact(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
+        : formatTokenUsageIo(tokens.input, tokens.output)
+    return { spans: [{ text, tone: 'success' }] }
   },
 }
 
-/** The performance: `2.0s 40 tok/s` (full). */
+/** The performance styles: full `2.0s 40 tok/s`, speed-only, or
+ * latency-only. */
 const performanceItem: FooterItemDefinition = {
   id: 'performance',
   label: 'Performance',
-  description: 'LLM wall time and output throughput.',
+  description: 'LLM wall time and output throughput, full, speed, or latency.',
   defaultZone: 'left',
   defaultImportance: 40,
-  formats: ['full', 'compact'],
+  formats: ['full', 'speed', 'latency'],
   defaultFormat: 'full',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, ref) {
     const performance = snapshot.usage.performance
-    return { spans: [{ text: formatPerformanceFull(performance.llmMs, performance.tokensPerSec), tone: 'textMuted' }] }
+    const text = ref.format === 'speed'
+      ? formatPerformanceSpeed(performance.tokensPerSec)
+      : ref.format === 'latency'
+        ? formatPerformanceLatency(performance.llmMs)
+        : formatPerformanceFull(performance.llmMs, performance.tokensPerSec)
+    return { spans: [{ text, tone: 'textMuted' }] }
   },
 }
 

--- a/src/footer/builtin-items.ts
+++ b/src/footer/builtin-items.ts
@@ -302,17 +302,6 @@ export function registerBuiltinFooterItems(registry: FooterItemRegistry): void {
   registry.register(versionItem)
 }
 
-/** Derive a deterministic compact preset label when the host does not
- * provide one. The final first-character fallback also keeps compact output
- * distinct from the badge for one-word or one-character labels. */
-function compactPresetLabel(label: string): string {
-  const trimmed = label.trim()
-  const words = trimmed.split(/\s+/u).filter(Boolean)
-  const initials = words.map(word => [...word][0] ?? '').join('').toUpperCase()
-  if (initials !== '' && initials.length < trimmed.length) return initials
-  return [...trimmed][0] ?? ''
-}
-
 /** The agent-preset badge: `[CM]`-style from the composition preset
  * (shortLabel when provided — the state layer never hardcodes it). */
 const agentPresetItem: FooterItemDefinition = {
@@ -327,16 +316,10 @@ const agentPresetItem: FooterItemDefinition = {
     if (snapshot.view.subject.kind !== 'main') return null
     const preset = snapshot.composition.agentPreset
     if (preset === undefined) return null
-    if (ref.format !== 'compact') {
-      return { spans: [{ text: `[${preset.label}]`, tone: 'accent' }] }
-    }
-    const compact = preset.shortLabel ?? compactPresetLabel(preset.label)
-    const compactBadge = `[${compact}]`
-    // A host may explicitly set a shortLabel equal to the full label. Drop
-    // the badge chrome in that degenerate case so the declared styles still
-    // have different, useful output rather than silently duplicating badge.
-    const text = compactBadge === `[${preset.label}]` ? compact : compactBadge
-    return { spans: [{ text, tone: 'accent' }] }
+    const text = ref.format === 'compact' && preset.shortLabel !== undefined
+      ? preset.shortLabel
+      : preset.label
+    return { spans: [{ text: `[${text}]`, tone: 'accent' }] }
   },
 }
 
@@ -546,7 +529,7 @@ const tokenUsageItem: FooterItemDefinition = {
 }
 
 /** The performance styles: full `2.0s 40 tok/s`, speed-only, or
- * latency-only. */
+ * average time-to-first-token latency-only. */
 const performanceItem: FooterItemDefinition = {
   id: 'performance',
   label: 'Performance',
@@ -560,7 +543,7 @@ const performanceItem: FooterItemDefinition = {
     const text = ref.format === 'speed'
       ? formatPerformanceSpeed(performance.tokensPerSec)
       : ref.format === 'latency'
-        ? formatPerformanceLatency(performance.llmMs)
+        ? formatPerformanceLatency(performance.firstTokenMs)
         : formatPerformanceFull(performance.llmMs, performance.tokensPerSec)
     return { spans: [{ text, tone: 'textMuted' }] }
   },

--- a/src/footer/formatters.ts
+++ b/src/footer/formatters.ts
@@ -9,15 +9,29 @@
 import { formatTokens } from '../token-usage.ts'
 import type { UsageStatus } from '../status/types.ts'
 
+/** Whether cwd uses Windows path syntax rather than a POSIX filename with
+ * a literal backslash. Drive paths and UNC paths are unambiguous; every other
+ * path keeps POSIX's slash-only separator semantics. */
+function isWindowsStyleCwd(cwd: string): boolean {
+  return /^[A-Za-z]:[\\/]/u.test(cwd) || /^\\\\/u.test(cwd)
+}
+
+/** Split cwd using only the separators valid for its detected path syntax. */
+function cwdParts(cwd: string): string[] {
+  const separator = isWindowsStyleCwd(cwd) ? /[\\/]+/u : '/'
+  return cwd.split(separator).filter(Boolean)
+}
+
 /** Whether a path is a filesystem root whose separator must be retained. */
 function isRootCwd(cwd: string): boolean {
-  return /^\/+$/u.test(cwd) || /^[A-Za-z]:[\\/]+$/u.test(cwd)
+  if (/^\/+$/u.test(cwd) || /^[A-Za-z]:[\\/]+$/u.test(cwd)) return true
+  return /^\\\\/u.test(cwd) && cwdParts(cwd).length === 2
 }
 
 /** Short cwd for the footer: last two path segments (idempotent). */
 export function shortCwd(cwd: string): string {
   if (isRootCwd(cwd)) return cwd
-  const parts = cwd.split(/[\\/]+/u).filter(Boolean)
+  const parts = cwdParts(cwd)
   return parts.slice(-2).join('/') || cwd
 }
 
@@ -87,8 +101,7 @@ export function formatWorkingDirectory(cwd: string, format: string): string {
   switch (format) {
     case 'basename': {
       if (isRootCwd(cwd)) return cwd
-      const parts = cwd.split(/[\\/]+/).filter(Boolean)
-      return parts.at(-1) ?? cwd
+      return cwdParts(cwd).at(-1) ?? cwd
     }
     case 'full':
       return cwd
@@ -148,9 +161,9 @@ export function formatPerformanceSpeed(tokensPerSec: number): string {
   return `${tokensPerSec} tok/s`
 }
 
-/** Performance, latency-only form: `2.0s`. */
-export function formatPerformanceLatency(llmMs: number): string {
-  return formatSeconds(llmMs)
+/** Performance, average time-to-first-token form: `2.0s`. */
+export function formatPerformanceLatency(firstTokenMs: number): string {
+  return formatSeconds(firstTokenMs)
 }
 
 /** Turn/step counters: `t3/s7`, `t3`, or `s7`. */

--- a/src/footer/formatters.ts
+++ b/src/footer/formatters.ts
@@ -9,9 +9,15 @@
 import { formatTokens } from '../token-usage.ts'
 import type { UsageStatus } from '../status/types.ts'
 
+/** Whether a path is a filesystem root whose separator must be retained. */
+function isRootCwd(cwd: string): boolean {
+  return /^\/+$/u.test(cwd) || /^[A-Za-z]:[\\/]+$/u.test(cwd)
+}
+
 /** Short cwd for the footer: last two path segments (idempotent). */
 export function shortCwd(cwd: string): string {
-  const parts = cwd.split('/').filter(Boolean)
+  if (isRootCwd(cwd)) return cwd
+  const parts = cwd.split(/[\\/]+/u).filter(Boolean)
   return parts.slice(-2).join('/') || cwd
 }
 
@@ -26,9 +32,85 @@ export function formatSeconds(ms: number): string {
   return `${trimDecimal(ms / 1000)}s`
 }
 
+/** Format a model according to the builtin style vocabulary. */
+export function formatModel(
+  provider: string | undefined,
+  id: string,
+  reasoningEffort: string | undefined,
+  format: string,
+): string {
+  const label = `${provider === undefined ? '' : `${provider}/`}${id}`
+    + (reasoningEffort === undefined ? '' : ` @${reasoningEffort}`)
+  switch (format) {
+    case 'plain':
+      return label
+    case 'compact':
+      return id
+    case 'badge':
+    default:
+      return `[${label}]`
+  }
+}
+
+const PERMISSION_LABELS: Readonly<Record<string, string>> = {
+  'danger-full-access': 'yolo',
+  'read-only': 'read-only',
+  'workspace-write': 'workspace-write',
+  custom: 'custom',
+}
+
+/** Format the known permission preset ids. Unknown ids are unavailable to
+ * the builtin item, preserving the legacy fail-soft behavior. */
+export function formatPermissionPreset(id: string, format: string): string | undefined {
+  const label = PERMISSION_LABELS[id]
+  if (label === undefined) return undefined
+  switch (format) {
+    case 'plain':
+      return label
+    case 'compact':
+      return id === 'read-only' ? 'ro' : id === 'workspace-write' ? 'ww' : label
+    case 'badge':
+    default:
+      return `[${label}]`
+  }
+}
+
+/** Format the plan state as a badge or a plain status label. */
+export function formatPlanState(effective: boolean, pending: boolean | undefined, format: string): string | undefined {
+  const state = pending !== undefined ? 'plan pending' : effective ? 'plan' : undefined
+  if (state === undefined) return undefined
+  return format === 'plain' ? state : `[${state}]`
+}
+
+/** Format a working directory using the finite builtin style vocabulary. */
+export function formatWorkingDirectory(cwd: string, format: string): string {
+  switch (format) {
+    case 'basename': {
+      if (isRootCwd(cwd)) return cwd
+      const parts = cwd.split(/[\\/]+/).filter(Boolean)
+      return parts.at(-1) ?? cwd
+    }
+    case 'full':
+      return cwd
+    case 'short':
+    default:
+      return shortCwd(cwd)
+  }
+}
+
+/** Format a branch name either plainly or with a visible label. */
+export function formatGitBranch(branch: string, format: string): string {
+  return format === 'label' ? `branch: ${branch}` : branch
+}
+
 /** Context pressure, full form: `160.0K/1.0M (16%)`. */
 export function formatContextFull(used: number, window: number, percent: number): string {
   return `${formatTokens(used)}/${formatTokens(window)} (${percent}%)`
+}
+
+/** Context pressure, percent form: `ctx 31%`. */
+export function formatContextPercent(percent: number): string {
+  return `ctx ${percent}%`
 }
 
 /** Cache-hit share: `C 91.9%`. */
@@ -36,9 +118,24 @@ export function formatCacheHit(pct: number): string {
   return `C ${pct.toFixed(1)}%`
 }
 
+/** Cache-hit share without the item marker: `91.9%`. */
+export function formatCacheHitCompact(pct: number): string {
+  return `${pct.toFixed(1)}%`
+}
+
 /** Token usage, io form: `2579/5507` (input/output). */
 export function formatTokenUsageIo(input: number, output: number): string {
   return `${input}/${output}`
+}
+
+/** Token usage, total form: `8.1k tokens` (all billed token classes). */
+export function formatTokenUsageTotal(input: number, output: number, cacheRead: number, cacheWrite: number): string {
+  return `${formatTokens(input + output + cacheRead + cacheWrite)} tokens`
+}
+
+/** Token usage, compact total form: `8.1k` (all billed token classes). */
+export function formatTokenUsageCompact(input: number, output: number, cacheRead: number, cacheWrite: number): string {
+  return formatTokens(input + output + cacheRead + cacheWrite)
 }
 
 /** Performance, full form: `2.0s 40 tok/s`. */
@@ -46,9 +143,27 @@ export function formatPerformanceFull(llmMs: number, tokensPerSec: number): stri
   return `${formatSeconds(llmMs)} ${tokensPerSec} tok/s`
 }
 
-/** Turn/step counters: `t3/s7`. */
-export function formatTurnsSteps(turns: number, steps: number): string {
-  return `t${turns}/s${steps}`
+/** Performance, speed-only form: `40 tok/s`. */
+export function formatPerformanceSpeed(tokensPerSec: number): string {
+  return `${tokensPerSec} tok/s`
+}
+
+/** Performance, latency-only form: `2.0s`. */
+export function formatPerformanceLatency(llmMs: number): string {
+  return formatSeconds(llmMs)
+}
+
+/** Turn/step counters: `t3/s7`, `t3`, or `s7`. */
+export function formatTurnsSteps(turns: number, steps: number, format = 'both'): string {
+  switch (format) {
+    case 'turns':
+      return `t${turns}`
+    case 'steps':
+      return `s${steps}`
+    case 'both':
+    default:
+      return `t${turns}/s${steps}`
+  }
 }
 
 /** The pi-vocabulary stats line (the legacy line-2 format), derived from

--- a/test/footer-configurator-model.test.ts
+++ b/test/footer-configurator-model.test.ts
@@ -199,17 +199,19 @@ test('Move Mode: M enters, ↑↓ reorder within the zone, Enter/Esc exits', () 
 test('F cycles the finite format on the Edit Row page (default removes the override)', () => {
   const m = model()
   m.activate()
-  walkTo(m, 'context')
+  walkTo(m, 'context') // formats: bar + percent + full
+  m.cycleFormat()
+  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
   m.cycleFormat()
   assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
   m.cycleFormat()
   assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, undefined)
 })
 
-test('the Item Editor opens with Style hidden for single-format items', () => {
+test('the Item Editor shows Style for multi-format items and hides it for single-format items', () => {
   const m = model()
   m.activate()
-  walkTo(m, 'context') // formats: bar + full
+  walkTo(m, 'context') // formats: bar + percent + full
   m.activate()
   assert.equal(m.state().mode, 'item')
   // Style first for a multi-format item; ↓ reaches Tone.
@@ -221,13 +223,18 @@ test('the Item Editor opens with Style hidden for single-format items', () => {
   assert.equal(m.state().mode, 'item')
   m.cancel()
   assert.equal(m.state().mode, 'row')
-  // A single-format item (model: badge only) has no Style row: Enter on
-  // the FIRST menu row opens the Tone picker directly.
-  walkTo(m, 'model')
-  m.activate()
-  assert.equal(m.state().mode, 'item')
-  m.activate()
-  assert.equal(m.state().mode, 'tone')
+
+  // A single-format item (stats-line) has no Style row: Enter on the
+  // FIRST menu row opens the Tone picker directly.
+  const single = new FooterConfiguratorModel({
+    schemaVersion: 1,
+    rows: [{ left: [{ id: 'stats-line' }], right: [] }],
+  }, registry)
+  single.activate()
+  single.activate()
+  assert.equal(single.state().mode, 'item')
+  single.activate()
+  assert.equal(single.state().mode, 'tone')
 })
 
 test('Esc walks the hierarchy ONE level at a time (row → item → picker → item → row)', () => {
@@ -263,16 +270,49 @@ test('the Style picker applies a format; the inline ←→ change cycles too', (
   m.activate() // item editor
   m.activate() // Style picker (opens on the current format: bar)
   assert.equal(m.state().mode, 'style')
-  m.moveDown()
+  m.moveDown() // Percent
+  m.moveDown() // Full
   m.activate()
   assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
   assert.equal(m.state().mode, 'item')
-  // Inline ←→ cycles without opening the picker: ← wraps back to bar.
+  // Inline ←→ cycles without opening the picker: full → percent → bar.
+  m.moveZone('left')
+  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
   m.moveZone('left')
   assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, undefined)
-  // → cycles to full again.
+  // → cycles to percent, then full.
+  m.moveZone('right')
+  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
   m.moveZone('right')
   assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
+})
+
+test('format changes preserve item ids, zones, and order', () => {
+  const m = new FooterConfiguratorModel({
+    schemaVersion: 1,
+    rows: [{
+      left: [{ id: 'model' }, { id: 'context' }, { id: 'turns-steps' }],
+      right: [{ id: 'git-branch' }],
+    }],
+  }, registry)
+  m.activate()
+  walkTo(m, 'context')
+  const before = m.state().layout.rows[0]!
+  const beforeLeftIds = before.left.map(ref => ref.id)
+  const beforeRightIds = before.right.map(ref => ref.id)
+  const beforeModel = before.left[0]!
+  const beforeTurns = before.left[2]!
+  const beforeBranch = before.right[0]!
+
+  m.cycleFormat() // context: bar → percent
+
+  const after = m.state().layout.rows[0]!
+  assert.deepEqual(after.left.map(ref => ref.id), beforeLeftIds)
+  assert.deepEqual(after.right.map(ref => ref.id), beforeRightIds)
+  assert.deepEqual(after.left[0], beforeModel)
+  assert.deepEqual(after.left[2], beforeTurns)
+  assert.deepEqual(after.right[0], beforeBranch)
+  assert.equal(after.left[1]!.format, 'percent')
 })
 
 test('the Tone picker persists the semantic token; Auto removes the override', () => {
@@ -301,7 +341,8 @@ test('Advanced: prefix/suffix/importance round-trip; empty removes the override'
   m.activate()
   walkTo(m, 'model')
   m.activate() // item editor
-  // Advanced is the LAST menu row (model has no Style entry).
+  // Advanced is the LAST menu row (model now has Style, Tone, Advanced).
+  m.moveDown()
   m.moveDown()
   m.activate()
   assert.equal(m.state().mode, 'advanced')
@@ -327,7 +368,7 @@ test('Advanced: prefix/suffix/importance round-trip; empty removes the override'
   // the pickers hang off the item editor (row → item → advanced).
   m.cancel()
   assert.equal(m.state().mode, 'item')
-  assert.equal(m.state().itemCursor, 1, 'the menu cursor still sits on Advanced')
+  assert.equal(m.state().itemCursor, 2, 'the menu cursor still sits on Advanced')
   // Importance: digits only, bounds-checked.
   m.activate() // → the advanced editor (field resets to prefix)
   m.moveDown()
@@ -434,6 +475,7 @@ test('the editable text is sanitized and bounded (the draft must re-parse)', () 
   walkTo(m, 'model')
   m.activate()
   m.moveDown()
+  m.moveDown()
   m.activate() // Advanced
   m.activate() // edit prefix
   // Control characters never enter the buffer (the readable residue is
@@ -460,7 +502,8 @@ test('preset resets re-anchor every page cursor (a stale buffer never survives)'
   m.activate() // row
   walkTo(m, 'model')
   m.activate() // item editor
-  m.moveDown() // Advanced (model menu: Tone, Advanced)
+  m.moveDown() // Tone
+  m.moveDown() // Advanced (model menu: Style, Tone, Advanced)
   m.activate() // the advanced page
   m.activate() // editing the prefix (buffer seeded)
   m.text('STALE')

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -239,7 +239,10 @@ test('the Item Editor edits style/tone; the picker renders live examples', async
   assert.ok(view.includes('Tone'), `the tone row missing:\n${view}`)
   assert.ok(view.includes('Advanced…'), `the advanced row missing:\n${view}`)
   assert.ok(view.includes('↑↓ Select · Enter Open · ←→ Change · Esc Back'), `item help missing:\n${view}`)
-  // ←→ cycles the style inline.
+  // ←→ cycles the style inline: bar → percent → full.
+  vt.sendInput('\x1b[C')
+  await vt.waitForRender()
+  assert.equal(model.preview().rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
   vt.sendInput('\x1b[C')
   await vt.waitForRender()
   assert.equal(model.preview().rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
@@ -249,8 +252,10 @@ test('the Item Editor edits style/tone; the picker renders live examples', async
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('Style · Context'), `style picker title missing:\n${view}`)
   assert.ok(view.includes('Bar'), `the bar example missing:\n${view}`)
+  assert.ok(view.includes('Percent'), `the percent example missing:\n${view}`)
   assert.ok(view.includes('Full'), `the full example missing:\n${view}`)
   // Walk to Full, apply.
+  vt.sendInput('\x1b[B')
   vt.sendInput('\x1b[B')
   vt.sendInput('\r')
   await vt.waitForRender()
@@ -266,8 +271,9 @@ test('the Advanced editor edits prefix inline and shows the values', async () =>
   vt.sendInput('\r') // → Edit Row 1
   await vt.waitForRender()
   while (idAt(model) !== 'model') vt.sendInput('\x1b[B')
-  vt.sendInput('\r') // → item editor (model: Tone first — no Style row)
+  vt.sendInput('\r') // → item editor (model: Style, Tone, Advanced)
   await vt.waitForRender()
+  vt.sendInput('\x1b[B') // → Tone
   vt.sendInput('\x1b[B') // → Advanced…
   vt.sendInput('\r')
   await vt.waitForRender()
@@ -312,8 +318,9 @@ test('the Advanced page sanitizes hand-built prefix/suffix values too', async ()
   await vt.waitForRender()
   vt.sendInput('\r') // → Edit Row 1
   await vt.waitForRender()
-  vt.sendInput('\r') // → item editor (single item; menu: Tone, Advanced)
+  vt.sendInput('\r') // → item editor (single item; menu: Style, Tone, Advanced)
   await vt.waitForRender()
+  vt.sendInput('\x1b[B') // → Tone
   vt.sendInput('\x1b[B') // → Advanced…
   vt.sendInput('\r') // → the Advanced page
   await vt.waitForRender()
@@ -382,6 +389,7 @@ test('bracketed paste feeds the Advanced prefix editor', async () => {
   while (idAt(model) !== 'model') vt.sendInput('\x1b[B')
   vt.sendInput('\r') // → item editor
   await vt.waitForRender()
+  vt.sendInput('\x1b[B') // → Tone
   vt.sendInput('\x1b[B') // → Advanced…
   vt.sendInput('\r') // → the Advanced page
   await vt.waitForRender()
@@ -444,7 +452,8 @@ test('CSI-u encoded printables type into the Add search and the prefix', async (
   while (idAt(model) !== 'model') vt.sendInput('\x1b[B')
   vt.sendInput('\r')
   await vt.waitForRender()
-  vt.sendInput('\x1b[B')
+  vt.sendInput('\x1b[B') // → Tone
+  vt.sendInput('\x1b[B') // → Advanced…
   vt.sendInput('\r')
   await vt.waitForRender()
   vt.sendInput('\r') // edit prefix
@@ -507,7 +516,9 @@ test('a legal-but-unlisted persisted tone displays as ITSELF (never Auto)', asyn
   await vt.waitForRender()
   vt.sendInput('\r') // → Edit Row 1
   await vt.waitForRender()
-  vt.sendInput('\r') // → item editor (model: Tone is the first menu row)
+  vt.sendInput('\r') // → item editor (model: Style, Tone, Advanced)
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B') // → Tone
   await vt.waitForRender()
   let view = vt.getViewport().join('\n')
   assert.ok(view.includes('Strong'), `the persisted token must display as itself:\n${view}`)

--- a/test/footer-items.test.ts
+++ b/test/footer-items.test.ts
@@ -7,8 +7,10 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { visibleWidth } from '@xmoon76/pi-tui'
 import { createBuiltinFooterRegistry } from '../src/footer/builtin-items.ts'
-import { renderSpans } from '../src/footer/composer.ts'
+import { FooterComposer, renderSpans } from '../src/footer/composer.ts'
+import { isFooterLayout, parseFooterLayout } from '../src/footer/layout.ts'
 import type { FooterItemRef } from '../src/footer/types.ts'
 import { emptyStatusSnapshot, type StatusSnapshot } from '../src/status/types.ts'
 
@@ -114,6 +116,20 @@ test('cwd shortens to the last two segments; empty → nothing', () => {
   assert.equal(render('cwd', emptyStatusSnapshot()), '')
 })
 
+test('cwd styles handle POSIX and Windows separators without losing roots', () => {
+  const windows = snapshotWith(snap => { snap.workspace.cwd = 'C:\\Users\\alice\\project' })
+  assert.equal(render('cwd', windows, { id: 'cwd', format: 'short' }), 'alice/project')
+  assert.equal(render('cwd', windows, { id: 'cwd', format: 'basename' }), 'project')
+  assert.equal(render('cwd', windows, { id: 'cwd', format: 'full' }), 'C:\\Users\\alice\\project')
+
+  const posixRoot = snapshotWith(snap => { snap.workspace.cwd = '/' })
+  assert.equal(render('cwd', posixRoot, { id: 'cwd', format: 'short' }), '/')
+  assert.equal(render('cwd', posixRoot, { id: 'cwd', format: 'basename' }), '/')
+  const windowsRoot = snapshotWith(snap => { snap.workspace.cwd = 'C:/' })
+  assert.equal(render('cwd', windowsRoot, { id: 'cwd', format: 'short' }), 'C:/')
+  assert.equal(render('cwd', windowsRoot, { id: 'cwd', format: 'basename' }), 'C:/')
+})
+
 test('git-branch renders the branch; empty → nothing', () => {
   const text = render('git-branch', snapshotWith(snap => { snap.workspace.branch = 'main' }))
   assert.equal(text, 'main')
@@ -169,6 +185,191 @@ test('ext:* bridges the extension footer text; empty → nothing', () => {
   assert.equal(withText === null ? '' : plain(renderSpans(withText.spans)), '[EXT]')
   assert.equal(render('ext:*', emptyStatusSnapshot()), '')
 })
+
+test('builtin styles render meaningful golden variants without changing defaults', () => {
+  const snap = snapshotWith(current => {
+    current.composition.agentPreset = { id: 'code', label: 'Code preset' }
+    current.composition.model = {
+      provider: 'deepseek',
+      id: 'flash',
+      displayName: 'flash',
+      reasoningEffort: 'high',
+    }
+    current.access.permissionPreset = { id: 'read-only', label: 'read-only', matched: true }
+    current.collaboration.plan = { effective: true }
+    current.workspace = { cwd: '/home/x/proj', branch: 'main' }
+    current.usage.context = { usedTokens: 25_000, windowTokens: 100_000, percent: 25 }
+    current.usage.tokens = { input: 1_200, output: 3_400, cacheRead: 2_000, cacheWrite: 100 }
+    current.usage.cacheHitPct = 91.9
+    current.usage.performance = { llmMs: 8_100, firstTokenMs: 2_000, tokensPerSec: 40 }
+    current.usage.turns = 3
+    current.usage.steps = 7
+    current.host.dshVersion = '1.2.3'
+  })
+
+  const cases: Array<{ id: string; formats: Array<[string, string]> }> = [
+    {
+      id: 'model',
+      formats: [
+        ['badge', '[deepseek/flash @high]'],
+        ['plain', 'deepseek/flash @high'],
+        ['compact', 'flash'],
+      ],
+    },
+    {
+      id: 'agent-preset',
+      formats: [['badge', '[Code preset]'], ['compact', '[CP]']],
+    },
+    {
+      id: 'permission-preset',
+      formats: [
+        ['badge', '[read-only]'],
+        ['plain', 'read-only'],
+        ['compact', 'ro'],
+      ],
+    },
+    {
+      id: 'plan-state',
+      formats: [['badge', '[plan]'], ['plain', 'plan']],
+    },
+    {
+      id: 'cwd',
+      formats: [['short', 'x/proj'], ['basename', 'proj'], ['full', '/home/x/proj']],
+    },
+    {
+      id: 'git-branch',
+      formats: [['plain', 'main'], ['label', 'branch: main']],
+    },
+    {
+      id: 'context',
+      formats: [
+        ['bar', '[███░░░░░░░░░] 25%'],
+        ['percent', 'ctx 25%'],
+        ['full', '25k/100k (25%)'],
+      ],
+    },
+    {
+      id: 'token-usage',
+      formats: [['io', '1200/3400'], ['total', '6.7k tokens'], ['compact', '6.7k']],
+    },
+    {
+      id: 'cache-hit',
+      formats: [['full', 'C 91.9%'], ['compact', '91.9%']],
+    },
+    {
+      id: 'performance',
+      formats: [['full', '8.1s 40 tok/s'], ['speed', '40 tok/s'], ['latency', '8.1s']],
+    },
+    {
+      id: 'turns-steps',
+      formats: [['both', 't3/s7'], ['turns', 't3'], ['steps', 's7']],
+    },
+    {
+      id: 'version',
+      formats: [['tui', 'v0.0.0'], ['dsh', 'dsh-1.2.3'], ['both', 'dsh-1.2.3/tui-0.0.0']],
+    },
+  ]
+
+  for (const { id, formats } of cases) {
+    const def = registry.get(id)!
+    assert.deepEqual(def.formats, formats.map(([format]) => format), `${id} format catalog`)
+    const outputs = formats.map(([format, expected]) => {
+      assert.equal(render(id, snap, { id, format }), expected, `${id}/${format}`)
+      return expected
+    })
+    assert.ok(new Set(outputs).size > 1, `${id} formats must not all render identically`)
+  }
+
+  // Keep the invariant registry-wide: a future multi-format builtin cannot
+  // silently escape the golden catalog above by being omitted from the list.
+  for (const id of registry.ids()) {
+    const def = registry.get(id)!
+    if (def.formats.length <= 1) continue
+    const rendered = def.formats.map(format => render(id, snap, { id, format }))
+    assert.ok(rendered.every(text => text !== ''), `${id} every declared format must render in the fixture`)
+    assert.ok(new Set(rendered).size > 1, `${id} formats must not all render identically`)
+  }
+
+  // A ref without an explicit format still selects each definition's old
+  // default formatter, so adding choices cannot alter the native layout.
+  assert.equal(render('model', snap), '[deepseek/flash @high]')
+  assert.equal(render('permission-preset', snap), '[read-only]')
+  assert.equal(render('plan-state', snap), '[plan]')
+  assert.equal(render('cwd', snap), 'x/proj')
+  assert.equal(render('git-branch', snap), 'main')
+  assert.equal(render('context', snap), '[███░░░░░░░░░] 25%')
+  assert.equal(render('token-usage', snap), '1200/3400')
+  assert.equal(render('cache-hit', snap), 'C 91.9%')
+  assert.equal(render('performance', snap), '8.1s 40 tok/s')
+  assert.equal(render('turns-steps', snap), 't3/s7')
+})
+
+test('new builtin styles fall back to the unchanged default formatter', () => {
+  const snap = snapshotWith(current => {
+    current.composition.agentPreset = { id: 'code', label: 'Code preset' }
+    current.composition.model = { provider: 'deepseek', id: 'flash', displayName: 'flash' }
+    current.access.permissionPreset = { id: 'read-only', label: 'read-only', matched: true }
+    current.collaboration.plan = { effective: true }
+    current.workspace = { cwd: '/home/x/proj', branch: 'main' }
+    current.usage.context = { usedTokens: 25_000, windowTokens: 100_000, percent: 25 }
+    current.usage.tokens = { input: 1_200, output: 3_400, cacheRead: 0, cacheWrite: 0 }
+    current.usage.cacheHitPct = 50
+    current.usage.performance = { llmMs: 8_100, firstTokenMs: 0, tokensPerSec: 40 }
+    current.host.dshVersion = '1.2.3'
+  })
+  assert.equal(render('agent-preset', snap, { id: 'agent-preset', format: 'unknown' }), '[Code preset]')
+  assert.equal(render('model', snap, { id: 'model', format: 'unknown' }), '[deepseek/flash]')
+  assert.equal(render('permission-preset', snap, { id: 'permission-preset', format: 'unknown' }), '[read-only]')
+  assert.equal(render('plan-state', snap, { id: 'plan-state', format: 'unknown' }), '[plan]')
+  assert.equal(render('cwd', snap, { id: 'cwd', format: 'unknown' }), 'x/proj')
+  assert.equal(render('git-branch', snap, { id: 'git-branch', format: 'unknown' }), 'main')
+  assert.equal(render('context', snap, { id: 'context', format: 'unknown' }), '[███░░░░░░░░░] 25%')
+  assert.equal(render('turns-steps', snap, { id: 'turns-steps', format: 'unknown' }), 't0/s0')
+  assert.equal(render('cache-hit', snap, { id: 'cache-hit', format: 'unknown' }), 'C 50.0%')
+  assert.equal(render('token-usage', snap, { id: 'token-usage', format: 'unknown' }), '1200/3400')
+  assert.equal(render('performance', snap, { id: 'performance', format: 'unknown' }), '8.1s 40 tok/s')
+  assert.equal(render('version', snap, { id: 'version', format: 'unknown' }), 'v0.0.0')
+  // `plain` (turns) and `compact` (performance) appeared in older custom
+  // documents even though they were never declared meaningful styles. They
+  // still degrade to the same effective legacy defaults instead of changing
+  // old layouts on load.
+  assert.equal(render('turns-steps', snap, { id: 'turns-steps', format: 'plain' }), 't0/s0')
+  assert.equal(render('performance', snap, { id: 'performance', format: 'compact' }), '8.1s 40 tok/s')
+})
+
+test('unknown persisted formats survive parsing and fail soft in the real composer', () => {
+  const snap = snapshotWith(current => {
+    current.usage.tokens = { input: 1_200, output: 3_400, cacheRead: 0, cacheWrite: 0 }
+    current.usage.cacheHitPct = 50
+    current.usage.performance = { llmMs: 8_100, firstTokenMs: 0, tokensPerSec: 40 }
+  })
+  const parsed = parseFooterLayout({
+    schemaVersion: 1,
+    rows: [{
+      left: [
+        { id: 'performance', format: 'future-performance' },
+        { id: 'cache-hit', format: 'future-cache' },
+        { id: 'token-usage', format: 'future-tokens' },
+      ],
+      right: [],
+    }],
+  })
+  assert.ok(isFooterLayout(parsed), 'unknown format strings must remain valid persisted layout data')
+  const output = new FooterComposer(registry).render({
+    snapshot: snap,
+    layout: parsed,
+    width: 40,
+    context: CONTEXT,
+  })
+  for (const row of output.split('\n')) {
+    assert.ok(visibleWidth(row) <= 40, `composer output overflows: ${JSON.stringify(row)}`)
+  }
+  const text = plain(output)
+  assert.ok(text.includes('8.1s 40 tok/s'), `performance must use its default: ${text}`)
+  assert.ok(text.includes('C 50.0%'), `cache hit must use its default: ${text}`)
+  assert.ok(text.includes('1200/3400'), `token usage must use its default: ${text}`)
+})
+
 test('the registry rejects duplicate ids and lists every id', () => {
   const def = registry.get('model')!
   const registry2 = createBuiltinFooterRegistry()

--- a/test/footer-items.test.ts
+++ b/test/footer-items.test.ts
@@ -122,9 +122,16 @@ test('cwd styles handle POSIX and Windows separators without losing roots', () =
   assert.equal(render('cwd', windows, { id: 'cwd', format: 'basename' }), 'project')
   assert.equal(render('cwd', windows, { id: 'cwd', format: 'full' }), 'C:\\Users\\alice\\project')
 
+  const posixBackslash = snapshotWith(snap => { snap.workspace.cwd = '/home/foo\\bar/project' })
+  assert.equal(render('cwd', posixBackslash, { id: 'cwd', format: 'short' }), 'foo\\bar/project')
+  assert.equal(render('cwd', posixBackslash, { id: 'cwd', format: 'basename' }), 'project')
+
   const posixRoot = snapshotWith(snap => { snap.workspace.cwd = '/' })
   assert.equal(render('cwd', posixRoot, { id: 'cwd', format: 'short' }), '/')
   assert.equal(render('cwd', posixRoot, { id: 'cwd', format: 'basename' }), '/')
+  const unc = snapshotWith(snap => { snap.workspace.cwd = '\\\\server\\share\\project' })
+  assert.equal(render('cwd', unc, { id: 'cwd', format: 'short' }), 'share/project')
+  assert.equal(render('cwd', unc, { id: 'cwd', format: 'basename' }), 'project')
   const windowsRoot = snapshotWith(snap => { snap.workspace.cwd = 'C:/' })
   assert.equal(render('cwd', windowsRoot, { id: 'cwd', format: 'short' }), 'C:/')
   assert.equal(render('cwd', windowsRoot, { id: 'cwd', format: 'basename' }), 'C:/')
@@ -188,7 +195,7 @@ test('ext:* bridges the extension footer text; empty → nothing', () => {
 
 test('builtin styles render meaningful golden variants without changing defaults', () => {
   const snap = snapshotWith(current => {
-    current.composition.agentPreset = { id: 'code', label: 'Code preset' }
+    current.composition.agentPreset = { id: 'code', label: 'Code preset', shortLabel: 'CP' }
     current.composition.model = {
       provider: 'deepseek',
       id: 'flash',
@@ -201,7 +208,7 @@ test('builtin styles render meaningful golden variants without changing defaults
     current.usage.context = { usedTokens: 25_000, windowTokens: 100_000, percent: 25 }
     current.usage.tokens = { input: 1_200, output: 3_400, cacheRead: 2_000, cacheWrite: 100 }
     current.usage.cacheHitPct = 91.9
-    current.usage.performance = { llmMs: 8_100, firstTokenMs: 2_000, tokensPerSec: 40 }
+    current.usage.performance = { llmMs: 1_104_000, firstTokenMs: 1_800, tokensPerSec: 40 }
     current.usage.turns = 3
     current.usage.steps = 7
     current.host.dshVersion = '1.2.3'
@@ -258,7 +265,7 @@ test('builtin styles render meaningful golden variants without changing defaults
     },
     {
       id: 'performance',
-      formats: [['full', '8.1s 40 tok/s'], ['speed', '40 tok/s'], ['latency', '8.1s']],
+      formats: [['full', '1104s 40 tok/s'], ['speed', '40 tok/s'], ['latency', '1.8s']],
     },
     {
       id: 'turns-steps',
@@ -300,7 +307,7 @@ test('builtin styles render meaningful golden variants without changing defaults
   assert.equal(render('context', snap), '[███░░░░░░░░░] 25%')
   assert.equal(render('token-usage', snap), '1200/3400')
   assert.equal(render('cache-hit', snap), 'C 91.9%')
-  assert.equal(render('performance', snap), '8.1s 40 tok/s')
+  assert.equal(render('performance', snap), '1104s 40 tok/s')
   assert.equal(render('turns-steps', snap), 't3/s7')
 })
 
@@ -318,6 +325,7 @@ test('new builtin styles fall back to the unchanged default formatter', () => {
     current.host.dshVersion = '1.2.3'
   })
   assert.equal(render('agent-preset', snap, { id: 'agent-preset', format: 'unknown' }), '[Code preset]')
+  assert.equal(render('agent-preset', snap, { id: 'agent-preset', format: 'compact' }), '[Code preset]')
   assert.equal(render('model', snap, { id: 'model', format: 'unknown' }), '[deepseek/flash]')
   assert.equal(render('permission-preset', snap, { id: 'permission-preset', format: 'unknown' }), '[read-only]')
   assert.equal(render('plan-state', snap, { id: 'plan-state', format: 'unknown' }), '[plan]')

--- a/test/footer-responsive.test.ts
+++ b/test/footer-responsive.test.ts
@@ -61,6 +61,25 @@ const RIGHT_ZONE_LAYOUT = {
   }],
 }
 
+const STYLE_LAYOUT = {
+  schemaVersion: 1 as const,
+  rows: [{
+    left: [
+      { id: 'permission-preset', format: 'compact' },
+      { id: 'plan-state', format: 'plain' },
+      { id: 'model', format: 'compact' },
+      { id: 'cwd', format: 'full' },
+      { id: 'git-branch', format: 'label' },
+      { id: 'context', format: 'percent' },
+      { id: 'cache-hit', format: 'compact' },
+      { id: 'token-usage', format: 'total' },
+      { id: 'performance', format: 'speed' },
+      { id: 'turns-steps', format: 'steps' },
+    ],
+    right: [],
+  }],
+}
+
 const WIDTHS = [200, 160, 120, 100, 80, 60, 40, 20]
 
 test('the default layout never overflows or breaks ANSI at any width', () => {
@@ -77,6 +96,18 @@ test('the default layout never overflows or breaks ANSI at any width', () => {
       // the outer dim after inner resets — the legacy structure).
       const truncated = row.match(/\x1b\[(?:[0-9;]*[^0-9;m]|[0-9;]*$)/)
       assert.equal(truncated, null, `truncated ANSI at ${width}: ${JSON.stringify(row)}`)
+    }
+  }
+})
+
+test('all builtin styles stay inside the composer width policy', () => {
+  const snap = busySnapshot()
+  for (const width of WIDTHS) {
+    const text = composer.render({ snapshot: snap, layout: STYLE_LAYOUT, width, context: CONTEXT })
+    for (const row of text.split('\n')) {
+      assert.ok(visibleWidth(row) <= width, `styled row overflows at ${width}: ${JSON.stringify(row)}`)
+      const truncated = row.match(/\x1b\[(?:[0-9;]*[^0-9;m]|[0-9;]*$)/)
+      assert.equal(truncated, null, `styled row has truncated ANSI at ${width}: ${JSON.stringify(row)}`)
     }
   }
 })


### PR DESCRIPTION
## Summary
- Add meaningful finite styles for builtin footer items while retaining legacy defaults.
- Keep unknown persisted formats fail-soft and preserve FooterLayoutV1/public extension compatibility.
- Expand golden, configurator, registry-invariant, parse/composer, and narrow-width coverage.
- Update bilingual README and changelog documentation.

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- Footer targeted tests: 89/89 passed
- Naming, client-boundary, and host-keybinding gates passed
- Local holistic review-fix loop: accepted with no open findings

## Review
- Merges into `main`.
- No remote changes beyond this feature branch.