### PR TITLE
feat: add custom footer text items

### DIFF
--- a/docs/client-server-migration.md
+++ b/docs/client-server-migration.md
@@ -85,7 +85,12 @@ Every new feature declares its machine ownership (AGENTS.md guardrail):
 - **The footer surface (composer/layout/items/configurator, `src/footer/`)
   is client-local presentation.** It consumes the snapshot; no Host
   service is read there. The extension footer items ride the public
-  extension service (Host-composed, Stable).
+  extension service (Host-composed, Stable). User Custom Text definitions are
+  compiled into the same local item contract, but their raw definition
+  collection is Host-owned settings data and is persisted separately from the
+  client-local `FooterLayoutV1` placement references. A future Remote adapter
+  must carry both fields through one whole-document settings round-trip; it
+  must not invent a callback or merge definitions into layout refs.
 - **The footer command status line (M5) is DIRECT-ONLY, client-local
   execution.** The trusted command runs on the Client machine's shell
   (like the local `!` shell) with a USER-layer-only trust gate. There is

--- a/docs/client-server-migration.md
+++ b/docs/client-server-migration.md
@@ -91,8 +91,10 @@ Every new feature declares its machine ownership (AGENTS.md guardrail):
   client-local `FooterLayoutV1` placement references. The Direct config port
   resolves definitions from the settings descriptor's USER layer only;
   merged/project values are pass-through storage and cannot create
-  `user:*` definitions. A future Remote adapter
-  must carry both fields through one whole-document settings round-trip; it
+  `user:*` definitions. It exposes a parsed runtime projection plus an
+  exact raw USER storage projection, so unrelated writes preserve
+  unknown/future definition kinds. A future Remote adapter must carry both
+  fields through one whole-document settings round-trip; it
   must not invent a callback or merge definitions into layout refs.
 - **The footer command status line (M5) is DIRECT-ONLY, client-local
   execution.** The trusted command runs on the Client machine's shell

--- a/docs/client-server-migration.md
+++ b/docs/client-server-migration.md
@@ -88,7 +88,10 @@ Every new feature declares its machine ownership (AGENTS.md guardrail):
   extension service (Host-composed, Stable). User Custom Text definitions are
   compiled into the same local item contract, but their raw definition
   collection is Host-owned settings data and is persisted separately from the
-  client-local `FooterLayoutV1` placement references. A future Remote adapter
+  client-local `FooterLayoutV1` placement references. The Direct config port
+  resolves definitions from the settings descriptor's USER layer only;
+  merged/project values are pass-through storage and cannot create
+  `user:*` definitions. A future Remote adapter
   must carry both fields through one whole-document settings round-trip; it
   must not invent a callback or merge definitions into layout refs.
 - **The footer command status line (M5) is DIRECT-ONLY, client-local

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -945,7 +945,9 @@ export interface InitialCommandCatalog {
  * value is intentional here: parsed runtime items would erase unknown/future
  * definitions during a downgrade or a fail-soft read. */
 function withUserFooterCustomItems(doc: TuiSettingsDoc, config: ConfigPort): TuiSettingsDoc {
-  return { ...doc, footerCustomItems: config.footerCustomItems.rawForPersistence() }
+  const raw = config.footerCustomItems.rawForPersistence()
+  if (raw.kind === 'unavailable') throw new Error('custom footer definitions unavailable; settings write aborted')
+  return { ...doc, footerCustomItems: raw.value }
 }
 
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1061,6 +1061,7 @@ export function registerTuiCommands(
     const controller = new KeybindingEditorController({
       settings,
       manager: app.keybindingsManager(),
+      projectSettingsForWrite: doc => withUserFooterCustomItems(doc, runner.config),
       onDiagnostic: diagnostic => runner.diag.debug('keybinding configuration', { error: diagnostic }),
     })
     let panel: KeybindingEditorPanel | undefined

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,7 +36,12 @@ import type { KeybindingEditorModel } from './keybinding-ui/model.ts'
 import { parseFooterLayout, isFooterLayout } from './footer/layout.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
 import { FooterComposer } from './footer/composer.ts'
-import { FooterCustomItemCatalog, parseFooterCustomItems, type FooterCustomItemSettings } from './footer/custom-items.ts'
+import {
+  FooterCustomItemCatalog,
+  parseFooterCustomItem,
+  parseFooterCustomItems,
+  type FooterCustomItemSettings,
+} from './footer/custom-items.ts'
 import { FooterItemRegistry } from './footer/item-registry.ts'
 import { FooterConfiguratorModel } from './footer/configurator-model.ts'
 import type { TuiApp } from './tui-app.ts'
@@ -951,6 +956,43 @@ function withUserFooterCustomItems(doc: TuiSettingsDoc, config: ConfigPort): Tui
 }
 
 /**
+ * Merge an intentional `/footer` save into the detached USER raw collection.
+ * The editor owns every recognized v1 text definition: an existing known id
+ * is replaced by its validated draft, and a missing known id is a deliberate
+ * delete. Entries this client cannot parse (future kinds or future fields)
+ * remain unchanged in their original slots so opening and saving the
+ * current UI does not destroy definitions owned by a newer client.
+ */
+function mergeFooterCustomItemsForSave(raw: unknown, saved: readonly FooterCustomItemSettings[]): readonly unknown[] {
+  if (!Array.isArray(raw)) return saved.map(item => ({ ...item }))
+  const savedById = new Map(saved.map(item => [item.id, item] as const))
+  const emittedKnown = new Set<string>()
+  const result: unknown[] = []
+  for (const candidate of raw) {
+    const known = parseFooterCustomItem(candidate)
+    if (known !== undefined) {
+      const replacement = savedById.get(known.id)
+      if (replacement !== undefined && !emittedKnown.has(known.id)) {
+        result.push({ ...replacement })
+        emittedKnown.add(known.id)
+      }
+      continue
+    }
+    // An explicitly-created v1 item wins an id collision with a future
+    // definition; otherwise preserving both would make the raw collection
+    // ambiguous to the newer owner.
+    const candidateId = typeof candidate === 'object' && candidate !== null && !Array.isArray(candidate)
+      ? (candidate as { id?: unknown }).id
+      : undefined
+    if (typeof candidateId !== 'string' || !savedById.has(candidateId)) result.push(candidate)
+  }
+  for (const item of saved) {
+    if (!emittedKnown.has(item.id)) result.push({ ...item })
+  }
+  return result
+}
+
+/**
  * Register the TUI-owned slash commands on the commands service. The
  * completion list is refreshed after every registration so TUI-owned
  * commands appear in the editor's tab list. Registration is sessionless:
@@ -1808,7 +1850,24 @@ export function registerTuiCommands(
             return
           }
           const savedCustomItems = customResult.items.map(item => ({ ...item }))
+          let persistedCustomItems: readonly unknown[] = savedCustomItems
           if (settings !== undefined) {
+            // `/footer` intentionally edits the custom-definition collection,
+            // but it only owns the v1 text entries this client understands.
+            // Keep detached USER entries for future kinds alongside the
+            // validated draft so an older client stays downgrade-safe.
+            let raw: ReturnType<ConfigPort['footerCustomItems']['rawForPersistence']>
+            try {
+              raw = runner.config.footerCustomItems.rawForPersistence()
+            } catch {
+              app.notify('custom footer definitions unavailable; settings write aborted', 'error')
+              return
+            }
+            if (raw.kind === 'unavailable') {
+              app.notify('custom footer definitions unavailable; settings write aborted', 'error')
+              return
+            }
+            persistedCustomItems = mergeFooterCustomItemsForSave(raw.value, savedCustomItems)
             // Persist FIRST; the memory commit happens only after the
             // settings write succeeds (plan §15.7 — a failed write keeps
             // the old layout and definitions and notifies). footerFallbackMode
@@ -1821,7 +1880,7 @@ export function registerTuiCommands(
                 footer: 'custom',
                 footerFallbackMode: 'custom',
                 footerLayout: parsed,
-                footerCustomItems: savedCustomItems,
+                footerCustomItems: persistedCustomItems,
               }))
               app.setFooterCustomItems(savedCustomItems)
               runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems }, savedCustomItems)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -35,6 +35,9 @@ import { KeybindingEditorPanel, KeybindingEditorUnavailablePanel } from './keybi
 import type { KeybindingEditorModel } from './keybinding-ui/model.ts'
 import { parseFooterLayout, isFooterLayout } from './footer/layout.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
+import { FooterComposer } from './footer/composer.ts'
+import { FooterCustomItemCatalog, parseFooterCustomItems } from './footer/custom-items.ts'
+import { FooterItemRegistry } from './footer/item-registry.ts'
 import { FooterConfiguratorModel } from './footer/configurator-model.ts'
 import type { TuiApp } from './tui-app.ts'
 import type { PickerCategory, PickerItem } from './tui-app.ts'
@@ -262,10 +265,10 @@ export interface TuiCommandRunner {
     create(options: CreateSessionRequest): Promise<SessionHandle>
     resume(options: ResumeSessionRequest): Promise<SessionHandle>
   }
-  /** M2: apply the persisted footer mode + layout to the app (shared by
-   * /settings, /reload and the startup path; fail-soft on invalid custom
+  /** M2/PR C: apply the persisted footer mode, layout and user definitions to
+   * the app (shared by /settings, /reload and startup; fail-soft on invalid
    * configs). */
-  applyFooterSettings(doc: { footer: string; footerLayout?: unknown } | undefined): void
+  applyFooterSettings(doc: { footer: string; footerLayout?: unknown; footerCustomItems?: unknown } | undefined): void
   /** The session READ port (migration M1.3): /sessions, /resume, /search,
    * the title batches, the context measurement and the export read go
    * through the port, never ctx directly. */
@@ -1634,7 +1637,7 @@ export function registerTuiCommands(
                 // settings write must not leave the live layout ahead of
                 // the document (the next reload would silently revert).
                 detach('settings footer write', async () => {
-                  const nextLayout = await serializeTuiSettingsMutation(settings, async () => {
+                  const next = await serializeTuiSettingsMutation(settings, async () => {
                     const doc = settings.get()
                     // Selecting custom with no (valid) layout initializes an
                     // editable copy of the default layout (plan §14.8).
@@ -1643,10 +1646,14 @@ export function registerTuiCommands(
                         ? DEFAULT_FOOTER_LAYOUT
                         : doc.footerLayout
                       : doc.footerLayout
-                    await settings.replace({ ...doc, footer: value, footerLayout: layout, footerFallbackMode: value })
-                    return layout
+                    // Preserve the detached USER value, not a merged/project
+                    // projection, while the whole-document write is queued.
+                    const raw = runner.config.footerCustomItems.rawForPersistence()
+                    if (raw.kind === 'unavailable') throw new Error('custom footer definitions unavailable; settings write aborted')
+                    await settings.replace({ ...doc, footer: value, footerLayout: layout, footerFallbackMode: value, footerCustomItems: raw.value })
+                    return { layout, customItems: raw.value }
                   })
-                  runner.applyFooterSettings({ footer: value, footerLayout: nextLayout })
+                  runner.applyFooterSettings({ footer: value, footerLayout: next.layout, footerCustomItems: next.customItems })
                 }, { notify: true })
               } else {
                 runner.applyFooterSettings({ footer: value })
@@ -1758,12 +1765,19 @@ export function registerTuiCommands(
       const initial = persisted !== undefined && isFooterLayout(persisted)
         ? persisted
         : app.getEffectiveFooterLayout()
-      const registry = app.getFooterItemRegistry()
-      const model = new FooterConfiguratorModel(initial, registry)
+      // Layer the draft catalog over the live app registry. Unsaved create /
+      // edit / rename / delete operations stay inside this catalog, so Esc
+      // cannot mutate the active footer or its persisted definitions.
+      const registry = new FooterItemRegistry(app.getFooterItemRegistry())
+      const customItems = new FooterCustomItemCatalog(app.getFooterCustomItems())
+      registry.setCustomSource(customItems)
+      const composer = new FooterComposer(registry)
+      const model = new FooterConfiguratorModel(initial, registry, customItems)
       app.openFooterConfigurator({
         model,
         registry,
-        onSave: (layout) => {
+        composer,
+        onSave: (layout, draftCustomItems) => {
           // Validate the draft (the model's operations keep it well-formed,
           // but the persisted value is never trusted).
           const parsed = parseFooterLayout(layout)
@@ -1771,26 +1785,34 @@ export function registerTuiCommands(
             app.notify(`footer layout invalid: ${parsed.message}`, 'error')
             return
           }
+          const customResult = parseFooterCustomItems(draftCustomItems ?? [])
+          if (customResult.invalidCount > 0 || customResult.items.length !== (draftCustomItems ?? []).length) {
+            app.notify('custom footer items invalid', 'error')
+            return
+          }
+          const savedCustomItems = customResult.items.map(item => ({ ...item }))
           if (settings !== undefined) {
             // Persist FIRST; the memory commit happens only after the
             // settings write succeeds (plan §15.7 — a failed write keeps
-            // the old layout and notifies). footerFallbackMode rides
-            // ALONG: the /settings path records the last native mode, and
-            // saving a custom layout IS a native-mode change — the command
-            // surface's restart fallback must resolve to THIS custom
-            // layout, not the mode the user had before opening /footer.
+            // the old layout and definitions and notifies). footerFallbackMode
+            // rides ALONG: the /settings path records the last native mode,
+            // and saving a custom layout IS a native-mode change — the command
+            // surface's restart fallback must resolve to THIS custom layout.
             detach('footer configurator write', async () => {
               await serializeTuiSettingsMutation(settings, () => settings.replace({
                 ...settings.get(),
                 footer: 'custom',
                 footerFallbackMode: 'custom',
                 footerLayout: parsed,
+                footerCustomItems: savedCustomItems,
               }))
-              runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed })
+              app.setFooterCustomItems(savedCustomItems)
+              runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems })
               app.notify('footer layout saved', 'info')
             }, { notify: true })
           } else {
-            runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed })
+            app.setFooterCustomItems(savedCustomItems)
+            runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems })
             app.notify('footer layout saved', 'info')
           }
         },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -941,10 +941,11 @@ export interface InitialCommandCatalog {
 /** Keep USER-owned Custom Text definitions out of whole-document writes that
  * start from a merged settings document. A project layer may contribute the
  * pass-through `footerCustomItems` field, but it must never be copied into
- * USER settings merely because an unrelated setting changed. */
+ * USER settings merely because an unrelated setting changed. The raw USER
+ * value is intentional here: parsed runtime items would erase unknown/future
+ * definitions during a downgrade or a fail-soft read. */
 function withUserFooterCustomItems(doc: TuiSettingsDoc, config: ConfigPort): TuiSettingsDoc {
-  const { items } = config.footerCustomItems.get()
-  return { ...doc, footerCustomItems: items.map(item => ({ ...item })) }
+  return { ...doc, footerCustomItems: config.footerCustomItems.rawForPersistence() }
 }
 
 /**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1049,7 +1049,6 @@ export function registerTuiCommands(
       recoverable: options.notify === true ? () => true : undefined,
     })
   }
-
   /** Build the one editor used by /keybindings and the /settings submenu.
    * The settings row is only a launcher; all reads/writes still go through
    * the controller and the same panel state machine. */
@@ -1850,24 +1849,7 @@ export function registerTuiCommands(
             return
           }
           const savedCustomItems = customResult.items.map(item => ({ ...item }))
-          let persistedCustomItems: readonly unknown[] = savedCustomItems
           if (settings !== undefined) {
-            // `/footer` intentionally edits the custom-definition collection,
-            // but it only owns the v1 text entries this client understands.
-            // Keep detached USER entries for future kinds alongside the
-            // validated draft so an older client stays downgrade-safe.
-            let raw: ReturnType<ConfigPort['footerCustomItems']['rawForPersistence']>
-            try {
-              raw = runner.config.footerCustomItems.rawForPersistence()
-            } catch {
-              app.notify('custom footer definitions unavailable; settings write aborted', 'error')
-              return
-            }
-            if (raw.kind === 'unavailable') {
-              app.notify('custom footer definitions unavailable; settings write aborted', 'error')
-              return
-            }
-            persistedCustomItems = mergeFooterCustomItemsForSave(raw.value, savedCustomItems)
             // Persist FIRST; the memory commit happens only after the
             // settings write succeeds (plan §15.7 — a failed write keeps
             // the old layout and definitions and notifies). footerFallbackMode
@@ -1875,13 +1857,25 @@ export function registerTuiCommands(
             // and saving a custom layout IS a native-mode change — the command
             // surface's restart fallback must resolve to THIS custom layout.
             detach('footer configurator write', async () => {
-              await serializeTuiSettingsMutation(settings, () => settings.replace({
-                ...settings.get(),
-                footer: 'custom',
-                footerFallbackMode: 'custom',
-                footerLayout: parsed,
-                footerCustomItems: persistedCustomItems,
-              }))
+              if (app.isDisposed()) return
+              await serializeTuiSettingsMutation(settings, async () => {
+                if (app.isDisposed()) return
+                // `/footer` intentionally edits the custom-definition
+                // collection, but it only owns the v1 text entries this client
+                // understands. Re-read the detached USER value at the commit
+                // point so queued saves do not erase intervening future data.
+                const raw = runner.config.footerCustomItems.rawForPersistence()
+                if (raw.kind === 'unavailable') throw new Error('custom footer definitions unavailable; settings write aborted')
+                const persistedCustomItems = mergeFooterCustomItemsForSave(raw.value, savedCustomItems)
+                await settings.replace({
+                  ...settings.get(),
+                  footer: 'custom',
+                  footerFallbackMode: 'custom',
+                  footerLayout: parsed,
+                  footerCustomItems: persistedCustomItems,
+                })
+              })
+              if (app.isDisposed()) return
               app.setFooterCustomItems(savedCustomItems)
               runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems }, savedCustomItems)
               app.notify('footer layout saved', 'info')

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -75,7 +75,7 @@ import type { SessionWriter } from './runtime/session-writer-port.ts'
 import type { InteractionPort } from './runtime/interaction-port.ts'
 import type { CreateSessionRequest, ResumeSessionRequest, SessionHandle } from './runtime/session-lifecycle-port.ts'
 import type { Catalog } from './runtime/catalog-port.ts'
-import type { ConfigPort, CredentialProviderOption, TuiSettingsDoc } from './runtime/config-port.ts'
+import type { ConfigPort, CredentialProviderOption } from './runtime/config-port.ts'
 import type { HostFilePort } from './runtime/host-file-port.ts'
 import {
   credentialOptionsFor,
@@ -3422,6 +3422,10 @@ export function registerTuiCommands(
         // it reports an error and the running keymap stays untouched.
         return serializeTuiSettingsMutation(settings, async (): Promise<CommandResult> => {
           try {
+            // The outer serializeTuiSettingsMutation call owns the whole
+            // transaction. Read and build the reset document only after all
+            // earlier footer/focus/fullscreen writes have settled, then
+            // persist it as the single next whole-document commit point.
             const doc = { ...withUserFooterCustomItems(settings.get(), runner.config) } as Record<string, unknown>
             delete doc.keybindings
             // Await the persistence write: the command result reflects the

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1695,7 +1695,9 @@ export function registerTuiCommands(
                 // settings write must not leave the live layout ahead of
                 // the document (the next reload would silently revert).
                 detach('settings footer write', async () => {
+                  if (app.isDisposed()) return
                   const next = await serializeTuiSettingsMutation(settings, async () => {
+                    if (app.isDisposed()) return undefined
                     const doc = settings.get()
                     // Selecting custom with no (valid) layout initializes an
                     // editable copy of the default layout (plan §14.8).
@@ -1711,6 +1713,7 @@ export function registerTuiCommands(
                     await settings.replace({ ...doc, footer: value, footerLayout: layout, footerFallbackMode: value, footerCustomItems: raw.value })
                     return { layout, customItems: raw.value }
                   })
+                  if (app.isDisposed() || next === undefined) return
                   runner.applyFooterSettings({ footer: value, footerLayout: next.layout, footerCustomItems: next.customItems })
                 }, { notify: true })
               } else {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,7 +36,7 @@ import type { KeybindingEditorModel } from './keybinding-ui/model.ts'
 import { parseFooterLayout, isFooterLayout } from './footer/layout.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
 import { FooterComposer } from './footer/composer.ts'
-import { FooterCustomItemCatalog, parseFooterCustomItems } from './footer/custom-items.ts'
+import { FooterCustomItemCatalog, parseFooterCustomItems, type FooterCustomItemSettings } from './footer/custom-items.ts'
 import { FooterItemRegistry } from './footer/item-registry.ts'
 import { FooterConfiguratorModel } from './footer/configurator-model.ts'
 import type { TuiApp } from './tui-app.ts'
@@ -70,7 +70,7 @@ import type { SessionWriter } from './runtime/session-writer-port.ts'
 import type { InteractionPort } from './runtime/interaction-port.ts'
 import type { CreateSessionRequest, ResumeSessionRequest, SessionHandle } from './runtime/session-lifecycle-port.ts'
 import type { Catalog } from './runtime/catalog-port.ts'
-import type { ConfigPort, CredentialProviderOption } from './runtime/config-port.ts'
+import type { ConfigPort, CredentialProviderOption, TuiSettingsDoc } from './runtime/config-port.ts'
 import type { HostFilePort } from './runtime/host-file-port.ts'
 import {
   credentialOptionsFor,
@@ -265,10 +265,15 @@ export interface TuiCommandRunner {
     create(options: CreateSessionRequest): Promise<SessionHandle>
     resume(options: ResumeSessionRequest): Promise<SessionHandle>
   }
-  /** M2/PR C: apply the persisted footer mode, layout and user definitions to
-   * the app (shared by /settings, /reload and startup; fail-soft on invalid
-   * configs). */
-  applyFooterSettings(doc: { footer: string; footerLayout?: unknown; footerCustomItems?: unknown } | undefined): void
+  /** M2/PR C: apply the persisted footer mode and layout to the app (shared
+   * by /settings, /reload and startup; fail-soft on invalid configs). The
+   * optional definitions are a validated /footer-save result, not the merged
+   * settings value; ordinary calls resolve definitions from the USER layer
+   * through the config port. */
+  applyFooterSettings(
+    doc: { footer: string; footerLayout?: unknown; footerCustomItems?: unknown } | undefined,
+    savedCustomItems?: readonly FooterCustomItemSettings[],
+  ): void
   /** The session READ port (migration M1.3): /sessions, /resume, /search,
    * the title batches, the context measurement and the export read go
    * through the port, never ctx directly. */
@@ -933,6 +938,15 @@ export interface InitialCommandCatalog {
   readonly skills?: HumanSkillCatalog
 }
 
+/** Keep USER-owned Custom Text definitions out of whole-document writes that
+ * start from a merged settings document. A project layer may contribute the
+ * pass-through `footerCustomItems` field, but it must never be copied into
+ * USER settings merely because an unrelated setting changed. */
+function withUserFooterCustomItems(doc: TuiSettingsDoc, config: ConfigPort): TuiSettingsDoc {
+  const { items } = config.footerCustomItems.get()
+  return { ...doc, footerCustomItems: items.map(item => ({ ...item })) }
+}
+
 /**
  * Register the TUI-owned slash commands on the commands service. The
  * completion list is refreshed after every registration so TUI-owned
@@ -1500,7 +1514,7 @@ export function registerTuiCommands(
                   // value IS the source-qualified identity.
                   detach('settings theme write', () => serializeTuiSettingsMutation(
                     settings,
-                    () => settings.replace({ ...settings.get(), theme: qualified }),
+                    () => settings.replace(withUserFooterCustomItems({ ...settings.get(), theme: qualified }, runner.config)),
                   ), { notify: true })
                 }
                 lastThemeChoice = qualified
@@ -1665,7 +1679,7 @@ export function registerTuiCommands(
               if (settings !== undefined) {
                 detach('settings busy enter write', () => serializeTuiSettingsMutation(
                    settings,
-                   () => settings.replace({ ...settings.get(), busyEnter: value }),
+                   () => settings.replace(withUserFooterCustomItems({ ...settings.get(), busyEnter: value }, runner.config)),
                  ), { notify: true })
               }
             }
@@ -1681,7 +1695,7 @@ export function registerTuiCommands(
               if (settings !== undefined) {
                 detach('settings icon style write', () => serializeTuiSettingsMutation(
                    settings,
-                   () => settings.replace({ ...settings.get(), iconStyle: value }),
+                   () => settings.replace(withUserFooterCustomItems({ ...settings.get(), iconStyle: value }, runner.config)),
                  ), { notify: true })
               }
             }
@@ -1691,7 +1705,7 @@ export function registerTuiCommands(
               if (settings !== undefined) {
                 detach('settings local shell sandbox write', () => serializeTuiSettingsMutation(
                    settings,
-                   () => settings.replace({ ...settings.get(), localShellSandbox: value }),
+                   () => settings.replace(withUserFooterCustomItems({ ...settings.get(), localShellSandbox: value }, runner.config)),
                  ), { notify: true })
               }
             }
@@ -1704,7 +1718,7 @@ export function registerTuiCommands(
               if (settings !== undefined) {
                 detach('settings home end keys write', () => serializeTuiSettingsMutation(
                    settings,
-                   () => settings.replace({ ...settings.get(), homeEndKeys: value }),
+                   () => settings.replace(withUserFooterCustomItems({ ...settings.get(), homeEndKeys: value }, runner.config)),
                  ), { notify: true })
               }
             }
@@ -1807,12 +1821,12 @@ export function registerTuiCommands(
                 footerCustomItems: savedCustomItems,
               }))
               app.setFooterCustomItems(savedCustomItems)
-              runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems })
+              runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems }, savedCustomItems)
               app.notify('footer layout saved', 'info')
             }, { notify: true })
           } else {
             app.setFooterCustomItems(savedCustomItems)
-            runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems })
+            runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems }, savedCustomItems)
             app.notify('footer layout saved', 'info')
           }
         },
@@ -3349,7 +3363,7 @@ export function registerTuiCommands(
         // it reports an error and the running keymap stays untouched.
         return serializeTuiSettingsMutation(settings, async (): Promise<CommandResult> => {
           try {
-            const doc = { ...settings.get() } as Record<string, unknown>
+            const doc = { ...withUserFooterCustomItems(settings.get(), runner.config) } as Record<string, unknown>
             delete doc.keybindings
             // Await the persistence write: the command result reflects the
             // ACTUAL outcome (a failed write must not report success — review

--- a/src/footer/configurator-model.ts
+++ b/src/footer/configurator-model.ts
@@ -5,9 +5,11 @@
  *   rows (Row Selector) → row (Edit Row) → item (Item Editor)
  *                                          ├─ style (Style picker)
  *                                          ├─ tone  (Tone picker)
- *                                          └─ advanced (Prefix/Suffix/
- *                                                       Importance/Reset)
- *   row → add (searchable Add picker)
+ *                                          ├─ custom Text/Tone
+ *                                          ├─ Advanced (Prefix/Suffix/
+ *                                          │            Importance/Reset)
+ *                                          └─ Rename/Delete definition
+ *   row → add (searchable Add picker → Create Custom Text flow)
  *   row ⇄ row-move (Move Mode)
  *
  * The UI component only renders and forwards keys; the whole model is
@@ -17,6 +19,7 @@
  * @module @xmoon76/dsh-pi-tui/footer/configurator-model
  */
 
+import { FooterCustomItemCatalog, type FooterCustomItemSettings, customItemId, customItemName } from './custom-items.ts'
 import type { FooterItemRegistry } from './item-registry.ts'
 import { MAX_ITEMS_PER_ROW, stripControlChars } from './layout.ts'
 import { COMPACT_FOOTER_LAYOUT, DEFAULT_FOOTER_LAYOUT } from './presets.ts'
@@ -32,6 +35,13 @@ export type FooterConfiguratorMode =
   | 'tone'
   | 'advanced'
   | 'add'
+  | 'create-name'
+  | 'create-text'
+  | 'create-tone'
+  | 'custom-text'
+  | 'custom-tone'
+  | 'custom-name'
+  | 'custom-delete'
 
 /** The advanced editor's fields (v1: the EXISTING ref fields only — no
  * new schema). `reset` is the trailing "Reset to default" action row. */
@@ -64,6 +74,14 @@ export interface FooterConfiguratorState {
   readonly editing: boolean
   /** The inline editor's buffer (raw; committed on Enter). */
   readonly editBuffer: string
+  /** The name currently being created (without the persisted `user:` prefix). */
+  readonly customName: string
+  /** The text currently being created. */
+  readonly customText: string
+  /** The tone currently being created. */
+  readonly customTone: FooterTone | 'auto'
+  /** A fail-soft validation message for the current custom-item flow. */
+  readonly customError: string
 }
 
 /** The tone picker's choices: persisted values use the EXISTING semantic
@@ -176,16 +194,34 @@ export function flatLengthOf(row: FooterRowLayout): number {
 }
 
 /** One item-editor menu entry (Style appears only for items with more
- * than one finite format — a single format has nothing to pick). */
-export type ItemMenuEntry = { readonly kind: 'style' } | { readonly kind: 'tone' } | { readonly kind: 'advanced' }
+ * than one finite format — a single format has nothing to pick). Custom Text
+ * definitions expose their definition-owned text/tone/name/delete controls in
+ * addition to the shared ref Advanced editor. */
+export type ItemMenuEntry =
+  | { readonly kind: 'style' }
+  | { readonly kind: 'tone' }
+  | { readonly kind: 'advanced' }
+  | { readonly kind: 'custom-text' }
+  | { readonly kind: 'custom-tone' }
+  | { readonly kind: 'custom-name' }
+  | { readonly kind: 'custom-delete' }
 
 /** The item editor's menu for one definition (undefined = an unknown id:
  * its format set is unknowable, so Style is hidden). */
-export function itemMenuFor(formats: readonly string[] | undefined): ItemMenuEntry[] {
+export function itemMenuFor(formats: readonly string[] | undefined, custom = false): ItemMenuEntry[] {
   const entries: ItemMenuEntry[] = []
   if (formats !== undefined && formats.length > 1) entries.push({ kind: 'style' })
-  entries.push({ kind: 'tone' })
+  if (custom) {
+    entries.push({ kind: 'custom-text' })
+    entries.push({ kind: 'custom-tone' })
+  } else {
+    entries.push({ kind: 'tone' })
+  }
   entries.push({ kind: 'advanced' })
+  if (custom) {
+    entries.push({ kind: 'custom-name' })
+    entries.push({ kind: 'custom-delete' })
+  }
   return entries
 }
 
@@ -202,9 +238,14 @@ export class FooterConfiguratorModel {
   private advancedField: FooterAdvancedField = 'prefix'
   private editing = false
   private editBuffer = ''
+  private customName = ''
+  private customText = ''
+  private customTone: FooterTone | 'auto' = 'auto'
+  private customError = ''
   private readonly registry: FooterItemRegistry
+  private readonly customItems: FooterCustomItemCatalog
 
-  constructor(initial: FooterLayoutV1, registry: FooterItemRegistry) {
+  constructor(initial: FooterLayoutV1, registry: FooterItemRegistry, customItems?: FooterCustomItemCatalog) {
     // A parser-valid layout always has 1..2 rows, but the model accepts
     // any FooterLayoutV1 (hand-built test layouts, foreign callers): a
     // zero-row draft would make editedRow() return undefined and crash
@@ -215,6 +256,12 @@ export class FooterConfiguratorModel {
       ? { schemaVersion: 1, rows: [{ left: [], right: [] }] }
       : initial)
     this.registry = registry
+    this.customItems = customItems ?? new FooterCustomItemCatalog()
+    // A caller that supplies a draft catalog expects the editor's picker and
+    // preview to see it through the same registry. Do not replace an existing
+    // app source when no draft catalog was requested (legacy callers use the
+    // app registry directly).
+    if (customItems !== undefined) registry.setCustomSource(customItems)
   }
 
   /** The current state (the draft layout is the live preview source). */
@@ -231,6 +278,10 @@ export class FooterConfiguratorModel {
       advancedField: this.advancedField,
       editing: this.editing,
       editBuffer: this.editBuffer,
+      customName: this.customName,
+      customText: this.customText,
+      customTone: this.customTone,
+      customError: this.customError,
     }
   }
 
@@ -245,9 +296,24 @@ export class FooterConfiguratorModel {
     return this.registry.ids().filter(id => !present.has(id))
   }
 
+  /** Detached custom definitions in their persisted order. */
+  customItemSettings(): FooterCustomItemSettings[] {
+    return this.customItems.snapshot()
+  }
+
+  /** Whether an id is one of this editor's user-owned definitions. */
+  isCustomItem(id: string): boolean {
+    return this.customItems.has(id)
+  }
+
+  /** The current user-owned definition for an item ref. */
+  customItem(id: string): FooterCustomItemSettings | undefined {
+    return this.customItems.get(id)
+  }
+
   /** The add picker's filtered matches: case-insensitive substring over
-   * the item's label, id and description (an unknown id matches on its
-   * raw id text). */
+   * the item's label, id, description, and user-defined text (an unknown id
+   * matches on its raw id text). */
   addMatches(): string[] {
     const query = this.addQuery.trim().toLowerCase()
     const all = this.availableIds()
@@ -258,6 +324,7 @@ export class FooterConfiguratorModel {
         id,
         def?.label ?? '',
         def?.description ?? '',
+        this.customItems.get(id)?.text ?? '',
       ].join('\n').toLowerCase()
       return haystack.includes(query)
     })
@@ -306,10 +373,13 @@ export class FooterConfiguratorModel {
         this.itemCursor = Math.max(0, this.itemCursor - 1)
         return
       case 'style':
+      case 'tone':
+      case 'custom-tone':
         this.pickerIndex = Math.max(0, this.pickerIndex - 1)
         return
-      case 'tone':
+      case 'create-tone':
         this.pickerIndex = Math.max(0, this.pickerIndex - 1)
+        this.customTone = FOOTER_TONE_CHOICES[this.pickerIndex]?.value ?? 'auto'
         return
       case 'advanced':
         if (!this.editing) this.advancedField = ADVANCED_FIELDS[Math.max(0, this.advancedFieldIndex() - 1)]!
@@ -333,7 +403,7 @@ export class FooterConfiguratorModel {
         this.reorderActive(1)
         return
       case 'item':
-        this.itemCursor = Math.min(itemMenuFor(this.itemFormats()).length - 1, this.itemCursor + 1)
+        this.itemCursor = Math.min(this.itemMenu().length - 1, this.itemCursor + 1)
         return
       case 'style': {
         const formats = this.itemFormats()
@@ -343,13 +413,20 @@ export class FooterConfiguratorModel {
       case 'tone':
         this.pickerIndex = Math.min(this.toneChoices().length - 1, this.pickerIndex + 1)
         return
+      case 'custom-tone':
+        this.pickerIndex = Math.min(this.customToneChoices().length - 1, this.pickerIndex + 1)
+        return
+      case 'create-tone':
+        this.pickerIndex = Math.min(FOOTER_TONE_CHOICES.length - 1, this.pickerIndex + 1)
+        this.customTone = FOOTER_TONE_CHOICES[this.pickerIndex]?.value ?? 'auto'
+        return
       case 'advanced':
         if (!this.editing) {
           this.advancedField = ADVANCED_FIELDS[Math.min(ADVANCED_FIELDS.length - 1, this.advancedFieldIndex() + 1)]!
         }
         return
       case 'add':
-        this.pickerIndex = Math.min(Math.max(0, this.addMatches().length - 1), this.pickerIndex + 1)
+        this.pickerIndex = Math.min(this.addMatches().length, this.pickerIndex + 1)
         return
     }
   }
@@ -363,6 +440,28 @@ export class FooterConfiguratorModel {
   /** The edited item's definition formats (undefined = unknown id). */
   private itemFormats(): readonly string[] | undefined {
     return this.registry.get(this.editedRefId())?.formats
+  }
+
+  private editedCustomItem(): FooterCustomItemSettings | undefined {
+    return this.customItems.get(this.editedRefId())
+  }
+
+  private itemMenu(): ItemMenuEntry[] {
+    return itemMenuFor(this.itemFormats(), this.editedCustomItem() !== undefined)
+  }
+
+  private customToneChoices(): ReadonlyArray<{ readonly value: FooterTone | 'auto'; readonly label: string }> {
+    return toneChoicesFor(this.editedCustomItem()?.tone ?? 'auto')
+  }
+
+  /** The add picker has one non-item action after its filtered matches. */
+  addOptionCount(): number {
+    return this.addMatches().length + 1
+  }
+
+  /** True when the highlighted add option is the create action. */
+  isCreateOption(): boolean {
+    return this.mode === 'add' && this.pickerIndex >= this.addMatches().length
   }
 
   /** The edited item's id (the flat cursor's ref; '' when the row is
@@ -409,7 +508,7 @@ export class FooterConfiguratorModel {
    * Style cycles the finite formats; Tone cycles the tone choices;
    * Advanced opens the editor (nothing to cycle inline). */
   private cycleItemSetting(direction: -1 | 1): void {
-    const menu = itemMenuFor(this.itemFormats())
+    const menu = this.itemMenu()
     const entry = menu[Math.min(this.itemCursor, menu.length - 1)]
     if (entry === undefined) return
     const ref = this.refAt(this.cursor)?.ref
@@ -428,6 +527,14 @@ export class FooterConfiguratorModel {
       const index = choices.findIndex(choice => choice.value === current)
       const next = (index + direction + choices.length) % choices.length
       this.applyTone(ref, choices[next]!.value)
+      return
+    }
+    if (entry.kind === 'custom-tone') {
+      const current = this.editedCustomItem()?.tone ?? 'auto'
+      const choices = this.customToneChoices()
+      const index = choices.findIndex(choice => choice.value === current)
+      const next = (index + direction + choices.length) % choices.length
+      this.applyCustomTone(choices[next]!.value)
     }
   }
 
@@ -451,6 +558,14 @@ export class FooterConfiguratorModel {
   private applyTone(ref: MutableRef, tone: FooterTone | 'auto'): void {
     if (tone === 'auto') delete ref.tone
     else ref.tone = tone
+  }
+
+  /** Persist a custom definition's tone in the draft catalog. */
+  private applyCustomTone(tone: FooterTone | 'auto'): void {
+    const id = this.editedRefId()
+    const result = this.customItems.updateTone(id, tone)
+    if (!result.ok) this.customError = result.error ?? 'The selected tone is invalid.'
+    else this.customError = ''
   }
 
   /** Reorder the cursor's item one position within its zone (Move Mode's
@@ -491,7 +606,7 @@ export class FooterConfiguratorModel {
         this.mode = 'row'
         return
       case 'item': {
-        const menu = itemMenuFor(this.itemFormats())
+        const menu = this.itemMenu()
         const entry = menu[Math.min(this.itemCursor, menu.length - 1)]
         if (entry === undefined) return
         if (entry.kind === 'style') {
@@ -500,6 +615,27 @@ export class FooterConfiguratorModel {
         } else if (entry.kind === 'tone') {
           this.mode = 'tone'
           this.pickerIndex = this.currentToneIndex()
+        } else if (entry.kind === 'custom-text') {
+          const item = this.editedCustomItem()
+          if (item === undefined) return
+          this.mode = 'custom-text'
+          this.editing = true
+          this.editBuffer = item.text
+          this.customError = ''
+        } else if (entry.kind === 'custom-tone') {
+          this.mode = 'custom-tone'
+          this.pickerIndex = this.currentCustomToneIndex()
+          this.customError = ''
+        } else if (entry.kind === 'custom-name') {
+          const item = this.editedCustomItem()
+          if (item === undefined) return
+          this.mode = 'custom-name'
+          this.editing = true
+          this.editBuffer = customItemName(item.id)
+          this.customError = ''
+        } else if (entry.kind === 'custom-delete') {
+          this.mode = 'custom-delete'
+          this.customError = ''
         } else {
           this.mode = 'advanced'
           this.advancedField = 'prefix'
@@ -525,6 +661,87 @@ export class FooterConfiguratorModel {
         this.mode = 'item'
         return
       }
+      case 'custom-tone': {
+        const choices = this.customToneChoices()
+        const choice = choices[Math.min(this.pickerIndex, choices.length - 1)]
+        if (choice !== undefined) this.applyCustomTone(choice.value)
+        this.mode = 'item'
+        return
+      }
+      case 'custom-text':
+        if (this.editing) {
+          this.commitCustomText()
+          return
+        }
+        this.mode = 'item'
+        return
+      case 'custom-name':
+        if (this.editing) {
+          this.commitCustomName()
+          return
+        }
+        this.mode = 'item'
+        return
+      case 'custom-delete': {
+        const id = this.editedRefId()
+        if (!this.customItems.remove(id)) {
+          this.customError = 'Footer item no longer exists.'
+          this.mode = 'item'
+          return
+        }
+        this.removeReferences(id)
+        this.mode = 'row'
+        this.itemCursor = 0
+        this.clampCursor()
+        return
+      }
+      case 'create-name': {
+        const name = this.customName.trim()
+        const id = customItemId(name)
+        if (id === undefined) {
+          this.customError = name === ''
+            ? 'Name is required.'
+            : 'Name must be visible, at most 64 characters, and contain no colon.'
+          return
+        }
+        if (this.customItems.has(id)) {
+          this.customError = `A footer item named "${name}" already exists.`
+          return
+        }
+        this.customError = ''
+        this.mode = 'create-text'
+        return
+      }
+      case 'create-text':
+        if (this.customText.trim() === '') {
+          this.customError = 'Text is required.'
+          return
+        }
+        this.customError = ''
+        this.mode = 'create-tone'
+        this.pickerIndex = 0
+        return
+      case 'create-tone': {
+        const choices = FOOTER_TONE_CHOICES
+        const choice = choices[Math.min(this.pickerIndex, choices.length - 1)]
+        if (choice === undefined) return
+        const created = this.customItems.create(this.customName, this.customText, choice.value)
+        if (created.item === undefined) {
+          this.customError = created.error ?? 'Custom footer item could not be created.'
+          return
+        }
+        if (!this.addAvailable(created.item.id, this.addSide)) {
+          // The row cap can only change through this model, but keep the
+          // catalog transactional if a future caller changes it between the
+          // picker render and Enter.
+          this.customItems.remove(created.item.id)
+          this.customError = 'The row is full — remove an item first.'
+          return
+        }
+        this.mode = 'row'
+        this.resetCustomFlow()
+        return
+      }
       case 'advanced':
         if (this.editing) {
           this.commitEdit()
@@ -539,6 +756,16 @@ export class FooterConfiguratorModel {
         return
       case 'add': {
         const matches = this.addMatches()
+        if (this.pickerIndex >= matches.length) {
+          if (this.flatCount() >= MAX_ITEMS_PER_ROW) return
+          this.customName = ''
+          this.customText = ''
+          this.customTone = 'auto'
+          this.customError = ''
+          this.editBuffer = ''
+          this.mode = 'create-name'
+          return
+        }
         const id = matches[Math.min(this.pickerIndex, matches.length - 1)]
         if (id === undefined) return
         const added = this.addAvailable(id, this.addSide)
@@ -554,10 +781,12 @@ export class FooterConfiguratorModel {
   /** Esc: navigate back. Returns false exactly when the configurator
    * should CLOSE (Esc on the Row Selector). */
   cancel(): boolean {
-    if (this.mode === 'advanced' && this.editing) {
+    if ((this.mode === 'advanced' || this.mode === 'custom-text' || this.mode === 'custom-name') && this.editing) {
       // First Esc inside an inline edit cancels the edit, not the page.
       this.editing = false
       this.editBuffer = ''
+      this.customError = ''
+      if (this.mode === 'custom-text' || this.mode === 'custom-name') this.mode = 'item'
       return true
     }
     switch (this.mode) {
@@ -571,6 +800,27 @@ export class FooterConfiguratorModel {
           return true
         }
         this.mode = 'row'
+        return true
+      case 'create-name':
+      case 'create-text':
+      case 'create-tone':
+        // Creation is a child flow of the Add picker; cancellation never
+        // closes the whole configurator and never mutates the draft catalog.
+        this.mode = 'add'
+        this.customError = ''
+        this.editBuffer = ''
+        return true
+      case 'custom-delete':
+      case 'custom-tone':
+        this.mode = 'item'
+        this.customError = ''
+        return true
+      case 'custom-text':
+      case 'custom-name':
+        this.mode = 'item'
+        this.customError = ''
+        this.editing = false
+        this.editBuffer = ''
         return true
       case 'row':
         this.mode = 'rows'
@@ -678,14 +928,39 @@ export class FooterConfiguratorModel {
     return index < 0 ? 0 : index
   }
 
-  /** Printable text: the add picker's query or the advanced inline
-   * editor's buffer. Everything else ignores it. */
+  /** The custom definition tone picker opens on its current definition
+   * value, not on the layout ref's independent tone override. */
+  private currentCustomToneIndex(): number {
+    const current = this.editedCustomItem()?.tone ?? 'auto'
+    const choices = this.customToneChoices()
+    const index = choices.findIndex(choice => choice.value === current)
+    return index < 0 ? 0 : index
+  }
+
+  /** Printable text: the add picker, custom-definition fields, or the
+   * advanced inline editor's buffer. Everything else ignores it. */
   text(data: string): void {
     const clean = stripControlChars(data)
     if (clean === '') return
     if (this.mode === 'add') {
       this.addQuery = (this.addQuery + clean).slice(0, 64)
       this.pickerIndex = 0
+      return
+    }
+    if (this.mode === 'create-name') {
+      this.customName = [...this.customName + clean].slice(0, 64).join('')
+      this.customError = ''
+      return
+    }
+    if (this.mode === 'create-text') {
+      this.customText = [...this.customText + clean].slice(0, 256).join('')
+      this.customError = ''
+      return
+    }
+    if (this.mode === 'custom-text' || this.mode === 'custom-name') {
+      const limit = this.mode === 'custom-text' ? 256 : 64
+      this.editBuffer = [...this.editBuffer + clean].slice(0, limit).join('')
+      this.customError = ''
       return
     }
     if (this.mode === 'advanced' && this.editing) {
@@ -704,6 +979,21 @@ export class FooterConfiguratorModel {
     if (this.mode === 'add') {
       this.addQuery = this.addQuery.slice(0, -1)
       this.pickerIndex = 0
+      return
+    }
+    if (this.mode === 'create-name') {
+      this.customName = [...this.customName].slice(0, -1).join('')
+      this.customError = ''
+      return
+    }
+    if (this.mode === 'create-text') {
+      this.customText = [...this.customText].slice(0, -1).join('')
+      this.customError = ''
+      return
+    }
+    if ((this.mode === 'custom-text' || this.mode === 'custom-name') && this.editing) {
+      this.editBuffer = [...this.editBuffer].slice(0, -1).join('')
+      this.customError = ''
       return
     }
     if (this.mode === 'advanced' && this.editing) {
@@ -757,6 +1047,59 @@ export class FooterConfiguratorModel {
     this.editBuffer = ''
   }
 
+  /** Commit the custom definition's text without touching the layout ref. */
+  private commitCustomText(): void {
+    const id = this.editedRefId()
+    const result = this.customItems.updateText(id, this.editBuffer)
+    if (!result.ok) {
+      this.customError = result.error ?? 'Text is invalid.'
+      return
+    }
+    this.customError = ''
+    this.editing = false
+    this.editBuffer = ''
+    this.mode = 'item'
+  }
+
+  /** Commit a custom definition rename and update every layout reference so
+   * no dangling old `user:*` id remains. */
+  private commitCustomName(): void {
+    const oldId = this.editedRefId()
+    const result = this.customItems.rename(oldId, this.editBuffer)
+    if (result.newId === undefined) {
+      this.customError = result.error ?? 'Name is invalid.'
+      return
+    }
+    if (result.newId !== oldId) {
+      for (const row of this.draft.rows) {
+        row.left = row.left.map(ref => ref.id === oldId ? { ...ref, id: result.newId! } : ref)
+        row.right = row.right.map(ref => ref.id === oldId ? { ...ref, id: result.newId! } : ref)
+      }
+    }
+    this.customError = ''
+    this.editing = false
+    this.editBuffer = ''
+    this.mode = 'item'
+  }
+
+  /** Remove every reference to a definition from every row. */
+  private removeReferences(id: string): void {
+    for (const row of this.draft.rows) {
+      row.left = row.left.filter(ref => ref.id !== id)
+      row.right = row.right.filter(ref => ref.id !== id)
+    }
+  }
+
+  /** Clear the create flow's transient fields after a successful add. */
+  private resetCustomFlow(): void {
+    this.customName = ''
+    this.customText = ''
+    this.customTone = 'auto'
+    this.customError = ''
+    this.editing = false
+    this.editBuffer = ''
+  }
+
   /** Reset the edited ref to the definition defaults (the Advanced
    * editor's "Reset to default"). */
   resetActiveRef(): void {
@@ -790,6 +1133,10 @@ export class FooterConfiguratorModel {
     this.advancedField = 'prefix'
     this.editing = false
     this.editBuffer = ''
+    this.customName = ''
+    this.customText = ''
+    this.customTone = 'auto'
+    this.customError = ''
   }
 
   /** Reset the draft to the builtin default layout. */

--- a/src/footer/configurator-model.ts
+++ b/src/footer/configurator-model.ts
@@ -195,8 +195,9 @@ export function flatLengthOf(row: FooterRowLayout): number {
 
 /** One item-editor menu entry (Style appears only for items with more
  * than one finite format — a single format has nothing to pick). Custom Text
- * definitions expose their definition-owned text/tone/name/delete controls in
- * addition to the shared ref Advanced editor. */
+ * definitions expose their definition-owned text/default-tone controls and
+ * name/delete actions alongside the shared placement-tone and Advanced
+ * controls. */
 export type ItemMenuEntry =
   | { readonly kind: 'style' }
   | { readonly kind: 'tone' }
@@ -214,9 +215,8 @@ export function itemMenuFor(formats: readonly string[] | undefined, custom = fal
   if (custom) {
     entries.push({ kind: 'custom-text' })
     entries.push({ kind: 'custom-tone' })
-  } else {
-    entries.push({ kind: 'tone' })
   }
+  entries.push({ kind: 'tone' })
   entries.push({ kind: 'advanced' })
   if (custom) {
     entries.push({ kind: 'custom-name' })
@@ -704,7 +704,7 @@ export class FooterConfiguratorModel {
             : 'Name must be visible, at most 64 characters, and contain no colon.'
           return
         }
-        if (this.customItems.has(id)) {
+        if (this.customItems.has(id) || this.registry.ids().includes(id)) {
           this.customError = `A footer item named "${name}" already exists.`
           return
         }
@@ -1065,6 +1065,11 @@ export class FooterConfiguratorModel {
    * no dangling old `user:*` id remains. */
   private commitCustomName(): void {
     const oldId = this.editedRefId()
+    const nextId = customItemId(this.editBuffer)
+    if (nextId !== undefined && nextId !== oldId && this.registry.ids().includes(nextId)) {
+      this.customError = `A footer item named "${customItemName(nextId)}" already exists.`
+      return
+    }
     const result = this.customItems.rename(oldId, this.editBuffer)
     if (result.newId === undefined) {
       this.customError = result.error ?? 'Name is invalid.'

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -10,7 +10,7 @@
  * Pages (the plan's hierarchy):
  *   rows  — Row Selector (↑↓ select, Enter edit, S save, Esc cancel)
  *   row   — Edit Row (Left/Right as VISUAL grouping; ←→ moves sides)
- *   item  — Item Editor (Style / Tone / Advanced…)
+ *   item  — Item Editor (Style / Text / Default tone / Tone / Advanced…)
  *   style — Style picker (live per-format examples)
  *   tone  — Tone picker (semantic tones)
  *   advanced — Prefix / Suffix / Importance inline editors + Reset
@@ -377,8 +377,9 @@ export class FooterConfiguratorPanel implements Component {
       case 'style':
         return `Style · ${this.itemLabel(state.rowIndex, state.cursor)}`
       case 'tone':
-      case 'custom-tone':
         return `Tone · ${this.itemLabel(state.rowIndex, state.cursor)}`
+      case 'custom-tone':
+        return `Default tone · ${this.itemLabel(state.rowIndex, state.cursor)}`
       case 'advanced':
         return `Advanced · ${this.itemLabel(state.rowIndex, state.cursor)}`
       case 'custom-text':
@@ -491,6 +492,9 @@ export class FooterConfiguratorPanel implements Component {
     if (flatLengthOf(row) >= MAX_ITEMS_PER_ROW) {
       return [color.textMuted('(row is full — remove an item first)')]
     }
+    if (this.model.isCreateOption()) {
+      return [color.textMuted('Create a user-defined static footer item.')]
+    }
     const matches = this.model.addMatches()
     const id = matches[Math.min(state.pickerIndex, Math.max(0, matches.length - 1))]
     if (id === undefined) return []
@@ -566,7 +570,7 @@ export class FooterConfiguratorPanel implements Component {
             // A legal-but-unlisted persisted token must display as ITSELF
             // (Strong/Dim/…), never as the 'Auto' fallback.
             const label = toneChoicesFor(ref?.tone).find(choice => choice.value === tone)?.label ?? 'Auto'
-            return this.menuRow(marker, 'Tone', this.tonePaint(tone, label), active)
+            return this.menuRow(marker, toneMenuLabel(entry.kind), this.tonePaint(tone, label), active)
           }
           if (entry.kind === 'custom-text') {
             const value = this.model.customItem(ref?.id ?? '')?.text
@@ -575,7 +579,7 @@ export class FooterConfiguratorPanel implements Component {
           if (entry.kind === 'custom-tone') {
             const tone = this.model.customItem(ref?.id ?? '')?.tone ?? 'auto'
             const label = toneChoicesFor(tone).find(choice => choice.value === tone)?.label ?? 'Auto'
-            return this.menuRow(marker, 'Tone', this.tonePaint(tone, label), active)
+            return this.menuRow(marker, toneMenuLabel(entry.kind), this.tonePaint(tone, label), active)
           }
           if (entry.kind === 'custom-name') return this.menuRow(marker, 'Rename definition', undefined, active)
           if (entry.kind === 'custom-delete') return this.menuRow(marker, 'Delete definition', undefined, active)
@@ -884,6 +888,11 @@ function longestPasteStartSuffix(data: string): number {
     if (data.endsWith(BRACKETED_PASTE_START.slice(0, length))) return length
   }
   return 0
+}
+
+/** The item page keeps definition tone and placement tone visibly distinct. */
+function toneMenuLabel(kind: string): string {
+  return kind === 'custom-tone' ? 'Default tone' : 'Tone'
 }
 
 /** Clip a title-part label (titles truncate ANSI-safely anyway). */

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -300,18 +300,22 @@ export class FooterConfiguratorPanel implements Component {
         // scanner, then feed the new chunk normally so a fresh marker suffix
         // cannot be lost. Longer malformed prefixes retain their old
         // fail-soft behavior: a reconstructed normal key is replayed as one
-        // key, otherwise only the incoming chunk is dispatched.
+        // key, otherwise the incoming chunk is rescanned for fresh paste
+        // markers before ordinary input dispatch.
         if (pendingStart === '\x1b') {
-          this.replayWithoutPaste(pendingStart)
-          if (data !== '') {
-            if (isReplayableInput(data)) this.replayWithoutPaste(data)
-            else this.handleInput(data)
+          // If the continuation contains a fresh complete marker, keep the
+          // scanner in the text flow: replaying the old ESC first could move
+          // out of the picker before the valid marker is seen.
+          if (data.includes(BRACKETED_PASTE_START)) {
+            this.rescanPasteInput(data)
+          } else {
+            this.replayWithoutPaste(pendingStart)
+            this.rescanPasteInput(data)
           }
         } else if (isReplayableInput(candidate)) {
           this.replayWithoutPaste(candidate)
-        } else if (data !== '') {
-          if (isReplayableInput(data)) this.replayWithoutPaste(data)
-          else this.handleInput(data)
+        } else {
+          this.rescanPasteInput(data)
         }
         return true
       }
@@ -375,6 +379,13 @@ export class FooterConfiguratorPanel implements Component {
     } finally {
       this.skipPasteOnce = previous
     }
+  }
+
+  /** Re-enter the scanner for bytes arriving after a rejected prefix. */
+  private rescanPasteInput(data: string): void {
+    if (data === '') return
+    if (this.feedPaste(data)) return
+    this.replayWithoutPaste(data)
   }
 
   private holdPasteStart(prefix: string): void {

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -63,6 +63,8 @@ export interface FooterConfiguratorOptions {
   /** The overlay's row budget source: re-read at EVERY render so a
    * terminal resize never leaves the panel clipped or oversized. */
   readonly maxVisible: () => number
+  /** Request a render after timer-driven input replay. */
+  readonly requestRender?: () => void
   readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void
   readonly onCancel: () => void
 }
@@ -76,6 +78,7 @@ export class FooterConfiguratorPanel implements Component {
   private readonly taskBrowserAvailable: () => boolean
   private readonly extensionFooterText: () => string
   private readonly maxVisible: () => number
+  private readonly requestRender: () => void
   private readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void
   private readonly onCancel: () => void
   /** The body scrollport's top offset (stable across renders — the cursor
@@ -85,10 +88,13 @@ export class FooterConfiguratorPanel implements Component {
    * `isInPaste` between the \x1b[200~/\x1b[201~ markers, `pasteBuffer`
    * accumulating the chunks — the markers (and the content) may split
    * across terminal chunks. `pasteStartPending` holds an incomplete start
-   * marker after its ESC+[ prefix without delaying a standalone Escape key. */
+   * marker, including an ambiguous lone ESC for a bounded replay. */
   private isInPaste = false
   private pasteBuffer = ''
   private pasteStartPending = ''
+  private pasteStartTimer: ReturnType<typeof setTimeout> | undefined
+  /** Recursive scanner replays bypass paste recognition exactly once. */
+  private skipPasteOnce = false
   /** The fork dispatches input to the focused component's handleInput. */
   readonly handleInput: (data: string) => void
 
@@ -100,20 +106,11 @@ export class FooterConfiguratorPanel implements Component {
     this.taskBrowserAvailable = options.taskBrowserAvailable
     this.extensionFooterText = options.extensionFooterText
     this.maxVisible = options.maxVisible
+    this.requestRender = options.requestRender ?? (() => {})
     this.onSave = options.onSave
     this.onCancel = options.onCancel
     this.handleInput = (data: string): void => {
       const state = this.model.state()
-      if (matchesKey(data, 'escape')) {
-        // The model navigates back page by page; only the Row Selector's
-        // Esc closes the configurator (cancel without saving).
-        if (!this.model.cancel()) this.onCancel()
-        return
-      }
-      if (matchesKey(data, 'enter')) {
-        this.model.activate()
-        return
-      }
       // Text-input pages swallow text keys FIRST (space is a query
       // character there, never the remove action). Text arrives in three
       // shapes — a plain printable chunk, a Kitty CSI-u / modifyOtherKeys
@@ -126,12 +123,22 @@ export class FooterConfiguratorPanel implements Component {
         || state.mode === 'create-text'
         || (state.mode === 'advanced' && state.editing)
         || ((state.mode === 'custom-text' || state.mode === 'custom-name') && state.editing)
+      if (textMode && matchesKey(data, 'backspace')) {
+        this.model.backspace()
+        return
+      }
+      if (textMode && !this.skipPasteOnce && this.feedPaste(data)) return
+      if (matchesKey(data, 'escape')) {
+        // The model navigates back page by page; only the Row Selector's
+        // Esc closes the configurator (cancel without saving).
+        if (!this.model.cancel()) this.onCancel()
+        return
+      }
+      if (matchesKey(data, 'enter')) {
+        this.model.activate()
+        return
+      }
       if (textMode) {
-        if (matchesKey(data, 'backspace')) {
-          this.model.backspace()
-          return
-        }
-        if (this.feedPaste(data)) return
         // A plain printable chunk (one character OR a coalesced burst —
         // fast typists and non-bracketed pastes deliver multi-char runs)
         // is text: the model strips control characters and enforces the
@@ -275,18 +282,28 @@ export class FooterConfiguratorPanel implements Component {
     const pendingStart = this.pasteStartPending
     if (pendingStart !== '') {
       this.pasteStartPending = ''
+      this.clearPasteStartTimer()
       const candidate = pendingStart + data
       if (continuesPasteStart(candidate)) {
         data = candidate
       } else {
-        // The pending bytes were only a possible paste prefix. Do not replay
-        // them through feedPaste (that would buffer the same malformed prefix
-        // forever); replay the incoming chunk normally. A complete CSI key
-        // reconstructed by the split is still dispatched as one key.
-        if (isReplayableInput(candidate)) {
-          this.handleInput(candidate)
+        // A lone ESC is ambiguous: it may be the first byte of a split paste
+        // marker or a real Escape key. Replay it without re-entering this
+        // scanner, then feed the new chunk normally so a fresh marker suffix
+        // cannot be lost. Longer malformed prefixes retain their old
+        // fail-soft behavior: a reconstructed normal key is replayed as one
+        // key, otherwise only the incoming chunk is dispatched.
+        if (pendingStart === '\x1b') {
+          this.replayWithoutPaste(pendingStart)
+          if (data !== '') {
+            if (isReplayableInput(data)) this.replayWithoutPaste(data)
+            else this.handleInput(data)
+          }
+        } else if (isReplayableInput(candidate)) {
+          this.replayWithoutPaste(candidate)
         } else if (data !== '') {
-          this.handleInput(data)
+          if (isReplayableInput(data)) this.replayWithoutPaste(data)
+          else this.handleInput(data)
         }
         return true
       }
@@ -314,18 +331,63 @@ export class FooterConfiguratorPanel implements Component {
       return true
     }
 
-    // Keep only an incomplete ESC+[200~ suffix. A lone ESC remains ordinary
-    // input so the configurator's Escape navigation is never delayed; the
-    // terminal's usual split boundary (ESC+[20 / 0~) is buffered here.
+    // A raw ESC is the one complete key that is also a possible first byte
+    // of the paste marker, so hold it before the normal-key fast path.
+    if (data === '\x1b') {
+      this.holdPasteStart(data)
+      return true
+    }
+
+    // A complete normal key sequence (including arrows and Kitty printables)
+    // must not be mistaken for the shared ESC+[ paste prefix.
+    if (isReplayableInput(data)) return false
+
+    // Keep an incomplete ESC+[200~ suffix. A lone ESC is held briefly as an
+    // ambiguous prefix; if no continuation arrives, the timer replays it as
+    // the configurator's ordinary Escape navigation. Longer prefixes use a
+    // longer bounded hold because they are already unlikely to be standalone
+    // keys and existing split-marker callers need time between chunks.
     const partialLength = longestPasteStartSuffix(data)
     if (partialLength > 0) {
       const ordinary = data.slice(0, -partialLength)
       if (ordinary !== '') this.handleInput(ordinary)
-      this.pasteStartPending = data.slice(-partialLength)
+      this.holdPasteStart(data.slice(-partialLength))
       return true
     }
 
     return false
+  }
+
+  /** Dispatch replayed bytes without sending them back into paste scanning. */
+  private replayWithoutPaste(data: string): void {
+    const previous = this.skipPasteOnce
+    this.skipPasteOnce = true
+    try {
+      this.handleInput(data)
+    } finally {
+      this.skipPasteOnce = previous
+    }
+  }
+
+  private holdPasteStart(prefix: string): void {
+    this.pasteStartPending = prefix
+    this.clearPasteStartTimer()
+    const delay = prefix === '\x1b' ? PASTE_ESC_TIMEOUT_MS : PASTE_PREFIX_TIMEOUT_MS
+    this.pasteStartTimer = setTimeout(() => {
+      this.pasteStartTimer = undefined
+      if (this.pasteStartPending !== prefix) return
+      this.pasteStartPending = ''
+      if (prefix === '\x1b') {
+        this.replayWithoutPaste(prefix)
+        this.requestRender()
+      }
+    }, delay)
+  }
+
+  private clearPasteStartTimer(): void {
+    if (this.pasteStartTimer === undefined) return
+    clearTimeout(this.pasteStartTimer)
+    this.pasteStartTimer = undefined
   }
 
   /** Consume all complete paste end markers in the current buffer. */
@@ -357,7 +419,7 @@ export class FooterConfiguratorPanel implements Component {
       if (partialLength > 0) {
         const ordinary = remaining.slice(0, -partialLength)
         if (ordinary !== '') this.handleInput(ordinary)
-        this.pasteStartPending = remaining.slice(-partialLength)
+        this.holdPasteStart(remaining.slice(-partialLength))
         return
       }
       this.handleInput(remaining)
@@ -862,6 +924,8 @@ export class FooterConfiguratorPanel implements Component {
 
 const BRACKETED_PASTE_START = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
+const PASTE_ESC_TIMEOUT_MS = 10
+const PASTE_PREFIX_TIMEOUT_MS = 250
 const REPLAYABLE_ESC_KEYS: readonly KeyId[] = [
   'tab', 'enter', 'backspace', 'delete', 'insert', 'home', 'end',
   'pageUp', 'pageDown', 'up', 'down', 'left', 'right',
@@ -870,7 +934,8 @@ const REPLAYABLE_ESC_KEYS: readonly KeyId[] = [
 
 /** Whether a pending-prefix candidate is a complete normal key sequence. */
 function isReplayableInput(data: string): boolean {
-  return decodePrintableKey(data) !== undefined
+  return matchesKey(data, 'escape')
+    || decodePrintableKey(data) !== undefined
     || REPLAYABLE_ESC_KEYS.some(key => matchesKey(data, key))
 }
 
@@ -881,10 +946,10 @@ function continuesPasteStart(data: string): boolean {
 }
 
 /** Return the longest proper start-marker prefix at the end of a chunk.
- * A one-byte ESC is intentionally excluded: it is a standalone Escape key
- * in normal terminal traffic and must not be held waiting for another chunk. */
+ * A one-byte ESC is included because it is ambiguous at a chunk boundary;
+ * the panel holds it briefly and replays it as Escape if no marker follows. */
 function longestPasteStartSuffix(data: string): number {
-  for (let length = Math.min(BRACKETED_PASTE_START.length - 1, data.length); length >= 2; length -= 1) {
+  for (let length = Math.min(BRACKETED_PASTE_START.length - 1, data.length); length >= 1; length -= 1) {
     if (data.endsWith(BRACKETED_PASTE_START.slice(0, length))) return length
   }
   return 0

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -211,8 +211,7 @@ export class FooterConfiguratorPanel implements Component {
   }
 
   dispose(): void {
-    this.clearPasteStartTimer()
-    this.pasteStartPending = ''
+    this.clearPasteStartPending()
     this.pasteBuffer = ''
     this.isInPaste = false
     this.skipPasteOnce = false
@@ -289,8 +288,7 @@ export class FooterConfiguratorPanel implements Component {
   private feedPaste(data: string): boolean {
     const pendingStart = this.pasteStartPending
     if (pendingStart !== '') {
-      this.pasteStartPending = ''
-      this.clearPasteStartTimer()
+      this.clearPasteStartPending()
       const candidate = pendingStart + data
       if (continuesPasteStart(candidate)) {
         data = candidate
@@ -337,6 +335,9 @@ export class FooterConfiguratorPanel implements Component {
       // also handles a complete marker reconstructed from pasteStartPending.
       const before = data.slice(0, startIndex)
       if (before !== '') this.handleInput(before)
+      // Dispatching `before` may have buffered a malformed prefix of its own;
+      // that prefix is not part of the now-complete paste start marker.
+      this.clearPasteStartPending()
       this.isInPaste = true
       this.pasteBuffer = data.slice(startIndex + BRACKETED_PASTE_START.length)
       this.finishPastes()
@@ -403,6 +404,11 @@ export class FooterConfiguratorPanel implements Component {
     }, delay)
   }
 
+  private clearPasteStartPending(): void {
+    this.pasteStartPending = ''
+    this.clearPasteStartTimer()
+  }
+
   private clearPasteStartTimer(): void {
     if (this.pasteStartTimer === undefined) return
     clearTimeout(this.pasteStartTimer)
@@ -429,6 +435,9 @@ export class FooterConfiguratorPanel implements Component {
       if (startIndex >= 0) {
         const before = remaining.slice(0, startIndex)
         if (before !== '') this.handleInput(before)
+        // The ordinary bytes before the next marker may have left a stale
+        // malformed-prefix candidate; it must not leak into this paste.
+        this.clearPasteStartPending()
         this.isInPaste = true
         this.pasteBuffer = remaining.slice(startIndex + BRACKETED_PASTE_START.length)
         remaining = ''

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -29,6 +29,7 @@ import {
   truncateToWidth,
   visibleWidth,
   type Component,
+  type KeyId,
 } from '@xmoon76/pi-tui'
 import { color } from '../theme.ts'
 import type { StatusSnapshot } from '../status/types.ts'
@@ -37,6 +38,7 @@ import { sanitizeCommandOutput } from './ansi-sanitize.ts'
 import {
   flatLengthOf,
   flatPositionOf,
+  FOOTER_TONE_CHOICES,
   itemMenuFor,
   toneChoicesFor,
 } from './configurator-model.ts'
@@ -61,7 +63,7 @@ export interface FooterConfiguratorOptions {
   /** The overlay's row budget source: re-read at EVERY render so a
    * terminal resize never leaves the panel clipped or oversized. */
   readonly maxVisible: () => number
-  readonly onSave: (layout: FooterLayoutV1) => void
+  readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void
   readonly onCancel: () => void
 }
 
@@ -74,7 +76,7 @@ export class FooterConfiguratorPanel implements Component {
   private readonly taskBrowserAvailable: () => boolean
   private readonly extensionFooterText: () => string
   private readonly maxVisible: () => number
-  private readonly onSave: (layout: FooterLayoutV1) => void
+  private readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void
   private readonly onCancel: () => void
   /** The body scrollport's top offset (stable across renders — the cursor
    * scrolls the body minimally; the fixed shell never moves). */
@@ -82,9 +84,11 @@ export class FooterConfiguratorPanel implements Component {
   /** Bracketed-paste buffering (the fork's Input-component pattern):
    * `isInPaste` between the \x1b[200~/\x1b[201~ markers, `pasteBuffer`
    * accumulating the chunks — the markers (and the content) may split
-   * across terminal chunks. */
+   * across terminal chunks. `pasteStartPending` holds an incomplete start
+   * marker after its ESC+[ prefix without delaying a standalone Escape key. */
   private isInPaste = false
   private pasteBuffer = ''
+  private pasteStartPending = ''
   /** The fork dispatches input to the focused component's handleInput. */
   readonly handleInput: (data: string) => void
 
@@ -117,7 +121,11 @@ export class FooterConfiguratorPanel implements Component {
       // (start marker, content, end marker — all ESC-led) — so "contains
       // ESC" is NOT a printable test: decodePrintableKey + the paste
       // protocol decide, exactly like the fork's Input component.
-      const textMode = state.mode === 'add' || (state.mode === 'advanced' && state.editing)
+      const textMode = state.mode === 'add'
+        || state.mode === 'create-name'
+        || state.mode === 'create-text'
+        || (state.mode === 'advanced' && state.editing)
+        || ((state.mode === 'custom-text' || state.mode === 'custom-name') && state.editing)
       if (textMode) {
         if (matchesKey(data, 'backspace')) {
           this.model.backspace()
@@ -138,8 +146,9 @@ export class FooterConfiguratorPanel implements Component {
         // the navigation keys below (arrows move the add list).
       }
       if (state.mode === 'rows' && matchesKey(data, 's')) {
-        // The Row Selector is the save point: S persists the draft.
-        this.onSave(this.model.preview())
+        // The Row Selector is the save point: S persists the layout and the
+        // definition catalog as one draft snapshot.
+        this.onSave(this.model.preview(), this.model.customItemSettings())
         return
       }
       if (state.mode === 'row') {
@@ -263,23 +272,97 @@ export class FooterConfiguratorPanel implements Component {
    * content to the model as one text input (the model strips control
    * characters and enforces the parser's bounds). */
   private feedPaste(data: string): boolean {
-    if (data.includes('\x1b[200~')) {
-      this.isInPaste = true
-      this.pasteBuffer = ''
-      data = data.replace('\x1b[200~', '')
+    const pendingStart = this.pasteStartPending
+    if (pendingStart !== '') {
+      this.pasteStartPending = ''
+      const candidate = pendingStart + data
+      if (continuesPasteStart(candidate)) {
+        data = candidate
+      } else {
+        // The pending bytes were only a possible paste prefix. Do not replay
+        // them through feedPaste (that would buffer the same malformed prefix
+        // forever); replay the incoming chunk normally. A complete CSI key
+        // reconstructed by the split is still dispatched as one key.
+        if (isReplayableInput(candidate)) {
+          this.handleInput(candidate)
+        } else if (data !== '') {
+          this.handleInput(data)
+        }
+        return true
+      }
     }
-    if (!this.isInPaste) return false
-    this.pasteBuffer += data
-    const endIndex = this.pasteBuffer.indexOf('\x1b[201~')
-    if (endIndex === -1) return true
-    const content = this.pasteBuffer.substring(0, endIndex)
-    const remaining = this.pasteBuffer.substring(endIndex + '\x1b[201~'.length)
-    this.isInPaste = false
-    this.pasteBuffer = ''
-    this.model.text(content)
-    // A trailing chunk after the end marker is ordinary input again.
-    if (remaining !== '') this.handleInput(remaining)
-    return true
+
+    // Once a paste has started, every byte belongs to the paste until the
+    // end marker. The end marker is allowed to split because it stays in
+    // pasteBuffer between calls.
+    if (this.isInPaste) {
+      this.pasteBuffer += data
+      this.finishPastes()
+      return true
+    }
+
+    const startIndex = data.indexOf(BRACKETED_PASTE_START)
+    if (startIndex >= 0) {
+      // Preserve ordinary input that arrived before a complete marker, then
+      // consume the marker and continue scanning the same chunk. This path
+      // also handles a complete marker reconstructed from pasteStartPending.
+      const before = data.slice(0, startIndex)
+      if (before !== '') this.handleInput(before)
+      this.isInPaste = true
+      this.pasteBuffer = data.slice(startIndex + BRACKETED_PASTE_START.length)
+      this.finishPastes()
+      return true
+    }
+
+    // Keep only an incomplete ESC+[200~ suffix. A lone ESC remains ordinary
+    // input so the configurator's Escape navigation is never delayed; the
+    // terminal's usual split boundary (ESC+[20 / 0~) is buffered here.
+    const partialLength = longestPasteStartSuffix(data)
+    if (partialLength > 0) {
+      const ordinary = data.slice(0, -partialLength)
+      if (ordinary !== '') this.handleInput(ordinary)
+      this.pasteStartPending = data.slice(-partialLength)
+      return true
+    }
+
+    return false
+  }
+
+  /** Consume all complete paste end markers in the current buffer. */
+  private finishPastes(): void {
+    let remaining = ''
+    while (this.isInPaste) {
+      const endIndex = this.pasteBuffer.indexOf(BRACKETED_PASTE_END)
+      if (endIndex < 0) return
+      const content = this.pasteBuffer.slice(0, endIndex)
+      remaining = this.pasteBuffer.slice(endIndex + BRACKETED_PASTE_END.length)
+      this.isInPaste = false
+      this.pasteBuffer = ''
+      this.model.text(content)
+      if (remaining === '') return
+
+      // A single terminal chunk can contain ordinary input or another paste
+      // after the end marker. Re-enter the scanner without sending the same
+      // bytes through the outer handleInput twice.
+      const startIndex = remaining.indexOf(BRACKETED_PASTE_START)
+      if (startIndex >= 0) {
+        const before = remaining.slice(0, startIndex)
+        if (before !== '') this.handleInput(before)
+        this.isInPaste = true
+        this.pasteBuffer = remaining.slice(startIndex + BRACKETED_PASTE_START.length)
+        remaining = ''
+        continue
+      }
+      const partialLength = longestPasteStartSuffix(remaining)
+      if (partialLength > 0) {
+        const ordinary = remaining.slice(0, -partialLength)
+        if (ordinary !== '') this.handleInput(ordinary)
+        this.pasteStartPending = remaining.slice(-partialLength)
+        return
+      }
+      this.handleInput(remaining)
+      return
+    }
   }
 
   /** The page title (the header). */
@@ -294,9 +377,20 @@ export class FooterConfiguratorPanel implements Component {
       case 'style':
         return `Style · ${this.itemLabel(state.rowIndex, state.cursor)}`
       case 'tone':
+      case 'custom-tone':
         return `Tone · ${this.itemLabel(state.rowIndex, state.cursor)}`
       case 'advanced':
         return `Advanced · ${this.itemLabel(state.rowIndex, state.cursor)}`
+      case 'custom-text':
+        return `Text · ${this.itemLabel(state.rowIndex, state.cursor)}`
+      case 'custom-name':
+        return `Rename · ${this.itemLabel(state.rowIndex, state.cursor)}`
+      case 'custom-delete':
+        return `Delete · ${this.itemLabel(state.rowIndex, state.cursor)}`
+      case 'create-name':
+      case 'create-text':
+      case 'create-tone':
+        return 'Create Custom Text'
       case 'add':
         // The side is decided when the picker opens (the cursor item's
         // zone): showing it spares the user guessing where the item will
@@ -320,9 +414,20 @@ export class FooterConfiguratorPanel implements Component {
         return '↑↓ Select · Enter Open · ←→ Change · Esc Back'
       case 'style':
       case 'tone':
+      case 'custom-tone':
         return '↑↓ Select · Enter Apply · Esc Back'
       case 'advanced':
         return state.editing ? 'Type · Enter Confirm · Esc Cancel' : '↑↓ Select · Enter Edit · Esc Back'
+      case 'custom-text':
+      case 'custom-name':
+        return 'Type · Enter Confirm · Esc Cancel'
+      case 'custom-delete':
+        return 'Enter Confirm · Esc Cancel'
+      case 'create-name':
+      case 'create-text':
+        return 'Type · Enter Next · Esc Cancel'
+      case 'create-tone':
+        return '↑↓ Select · Enter Create · Esc Cancel'
       case 'add':
         return 'Type to search · ↑↓ Select · Enter Add · Esc Back'
       default:
@@ -335,9 +440,21 @@ export class FooterConfiguratorPanel implements Component {
    * pages. FIXED chrome — never scrolls with the body. */
   private previewLines(width: number): string[] {
     const state = this.model.state()
-    if (state.mode === 'item' || state.mode === 'style' || state.mode === 'tone' || state.mode === 'advanced') {
+    if (state.mode === 'item' || state.mode === 'style' || state.mode === 'tone'
+      || state.mode === 'advanced' || state.mode === 'custom-text' || state.mode === 'custom-tone'
+      || state.mode === 'custom-name' || state.mode === 'custom-delete') {
       const ref = this.refAt(state.rowIndex, state.cursor)
       return [ref === undefined ? color.textMuted('(no item)') : this.itemPreview(ref)]
+    }
+    if (state.mode === 'create-name' || state.mode === 'create-text' || state.mode === 'create-tone') {
+      const tone = state.mode === 'create-tone'
+        ? FOOTER_TONE_CHOICES[state.pickerIndex]?.value ?? state.customTone
+        : state.customTone
+      const text = state.customText === '' ? color.textMuted('(enter text)') : renderSpans([{
+        text: stripControlChars(state.customText),
+        ...(tone === 'auto' ? {} : { tone }),
+      }])
+      return [text]
     }
     const preview = this.composer.render({
       snapshot: this.snapshot(),
@@ -435,7 +552,8 @@ export class FooterConfiguratorPanel implements Component {
       }
       case 'item': {
         const ref = this.refAt(state.rowIndex, state.cursor)
-        const menu = itemMenuFor(ref === undefined ? undefined : this.registry.get(ref.id)?.formats)
+        const custom = ref !== undefined && this.model.isCustomItem(ref.id)
+        const menu = itemMenuFor(ref === undefined ? undefined : this.registry.get(ref.id)?.formats, custom)
         const lines = menu.map((entry, index) => {
           const active = index === state.itemCursor
           const marker = active ? color.primary('›') : ' '
@@ -450,6 +568,17 @@ export class FooterConfiguratorPanel implements Component {
             const label = toneChoicesFor(ref?.tone).find(choice => choice.value === tone)?.label ?? 'Auto'
             return this.menuRow(marker, 'Tone', this.tonePaint(tone, label), active)
           }
+          if (entry.kind === 'custom-text') {
+            const value = this.model.customItem(ref?.id ?? '')?.text
+            return this.menuRow(marker, 'Text', value === undefined ? undefined : color.text(value), active)
+          }
+          if (entry.kind === 'custom-tone') {
+            const tone = this.model.customItem(ref?.id ?? '')?.tone ?? 'auto'
+            const label = toneChoicesFor(tone).find(choice => choice.value === tone)?.label ?? 'Auto'
+            return this.menuRow(marker, 'Tone', this.tonePaint(tone, label), active)
+          }
+          if (entry.kind === 'custom-name') return this.menuRow(marker, 'Rename definition', undefined, active)
+          if (entry.kind === 'custom-delete') return this.menuRow(marker, 'Delete definition', undefined, active)
           return this.menuRow(marker, 'Advanced…', undefined, active)
         })
         return { lines, cursor: Math.min(state.itemCursor, Math.max(0, menu.length - 1)) }
@@ -486,6 +615,76 @@ export class FooterConfiguratorPanel implements Component {
         })
         return { lines, cursor: Math.min(state.pickerIndex, Math.max(0, choices.length - 1)) }
       }
+      case 'custom-tone': {
+        const ref = this.refAt(state.rowIndex, state.cursor)
+        const current = this.model.customItem(ref?.id ?? '')?.tone ?? 'auto'
+        const choices = toneChoicesFor(current)
+        const lines = choices.map((choice, index) => {
+          const active = index === state.pickerIndex
+          const marker = active ? color.primary('›') : ' '
+          const painted = this.tonePaint(choice.value, choice.label)
+          const suffix = current === choice.value ? color.textMuted('  (current)') : ''
+          return `${marker} ${painted}${suffix}`
+        })
+        return { lines, cursor: Math.min(state.pickerIndex, Math.max(0, choices.length - 1)) }
+      }
+      case 'custom-text':
+      case 'custom-name': {
+        const label = state.mode === 'custom-text' ? 'Text' : 'Name'
+        const raw = stripControlChars(state.editBuffer)
+        const value = raw === '' ? color.textMuted('(empty)') : color.textStrong(`${raw}▏`)
+        const lines = [this.menuRow(color.primary('›'), label, value, true)]
+        if (state.customError !== '') lines.push(color.error(state.customError))
+        return { lines, cursor: 0 }
+      }
+      case 'custom-delete': {
+        const ref = this.refAt(state.rowIndex, state.cursor)
+        const id = ref?.id ?? ''
+        const count = this.referenceCount(id)
+        const lines = [
+          color.error(`Delete ${this.itemLabel(state.rowIndex, state.cursor)}?`),
+          color.textMuted(count === 0
+            ? 'This definition is not currently placed in the layout.'
+            : `${count} layout reference${count === 1 ? '' : 's'} will be removed.`),
+        ]
+        if (state.customError !== '') lines.push(color.error(state.customError))
+        return { lines, cursor: 0 }
+      }
+      case 'create-name': {
+        const lines = [
+          this.menuRow(color.primary('›'), 'Name', state.customName === '' ? color.textMuted('(required)') : color.textStrong(`${stripControlChars(state.customName)}▏`), true),
+          color.textMuted('Use a stable name; it is stored as user:<name>.'),
+        ]
+        if (state.customError !== '') lines.push(color.error(state.customError))
+        return { lines, cursor: 0 }
+      }
+      case 'create-text': {
+        const name = state.customName === '' ? color.textMuted('(unnamed)') : color.text(state.customName)
+        const value = state.customText === '' ? color.textMuted('(required)') : color.textStrong(`${stripControlChars(state.customText)}▏`)
+        const lines = [
+          this.menuRow(' ', 'Name', name, false),
+          this.menuRow(color.primary('›'), 'Text', value, true),
+        ]
+        if (state.customError !== '') lines.push(color.error(state.customError))
+        return { lines, cursor: 1 }
+      }
+      case 'create-tone': {
+        const lines = [
+          this.menuRow(' ', 'Name', color.text(state.customName), false),
+          this.menuRow(' ', 'Text', color.text(state.customText), false),
+          color.textStrong('Tone'),
+          ...FOOTER_TONE_CHOICES.map((choice, index) => {
+            const active = index === state.pickerIndex
+            const marker = active ? color.primary('›') : ' '
+            const suffix = choice.value === (FOOTER_TONE_CHOICES[state.pickerIndex]?.value ?? 'auto')
+              ? color.textMuted('  (selected)')
+              : ''
+            return `${marker} ${this.tonePaint(choice.value, choice.label)}${suffix}`
+          }),
+        ]
+        if (state.customError !== '') lines.push(color.error(state.customError))
+        return { lines, cursor: Math.min(3 + state.pickerIndex, lines.length - 1) }
+      }
       case 'advanced': {
         const ref = this.refAt(state.rowIndex, state.cursor)
         const fields: Array<{ field: 'prefix' | 'suffix' | 'importance' | 'reset'; label: string; value: string }> = [
@@ -518,19 +717,21 @@ export class FooterConfiguratorPanel implements Component {
       }
       case 'add': {
         const matches = this.model.addMatches()
-        if (matches.length === 0) return { lines: [color.textMuted('(no matching items)')], cursor: 0 }
         const lines = matches.map((id, index) => {
-          const active = index === Math.min(state.pickerIndex, matches.length - 1)
+          const active = index === state.pickerIndex
           const marker = active ? color.primary('›') : ' '
           const def = this.registry.get(id)
           // An UNKNOWN id renders its raw text: strip control characters
-          // (the parser rejects them in layouts, but a registry id from an
-          // extension source is never trusted — an ESC/OSC id must not
-          // reach the panel).
+          // (the parser rejects them in layouts, but an extension source is
+          // never trusted — an ESC/OSC id must not reach the panel).
           const label = def === undefined ? stripControlChars(id) : stripControlChars(def.label)
           return `${marker} ${active ? color.textStrong(label) : color.text(label)}`
         })
-        return { lines, cursor: Math.min(state.pickerIndex, matches.length - 1) }
+        const createIndex = matches.length
+        if (matches.length === 0) lines.push(color.textMuted('(no matching items)'))
+        const createActive = state.pickerIndex === createIndex
+        lines.push(`${createActive ? color.primary('›') : ' '} ${createActive ? color.textStrong('+ Create Custom Text') : color.text('+ Create Custom Text')}`)
+        return { lines, cursor: Math.min(state.pickerIndex, createIndex) }
       }
     }
   }
@@ -641,11 +842,48 @@ export class FooterConfiguratorPanel implements Component {
     return clipText(this.refLabel(ref))
   }
 
+  /** Count all layout references to a definition before a delete. */
+  private referenceCount(id: string): number {
+    return this.model.preview().rows.reduce((count, row) => count
+      + row.left.filter(ref => ref.id === id).length
+      + row.right.filter(ref => ref.id === id).length, 0)
+  }
+
   /** The item's current style name for the Edit Row list (empty for an
    * unknown definition). */
   private styleText(ref: FooterItemRef): string {
     return this.formatDisplay(ref)
   }
+}
+
+const BRACKETED_PASTE_START = '\x1b[200~'
+const BRACKETED_PASTE_END = '\x1b[201~'
+const REPLAYABLE_ESC_KEYS: readonly KeyId[] = [
+  'tab', 'enter', 'backspace', 'delete', 'insert', 'home', 'end',
+  'pageUp', 'pageDown', 'up', 'down', 'left', 'right',
+  'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12',
+]
+
+/** Whether a pending-prefix candidate is a complete normal key sequence. */
+function isReplayableInput(data: string): boolean {
+  return decodePrintableKey(data) !== undefined
+    || REPLAYABLE_ESC_KEYS.some(key => matchesKey(data, key))
+}
+
+/** Whether the candidate still begins with a valid paste start marker. */
+function continuesPasteStart(data: string): boolean {
+  const length = Math.min(data.length, BRACKETED_PASTE_START.length)
+  return data.slice(0, length) === BRACKETED_PASTE_START.slice(0, length)
+}
+
+/** Return the longest proper start-marker prefix at the end of a chunk.
+ * A one-byte ESC is intentionally excluded: it is a standalone Escape key
+ * in normal terminal traffic and must not be held waiting for another chunk. */
+function longestPasteStartSuffix(data: string): number {
+  for (let length = Math.min(BRACKETED_PASTE_START.length - 1, data.length); length >= 2; length -= 1) {
+    if (data.endsWith(BRACKETED_PASTE_START.slice(0, length))) return length
+  }
+  return 0
 }
 
 /** Clip a title-part label (titles truncate ANSI-safely anyway). */

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -210,6 +210,14 @@ export class FooterConfiguratorPanel implements Component {
     // mutation from outside (reset helpers) calls this.
   }
 
+  dispose(): void {
+    this.clearPasteStartTimer()
+    this.pasteStartPending = ''
+    this.pasteBuffer = ''
+    this.isInPaste = false
+    this.skipPasteOnce = false
+  }
+
   render(width: number): string[] {
     const state = this.model.state()
     // The budget is re-read EVERY render (resize-safe); the caller's

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -301,15 +301,11 @@ export class FooterConfiguratorPanel implements Component {
         // key, otherwise the incoming chunk is rescanned for fresh paste
         // markers before ordinary input dispatch.
         if (pendingStart === '\x1b') {
-          // If the continuation contains a fresh complete marker, keep the
-          // scanner in the text flow: replaying the old ESC first could move
-          // out of the picker before the valid marker is seen.
-          if (data.includes(BRACKETED_PASTE_START)) {
-            this.rescanPasteInput(data)
-          } else {
-            this.replayWithoutPaste(pendingStart)
-            this.rescanPasteInput(data)
-          }
+          // This is a rejected standalone ESC, not the marker's first byte;
+          // preserve its normal navigation semantics before rescanning the
+          // new chunk for a fresh marker.
+          this.replayWithoutPaste(pendingStart)
+          this.rescanPasteInput(data)
         } else if (isReplayableInput(candidate)) {
           this.replayWithoutPaste(candidate)
         } else {
@@ -335,9 +331,10 @@ export class FooterConfiguratorPanel implements Component {
       // also handles a complete marker reconstructed from pasteStartPending.
       const before = data.slice(0, startIndex)
       if (before !== '') this.handleInput(before)
-      // Dispatching `before` may have buffered a malformed prefix of its own;
-      // that prefix is not part of the now-complete paste start marker.
-      this.clearPasteStartPending()
+      // Dispatching `before` may have buffered a prefix of its own. Preserve
+      // a genuine lone Escape, but discard longer malformed bytes before the
+      // now-complete paste start marker.
+      this.replayPendingEscapeBeforePaste()
       this.isInPaste = true
       this.pasteBuffer = data.slice(startIndex + BRACKETED_PASTE_START.length)
       this.finishPastes()
@@ -404,6 +401,12 @@ export class FooterConfiguratorPanel implements Component {
     }, delay)
   }
 
+  private replayPendingEscapeBeforePaste(): void {
+    const pending = this.pasteStartPending
+    this.clearPasteStartPending()
+    if (pending === '\x1b') this.replayWithoutPaste(pending)
+  }
+
   private clearPasteStartPending(): void {
     this.pasteStartPending = ''
     this.clearPasteStartTimer()
@@ -435,9 +438,10 @@ export class FooterConfiguratorPanel implements Component {
       if (startIndex >= 0) {
         const before = remaining.slice(0, startIndex)
         if (before !== '') this.handleInput(before)
-        // The ordinary bytes before the next marker may have left a stale
-        // malformed-prefix candidate; it must not leak into this paste.
-        this.clearPasteStartPending()
+        // The ordinary bytes before the next marker may have left a prefix
+        // candidate; preserve a lone Escape, but do not leak a longer
+        // malformed prefix into this paste.
+        this.replayPendingEscapeBeforePaste()
         this.isInPaste = true
         this.pasteBuffer = remaining.slice(startIndex + BRACKETED_PASTE_START.length)
         remaining = ''

--- a/src/footer/custom-items.ts
+++ b/src/footer/custom-items.ts
@@ -104,23 +104,29 @@ export function parseFooterCustomItem(input: unknown): FooterCustomItemSettings 
 }
 
 /** Parse the collection without letting one malformed or duplicate entry
- * break startup. The first definition for an id wins deterministically. */
+ * break startup. The first definition for an id wins deterministically. A
+ * hostile collection-level proxy/iterator fails closed as one invalid
+ * collection instead of escaping into startup or reload. */
 export function parseFooterCustomItems(input: unknown): FooterCustomItemsParseResult {
-  if (input === undefined) return { items: [], invalidCount: 0 }
-  if (!Array.isArray(input)) return { items: [], invalidCount: 1 }
-  const items: FooterCustomItemSettings[] = []
-  const ids = new Set<string>()
-  let invalidCount = 0
-  for (const candidate of input) {
-    const item = parseFooterCustomItem(candidate)
-    if (item === undefined || ids.has(item.id)) {
-      invalidCount += 1
-      continue
+  try {
+    if (input === undefined) return { items: [], invalidCount: 0 }
+    if (!Array.isArray(input)) return { items: [], invalidCount: 1 }
+    const items: FooterCustomItemSettings[] = []
+    const ids = new Set<string>()
+    let invalidCount = 0
+    for (const candidate of input) {
+      const item = parseFooterCustomItem(candidate)
+      if (item === undefined || ids.has(item.id)) {
+        invalidCount += 1
+        continue
+      }
+      ids.add(item.id)
+      items.push(item)
     }
-    ids.add(item.id)
-    items.push(item)
+    return { items, invalidCount }
+  } catch {
+    return { items: [], invalidCount: 1 }
   }
-  return { items, invalidCount }
 }
 
 /** Compile one validated custom definition into the ordinary footer item

--- a/src/footer/custom-items.ts
+++ b/src/footer/custom-items.ts
@@ -1,0 +1,247 @@
+/**
+ * User-owned custom footer item definitions (PR C). Custom definitions are
+ * persisted separately from FooterLayoutV1: the layout stores only the
+ * canonical `user:*` reference, while this catalog stores what that item is.
+ *
+ * The compiler deliberately produces the same synchronous, pure
+ * FooterItemDefinition used by builtin and extension items. It never reads a
+ * snapshot, performs I/O, or executes a command.
+ * @module @xmoon76/dsh-pi-tui/footer/custom-items
+ */
+
+import type { FooterItemExternalSource } from './item-registry.ts'
+import type { FooterItemDefinition, FooterTone } from './types.ts'
+
+/** The namespace reserved for user-created definitions. */
+export const CUSTOM_FOOTER_ITEM_PREFIX = 'user:'
+/** Maximum display name length (measured in Unicode code points). */
+export const MAX_CUSTOM_ITEM_NAME_LENGTH = 64
+/** Maximum custom text length (measured in Unicode code points). */
+export const MAX_CUSTOM_ITEM_TEXT_LENGTH = 256
+
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/u
+const TONES: ReadonlySet<string> = new Set([
+  'primary', 'accent', 'text', 'textStrong', 'textDim', 'textMuted',
+  'border', 'success', 'warning', 'error', 'roleUser', 'shellMode',
+])
+
+/** The PR C v1 definition union. PR D can add another discriminant here
+ * without changing FooterItemRef or the layout schema. */
+export type FooterCustomItemSettings = {
+  readonly schemaVersion: 1
+  readonly id: string
+  readonly kind: 'text'
+  readonly text: string
+  readonly tone?: FooterTone | 'auto'
+}
+
+/** A parser result that also lets the caller report invalid entries once
+ * without preventing valid user definitions from loading. */
+export interface FooterCustomItemsParseResult {
+  readonly items: readonly FooterCustomItemSettings[]
+  readonly invalidCount: number
+}
+
+function codePointLength(text: string): number {
+  return [...text].length
+}
+
+/** Normalize the name typed by the user and return undefined for a name that
+ * cannot form a stable user namespace id. Colons are reserved so a user name
+ * cannot impersonate another canonical namespace such as `ext:*`. */
+export function normalizeCustomItemName(input: string): string | undefined {
+  const name = input.trim()
+  if (name === '' || CONTROL_CHARS.test(name)) return undefined
+  if (name.includes(':')) return undefined
+  if (codePointLength(name) > MAX_CUSTOM_ITEM_NAME_LENGTH) return undefined
+  return name
+}
+
+/** Convert a user-facing name to the deterministic persisted id. */
+export function customItemId(name: string): string | undefined {
+  const normalized = normalizeCustomItemName(name)
+  return normalized === undefined ? undefined : `${CUSTOM_FOOTER_ITEM_PREFIX}${normalized}`
+}
+
+/** Return the user-facing part of a canonical id. */
+export function customItemName(id: string): string {
+  return id.startsWith(CUSTOM_FOOTER_ITEM_PREFIX)
+    ? id.slice(CUSTOM_FOOTER_ITEM_PREFIX.length)
+    : id
+}
+
+function isTone(value: unknown): value is FooterTone | 'auto' {
+  return value === 'auto' || (typeof value === 'string' && TONES.has(value))
+}
+
+/** Parse one persisted definition. Invalid definitions are rejected at this
+ * boundary; callers can keep the rest of the collection. */
+export function parseFooterCustomItem(input: unknown): FooterCustomItemSettings | undefined {
+  try {
+    if (typeof input !== 'object' || input === null || Array.isArray(input)) return undefined
+    const raw = input as Record<string, unknown>
+    if (raw.schemaVersion !== 1 || raw.kind !== 'text') return undefined
+    if (typeof raw.id !== 'string' || customItemId(customItemName(raw.id)) !== raw.id) return undefined
+    if (typeof raw.text !== 'string' || raw.text.trim() === '' || CONTROL_CHARS.test(raw.text)) return undefined
+    if (codePointLength(raw.text) > MAX_CUSTOM_ITEM_TEXT_LENGTH) return undefined
+    if (raw.tone !== undefined && !isTone(raw.tone)) return undefined
+    // Preserve an explicit `auto` token for settings round-trips. Compilation
+    // treats it like an absent tone, but silently dropping a valid user field
+    // would make an unrelated get→replace cycle lossy.
+    const tone = raw.tone === undefined ? undefined : raw.tone
+    return {
+      schemaVersion: 1,
+      id: raw.id,
+      kind: 'text',
+      text: raw.text,
+      ...(tone === undefined ? {} : { tone }),
+    }
+  } catch {
+    // Settings are untrusted; a hostile getter/proxy is one invalid entry,
+    // not a reason to abort startup or discard the valid remainder.
+    return undefined
+  }
+}
+
+/** Parse the collection without letting one malformed or duplicate entry
+ * break startup. The first definition for an id wins deterministically. */
+export function parseFooterCustomItems(input: unknown): FooterCustomItemsParseResult {
+  if (input === undefined) return { items: [], invalidCount: 0 }
+  if (!Array.isArray(input)) return { items: [], invalidCount: 1 }
+  const items: FooterCustomItemSettings[] = []
+  const ids = new Set<string>()
+  let invalidCount = 0
+  for (const candidate of input) {
+    const item = parseFooterCustomItem(candidate)
+    if (item === undefined || ids.has(item.id)) {
+      invalidCount += 1
+      continue
+    }
+    ids.add(item.id)
+    items.push(item)
+  }
+  return { items, invalidCount }
+}
+
+/** Compile one validated custom definition into the ordinary footer item
+ * contract. */
+export function compileCustomTextItem(settings: FooterCustomItemSettings): FooterItemDefinition {
+  const tone = settings.tone === undefined || settings.tone === 'auto' ? undefined : settings.tone
+  return {
+    id: settings.id,
+    label: customItemName(settings.id),
+    description: 'A user-defined text value.',
+    defaultZone: 'left',
+    defaultImportance: 50,
+    formats: ['plain'],
+    defaultFormat: 'plain',
+    render: () => ({
+      spans: [{ text: settings.text, ...(tone === undefined ? {} : { tone }) }],
+    }),
+  }
+}
+
+/** The mutable, local catalog used by the app and by an unsaved configurator
+ * draft. Its source is attached to FooterItemRegistry, so the composer never
+ * needs a custom-item branch. */
+export class FooterCustomItemCatalog implements FooterItemExternalSource {
+  private items: FooterCustomItemSettings[] = []
+  private definitions = new Map<string, FooterItemDefinition>()
+
+  constructor(initial: unknown = undefined) {
+    this.replace(initial)
+  }
+
+  /** Replace the catalog from persisted/raw data and return the number of
+   * skipped invalid or duplicate entries. */
+  replace(input: unknown): number {
+    const parsed = parseFooterCustomItems(input)
+    this.items = parsed.items.map(item => ({ ...item }))
+    this.definitions = new Map(this.items.map(item => [item.id, compileCustomTextItem(item)]))
+    return parsed.invalidCount
+  }
+
+  /** Return a detached copy suitable for a settings document or a draft. */
+  snapshot(): FooterCustomItemSettings[] {
+    return this.items.map(item => ({ ...item }))
+  }
+
+  ids(): string[] {
+    return this.items.map(item => item.id)
+  }
+
+  definition(id: string): FooterItemDefinition | undefined {
+    return this.definitions.get(id)
+  }
+
+  /** Return one detached persisted definition for editor inspection. */
+  get(id: string): FooterCustomItemSettings | undefined {
+    const item = this.items.find(candidate => candidate.id === id)
+    return item === undefined ? undefined : { ...item }
+  }
+
+  has(id: string): boolean {
+    return this.definitions.has(id)
+  }
+
+  /** Create one definition from the three fields in the editor. */
+  create(name: string, text: string, tone: FooterTone | 'auto'): { item?: FooterCustomItemSettings; error?: string } {
+    const id = customItemId(name)
+    if (id === undefined) return { error: 'Name must be non-empty, visible, and contain no colon.' }
+    if (this.has(id)) return { error: `A footer item named "${customItemName(id)}" already exists.` }
+    const parsed = parseFooterCustomItem({ schemaVersion: 1, id, kind: 'text', text, tone })
+    if (parsed === undefined) return { error: 'Text must be non-empty, visible, and at most 256 characters.' }
+    this.items.push(parsed)
+    this.definitions.set(parsed.id, compileCustomTextItem(parsed))
+    return { item: { ...parsed } }
+  }
+
+  updateText(id: string, text: string): { ok: boolean; error?: string } {
+    const current = this.items.find(item => item.id === id)
+    if (current === undefined) return { ok: false, error: 'Footer item no longer exists.' }
+    const parsed = parseFooterCustomItem({ ...current, text })
+    if (parsed === undefined) return { ok: false, error: 'Text must be non-empty, visible, and at most 256 characters.' }
+    this.replaceItem(parsed)
+    return { ok: true }
+  }
+
+  updateTone(id: string, tone: FooterTone | 'auto'): { ok: boolean; error?: string } {
+    const current = this.items.find(item => item.id === id)
+    if (current === undefined) return { ok: false, error: 'Footer item no longer exists.' }
+    const parsed = parseFooterCustomItem({ ...current, tone })
+    if (parsed === undefined) return { ok: false, error: 'The selected tone is invalid.' }
+    this.replaceItem(parsed)
+    return { ok: true }
+  }
+
+  rename(id: string, name: string): { newId?: string; error?: string } {
+    const current = this.items.find(item => item.id === id)
+    if (current === undefined) return { error: 'Footer item no longer exists.' }
+    const nextId = customItemId(name)
+    if (nextId === undefined) return { error: 'Name must be non-empty, visible, and contain no colon.' }
+    if (nextId !== id && this.has(nextId)) return { error: `A footer item named "${customItemName(nextId)}" already exists.` }
+    if (nextId === id) return { newId: id }
+    const parsed = parseFooterCustomItem({ ...current, id: nextId })
+    if (parsed === undefined) return { error: 'The new name is invalid.' }
+    const index = this.items.findIndex(item => item.id === id)
+    this.items[index] = parsed
+    this.definitions.delete(id)
+    this.definitions.set(nextId, compileCustomTextItem(parsed))
+    return { newId: nextId }
+  }
+
+  remove(id: string): boolean {
+    const index = this.items.findIndex(item => item.id === id)
+    if (index < 0) return false
+    this.items.splice(index, 1)
+    this.definitions.delete(id)
+    return true
+  }
+
+  private replaceItem(item: FooterCustomItemSettings): void {
+    const index = this.items.findIndex(candidate => candidate.id === item.id)
+    if (index < 0) return
+    this.items[index] = item
+    this.definitions.set(item.id, compileCustomTextItem(item))
+  }
+}

--- a/src/footer/item-registry.ts
+++ b/src/footer/item-registry.ts
@@ -8,6 +8,8 @@
 
 import type { FooterItemDefinition } from './types.ts'
 
+const USER_ITEM_PREFIX = 'user:'
+
 /** A live external item source (M4: the extension host's configurable
  * footer items — resolved on demand so replace()/dispose() show up on the
  * next compose). */
@@ -20,9 +22,22 @@ export interface FooterItemExternalSource {
 export class FooterItemRegistry {
   private readonly items = new Map<string, FooterItemDefinition>()
   private external: FooterItemExternalSource | undefined
+  private custom: FooterItemExternalSource | undefined
+  private readonly base: FooterItemRegistry | undefined
+
+  /** Create a registry optionally layered over another registry. A layered
+   * registry is used by the unsaved footer editor: it sees the live builtin /
+   * extension catalog while keeping its custom-definition draft isolated from
+   * the active footer. */
+  constructor(base?: FooterItemRegistry) {
+    this.base = base
+  }
 
   /** Register one builtin item; a duplicate id is an explicit error. */
   register(definition: FooterItemDefinition): void {
+    if (definition.id.startsWith(USER_ITEM_PREFIX)) {
+      throw new Error(`footer item id "${definition.id}" is reserved for custom items`)
+    }
     if (this.items.has(definition.id)) {
       throw new Error(`duplicate footer item id "${definition.id}"`)
     }
@@ -35,13 +50,67 @@ export class FooterItemRegistry {
     this.external = source
   }
 
-  /** Look up one item by id; undefined for unknown ids. */
-  get(id: string): FooterItemDefinition | undefined {
-    return this.items.get(id) ?? this.external?.definition(id)
+  /** Attach user-owned definitions as a separate live source. This keeps
+   * custom definitions in the ordinary registry/composer path without
+   * exposing their settings model to extension consumers. */
+  setCustomSource(source: FooterItemExternalSource | undefined): void {
+    this.custom = source
   }
 
-  /** Every registered id (builtin + live external), in registration order. */
+  /** Look up one item by id; undefined for unknown ids. Local draft sources
+   * take precedence over the base registry so an editor can safely preview a
+   * renamed or edited custom definition. */
+  get(id: string): FooterItemDefinition | undefined {
+    const local = this.items.get(id)
+    if (local !== undefined) return local
+    // The user namespace is reserved for custom definitions. A malformed or
+    // future external source must not be allowed to shadow a non-custom item
+    // in that namespace, so non-custom layers win this one collision case.
+    if (id.startsWith(USER_ITEM_PREFIX) && this.hasNonCustomDefinition(id)) {
+      return this.nonCustomDefinition(id)
+    }
+    // `user:*` is the reserved custom-definition namespace. Once a draft
+    // catalog is attached, an absent id in that catalog is a deliberate
+    // deletion, not a reason to fall through to the active base catalog.
+    // Without this tombstone rule, deleting a saved custom item in an
+    // unsaved editor would still render the base definition.
+    if (this.custom !== undefined && id.startsWith(USER_ITEM_PREFIX)) return this.custom.definition(id)
+    return this.custom?.definition(id)
+      ?? this.external?.definition(id)
+      ?? this.base?.get(id)
+  }
+
+  /** Every registered id (builtin + live external + custom), in stable
+   * catalog order. Layered registries de-duplicate ids exposed by the base. */
   ids(): string[] {
-    return [...this.items.keys(), ...(this.external?.ids() ?? [])]
+    const baseIds = this.base?.ids() ?? []
+    const visibleBaseIds = this.custom === undefined
+      ? baseIds
+      : baseIds.filter(id => !id.startsWith(USER_ITEM_PREFIX) || this.hasNonCustomDefinition(id))
+    const customIds = (this.custom?.ids() ?? [])
+      .filter(id => !this.hasNonCustomDefinition(id))
+    const ids = [
+      ...this.items.keys(),
+      ...(this.external?.ids() ?? []),
+      ...customIds,
+      ...visibleBaseIds,
+    ]
+    return [...new Set(ids)]
+  }
+
+  /** Resolve only builtin/extension layers, skipping every custom source. */
+  private nonCustomDefinition(id: string): FooterItemDefinition | undefined {
+    const local = this.items.get(id)
+    if (local !== undefined) return local
+    return this.external?.definition(id) ?? this.base?.nonCustomDefinition(id)
+  }
+
+  /** Whether a non-custom layer claims this id. IDs are used rather than
+   * calling definition() so a live source that is temporarily unavailable
+   * still cannot be shadowed by a custom source. */
+  private hasNonCustomDefinition(id: string): boolean {
+    if (this.items.has(id)) return true
+    if (this.external?.ids().includes(id) === true) return true
+    return this.base?.hasNonCustomDefinition(id) ?? false
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1576,8 +1576,11 @@ export function apply(ctx: Context, config: Config): void {
     // Declare this before mounting the TUI: fullscreen initialization can
     // synchronously invoke its persistence callback. Use the raw USER value so
     // unknown/future definitions survive unrelated writes unchanged.
-    const userFooterCustomItemsForSave = (): unknown =>
-      backend.config.footerCustomItems.rawForPersistence()
+    const userFooterCustomItemsForSave = (): unknown => {
+      const raw = backend.config.footerCustomItems.rawForPersistence()
+      if (raw.kind === 'unavailable') throw new Error('custom footer definitions unavailable; settings write aborted')
+      return raw.value
+    }
 
     // Launch-time preset entry: `--preset` wins over $DSH_PI_TUI_PRESET, and
     // both fall back to the saved default (settings `agent-presets.default`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5347,6 +5347,9 @@ export function apply(ctx: Context, config: Config): void {
           runDetached('settings history cleanup', () => {
             return serializeTuiSettingsMutation(tuiSettings, () => {
               const doc = { ...tuiSettings.get() } as Record<string, unknown>
+              // This is a whole-document write from the merged settings view;
+              // keep the raw USER custom definitions out of the project layer.
+              doc.footerCustomItems = userFooterCustomItemsForSave()
               delete doc.history
               return tuiSettings.replace(doc)
             })

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,7 @@ import { resolveDisplaySubject } from './status/resolve-subject.ts'
 import type { CompositionStatus, HostStatus, WorkspaceStatus } from './status/types.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
 import { parseFooterLayout, isFooterLayout, resolveCommandFooterFallback } from './footer/layout.ts'
+import { parseFooterCustomItems } from './footer/custom-items.ts'
 import { FooterCommandRunner } from './footer/command-runner.ts'
 import { color, type ColorPalette } from './theme.ts'
 import { startProcessTui, type CompactionPhase, type QueueItem, type TuiApp } from './tui-app.ts'
@@ -1485,6 +1486,11 @@ export function apply(ctx: Context, config: Config): void {
             }),
           })),
         }),
+        // PR C: retain the definition collection as raw data. The custom-item
+        // parser is the fail-soft authority, so malformed entries (or even a
+        // malformed collection) are skipped instead of making the whole TUI
+        // unavailable.
+        footerCustomItems: z.any(),
         // M5: the trusted command status-line config (the command is
         // executed ONLY when it lives in the USER layer — see
         // resolveTrustedFooterCommand).
@@ -1530,7 +1536,7 @@ export function apply(ctx: Context, config: Config): void {
       // The base layout is the builtin default; the schemastery output
       // type is fully-populated, so the cast bridges the sparse literal
       // (the runtime validation accepts missing optional fields).
-      { base: { theme: 'auto', iconStyle: 'emoji', footer: 'full', footerFallbackMode: 'default', footerLayout: DEFAULT_FOOTER_LAYOUT as never, footerCommand: undefined as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off' } },
+      { base: { theme: 'auto', iconStyle: 'emoji', footer: 'full', footerFallbackMode: 'default', footerLayout: DEFAULT_FOOTER_LAYOUT as never, footerCustomItems: undefined as never, footerCommand: undefined as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off' } },
     )
     // The ONE authoritative Focus runtime state (plan §5): restored from
     // the persisted document BEFORE the first compose/resume below, mutated
@@ -5165,6 +5171,7 @@ export function apply(ctx: Context, config: Config): void {
     // M5: `command` arms the trusted command surface (the trust gate reads
     // the USER layer only — a project-supplied config is refused).
     let footerWarningShown = false
+    let customFooterWarningShown = false
     // footerCommandRunner / footerCommandUnsubscribe are hoisted ABOVE
     // cleanup (TDZ guard — the startup-eager onTerminalResize callback
     // reads the runner before this block can run); only the warning
@@ -5176,8 +5183,16 @@ export function apply(ctx: Context, config: Config): void {
       footerCommandRunner = undefined
       app.setFooterCommandRows(undefined)
     }
-    const applyFooterSettings = (doc: { footer: string; footerLayout?: unknown } | undefined): void => {
+    const applyFooterSettings = (doc: { footer: string; footerLayout?: unknown; footerCustomItems?: unknown } | undefined): void => {
       if (doc === undefined) return
+      if ('footerCustomItems' in doc) {
+        const customResult = parseFooterCustomItems(doc.footerCustomItems)
+        app.setFooterCustomItems(customResult.items)
+        if (customResult.invalidCount > 0 && !customFooterWarningShown) {
+          customFooterWarningShown = true
+          app.notify(`${customResult.invalidCount} custom footer item${customResult.invalidCount === 1 ? '' : 's'} invalid — skipped`, 'error')
+        }
+      }
       if (doc.footer === 'command') {
         // The native FALLBACK layout must be established from the
         // PERSISTED document, never from whatever the memory happens to

--- a/src/index.ts
+++ b/src/index.ts
@@ -1570,6 +1570,14 @@ export function apply(ctx: Context, config: Config): void {
       new DirectHostFilePort((sessionId) => liveAgent?.session.id === sessionId ? liveAgent : undefined),
     )
 
+    // Whole-document settings writes must not copy a project-layer
+    // footerCustomItems value into the USER section. The config port is the
+    // only source allowed to supply definitions for a non-/footer write.
+    // Declare this before mounting the TUI: fullscreen initialization can
+    // synchronously invoke its persistence callback.
+    const userFooterCustomItemsForSave = (): FooterCustomItemSettings[] =>
+      backend.config.footerCustomItems.get().items.map(item => ({ ...item }))
+
     // Launch-time preset entry: `--preset` wins over $DSH_PI_TUI_PRESET, and
     // both fall back to the saved default (settings `agent-presets.default`,
     // then the roster config) when absent. A fresh session starts on it; a
@@ -5183,11 +5191,6 @@ export function apply(ctx: Context, config: Config): void {
       footerCommandRunner = undefined
       app.setFooterCommandRows(undefined)
     }
-    // Whole-document settings writes must not copy a project-layer
-    // footerCustomItems value into the USER section. The config port is the
-    // only source allowed to supply definitions for a non-/footer write.
-    const userFooterCustomItemsForSave = (): FooterCustomItemSettings[] =>
-      backend.config.footerCustomItems.get().items.map(item => ({ ...item }))
     const applyFooterSettings = (
       doc: { footer: string; footerLayout?: unknown; footerCustomItems?: unknown } | undefined,
       savedCustomItems?: readonly FooterCustomItemSettings[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ import { resolveDisplaySubject } from './status/resolve-subject.ts'
 import type { CompositionStatus, HostStatus, WorkspaceStatus } from './status/types.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
 import { parseFooterLayout, isFooterLayout, resolveCommandFooterFallback } from './footer/layout.ts'
-import { parseFooterCustomItems } from './footer/custom-items.ts'
+import type { FooterCustomItemSettings } from './footer/custom-items.ts'
 import { FooterCommandRunner } from './footer/command-runner.ts'
 import { color, type ColorPalette } from './theme.ts'
 import { startProcessTui, type CompactionPhase, type QueueItem, type TuiApp } from './tui-app.ts'
@@ -4467,7 +4467,7 @@ export function apply(ctx: Context, config: Config): void {
         if (settings !== undefined) {
           runDetached('settings fullscreen write', () => serializeTuiSettingsMutation(
              settings,
-             () => settings.replace({ ...settings.get(), fullscreen: fullscreen ? 'on' : 'off' }),
+             () => settings.replace({ ...settings.get(), footerCustomItems: userFooterCustomItemsForSave(), fullscreen: fullscreen ? 'on' : 'off' }),
            ), {
             diag,
             notify: (message) => app.notify(message, 'error'),
@@ -5183,15 +5183,28 @@ export function apply(ctx: Context, config: Config): void {
       footerCommandRunner = undefined
       app.setFooterCommandRows(undefined)
     }
-    const applyFooterSettings = (doc: { footer: string; footerLayout?: unknown; footerCustomItems?: unknown } | undefined): void => {
+    // Whole-document settings writes must not copy a project-layer
+    // footerCustomItems value into the USER section. The config port is the
+    // only source allowed to supply definitions for a non-/footer write.
+    const userFooterCustomItemsForSave = (): FooterCustomItemSettings[] =>
+      backend.config.footerCustomItems.get().items.map(item => ({ ...item }))
+    const applyFooterSettings = (
+      doc: { footer: string; footerLayout?: unknown; footerCustomItems?: unknown } | undefined,
+      savedCustomItems?: readonly FooterCustomItemSettings[],
+    ): void => {
       if (doc === undefined) return
-      if ('footerCustomItems' in doc) {
-        const customResult = parseFooterCustomItems(doc.footerCustomItems)
-        app.setFooterCustomItems(customResult.items)
-        if (customResult.invalidCount > 0 && !customFooterWarningShown) {
-          customFooterWarningShown = true
-          app.notify(`${customResult.invalidCount} custom footer item${customResult.invalidCount === 1 ? '' : 's'} invalid — skipped`, 'error')
-        }
+      // The merged document's footerCustomItems field is pass-through storage
+      // only. Normal startup/reload/settings reads use the ConfigPort's
+      // USER-layer semantic resolver; the optional second argument is supplied
+      // only by the validated /footer save after its write succeeds, so the
+      // just-committed draft is applied without trusting merged project data.
+      const customResult = savedCustomItems === undefined
+        ? backend.config.footerCustomItems.get()
+        : { items: savedCustomItems, invalidCount: 0 }
+      app.setFooterCustomItems(customResult.items)
+      if (customResult.invalidCount > 0 && !customFooterWarningShown) {
+        customFooterWarningShown = true
+        app.notify(`${customResult.invalidCount} custom footer item${customResult.invalidCount === 1 ? '' : 's'} invalid — skipped`, 'error')
       }
       if (doc.footer === 'command') {
         // The native FALLBACK layout must be established from the
@@ -5847,7 +5860,7 @@ export function apply(ctx: Context, config: Config): void {
       if (settings !== undefined) {
         runDetached('settings focus write', () => serializeTuiSettingsMutation(
            settings,
-           () => settings.replace({ ...settings.get(), focusMode: enabled ? 'on' : 'off' }),
+           () => settings.replace({ ...settings.get(), footerCustomItems: userFooterCustomItemsForSave(), focusMode: enabled ? 'on' : 'off' }),
          ), {
           diag,
           notify: (message) => app.notify(`focus mode persistence failed: ${message}`, 'error'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1574,9 +1574,10 @@ export function apply(ctx: Context, config: Config): void {
     // footerCustomItems value into the USER section. The config port is the
     // only source allowed to supply definitions for a non-/footer write.
     // Declare this before mounting the TUI: fullscreen initialization can
-    // synchronously invoke its persistence callback.
-    const userFooterCustomItemsForSave = (): FooterCustomItemSettings[] =>
-      backend.config.footerCustomItems.get().items.map(item => ({ ...item }))
+    // synchronously invoke its persistence callback. Use the raw USER value so
+    // unknown/future definitions survive unrelated writes unchanged.
+    const userFooterCustomItemsForSave = (): unknown =>
+      backend.config.footerCustomItems.rawForPersistence()
 
     // Launch-time preset entry: `--preset` wins over $DSH_PI_TUI_PRESET, and
     // both fall back to the saved default (settings `agent-presets.default`,

--- a/src/keybinding-ui/controller.ts
+++ b/src/keybinding-ui/controller.ts
@@ -81,6 +81,11 @@ export type KeybindingMutationRunner = (
 export interface KeybindingEditorControllerOptions {
   readonly settings: TuiSettingsConfig | undefined
   readonly manager: HostKeybindingManager
+  /** Project foreign/raw settings fields before a whole-document replace.
+   * The editor owns only `keybindings`; callers may preserve fields whose
+   * authority belongs to another domain without coupling this controller to
+   * that domain. Runs inside the settings mutation transaction. */
+  readonly projectSettingsForWrite?: (doc: TuiSettingsDoc) => TuiSettingsDoc
   readonly onDiagnostic?: (message: string) => void
 }
 
@@ -268,11 +273,13 @@ function applyMutation(
 export class KeybindingEditorController {
   private readonly settings: TuiSettingsConfig | undefined
   private readonly manager: HostKeybindingManager
+  private readonly projectSettingsForWrite: (doc: TuiSettingsDoc) => TuiSettingsDoc
   private readonly onDiagnostic: (message: string) => void
 
   constructor(options: KeybindingEditorControllerOptions) {
     this.settings = options.settings
     this.manager = options.manager
+    this.projectSettingsForWrite = options.projectSettingsForWrite ?? (doc => doc)
     this.onDiagnostic = options.onDiagnostic ?? (() => {})
   }
 
@@ -333,9 +340,14 @@ export class KeybindingEditorController {
         )
         if (newConflict !== undefined) return { kind: 'rejected', message: describeConflict(newConflict) }
 
-        const nextDoc = { ...currentDoc } as TuiSettingsDoc
+        let nextDoc = { ...currentDoc } as TuiSettingsDoc
         if (nextRaw === undefined) delete nextDoc.keybindings
         else nextDoc.keybindings = nextRaw
+        // The controller owns only keybindings. The optional projector keeps
+        // foreign/raw fields on their authoritative layer before the single
+        // whole-document replace; it runs while this queue transaction is
+        // held, so its reads observe the same commit point.
+        nextDoc = this.projectSettingsForWrite(nextDoc)
         // The transaction intentionally has one replace and only projects the
         // same parsed candidate after persistence succeeds.
         await Promise.resolve(settings.replace(nextDoc))

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -27,7 +27,7 @@
 
 import type { AuthorizationTarget } from '../authorization.ts'
 import type { FooterCommandConfig } from '../footer/command-runner.ts'
-import type { FooterCustomItemSettings } from '../footer/custom-items.ts'
+import type { FooterCustomItemSettings, FooterCustomItemsParseResult } from '../footer/custom-items.ts'
 
 /** The TUI settings document (theme/iconStyle/footer/footerLayout/
  * footerCustomItems/fullscreen/busyEnter/localShellSandbox/homeEndKeys/focusMode).
@@ -49,9 +49,11 @@ export interface TuiSettingsDoc {
   footer: string
   footerFallbackMode?: string
   footerLayout?: unknown
-  /** PR C: user-owned custom definitions. The layout stores only their
-   * canonical `user:*` ids; this field carries the independent definition
-   * collection across a whole-document get/replace cycle. */
+  /** PR C: untrusted whole-document pass-through for custom definitions. The
+   * USER-owned semantic read is `ConfigPort.footerCustomItems`; consumers
+   * must not treat this merged/resolved value as an authority because a
+   * project layer may contribute it. It remains here so get/replace cycles
+   * preserve the stored field verbatim. */
   footerCustomItems?: FooterCustomItemSettings[]
   /** The M5 command status surface's TRUSTED configuration (the user-layer
    * `footerCommand` value, validated by footer/command-trust). Part of the
@@ -117,6 +119,13 @@ export interface FooterCommandTrust {
   /** The trusted command config (the user layer's footerCommand, bounds
    * validated), undefined when untrusted/absent. */
   readonly command: FooterCommandConfig | undefined
+}
+
+/** The USER-layer Custom Text definition read (PR C). The adapter reads the
+ * settings descriptor's user section and returns a detached, fail-soft parse
+ * result; merged/project settings never reach this surface. */
+export interface FooterCustomItemsConfig {
+  get(): FooterCustomItemsParseResult
 }
 
 /** The TUI settings document surface as the commands surface names it
@@ -319,6 +328,8 @@ export interface ConfigPort {
   readonly tuiSettings: TuiSettingsConfig | undefined
   /** The M5 footer-command trust read (USER-layer only). */
   readonly footerCommandTrust: FooterCommandTrust
+  /** The PR C Custom Text definitions (USER-layer only). */
+  readonly footerCustomItems: FooterCustomItemsConfig
   /** Provider profiles (the add-provider wizard + /login section reads). */
   readonly providers: ProviderProfileConfig
   /** Credentials (API keys + stored records). */

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -27,7 +27,7 @@
 
 import type { AuthorizationTarget } from '../authorization.ts'
 import type { FooterCommandConfig } from '../footer/command-runner.ts'
-import type { FooterCustomItemSettings, FooterCustomItemsParseResult } from '../footer/custom-items.ts'
+import type { FooterCustomItemsParseResult } from '../footer/custom-items.ts'
 
 /** The TUI settings document (theme/iconStyle/footer/footerLayout/
  * footerCustomItems/fullscreen/busyEnter/localShellSandbox/homeEndKeys/focusMode).
@@ -54,7 +54,7 @@ export interface TuiSettingsDoc {
    * must not treat this merged/resolved value as an authority because a
    * project layer may contribute it. It remains here so get/replace cycles
    * preserve the stored field verbatim. */
-  footerCustomItems?: FooterCustomItemSettings[]
+  footerCustomItems?: unknown
   /** The M5 command status surface's TRUSTED configuration (the user-layer
    * `footerCommand` value, validated by footer/command-trust). Part of the
    * SEMANTIC document: a whole-document replace that drops it would wipe
@@ -122,10 +122,15 @@ export interface FooterCommandTrust {
 }
 
 /** The USER-layer Custom Text definition read (PR C). The adapter reads the
- * settings descriptor's user section and returns a detached, fail-soft parse
- * result; merged/project settings never reach this surface. */
+ * settings descriptor's user section. `get()` is the safe runtime projection;
+ * `rawForPersistence()` is the exact USER-layer storage value and exists only
+ * for whole-document round-trips. Merged/project settings never reach either
+ * surface. */
 export interface FooterCustomItemsConfig {
+  /** Valid Custom Text definitions plus a fail-soft invalid-entry count. */
   get(): FooterCustomItemsParseResult
+  /** The exact raw USER-layer footerCustomItems value, or undefined if absent. */
+  rawForPersistence(): unknown
 }
 
 /** The TUI settings document surface as the commands surface names it

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -123,15 +123,20 @@ export interface FooterCommandTrust {
 
 /** The USER-layer Custom Text definition read (PR C). The adapter reads the
  * settings descriptor's user section. `get()` is the safe runtime projection;
- * `rawForPersistence()` is the exact USER-layer storage value and exists only
- * for whole-document round-trips. Merged/project settings never reach either
- * surface. */
+ * `rawForPersistence()` is a detached exact USER-layer storage projection and
+ * exists only for whole-document round-trips. Merged/project settings never
+ * reach either surface. */
 export interface FooterCustomItemsConfig {
   /** Valid Custom Text definitions plus a fail-soft invalid-entry count. */
   get(): FooterCustomItemsParseResult
-  /** The exact raw USER-layer footerCustomItems value, or undefined if absent. */
-  rawForPersistence(): unknown
+  /** A detached raw value, or `unavailable` when it cannot be read safely. */
+  rawForPersistence(): FooterCustomItemsRaw
 }
+
+/** Result of reading the USER-layer raw custom-item storage value. */
+export type FooterCustomItemsRaw =
+  | { readonly kind: 'available'; readonly value: unknown }
+  | { readonly kind: 'unavailable' }
 
 /** The TUI settings document surface as the commands surface names it
  * (kept as the public commands-surface type — see commands.ts). Like

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -27,9 +27,11 @@
 
 import type { AuthorizationTarget } from '../authorization.ts'
 import type { FooterCommandConfig } from '../footer/command-runner.ts'
+import type { FooterCustomItemSettings } from '../footer/custom-items.ts'
 
 /** The TUI settings document (theme/iconStyle/footer/footerLayout/
- * fullscreen/busyEnter/localShellSandbox/homeEndKeys/focusMode). The old
+ * footerCustomItems/fullscreen/busyEnter/localShellSandbox/homeEndKeys/focusMode).
+ * The old
  * `history` field moved to $DSH_HOME/user-history/*.jsonl and is
  * deliberately NOT part of the document anymore. `footerLayout` is the
  * M2 versioned custom layout (nested settings object), absent when not
@@ -47,6 +49,10 @@ export interface TuiSettingsDoc {
   footer: string
   footerFallbackMode?: string
   footerLayout?: unknown
+  /** PR C: user-owned custom definitions. The layout stores only their
+   * canonical `user:*` ids; this field carries the independent definition
+   * collection across a whole-document get/replace cycle. */
+  footerCustomItems?: FooterCustomItemSettings[]
   /** The M5 command status surface's TRUSTED configuration (the user-layer
    * `footerCommand` value, validated by footer/command-trust). Part of the
    * SEMANTIC document: a whole-document replace that drops it would wipe

--- a/src/runtime/direct/config-direct.ts
+++ b/src/runtime/direct/config-direct.ts
@@ -202,11 +202,12 @@ class DirectFooterCustomItems implements FooterCustomItemsConfig {
   private readRaw(): { value: unknown; failed: boolean } {
     try {
       const settings = this.ctx.get('settings') as { describe?(): readonly SettingsDescriptorLike[] | undefined } | undefined
-      if (settings !== undefined && typeof settings.describe !== 'function') return { value: undefined, failed: true }
-      const descriptors = settings?.describe?.()
-      if (settings !== undefined && descriptors === undefined) return { value: undefined, failed: true }
-      const descriptor = descriptors?.find(entry => entry.ns === settingsNamespace('dsh-pi-tui'))
-      const user = descriptor?.user
+      if (settings === undefined || typeof settings.describe !== 'function') return { value: undefined, failed: true }
+      const descriptors = settings.describe()
+      if (descriptors === undefined) return { value: undefined, failed: true }
+      const descriptor = descriptors.find(entry => entry.ns === settingsNamespace('dsh-pi-tui'))
+      if (descriptor === undefined) return { value: undefined, failed: true }
+      const user = descriptor.user
       if (user === undefined) return { value: undefined, failed: false }
       if (typeof user !== 'object' || user === null || Array.isArray(user)) return { value: undefined, failed: true }
       return { value: (user as Record<string, unknown>).footerCustomItems, failed: false }

--- a/src/runtime/direct/config-direct.ts
+++ b/src/runtime/direct/config-direct.ts
@@ -48,6 +48,7 @@ import type {
   CredentialProviderOption,
   FooterCommandTrust,
   FooterCustomItemsConfig,
+  FooterCustomItemsRaw,
   PermissionConfig,
   PresetDefaultConfig,
   ProviderProfileConfig,
@@ -171,9 +172,10 @@ class DirectFooterCommandTrust implements FooterCommandTrust {
 /** The Direct PR C Custom Text read: only the settings descriptor's USER
  * section is authoritative. The merged document remains a pass-through for
  * persistence, but project-layer values can never create a user definition.
- * `get()` parses a safe runtime projection; `rawForPersistence()` returns the
- * exact USER-layer value so unknown/future definitions survive unrelated writes.
- * A malformed descriptor/collection degrades to an empty fail-soft result. */
+ * `get()` parses a safe runtime projection; `rawForPersistence()` returns a
+ * detached exact USER-layer value so unknown/future definitions survive
+ * unrelated writes. A malformed descriptor/collection degrades to an empty
+ * fail-soft result, while an unsafe raw clone refuses the write. */
 class DirectFooterCustomItems implements FooterCustomItemsConfig {
   private readonly ctx: HostContextLike
 
@@ -187,16 +189,26 @@ class DirectFooterCustomItems implements FooterCustomItemsConfig {
     return parseFooterCustomItems(raw.value)
   }
 
-  rawForPersistence(): unknown {
-    return this.readRaw().value
+  rawForPersistence(): FooterCustomItemsRaw {
+    const raw = this.readRaw()
+    if (raw.failed) return { kind: 'unavailable' }
+    try {
+      return { kind: 'available', value: structuredClone(raw.value) }
+    } catch {
+      return { kind: 'unavailable' }
+    }
   }
 
   private readRaw(): { value: unknown; failed: boolean } {
     try {
       const settings = this.ctx.get('settings') as { describe?(): readonly SettingsDescriptorLike[] | undefined } | undefined
-      const descriptor = settings?.describe?.()?.find(entry => entry.ns === settingsNamespace('dsh-pi-tui'))
+      if (settings !== undefined && typeof settings.describe !== 'function') return { value: undefined, failed: true }
+      const descriptors = settings?.describe?.()
+      if (settings !== undefined && descriptors === undefined) return { value: undefined, failed: true }
+      const descriptor = descriptors?.find(entry => entry.ns === settingsNamespace('dsh-pi-tui'))
       const user = descriptor?.user
-      if (typeof user !== 'object' || user === null) return { value: undefined, failed: false }
+      if (user === undefined) return { value: undefined, failed: false }
+      if (typeof user !== 'object' || user === null || Array.isArray(user)) return { value: undefined, failed: true }
       return { value: (user as Record<string, unknown>).footerCustomItems, failed: false }
     } catch {
       return { value: undefined, failed: true }

--- a/src/runtime/direct/config-direct.ts
+++ b/src/runtime/direct/config-direct.ts
@@ -171,6 +171,8 @@ class DirectFooterCommandTrust implements FooterCommandTrust {
 /** The Direct PR C Custom Text read: only the settings descriptor's USER
  * section is authoritative. The merged document remains a pass-through for
  * persistence, but project-layer values can never create a user definition.
+ * `get()` parses a safe runtime projection; `rawForPersistence()` returns the
+ * exact USER-layer value so unknown/future definitions survive unrelated writes.
  * A malformed descriptor/collection degrades to an empty fail-soft result. */
 class DirectFooterCustomItems implements FooterCustomItemsConfig {
   private readonly ctx: HostContextLike
@@ -180,14 +182,24 @@ class DirectFooterCustomItems implements FooterCustomItemsConfig {
   }
 
   get(): FooterCustomItemsParseResult {
+    const raw = this.readRaw()
+    if (raw.failed) return { items: [], invalidCount: 1 }
+    return parseFooterCustomItems(raw.value)
+  }
+
+  rawForPersistence(): unknown {
+    return this.readRaw().value
+  }
+
+  private readRaw(): { value: unknown; failed: boolean } {
     try {
       const settings = this.ctx.get('settings') as { describe?(): readonly SettingsDescriptorLike[] | undefined } | undefined
       const descriptor = settings?.describe?.()?.find(entry => entry.ns === settingsNamespace('dsh-pi-tui'))
       const user = descriptor?.user
-      if (typeof user !== 'object' || user === null) return { items: [], invalidCount: 0 }
-      return parseFooterCustomItems((user as Record<string, unknown>).footerCustomItems)
+      if (typeof user !== 'object' || user === null) return { value: undefined, failed: false }
+      return { value: (user as Record<string, unknown>).footerCustomItems, failed: false }
     } catch {
-      return { items: [], invalidCount: 1 }
+      return { value: undefined, failed: true }
     }
   }
 }

--- a/src/runtime/direct/config-direct.ts
+++ b/src/runtime/direct/config-direct.ts
@@ -38,6 +38,7 @@ import {
 import { cancellationError } from '../../detached.ts'
 import { safeErrorMessage } from '../../error-boundary.ts'
 import { resolveTrustedFooterCommand, resolveUserLayerFooterMode } from '../../footer/command-trust.ts'
+import { parseFooterCustomItems, type FooterCustomItemsParseResult } from '../../footer/custom-items.ts'
 import type {
   AuthorizationConfig,
   AuthorizationFlowEvent,
@@ -46,6 +47,7 @@ import type {
   CredentialConfig,
   CredentialProviderOption,
   FooterCommandTrust,
+  FooterCustomItemsConfig,
   PermissionConfig,
   PresetDefaultConfig,
   ProviderProfileConfig,
@@ -94,6 +96,7 @@ export interface AgentPresetsServiceLike {
 export class DirectConfigPort implements ConfigPort {
   readonly tuiSettings: TuiSettingsConfig | undefined
   readonly footerCommandTrust: FooterCommandTrust
+  readonly footerCustomItems: FooterCustomItemsConfig
   readonly providers: ProviderProfileConfig
   readonly credentials: CredentialConfig
   readonly authorization: AuthorizationConfig
@@ -107,6 +110,7 @@ export class DirectConfigPort implements ConfigPort {
   ) {
     this.tuiSettings = tuiSettings
     this.footerCommandTrust = new DirectFooterCommandTrust(ctx)
+    this.footerCustomItems = new DirectFooterCustomItems(ctx)
     this.providers = new DirectProviderProfileConfig(ctx)
     this.credentials = new DirectCredentialConfig(ctx)
     this.authorization = new DirectAuthorizationConfig(ctx)
@@ -161,6 +165,30 @@ class DirectFooterCommandTrust implements FooterCommandTrust {
     // macrotask so a settings change is picked up.
     queueMicrotask(() => { this.descriptorCache = null })
     return found
+  }
+}
+
+/** The Direct PR C Custom Text read: only the settings descriptor's USER
+ * section is authoritative. The merged document remains a pass-through for
+ * persistence, but project-layer values can never create a user definition.
+ * A malformed descriptor/collection degrades to an empty fail-soft result. */
+class DirectFooterCustomItems implements FooterCustomItemsConfig {
+  private readonly ctx: HostContextLike
+
+  constructor(ctx: HostContextLike) {
+    this.ctx = ctx
+  }
+
+  get(): FooterCustomItemsParseResult {
+    try {
+      const settings = this.ctx.get('settings') as { describe?(): readonly SettingsDescriptorLike[] | undefined } | undefined
+      const descriptor = settings?.describe?.()?.find(entry => entry.ns === settingsNamespace('dsh-pi-tui'))
+      const user = descriptor?.user
+      if (typeof user !== 'object' || user === null) return { items: [], invalidCount: 0 }
+      return parseFooterCustomItems((user as Record<string, unknown>).footerCustomItems)
+    } catch {
+      return { items: [], invalidCount: 1 }
+    }
   }
 }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1768,6 +1768,9 @@ export class TuiApp {
   private historyPanel: HistoryPanel | undefined
   /** The overlay handle of the history panel (hide() closes it). */
   private historyOverlay: OverlayHandle | undefined
+  /** Footer configurators own paste timers outside the generic overlay
+   * disposal path; final surface disposal closes every still-open one. */
+  private readonly footerConfiguratorClosers = new Set<() => void>()
   /** The injected Ctrl+R search source (the runner wires the file-backed
    * implementation; the host never touches the filesystem). */
   private readonly historySearchSource: HistorySearchSource | undefined
@@ -2581,6 +2584,11 @@ export class TuiApp {
     // must not hang.
     for (const settle of [...this.pendingBrokerSettles]) settle()
     this.pendingBrokerSettles.clear()
+    // Footer configurators are wrapped in a generic Frame, whose removal
+    // does not forward Component.dispose(); close their owned timers before
+    // the broker drops the physical overlay handles.
+    for (const close of [...this.footerConfiguratorClosers]) close()
+    this.footerConfiguratorClosers.clear()
     this.overlayBroker.clear()
     // The transcript-search overlay dies with the surface: stale handles
     // must never focus() or repaint a dead component.
@@ -9783,6 +9791,7 @@ export class TuiApp {
     const close = (): void => {
       if (closed) return
       closed = true
+      this.footerConfiguratorClosers.delete(close)
       panel?.dispose()
       handle?.hide()
     }
@@ -9826,6 +9835,7 @@ export class TuiApp {
       // CURRENT terminal height on every overlay frame.
       maxHeight: '100%',
     })
+    this.footerConfiguratorClosers.add(close)
     return close
   }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -3843,7 +3843,10 @@ export class TuiApp {
     // (overlayHandles, overlayDependents, the active question's suspension)
     // is then cleared wholesale — every one of those handles is dead, and
     // the pending-approval rebuild re-suspends a fresh handle on the new
-    // screen.
+    // screen. Footer configurators have a timer-bearing panel behind their
+    // generic Frame, so close those explicitly before dropping the graph.
+    for (const close of [...this.footerConfiguratorClosers]) close()
+    this.footerConfiguratorClosers.clear()
     for (const handle of this.overlayBroker.handles()) handle.hide()
     this.overlayBroker.clear()
     if (this.activeQuestions !== undefined) this.activeQuestions.suspendedOverlays.clear()

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9791,6 +9791,7 @@ export class TuiApp {
         const rows = Math.max(1, this.terminal.rows - 2)
         return Math.min(30, rows)
       },
+      requestRender: () => this.requestRender(),
       onSave: (layout, customItems) => {
         handle?.hide()
         options.onSave(layout, customItems)

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -76,6 +76,7 @@ import { resolveFooterInstruction } from './footer/instruction.ts'
 import { layoutForPreset } from './footer/presets.ts'
 import { FooterConfiguratorModel } from './footer/configurator-model.ts'
 import { FooterConfiguratorPanel } from './footer/configurator.ts'
+import { FooterCustomItemCatalog } from './footer/custom-items.ts'
 import type { FooterItemRegistry } from './footer/item-registry.ts'
 import type { FooterLayoutV1 } from './footer/types.ts'
 import { isViewerAccessInteractive, resolveViewerAccess, viewerAccessHint, type ViewerAccess } from './tasks-browser.ts'
@@ -1608,8 +1609,11 @@ export class TuiApp {
    * render path. Disposed with the surface so a long-lived EXTERNAL store
    * never retains a dead TuiApp's listener. */
   private statusStoreUnsubscribe: (() => void) | undefined
-  /** The builtin footer item registry (M1): the composer's catalog. */
+  /** The builtin/footer item registry (M1): the composer's catalog. */
   private readonly footerItemRegistry: FooterItemRegistry
+  /** User-owned custom definitions. The active composer reads this source;
+   * unsaved configurator drafts use a layered catalog instead. */
+  private readonly footerCustomItems: FooterCustomItemCatalog
   /** The footer composer (M1): renders the active layout against the
    * snapshot. */
   private readonly footerComposer: FooterComposer
@@ -2134,6 +2138,12 @@ export class TuiApp {
       ids: () => this.extensionHost!.footerItemIds(),
       definition: (id) => this.extensionHost!.footerItemDefinition(id),
     })
+    // PR C: user-owned definitions use the ordinary item registry and
+    // composer path. The source is replaced atomically by
+    // setFooterCustomItems(), so a malformed settings entry cannot reach the
+    // render callback.
+    this.footerCustomItems = new FooterCustomItemCatalog()
+    this.footerItemRegistry.setCustomSource(this.footerCustomItems)
     this.footerComposer = new FooterComposer(this.footerItemRegistry)
     // F-17: an invalidation batch re-bakes the outlets; the host then
     // re-merges its chrome rows so the new content reaches the screen.
@@ -9112,6 +9122,21 @@ export class TuiApp {
     return this.footerItemRegistry
   }
 
+  /** PR C: replace the user-owned custom definition catalog. Invalid or
+   * duplicate entries are skipped and the returned count lets the runner
+   * issue one fail-soft diagnostic without blocking startup. */
+  setFooterCustomItems(input: unknown): number {
+    const invalidCount = this.footerCustomItems.replace(input)
+    this.renderFooter()
+    return invalidCount
+  }
+
+  /** PR C: detached custom definitions for an unsaved configurator draft or
+   * a settings write. */
+  getFooterCustomItems(): import('./footer/custom-items.ts').FooterCustomItemSettings[] {
+    return this.footerCustomItems.snapshot()
+  }
+
   /** M5: set the command surface's sanitized rows (undefined restores the
    * native composer surface). The rows are already sanitized + capped by
    * the runner; the Host instruction still merges on top. */
@@ -9745,7 +9770,9 @@ export class TuiApp {
   openFooterConfigurator(options: {
     model: FooterConfiguratorModel
     registry: FooterItemRegistry
-    onSave: (layout: FooterLayoutV1) => void
+    /** A layered composer for an unsaved custom-definition draft. */
+    composer?: FooterComposer
+    onSave: (layout: FooterLayoutV1, customItems?: readonly import('./footer/custom-items.ts').FooterCustomItemSettings[]) => void
     onCancel: () => void
   }): () => void {
     let handle: OverlayHandle | undefined
@@ -9753,7 +9780,7 @@ export class TuiApp {
       model: options.model,
       registry: options.registry,
       snapshot: () => this.statusStore.snapshot(),
-      composer: this.footerComposer,
+      composer: options.composer ?? this.footerComposer,
       taskBrowserAvailable: () => this.taskBrowserAvailable(),
       extensionFooterText: () => this.extensionHost?.footerText() ?? '',
       maxVisible: () => {
@@ -9764,9 +9791,9 @@ export class TuiApp {
         const rows = Math.max(1, this.terminal.rows - 2)
         return Math.min(30, rows)
       },
-      onSave: (layout) => {
+      onSave: (layout, customItems) => {
         handle?.hide()
-        options.onSave(layout)
+        options.onSave(layout, customItems)
       },
       onCancel: () => {
         handle?.hide()

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9776,7 +9776,17 @@ export class TuiApp {
     onCancel: () => void
   }): () => void {
     let handle: OverlayHandle | undefined
-    const panel = new FooterConfiguratorPanel({
+    let panel: FooterConfiguratorPanel | undefined
+    let closed = false
+    // The generic Frame/overlay stack does not own or forward the panel's
+    // optional Component.dispose(), so every close path owns this cleanup.
+    const close = (): void => {
+      if (closed) return
+      closed = true
+      panel?.dispose()
+      handle?.hide()
+    }
+    panel = new FooterConfiguratorPanel({
       model: options.model,
       registry: options.registry,
       snapshot: () => this.statusStore.snapshot(),
@@ -9793,11 +9803,11 @@ export class TuiApp {
       },
       requestRender: () => this.requestRender(),
       onSave: (layout, customItems) => {
-        handle?.hide()
+        close()
         options.onSave(layout, customItems)
       },
       onCancel: () => {
-        handle?.hide()
+        close()
         options.onCancel()
       },
     })
@@ -9816,7 +9826,7 @@ export class TuiApp {
       // CURRENT terminal height on every overlay frame.
       maxHeight: '100%',
     })
-    return () => handle?.hide()
+    return close
   }
 
   /**

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -121,6 +121,7 @@ function setup(options: { busyEnter?: string; localShellSandbox?: string } = {})
   app.start()
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   const settings = fakeTuiSettings(options.busyEnter ?? 'queue', options.localShellSandbox ?? 'bypass')
   const runner: TuiCommandRunner = {
     ctx,

--- a/test/footer-command-trust.test.ts
+++ b/test/footer-command-trust.test.ts
@@ -114,7 +114,7 @@ test('the Direct config-port trust read resolves the same USER-layer facts', asy
 test('the Direct custom-item read separates USER raw storage from the safe runtime projection', async () => {
   const userRaw: unknown[] = [
     { schemaVersion: 1, id: 'user:user-owned', kind: 'text', text: 'USER' },
-    { schemaVersion: 1, id: 'user:future-command', kind: 'command', command: 'date' },
+    { schemaVersion: 1, id: 'user:future-command', kind: 'command', command: 'date', payload: { nested: ['preserve'] } },
   ]
   const projectRaw: unknown[] = [{ schemaVersion: 1, id: 'user:project-owned', kind: 'text', text: 'PROJECT' }]
   const port = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
@@ -125,7 +125,24 @@ test('the Direct custom-item read separates USER raw storage from the safe runti
   } as never, () => undefined)
   assert.deepEqual(port.footerCustomItems.get().items, [userRaw[0]])
   assert.equal(port.footerCustomItems.get().invalidCount, 1)
-  assert.deepEqual(port.footerCustomItems.rawForPersistence(), userRaw)
+  const raw = port.footerCustomItems.rawForPersistence()
+  assert.equal(raw.kind, 'available')
+  if (raw.kind === 'available') {
+    assert.deepEqual(raw.value, userRaw)
+    assert.notEqual(raw.value, userRaw, 'raw persistence must not expose descriptor-owned references')
+    assert.notEqual(
+      (raw.value as Array<Record<string, unknown>>)[1]?.payload,
+      (userRaw[1] as Record<string, unknown>).payload,
+      'raw persistence must deep-clone unknown/future fields too',
+    )
+  }
+
+  const revoked = Proxy.revocable([], {})
+  revoked.revoke()
+  const unsafe = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
+    get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', user: { footerCustomItems: revoked.proxy } }] }),
+  } as never, undefined, () => undefined)
+  assert.deepEqual(unsafe.footerCustomItems.rawForPersistence(), { kind: 'unavailable' })
 
   const noUser = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
     get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', value: { footerCustomItems: projectRaw } }] }),
@@ -134,7 +151,13 @@ test('the Direct custom-item read separates USER raw storage from the safe runti
     replace: () => {},
   } as never, () => undefined)
   assert.deepEqual(noUser.footerCustomItems.get().items, [])
-  assert.equal(noUser.footerCustomItems.rawForPersistence(), undefined)
+  assert.deepEqual(noUser.footerCustomItems.rawForPersistence(), { kind: 'available', value: undefined })
+
+  const unavailable = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
+    get: () => ({ describe: () => { throw new Error('settings read failed') } }),
+  } as never, undefined, () => undefined)
+  assert.deepEqual(unavailable.footerCustomItems.get(), { items: [], invalidCount: 1 })
+  assert.deepEqual(unavailable.footerCustomItems.rawForPersistence(), { kind: 'unavailable' })
 })
 
 test('TuiSettingsDoc round-trip: a whole-document replace never wipes the trusted footerCommand (review P2 migration contract)', async () => {

--- a/test/footer-command-trust.test.ts
+++ b/test/footer-command-trust.test.ts
@@ -129,12 +129,20 @@ test('TuiSettingsDoc round-trip: a whole-document replace never wipes the truste
     refreshIntervalMs: 2000,
     maxRows: 2,
   }
+  const footerCustomItems = [{
+    schemaVersion: 1 as const,
+    id: 'user:environment',
+    kind: 'text' as const,
+    text: 'PROD',
+    tone: 'warning' as const,
+  }]
   let backing: Record<string, unknown> = {
     theme: 'dark',
     iconStyle: 'emoji',
     footer: 'command',
     footerFallbackMode: 'default',
     footerCommand,
+    footerCustomItems,
     fullscreen: 'off',
     busyEnter: 'queue',
     localShellSandbox: 'bypass',
@@ -155,4 +163,6 @@ test('TuiSettingsDoc round-trip: a whole-document replace never wipes the truste
   const reread = port.tuiSettings.get()
   assert.deepEqual(reread.footerCommand, footerCommand,
     'footerCommand must survive a whole-document replace')
+  assert.deepEqual(reread.footerCustomItems, footerCustomItems,
+    'footerCustomItems must survive a whole-document replace')
 })

--- a/test/footer-command-trust.test.ts
+++ b/test/footer-command-trust.test.ts
@@ -111,6 +111,26 @@ test('the Direct config-port trust read resolves the same USER-layer facts', asy
   assert.equal(empty.footerCommandTrust.command, undefined)
 })
 
+test('the Direct custom-item read accepts only the USER settings layer', async () => {
+  const userItems = [{ schemaVersion: 1 as const, id: 'user:user-owned', kind: 'text' as const, text: 'USER' }]
+  const projectItems = [{ schemaVersion: 1 as const, id: 'user:project-owned', kind: 'text' as const, text: 'PROJECT' }]
+  const port = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
+    get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', value: { footerCustomItems: projectItems }, user: { footerCustomItems: userItems } }] }),
+  } as never, {
+    get: () => ({ footerCustomItems: projectItems }),
+    replace: () => {},
+  } as never, () => undefined)
+  assert.deepEqual(port.footerCustomItems.get().items, userItems)
+
+  const noUser = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
+    get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', value: { footerCustomItems: projectItems } }] }),
+  } as never, {
+    get: () => ({ footerCustomItems: projectItems }),
+    replace: () => {},
+  } as never, () => undefined)
+  assert.deepEqual(noUser.footerCustomItems.get().items, [])
+})
+
 test('TuiSettingsDoc round-trip: a whole-document replace never wipes the trusted footerCommand (review P2 migration contract)', async () => {
   // The settings port is get/replace WHOLE-DOCUMENT: a future Remote
   // adapter serializes the DECLARED DTO, so every semantic field must be

--- a/test/footer-command-trust.test.ts
+++ b/test/footer-command-trust.test.ts
@@ -158,6 +158,18 @@ test('the Direct custom-item read separates USER raw storage from the safe runti
   } as never, undefined, () => undefined)
   assert.deepEqual(unavailable.footerCustomItems.get(), { items: [], invalidCount: 1 })
   assert.deepEqual(unavailable.footerCustomItems.rawForPersistence(), { kind: 'unavailable' })
+
+  const absentService = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
+    get: () => undefined,
+  } as never, undefined, () => undefined)
+  assert.deepEqual(absentService.footerCustomItems.get(), { items: [], invalidCount: 1 })
+  assert.deepEqual(absentService.footerCustomItems.rawForPersistence(), { kind: 'unavailable' })
+
+  const absentDescriptor = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
+    get: () => ({ describe: () => [] }),
+  } as never, undefined, () => undefined)
+  assert.deepEqual(absentDescriptor.footerCustomItems.get(), { items: [], invalidCount: 1 })
+  assert.deepEqual(absentDescriptor.footerCustomItems.rawForPersistence(), { kind: 'unavailable' })
 })
 
 test('TuiSettingsDoc round-trip: a whole-document replace never wipes the trusted footerCommand (review P2 migration contract)', async () => {

--- a/test/footer-command-trust.test.ts
+++ b/test/footer-command-trust.test.ts
@@ -111,24 +111,30 @@ test('the Direct config-port trust read resolves the same USER-layer facts', asy
   assert.equal(empty.footerCommandTrust.command, undefined)
 })
 
-test('the Direct custom-item read accepts only the USER settings layer', async () => {
-  const userItems = [{ schemaVersion: 1 as const, id: 'user:user-owned', kind: 'text' as const, text: 'USER' }]
-  const projectItems = [{ schemaVersion: 1 as const, id: 'user:project-owned', kind: 'text' as const, text: 'PROJECT' }]
+test('the Direct custom-item read separates USER raw storage from the safe runtime projection', async () => {
+  const userRaw: unknown[] = [
+    { schemaVersion: 1, id: 'user:user-owned', kind: 'text', text: 'USER' },
+    { schemaVersion: 1, id: 'user:future-command', kind: 'command', command: 'date' },
+  ]
+  const projectRaw: unknown[] = [{ schemaVersion: 1, id: 'user:project-owned', kind: 'text', text: 'PROJECT' }]
   const port = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
-    get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', value: { footerCustomItems: projectItems }, user: { footerCustomItems: userItems } }] }),
+    get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', value: { footerCustomItems: projectRaw }, user: { footerCustomItems: userRaw } }] }),
   } as never, {
-    get: () => ({ footerCustomItems: projectItems }),
+    get: () => ({ footerCustomItems: projectRaw }),
     replace: () => {},
   } as never, () => undefined)
-  assert.deepEqual(port.footerCustomItems.get().items, userItems)
+  assert.deepEqual(port.footerCustomItems.get().items, [userRaw[0]])
+  assert.equal(port.footerCustomItems.get().invalidCount, 1)
+  assert.deepEqual(port.footerCustomItems.rawForPersistence(), userRaw)
 
   const noUser = new (await import('../src/runtime/direct/config-direct.ts')).DirectConfigPort({
-    get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', value: { footerCustomItems: projectItems } }] }),
+    get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', value: { footerCustomItems: projectRaw } }] }),
   } as never, {
-    get: () => ({ footerCustomItems: projectItems }),
+    get: () => ({ footerCustomItems: projectRaw }),
     replace: () => {},
   } as never, () => undefined)
   assert.deepEqual(noUser.footerCustomItems.get().items, [])
+  assert.equal(noUser.footerCustomItems.rawForPersistence(), undefined)
 })
 
 test('TuiSettingsDoc round-trip: a whole-document replace never wipes the trusted footerCommand (review P2 migration contract)', async () => {

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -310,7 +310,9 @@ test('/footer serializes overlapping saves and re-reads future USER definitions'
     return () => {}
   }) as TuiApp['openFooterConfigurator']
   let settingsChange: Parameters<TuiApp['openSettings']>[1] | undefined
+  let settingsItems: Parameters<TuiApp['openSettings']>[0] | undefined
   app.openSettings = ((...args: Parameters<TuiApp['openSettings']>) => {
+    settingsItems = args[0]
     settingsChange = args[1]
     return () => {}
   }) as TuiApp['openSettings']
@@ -416,6 +418,36 @@ test('/footer serializes overlapping saves and re-reads future USER definitions'
   assert.deepEqual(applied[1]!.footerLayout, layoutOne)
   assert.equal((applied[2]!.footerLayout as FooterLayoutV1).rows[0]!.left[0]!.id, 'view-scope')
   assert.deepEqual(app.getFooterCustomItems(), [{ ...known, text: 'TWO' }])
+
+  // The keybinding editor is another whole-document writer introduced by
+  // main. Its merged settings read must not promote a project definition into
+  // USER when the user changes only a shortcut. The real command wiring uses
+  // DirectConfigPort.rawForPersistence() through the projector hook.
+  const projectOnly = { schemaVersion: 1, id: 'user:project-only', kind: 'text', text: 'PROJECT', tone: 'warning' }
+  currentDoc = { ...currentDoc, footerCustomItems: [projectOnly] }
+  const keyboardRow = settingsItems?.find(item => item.id === 'keyboard-shortcuts')
+  const keyboardSubmenu = keyboardRow?.submenu
+  assert.ok(keyboardRow !== undefined && keyboardSubmenu !== undefined, 'settings must expose the keyboard shortcuts submenu')
+  const panel = keyboardSubmenu(keyboardRow.currentValue, () => {})
+  const handleInput = panel.handleInput?.bind(panel)
+  assert.ok(handleInput !== undefined, 'the keyboard shortcuts submenu must accept input')
+  handleInput('app.todo.toggle')
+  handleInput('\r')
+  handleInput('r')
+  for (let index = 0; index < 10; index += 1) await Promise.resolve()
+  assert.equal(pendingWrites.length, 4, `the keybinding mutation must reach the settings writer\n${panel.render(100).join('\n')}`)
+  const keybindingWrite = pendingWrites[3]!
+  assert.deepEqual(keybindingWrite.next.footerCustomItems, userRaw, 'keybinding writes must use exact USER raw footer definitions')
+  assert.equal(
+    (keybindingWrite.next.footerCustomItems as Array<{ id: string }>).some(item => item.id === projectOnly.id),
+    false,
+    'the merged project definition must not be written to USER settings',
+  )
+  assert.deepEqual(keybindingWrite.next.keybindings, {}, 'the keybinding editor must still persist its own mutation')
+  currentDoc = { ...keybindingWrite.next, footerCustomItems: userRaw }
+  keybindingWrite.resolve()
+  for (let index = 0; index < 10; index += 1) await Promise.resolve()
+  panel.dispose?.()
   app.stop()
 })
 

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -14,6 +14,7 @@ import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from
 import { DEFAULT_FOOTER_LAYOUT } from '../src/footer/presets.ts'
 import type { FooterLayoutV1 } from '../src/footer/types.ts'
 import type { FooterCustomItemSettings } from '../src/footer/custom-items.ts'
+import { serializeTuiSettingsMutation } from '../src/runtime/config-port.ts'
 import { DirectConfigPort } from '../src/runtime/direct/config-direct.ts'
 import { DirectCatalogPort } from '../src/runtime/direct/catalog-direct.ts'
 import { DirectHostFilePort } from '../src/runtime/direct/host-file-direct.ts'
@@ -68,6 +69,87 @@ function fakeSettings(initial: { footer: string; footerLayout?: unknown; footerF
     },
   }
 }
+
+test('footer, focus, and fullscreen writes share one FIFO at the live commit point', async () => {
+  let doc: ReturnType<TuiSettingsLike['get']> = {
+    theme: 'auto',
+    iconStyle: 'emoji',
+    footer: 'custom',
+    footerLayout: { source: 'old' },
+    footerCustomItems: [],
+    fullscreen: 'on',
+    busyEnter: 'queue',
+    localShellSandbox: 'bypass',
+    homeEndKeys: 'viewport',
+    focusMode: 'off',
+  }
+  const pending: Array<{ next: ReturnType<TuiSettingsLike['get']>; resolve: () => void }> = []
+  const settings: TuiSettingsLike = {
+    get: () => ({ ...doc }),
+    replace: (next) => new Promise<void>(resolve => pending.push({ next, resolve })),
+  }
+  const footerWrite = serializeTuiSettingsMutation(settings, () => settings.replace({ ...settings.get(), footerLayout: { source: 'footer' } }))
+  const focusWrite = serializeTuiSettingsMutation(settings, () => settings.replace({ ...settings.get(), focusMode: 'on' }))
+  const fullscreenWrite = serializeTuiSettingsMutation(settings, () => settings.replace({ ...settings.get(), fullscreen: 'off' }))
+  const flush = async (): Promise<void> => {
+    for (let index = 0; index < 8; index += 1) await Promise.resolve()
+  }
+
+  await flush()
+  assert.equal(pending.length, 1, 'the focus and fullscreen writes must wait behind footer')
+  assert.deepEqual(pending[0]!.next.footerLayout, { source: 'footer' })
+  doc = { ...pending[0]!.next }
+  pending[0]!.resolve()
+  await flush()
+  assert.equal(pending.length, 2, 'focus must start only after footer settles')
+  assert.deepEqual(pending[1]!.next.footerLayout, { source: 'footer' })
+  assert.equal(pending[1]!.next.focusMode, 'on')
+  doc = { ...pending[1]!.next }
+  pending[1]!.resolve()
+  await flush()
+  assert.equal(pending.length, 3, 'fullscreen must start only after focus settles')
+  assert.deepEqual(pending[2]!.next.footerLayout, { source: 'footer' })
+  assert.equal(pending[2]!.next.focusMode, 'on')
+  assert.equal(pending[2]!.next.fullscreen, 'off')
+  doc = { ...pending[2]!.next }
+  pending[2]!.resolve()
+  await Promise.all([footerWrite, focusWrite, fullscreenWrite])
+})
+
+test('a failed whole-document settings write does not block later queued writes', async () => {
+  const doc: ReturnType<TuiSettingsLike['get']> = {
+    theme: 'auto',
+    iconStyle: 'emoji',
+    footer: 'default',
+    fullscreen: 'on',
+    busyEnter: 'queue',
+    localShellSandbox: 'bypass',
+    homeEndKeys: 'viewport',
+    focusMode: 'off',
+  }
+  let calls = 0
+  let rejectFirst: (error: Error) => void = () => {}
+  let resolveSecond: () => void = () => {}
+  const settings: TuiSettingsLike = {
+    get: () => ({ ...doc }),
+    replace: () => {
+      calls += 1
+      if (calls === 1) return new Promise<void>((_resolve, reject) => { rejectFirst = reject })
+      return new Promise<void>(resolve => { resolveSecond = resolve })
+    },
+  }
+  const first = serializeTuiSettingsMutation(settings, () => settings.replace({ ...settings.get(), footer: 'custom' }))
+  const second = serializeTuiSettingsMutation(settings, () => settings.replace({ ...settings.get(), focusMode: 'on' }))
+  for (let index = 0; index < 8; index += 1) await Promise.resolve()
+  assert.equal(calls, 1)
+  const firstOutcome = assert.rejects(first, /settings failure/)
+  rejectFirst(new Error('settings failure'))
+  await firstOutcome
+  for (let index = 0; index < 8; index += 1) await Promise.resolve()
+  assert.equal(calls, 2, 'the queue must advance after a rejection')
+  resolveSecond()
+  await second
+})
 
 test('/footer is sessionless and opens the configurator; S saves and persists', async () => {
   const ctx = new Context()

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -12,6 +12,8 @@ import { Context } from '@deepseek-ai/cordis'
 import { TuiApp } from '../src/tui-app.ts'
 import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from '../src/commands.ts'
 import { DEFAULT_FOOTER_LAYOUT } from '../src/footer/presets.ts'
+import type { FooterLayoutV1 } from '../src/footer/types.ts'
+import type { FooterCustomItemSettings } from '../src/footer/custom-items.ts'
 import { DirectConfigPort } from '../src/runtime/direct/config-direct.ts'
 import { DirectCatalogPort } from '../src/runtime/direct/catalog-direct.ts'
 import { DirectHostFilePort } from '../src/runtime/direct/host-file-direct.ts'
@@ -188,6 +190,129 @@ test('/footer is sessionless and opens the configurator; S saves and persists', 
   vt.sendInput('\x1b')
   await vt.waitForRender()
   assert.equal(applied.length, 1, 'Esc on the alias-opened panel must not write')
+  app.stop()
+})
+
+test('/footer serializes overlapping saves and re-reads future USER definitions', async () => {
+  const ctx = new Context()
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const commands = fakeCommands()
+  ctx.provide('commands', commands.service as never)
+  const known = { schemaVersion: 1 as const, id: 'user:environment', kind: 'text' as const, text: 'OLD', tone: 'warning' as const }
+  const futureOne = { schemaVersion: 1, id: 'user:future-one', kind: 'command', command: 'one' }
+  const futureTwo = { schemaVersion: 1, id: 'user:future-two', kind: 'command', command: 'two' }
+  let userRaw: unknown[] = [known, futureOne]
+  let currentDoc: ReturnType<TuiSettingsLike['get']> = {
+    theme: 'auto',
+    iconStyle: 'emoji',
+    footer: 'default',
+    fullscreen: 'on',
+    busyEnter: 'queue',
+    localShellSandbox: 'bypass',
+    homeEndKeys: 'viewport',
+    focusMode: 'off',
+    footerCustomItems: userRaw,
+  }
+  const pendingWrites: Array<{ next: ReturnType<TuiSettingsLike['get']>; resolve: () => void }> = []
+  const settings: TuiSettingsLike = {
+    get: () => ({ ...currentDoc, footerCustomItems: userRaw }),
+    replace: (next) => new Promise<void>(resolve => pendingWrites.push({ next, resolve })),
+  }
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: { footerCustomItems: userRaw } }] } as never)
+  const saveCallbacks: Array<Parameters<TuiApp['openFooterConfigurator']>[0]['onSave']> = []
+  app.openFooterConfigurator = ((options: Parameters<TuiApp['openFooterConfigurator']>[0]) => {
+    saveCallbacks.push(options.onSave)
+    return () => {}
+  }) as TuiApp['openFooterConfigurator']
+  const applied: Array<{ footerLayout?: unknown; footerCustomItems?: unknown }> = []
+  const runner: TuiCommandRunner = {
+    ctx,
+    app,
+    diag: { warn: () => {}, error: () => {}, info: () => {} } as never,
+    get liveAgent() { return undefined },
+    ensureSession: async () => {},
+    get selected() { return { current: undefined, assembled: undefined, saveSelection: async () => {} } },
+    tuiSettings: settings,
+    agents: {} as never,
+    sessionReader: { list: async () => [], search: async () => [], titles: async () => new Map(), measureContext: () => undefined, readExportData: async () => ({ kind: 'none' }) },
+    sessionWriter: { followup: () => {}, steer: () => {}, dequeue: () => {}, cancel: () => {}, rename: () => true, refreshTitle: async () => ({ kind: 'ok' as const, title: undefined }) },
+    interaction: { registerQuestionProvider: () => true, onApprovalRequest: () => {}, setApprovalPolicy: () => true },
+    catalog: new DirectCatalogPort(ctx as never, () => undefined),
+    config: new DirectConfigPort(ctx as never, undefined, () => undefined),
+    hostFile: new DirectHostFilePort(() => undefined),
+    commandRegistry: ctx.get('commands') as never,
+    cwd: '/ws',
+    sessionCwd: () => '/ws',
+    imageStore: {} as never,
+    copyToClipboard: async () => true,
+    imageLimits: () => undefined,
+    insertIntoEditor: () => {},
+    prepareDraftMessage: async (text) => ({ role: 'user', id: `u:${text}`, content: [{ type: 'text', text }], source: { kind: 'user' } }) as never,
+    signal: new AbortController().signal,
+    get sessionGeneration() { return 0 },
+    switchSession: async () => undefined,
+    transitionTo: async <T>(steps: { prepare?: () => Promise<void> | void; create: () => Promise<T> }) => {
+      await steps.prepare?.()
+      return { ok: true, next: await steps.create() }
+    },
+    currentPreset: () => undefined,
+    get pendingPreset() { return undefined },
+    set pendingPreset(_id: string | undefined) {},
+    get effectivePresetId() { return undefined },
+    refreshCatalog: async () => ({ kind: 'failed', error: 'not wired in tests' }),
+    recomposeBlank: async () => ({ kind: 'switched', preset: 'standard' }),
+    refreshStatus: () => {},
+    focusEnabled: () => false,
+    setFocusMode: () => {},
+    updateWelcomeCard: () => {},
+    openJobView: () => {},
+    openTasksBrowser: () => {},
+    openRewindPicker: () => {},
+    sessionTransitionPending: () => false,
+    withSessionTransition: async <T>(task: () => T | Promise<T>) => task(),
+    withSessionWriter: async <T>(_sessionId: string, task: () => T | Promise<T>) => task(),
+    enterView: async () => {},
+    requestExit: () => {},
+    extensions: undefined,
+    exit: () => {},
+    applyFooterSettings: (doc) => {
+      if (doc !== undefined) applied.push({ footerLayout: doc.footerLayout, footerCustomItems: doc.footerCustomItems })
+    },
+  }
+  registerTuiCommands(runner)
+  const footer = commands.defs.find(entry => entry.name === 'footer')
+  assert.ok(footer?.handler !== undefined)
+  await (footer.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
+  await (footer.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
+  assert.equal(saveCallbacks.length, 2)
+
+  const layoutOne: FooterLayoutV1 = { schemaVersion: 1, rows: [{ left: [{ id: 'model' }], right: [] }] }
+  const layoutTwo: FooterLayoutV1 = { schemaVersion: 1, rows: [{ left: [{ id: 'view-scope' }], right: [] }] }
+  saveCallbacks[0]!(layoutOne, [{ ...known, text: 'ONE' }])
+  saveCallbacks[1]!(layoutTwo, [{ ...known, text: 'TWO' }])
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
+  assert.equal(pendingWrites.length, 1, 'the second save must wait for the first write')
+  assert.deepEqual(pendingWrites[0]!.next.footerCustomItems, [{ ...known, text: 'ONE' }, futureOne])
+
+  const first = pendingWrites[0]!
+  currentDoc = { ...first.next, footerCustomItems: first.next.footerCustomItems }
+  userRaw = [...(first.next.footerCustomItems as unknown[]), futureTwo]
+  currentDoc = { ...currentDoc, footerCustomItems: userRaw }
+  first.resolve()
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
+  assert.equal(pendingWrites.length, 2, 'the queued second save must start after the first settles')
+  assert.deepEqual(pendingWrites[1]!.next.footerCustomItems, [{ ...known, text: 'TWO' }, futureOne, futureTwo])
+
+  const second = pendingWrites[1]!
+  currentDoc = { ...second.next, footerCustomItems: second.next.footerCustomItems }
+  userRaw = [...(second.next.footerCustomItems as unknown[])]
+  second.resolve()
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
+  assert.equal(applied.length, 2)
+  assert.deepEqual((applied[1]!.footerLayout as FooterLayoutV1).rows[0]!.left[0]!.id, 'view-scope')
+  assert.deepEqual(app.getFooterCustomItems(), [{ ...known, text: 'TWO' }])
   app.stop()
 })
 

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -481,6 +481,7 @@ test('/settings footer change is PERSIST-FIRST: a failed write keeps the old lay
   app.start()
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   const doc = { footer: 'default' as string, footerLayout: undefined as unknown }
   const failingSettings: TuiSettingsLike = {
     get: () => ({ theme: 'auto', iconStyle: 'emoji', footer: doc.footer, footerLayout: doc.footerLayout, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }),
@@ -554,6 +555,7 @@ test('/settings footer change PERSISTS footerFallbackMode (the command-mode rest
   app.start()
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   const settings = fakeSettings({ footer: 'default' })
   const applied: Array<{ footer: string }> = []
   const runner: TuiCommandRunner = {

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -162,6 +162,7 @@ test('/footer is sessionless and opens the configurator; S saves and persists', 
   await vt.waitForRender()
   vt.sendInput('s')
   await vt.waitForRender()
+  for (let index = 0; index < 20; index += 1) await Promise.resolve()
   assert.equal(applied.length, 1, 'S must apply the layout')
   assert.equal(applied[0]!.footer, 'custom')
   assert.equal(settings.doc.footer, 'custom', 'the settings document must persist')
@@ -226,6 +227,11 @@ test('/footer serializes overlapping saves and re-reads future USER definitions'
     saveCallbacks.push(options.onSave)
     return () => {}
   }) as TuiApp['openFooterConfigurator']
+  let settingsChange: Parameters<TuiApp['openSettings']>[1] | undefined
+  app.openSettings = ((...args: Parameters<TuiApp['openSettings']>) => {
+    settingsChange = args[1]
+    return () => {}
+  }) as TuiApp['openSettings']
   const applied: Array<{ footerLayout?: unknown; footerCustomItems?: unknown }> = []
   const runner: TuiCommandRunner = {
     ctx,
@@ -283,17 +289,22 @@ test('/footer serializes overlapping saves and re-reads future USER definitions'
   }
   registerTuiCommands(runner)
   const footer = commands.defs.find(entry => entry.name === 'footer')
+  const settingsCommand = commands.defs.find(entry => entry.name === 'settings')
   assert.ok(footer?.handler !== undefined)
+  assert.ok(settingsCommand?.handler !== undefined)
   await (footer.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
   await (footer.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
+  await (settingsCommand.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
   assert.equal(saveCallbacks.length, 2)
+  assert.ok(settingsChange !== undefined)
 
   const layoutOne: FooterLayoutV1 = { schemaVersion: 1, rows: [{ left: [{ id: 'model' }], right: [] }] }
   const layoutTwo: FooterLayoutV1 = { schemaVersion: 1, rows: [{ left: [{ id: 'view-scope' }], right: [] }] }
   saveCallbacks[0]!(layoutOne, [{ ...known, text: 'ONE' }])
+  settingsChange!('footer', 'compact', () => {})
   saveCallbacks[1]!(layoutTwo, [{ ...known, text: 'TWO' }])
   for (let index = 0; index < 5; index += 1) await Promise.resolve()
-  assert.equal(pendingWrites.length, 1, 'the second save must wait for the first write')
+  assert.equal(pendingWrites.length, 1, 'the settings and second footer saves must wait for the first write')
   assert.deepEqual(pendingWrites[0]!.next.footerCustomItems, [{ ...known, text: 'ONE' }, futureOne])
 
   const first = pendingWrites[0]!
@@ -302,16 +313,26 @@ test('/footer serializes overlapping saves and re-reads future USER definitions'
   currentDoc = { ...currentDoc, footerCustomItems: userRaw }
   first.resolve()
   for (let index = 0; index < 5; index += 1) await Promise.resolve()
-  assert.equal(pendingWrites.length, 2, 'the queued second save must start after the first settles')
-  assert.deepEqual(pendingWrites[1]!.next.footerCustomItems, [{ ...known, text: 'TWO' }, futureOne, futureTwo])
+  assert.equal(pendingWrites.length, 2, 'the queued settings footer save must start after the first settles')
+  assert.equal(pendingWrites[1]!.next.footer, 'compact')
+  assert.deepEqual(pendingWrites[1]!.next.footerCustomItems, [{ ...known, text: 'ONE' }, futureOne, futureTwo])
 
-  const second = pendingWrites[1]!
+  const modeWrite = pendingWrites[1]!
+  currentDoc = { ...modeWrite.next, footerCustomItems: modeWrite.next.footerCustomItems }
+  userRaw = [...(modeWrite.next.footerCustomItems as unknown[])]
+  modeWrite.resolve()
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
+  assert.equal(pendingWrites.length, 3, 'the second configurator save must wait for the settings footer write')
+  assert.deepEqual(pendingWrites[2]!.next.footerCustomItems, [{ ...known, text: 'TWO' }, futureOne, futureTwo])
+
+  const second = pendingWrites[2]!
   currentDoc = { ...second.next, footerCustomItems: second.next.footerCustomItems }
   userRaw = [...(second.next.footerCustomItems as unknown[])]
   second.resolve()
   for (let index = 0; index < 5; index += 1) await Promise.resolve()
-  assert.equal(applied.length, 2)
-  assert.deepEqual((applied[1]!.footerLayout as FooterLayoutV1).rows[0]!.left[0]!.id, 'view-scope')
+  assert.equal(applied.length, 3)
+  assert.deepEqual(applied[1]!.footerLayout, layoutOne)
+  assert.equal((applied[2]!.footerLayout as FooterLayoutV1).rows[0]!.left[0]!.id, 'view-scope')
   assert.deepEqual(app.getFooterCustomItems(), [{ ...known, text: 'TWO' }])
   app.stop()
 })
@@ -519,6 +540,7 @@ test('/footer starts from the EFFECTIVE COMPACT layout (a compact user pressing 
   // Save UNCHANGED (S): the saved custom layout must stay ONE row.
   vt.sendInput('s')
   await vt.waitForRender()
+  for (let index = 0; index < 20; index += 1) await Promise.resolve()
   assert.equal(applied.length, 1, 'S must apply the layout')
   const saved = applied[0]!.footerLayout as { rows: unknown[] }
   assert.equal(saved.rows.length, 1, `an unchanged compact save must stay one row:\n${JSON.stringify(saved)}`)
@@ -593,6 +615,7 @@ test('/footer Enter with a FAILED settings write keeps the old layout and notifi
   vt.sendInput('\x1b')
   await vt.waitForRender()
   vt.sendInput('s')
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
   // The write fails: the memory commit must NOT happen (the old layout
   // stays) — the apply is deferred until the write succeeds. Spin the
   // event loop a BOUNDED number of turns (never a wall-clock sleep — the

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -35,9 +35,9 @@ function fakeCommands(): { defs: Array<{ name: string; handler?: unknown }>; ser
 }
 
 /** A fake settings document. */
-function fakeSettings(initial: { footer: string; footerLayout?: unknown; footerFallbackMode?: string }): {
+function fakeSettings(initial: { footer: string; footerLayout?: unknown; footerFallbackMode?: string; footerCustomItems?: unknown }): {
   value: TuiSettingsLike
-  doc: { footer: string; footerLayout?: unknown; footerFallbackMode?: string }
+  doc: { footer: string; footerLayout?: unknown; footerFallbackMode?: string; footerCustomItems?: unknown }
 } {
   const doc = { ...initial }
   return {
@@ -49,16 +49,18 @@ function fakeSettings(initial: { footer: string; footerLayout?: unknown; footerF
         footer: doc.footer,
         footerLayout: doc.footerLayout,
         footerFallbackMode: doc.footerFallbackMode,
+        footerCustomItems: doc.footerCustomItems as never,
         fullscreen: 'on',
         busyEnter: 'queue',
         localShellSandbox: 'bypass',
         homeEndKeys: 'viewport',
         focusMode: 'off',
       }),
-      replace: (next: { footer: string; footerLayout?: unknown; footerFallbackMode?: string }) => {
+      replace: (next: { footer: string; footerLayout?: unknown; footerFallbackMode?: string; footerCustomItems?: unknown }) => {
         doc.footer = next.footer
         doc.footerLayout = next.footerLayout
         doc.footerFallbackMode = next.footerFallbackMode
+        doc.footerCustomItems = next.footerCustomItems
         return undefined
       },
     },
@@ -72,8 +74,10 @@ test('/footer is sessionless and opens the configurator; S saves and persists', 
   app.start()
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
-  const settings = fakeSettings({ footer: 'default' })
-  const applied: Array<{ footer: string; footerLayout?: unknown }> = []
+  const customItems = [{ schemaVersion: 1 as const, id: 'user:environment', kind: 'text' as const, text: 'PROD', tone: 'warning' as const }]
+  app.setFooterCustomItems(customItems)
+  const settings = fakeSettings({ footer: 'default', footerCustomItems: customItems })
+  const applied: Array<{ footer: string; footerLayout?: unknown; footerCustomItems?: unknown }> = []
   const runner: TuiCommandRunner = {
     ctx,
     app,
@@ -162,6 +166,8 @@ test('/footer is sessionless and opens the configurator; S saves and persists', 
   assert.equal(settings.doc.footerFallbackMode, 'custom', 'the fallback mode must persist as custom')
   const saved = settings.doc.footerLayout as { rows: Array<{ left: Array<{ id: string }> }> }
   assert.ok(!saved.rows[0]!.left.some(ref => ref.id === 'view-scope'), 'the persisted layout must reflect the toggle')
+  assert.deepEqual(settings.doc.footerCustomItems, customItems, 'saving the layout must preserve custom definitions')
+  assert.deepEqual(applied[0]!.footerCustomItems, customItems, 'apply must carry custom definitions alongside the layout')
   assert.equal(app.getFooterMode(), 'custom', 'the app must apply the custom layout')
 
   // The approved `/statusline` alias (other-agent muscle memory) registers

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -75,8 +75,11 @@ test('/footer is sessionless and opens the configurator; S saves and persists', 
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
   const customItems = [{ schemaVersion: 1 as const, id: 'user:environment', kind: 'text' as const, text: 'PROD', tone: 'warning' as const }]
+  const futureCustomItem = { schemaVersion: 1, id: 'user:future', kind: 'command', command: 'echo future' }
+  const persistedCustomItems = [...customItems, futureCustomItem]
   app.setFooterCustomItems(customItems)
-  const settings = fakeSettings({ footer: 'default', footerCustomItems: customItems })
+  const settings = fakeSettings({ footer: 'default', footerCustomItems: persistedCustomItems })
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: { footerCustomItems: persistedCustomItems } }] } as never)
   const applied: Array<{ footer: string; footerLayout?: unknown; footerCustomItems?: unknown }> = []
   const runner: TuiCommandRunner = {
     ctx,
@@ -166,7 +169,7 @@ test('/footer is sessionless and opens the configurator; S saves and persists', 
   assert.equal(settings.doc.footerFallbackMode, 'custom', 'the fallback mode must persist as custom')
   const saved = settings.doc.footerLayout as { rows: Array<{ left: Array<{ id: string }> }> }
   assert.ok(!saved.rows[0]!.left.some(ref => ref.id === 'view-scope'), 'the persisted layout must reflect the toggle')
-  assert.deepEqual(settings.doc.footerCustomItems, customItems, 'saving the layout must preserve custom definitions')
+  assert.deepEqual(settings.doc.footerCustomItems, persistedCustomItems, 'saving the layout must preserve known and future custom definitions')
   assert.deepEqual(applied[0]!.footerCustomItems, customItems, 'apply must carry custom definitions alongside the layout')
   assert.equal(app.getFooterMode(), 'custom', 'the app must apply the custom layout')
 
@@ -332,6 +335,7 @@ test('/footer starts from the EFFECTIVE COMPACT layout (a compact user pressing 
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
   const settings = fakeSettings({ footer: 'compact' })
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   const applied: Array<{ footer: string; footerLayout?: unknown }> = []
   const runner: TuiCommandRunner = {
     ctx, app, diag: {} as never,
@@ -403,6 +407,7 @@ test('/footer Enter with a FAILED settings write keeps the old layout and notifi
   app.start()
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   // A settings document whose replace REJECTS (the write fails).
   const doc = { footer: 'default' as string, footerLayout: undefined as unknown }
   const failingSettings: TuiSettingsLike = {

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -428,6 +428,56 @@ test('bracketed paste split across terminal chunks buffers until the end marker'
   app.stop()
 })
 
+test('a bracketed-paste start marker split across chunks is recognized', async () => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+  // The start marker is split after ESC+[20; the first chunk must not leak
+  // into the search and the second chunk must complete the protocol.
+  vt.sendInput('\x1b[20')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, '')
+  vt.sendInput('0~cach\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, 'cach')
+  assert.ok(vt.getViewport().join('\n').includes('Cache hit'))
+  app.stop()
+})
+
+test('malformed paste prefixes preserve Escape, arrows, and following text', async () => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+  vt.sendInput('cache')
+  await vt.waitForRender()
+
+  // A prefix that never becomes 200~ must not consume a later Escape.
+  vt.sendInput('\x1b[20')
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, '', 'Escape must still clear the pending search')
+
+  // The malformed prefix must not consume a complete arrow sequence either.
+  vt.sendInput('\x1b[20')
+  vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  assert.equal(model.state().pickerIndex, 1, 'the arrow must still move the picker')
+
+  vt.sendInput('\x1b[20')
+  vt.sendInput('x')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, 'x', 'ordinary input after the prefix must survive')
+  app.stop()
+})
+
 test('CSI-u encoded printables type into the Add search and the prefix', async () => {
   const { vt, app } = startApp()
   const model = openDefault(app)

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -482,6 +482,29 @@ test('a lone Escape is replayed as navigation after the paste-prefix timeout', a
   app.stop()
 })
 
+test('programmatic configurator close disposes a pending paste-prefix timer', async () => {
+  const { vt, app } = startApp()
+  const model = new FooterConfiguratorModel(DEFAULT_FOOTER_LAYOUT, app.getFooterItemRegistry())
+  const close = app.openFooterConfigurator({
+    model,
+    registry: app.getFooterItemRegistry(),
+    onSave: () => {},
+    onCancel: () => {},
+  })
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+  vt.sendInput('cache')
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // arm the ambiguous paste-prefix timer
+  close()
+  await new Promise<void>(resolve => setTimeout(resolve, 30))
+  assert.equal(model.state().addQuery, 'cache', 'closing must prevent stale Escape replay')
+  app.stop()
+})
+
 test('malformed paste prefixes preserve Escape, arrows, and following text', async () => {
   const { vt, app } = startApp()
   const model = openDefault(app)

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -466,6 +466,35 @@ test('a bracketed-paste start marker split exactly after ESC is recognized', asy
   app.stop()
 })
 
+test('recovery rescans a valid paste marker after rejected prefixes', async () => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+
+  // A longer rejected prefix must not swallow a complete marker in the next
+  // chunk.
+  vt.sendInput('\x1b[20')
+  vt.sendInput('\x1b[200~cach\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, 'cach')
+
+  // Repeat from an empty picker: the stale lone ESC cannot move out of the
+  // page before the fresh marker is rescanned.
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, '')
+  vt.sendInput('\x1b')
+  vt.sendInput('\x1b[200~hit\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(model.state().mode, 'add')
+  assert.equal(model.state().addQuery, 'hit')
+  app.stop()
+})
+
 test('a lone Escape is replayed as navigation after the paste-prefix timeout', async () => {
   const { vt, app } = startApp()
   const model = openDefault(app)
@@ -482,7 +511,7 @@ test('a lone Escape is replayed as navigation after the paste-prefix timeout', a
   app.stop()
 })
 
-test('programmatic configurator close disposes a pending paste-prefix timer', async () => {
+test('programmatic configurator close disposes a pending paste-prefix timer', async (t) => {
   const { vt, app } = startApp()
   const model = new FooterConfiguratorModel(DEFAULT_FOOTER_LAYOUT, app.getFooterItemRegistry())
   const close = app.openFooterConfigurator({
@@ -498,9 +527,11 @@ test('programmatic configurator close disposes a pending paste-prefix timer', as
   await vt.waitForRender()
   vt.sendInput('cache')
   await vt.waitForRender()
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  t.after(() => t.mock.timers.reset())
   vt.sendInput('\x1b') // arm the ambiguous paste-prefix timer
   close()
-  await new Promise<void>(resolve => setTimeout(resolve, 30))
+  t.mock.timers.tick(30)
   assert.equal(model.state().addQuery, 'cache', 'closing must prevent stale Escape replay')
   app.stop()
 })

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -448,6 +448,40 @@ test('a bracketed-paste start marker split across chunks is recognized', async (
   app.stop()
 })
 
+test('a bracketed-paste start marker split exactly after ESC is recognized', async () => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+  // ESC is ambiguous until the next chunk: it must stay buffered long
+  // enough to join the remainder of the bracketed-paste marker.
+  vt.sendInput('\x1b')
+  vt.sendInput('[200~cach\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, 'cach')
+  assert.ok(vt.getViewport().join('\n').includes('Cache hit'))
+  app.stop()
+})
+
+test('a lone Escape is replayed as navigation after the paste-prefix timeout', async () => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+  vt.sendInput('cache')
+  await vt.waitForRender()
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, '', 'a standalone Escape must still clear the search')
+  app.stop()
+})
+
 test('malformed paste prefixes preserve Escape, arrows, and following text', async () => {
   const { vt, app } = startApp()
   const model = openDefault(app)

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -492,6 +492,24 @@ test('a paste start clears stale prefix state before later chunks arrive', async
   app.stop()
 })
 
+test('a real Escape before a new same-chunk paste is not discarded', async () => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+
+  // The first paste ends, then Escape and a second paste follow in the same
+  // terminal chunk. Escape must clear the old query before the new paste lands.
+  vt.sendInput('\x1b[200~one\x1b[201~\x1b\x1b[200~two\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(model.state().mode, 'add')
+  assert.equal(model.state().addQuery, 'two')
+  app.stop()
+})
+
 test('recovery rescans a valid paste marker after rejected prefixes', async () => {
   const { vt, app } = startApp()
   const model = openDefault(app)
@@ -508,11 +526,11 @@ test('recovery rescans a valid paste marker after rejected prefixes', async () =
   await vt.waitForRender()
   assert.equal(model.state().addQuery, 'cach')
 
-  // Repeat from an empty picker: the stale lone ESC cannot move out of the
-  // page before the fresh marker is rescanned.
-  vt.sendInput('\x1b')
+  // A rejected lone ESC is replayed before a fresh marker. The non-empty
+  // query makes both effects observable: Escape clears it, then the marker
+  // contributes the new paste text.
+  vt.sendInput('seed')
   await vt.waitForRender()
-  assert.equal(model.state().addQuery, '')
   vt.sendInput('\x1b')
   vt.sendInput('\x1b[200~hit\x1b[201~')
   await vt.waitForRender()
@@ -560,6 +578,24 @@ test('programmatic configurator close disposes a pending paste-prefix timer', as
   t.mock.timers.tick(30)
   assert.equal(model.state().addQuery, 'cache', 'closing must prevent stale Escape replay')
   app.stop()
+})
+
+test('final app disposal cancels a configurator paste-prefix timer', async (t) => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+  vt.sendInput('cache')
+  await vt.waitForRender()
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  t.after(() => t.mock.timers.reset())
+  vt.sendInput('\x1b') // arm the ambiguous paste-prefix timer
+  app.dispose()
+  t.mock.timers.tick(30)
+  assert.equal(model.state().addQuery, 'cache', 'final disposal must prevent stale Escape replay')
 })
 
 test('malformed paste prefixes preserve Escape, arrows, and following text', async () => {

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -466,6 +466,32 @@ test('a bracketed-paste start marker split exactly after ESC is recognized', asy
   app.stop()
 })
 
+test('a paste start clears stale prefix state before later chunks arrive', async () => {
+  const { vt, app } = startApp()
+  const model = openDefault(app)
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('a')
+  await vt.waitForRender()
+
+  // The malformed prefix before the start marker must not remain active while
+  // the paste's content and end marker arrive in a later chunk.
+  vt.sendInput('\x1b[20\x1b[200~')
+  vt.sendInput('one\x1b[201~')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, 'one')
+
+  // Verify that the scanner can immediately accept another split paste and
+  // ordinary text after the first paste completes.
+  vt.sendInput('\x1b[200~two')
+  vt.sendInput('\x1b[201~')
+  vt.sendInput('tail')
+  await vt.waitForRender()
+  assert.equal(model.state().addQuery, 'onetwotail')
+  app.stop()
+})
+
 test('recovery rescans a valid paste marker after rejected prefixes', async () => {
   const { vt, app } = startApp()
   const model = openDefault(app)

--- a/test/footer-custom-items.test.ts
+++ b/test/footer-custom-items.test.ts
@@ -12,7 +12,7 @@ import { FooterComposer } from '../src/footer/composer.ts'
 import { FooterCustomItemCatalog, parseFooterCustomItem, parseFooterCustomItems } from '../src/footer/custom-items.ts'
 import { createBuiltinFooterRegistry } from '../src/footer/builtin-items.ts'
 import { FooterItemRegistry } from '../src/footer/item-registry.ts'
-import { FooterConfiguratorModel } from '../src/footer/configurator-model.ts'
+import { FooterConfiguratorModel, itemMenuFor } from '../src/footer/configurator-model.ts'
 import type { FooterItemDefinition } from '../src/footer/types.ts'
 import { emptyStatusSnapshot } from '../src/status/types.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
@@ -177,6 +177,43 @@ test('the Add picker searches custom definitions and creates multiple items auto
   assert.equal(m.customItemSettings().length, 4)
 })
 
+test('custom item editing separates default and placement tone entries', () => {
+  assert.deepEqual(itemMenuFor(['plain'], true).map(entry => entry.kind), [
+    'custom-text', 'custom-tone', 'tone', 'advanced', 'custom-name', 'custom-delete',
+  ])
+})
+
+test('custom names cannot collide with an extension-owned user namespace id', () => {
+  const catalog = new FooterCustomItemCatalog([VALID_ENVIRONMENT])
+  const registry = new FooterItemRegistry()
+  registry.setExternalSource({
+    ids: () => ['user:occupied'],
+    definition: id => id === 'user:occupied' ? {
+      id,
+      label: 'Occupied',
+      description: 'Extension item.',
+      defaultZone: 'left',
+      defaultImportance: 50,
+      formats: ['plain'],
+      defaultFormat: 'plain',
+      render: () => ({ spans: [{ text: 'EXT' }] }),
+    } : undefined,
+  })
+  const m = new FooterConfiguratorModel({
+    schemaVersion: 1,
+    rows: [{ left: [{ id: 'user:environment' }], right: [] }],
+  }, registry, catalog)
+  m.activate() // row
+  m.activate() // item
+  for (let i = 0; i < 4; i += 1) m.moveDown() // Rename definition
+  m.activate()
+  for (let i = 0; i < 'environment'.length; i += 1) m.backspace()
+  m.text('occupied')
+  m.activate()
+  assert.match(m.state().customError, /already exists/)
+  assert.ok(m.customItem('user:environment') !== undefined)
+})
+
 test('custom Text supports text/tone editing, rename, and referenced delete cleanup', () => {
   const catalog = new FooterCustomItemCatalog([VALID_ENVIRONMENT])
   const registry = new FooterItemRegistry()
@@ -194,11 +231,25 @@ test('custom Text supports text/tone editing, rename, and referenced delete clea
   m.activate()
   assert.equal(m.customItem('user:environment')?.text, 'STAGE')
 
-  // Tone: choose Primary in the definition picker.
+  // Default tone: choose Primary in the definition picker.
   m.moveDown()
   m.activate()
   for (let i = 0; i < 5; i += 1) m.moveUp()
   m.activate()
+  assert.equal(m.customItem('user:environment')?.tone, 'primary')
+
+  // Placement tone is a separate FooterItemRef override. It wins over the
+  // definition tone until the placement is explicitly returned to Auto.
+  m.moveDown()
+  m.activate()
+  for (let i = 0; i < 7; i += 1) m.moveDown()
+  m.activate()
+  assert.equal(m.state().layout.rows[0]!.left[0]!.tone, 'error')
+  assert.equal(m.customItem('user:environment')?.tone, 'primary')
+  m.activate()
+  for (let i = 0; i < 7; i += 1) m.moveUp()
+  m.activate()
+  assert.equal(m.state().layout.rows[0]!.left[0]!.tone, undefined)
   assert.equal(m.customItem('user:environment')?.tone, 'primary')
 
   // Rename: all references receive the new canonical id.
@@ -245,7 +296,9 @@ test('Custom Text creation is visible in the real configurator UI and saves both
   vt.sendInput('a') // add picker
   vt.sendInput('no-match') // make the create action the only option
   await vt.waitForRender()
-  assert.ok(vt.getViewport().join('\n').includes('+ Create Custom Text'))
+  const addView = vt.getViewport().join('\n')
+  assert.ok(addView.includes('+ Create Custom Text'))
+  assert.ok(addView.includes('Create a user-defined static footer item.'), `create action must describe itself:\n${addView}`)
   vt.sendInput('\r') // create name
   vt.sendInput('Environment')
   vt.sendInput('\r') // create text
@@ -258,6 +311,8 @@ test('Custom Text creation is visible in the real configurator UI and saves both
   await vt.waitForRender()
   const itemView = vt.getViewport().join('\n')
   assert.ok(itemView.includes('Text'), `custom item editor must expose Text:\n${itemView}`)
+  assert.ok(itemView.includes('Default tone'), `custom item editor must expose definition tone:\n${itemView}`)
+  assert.ok(itemView.includes('Tone'), `custom item editor must expose placement tone:\n${itemView}`)
   assert.ok(itemView.includes('Rename definition'), `custom item editor must expose rename:\n${itemView}`)
   assert.ok(itemView.includes('Delete definition'), `custom item editor must expose delete:\n${itemView}`)
   vt.sendInput('\x1b') // item -> row

--- a/test/footer-custom-items.test.ts
+++ b/test/footer-custom-items.test.ts
@@ -74,6 +74,18 @@ test('invalid and duplicate custom definitions fail soft while valid definitions
   assert.equal(parseFooterCustomItems(undefined).invalidCount, 0)
 })
 
+test('hostile custom-item collections fail soft without escaping startup', () => {
+  const revoked = Proxy.revocable([], {})
+  revoked.revoke()
+  assert.deepEqual(parseFooterCustomItems(revoked.proxy), { items: [], invalidCount: 1 })
+
+  const throwingIterator: unknown[] = [VALID_ENVIRONMENT]
+  Object.defineProperty(throwingIterator, Symbol.iterator, {
+    get: () => { throw new Error('hostile iterator getter') },
+  })
+  assert.deepEqual(parseFooterCustomItems(throwingIterator), { items: [], invalidCount: 1 })
+})
+
 test('the reserved user namespace cannot be shadowed by builtin or extension items', () => {
   const definition: FooterItemDefinition = {
     id: 'user:extension',

--- a/test/footer-custom-items.test.ts
+++ b/test/footer-custom-items.test.ts
@@ -1,0 +1,289 @@
+/**
+ * PR C tests for user-owned Custom Text footer definitions: parsing and
+ * compilation, the hierarchical create/edit/rename/delete flow, searchable
+ * picker integration, and the settings-safe separation from FooterLayoutV1.
+ * @module @xmoon76/dsh-pi-tui/footer-custom-items.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TuiApp } from '../src/tui-app.ts'
+import { FooterComposer } from '../src/footer/composer.ts'
+import { FooterCustomItemCatalog, parseFooterCustomItem, parseFooterCustomItems } from '../src/footer/custom-items.ts'
+import { createBuiltinFooterRegistry } from '../src/footer/builtin-items.ts'
+import { FooterItemRegistry } from '../src/footer/item-registry.ts'
+import { FooterConfiguratorModel } from '../src/footer/configurator-model.ts'
+import type { FooterItemDefinition } from '../src/footer/types.ts'
+import { emptyStatusSnapshot } from '../src/status/types.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+const VALID_ENVIRONMENT = {
+  schemaVersion: 1 as const,
+  id: 'user:environment',
+  kind: 'text' as const,
+  text: 'PROD',
+  tone: 'warning' as const,
+}
+
+function plain(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, '')
+}
+
+function emptyModel(catalog = new FooterCustomItemCatalog()): FooterConfiguratorModel {
+  const registry = new FooterItemRegistry()
+  return new FooterConfiguratorModel({ schemaVersion: 1, rows: [{ left: [], right: [] }] }, registry, catalog)
+}
+
+function createText(m: FooterConfiguratorModel, name: string, text: string): void {
+  m.activate() // rows -> row
+  m.startAdd()
+  m.text('no-match')
+  m.activate() // add -> create-name
+  m.text(name)
+  m.activate() // create-name -> create-text
+  m.text(text)
+  m.activate() // create-text -> create-tone
+  m.activate() // default Auto -> row
+}
+
+test('custom definitions use stable user:* ids and reject namespace collisions or controls', () => {
+  assert.equal(parseFooterCustomItem(VALID_ENVIRONMENT)?.id, 'user:environment')
+  assert.equal(parseFooterCustomItem({ ...VALID_ENVIRONMENT, tone: 'auto' })?.tone, 'auto')
+  assert.equal(parseFooterCustomItem({ ...VALID_ENVIRONMENT, id: 'model' }), undefined)
+  assert.equal(parseFooterCustomItem({ ...VALID_ENVIRONMENT, id: 'ext:plugin/item' }), undefined)
+  assert.equal(parseFooterCustomItem({ ...VALID_ENVIRONMENT, id: 'user:' }), undefined)
+  assert.equal(parseFooterCustomItem({ ...VALID_ENVIRONMENT, text: 'PROD\u001b[2J' }), undefined)
+  assert.equal(parseFooterCustomItem({ ...VALID_ENVIRONMENT, tone: '#fff' }), undefined)
+})
+
+test('invalid and duplicate custom definitions fail soft while valid definitions survive', () => {
+  const catalog = new FooterCustomItemCatalog([VALID_ENVIRONMENT])
+  assert.match(catalog.create('environment', 'SECOND', 'auto').error ?? '', /already exists/)
+  const hostile = {}
+  Object.defineProperty(hostile, 'schemaVersion', { get: () => { throw new Error('hostile getter') } })
+  const result = parseFooterCustomItems([
+    VALID_ENVIRONMENT,
+    { ...VALID_ENVIRONMENT, text: 'SECOND' },
+    { ...VALID_ENVIRONMENT, id: 'user:region', kind: 'command' },
+    { ...VALID_ENVIRONMENT, id: 'user:empty', text: '' },
+    hostile,
+    { ...VALID_ENVIRONMENT, id: 'user:stage', text: 'STAGE', tone: 'accent' },
+  ])
+  assert.deepEqual(result.items, [VALID_ENVIRONMENT, { ...VALID_ENVIRONMENT, id: 'user:stage', text: 'STAGE', tone: 'accent' }])
+  assert.equal(result.invalidCount, 4)
+  assert.equal(parseFooterCustomItems(undefined).invalidCount, 0)
+})
+
+test('the reserved user namespace cannot be shadowed by builtin or extension items', () => {
+  const definition: FooterItemDefinition = {
+    id: 'user:extension',
+    label: 'Extension collision',
+    defaultZone: 'left',
+    defaultImportance: 1,
+    formats: ['plain'],
+    defaultFormat: 'plain',
+    render: () => ({ spans: [{ text: 'EXT' }] }),
+  }
+  assert.throws(
+    () => new FooterItemRegistry().register({ ...definition, id: 'user:builtin' }),
+    /reserved for custom items/,
+  )
+
+  const registry = new FooterItemRegistry()
+  registry.setExternalSource({
+    ids: () => [definition.id],
+    definition: id => id === definition.id ? definition : undefined,
+  })
+  registry.setCustomSource(new FooterCustomItemCatalog([{
+    schemaVersion: 1,
+    id: definition.id,
+    kind: 'text',
+    text: 'CUSTOM',
+  }]))
+  assert.equal(registry.get(definition.id), definition, 'the external item must win the namespace collision')
+  assert.deepEqual(registry.ids(), [definition.id], 'the collision must not duplicate the picker entry')
+})
+
+test('a layered draft catalog can delete without falling back to the active catalog', () => {
+  const active = new FooterCustomItemCatalog([VALID_ENVIRONMENT])
+  const base = new FooterItemRegistry()
+  base.setCustomSource(active)
+  const draft = new FooterCustomItemCatalog(active.snapshot())
+  const layered = new FooterItemRegistry(base)
+  layered.setCustomSource(draft)
+  assert.ok(layered.get('user:environment'))
+  assert.equal(draft.remove('user:environment'), true)
+  assert.equal(layered.get('user:environment'), undefined)
+  assert.equal(layered.ids().includes('user:environment'), false)
+  assert.ok(base.get('user:environment'), 'the active catalog must remain unchanged')
+})
+
+test('compiled custom text is an ordinary synchronous footer item', () => {
+  const catalog = new FooterCustomItemCatalog([VALID_ENVIRONMENT])
+  const registry = new FooterItemRegistry()
+  registry.setCustomSource(catalog)
+  const definition = registry.get('user:environment')
+  assert.ok(definition)
+  const segment = definition.render(emptyStatusSnapshot(), { id: 'user:environment' }, 'preferred', {
+    taskBrowserAvailable: false,
+    extensionFooterText: '',
+  })
+  assert.deepEqual(segment?.spans[0], { text: 'PROD', tone: 'warning' })
+
+  const composer = new FooterComposer(registry)
+  const rendered = composer.render({
+    snapshot: emptyStatusSnapshot(),
+    layout: { schemaVersion: 1, rows: [{ left: [{ id: 'user:environment' }], right: [] }] },
+    width: 80,
+    context: { taskBrowserAvailable: false, extensionFooterText: '' },
+  })
+  assert.ok(plain(rendered).includes('PROD'))
+})
+
+test('the Add picker searches custom definitions and creates multiple items automatically', () => {
+  const m = emptyModel(new FooterCustomItemCatalog([
+    VALID_ENVIRONMENT,
+    { schemaVersion: 1, id: 'user:region', kind: 'text', text: 'EU' },
+  ]))
+  m.activate()
+  m.startAdd()
+  m.text('environment')
+  assert.deepEqual(m.addMatches(), ['user:environment'])
+  for (let i = 0; i < 'environment'.length; i += 1) m.backspace()
+  m.text('prod')
+  assert.deepEqual(m.addMatches(), ['user:environment'])
+  m.cancel() // clear query
+  m.startAdd()
+  m.text('no-match')
+  m.activate() // create Environment
+  m.text('Environment')
+  m.activate()
+  m.text('PROD')
+  m.activate()
+  m.activate()
+  assert.equal(m.state().mode, 'row')
+  assert.ok(m.state().layout.rows[0]!.left.some(ref => ref.id === 'user:Environment'))
+
+  // A second pass proves the catalog is a collection, not a singleton.
+  m.startAdd()
+  m.text('another-no-match')
+  m.activate()
+  m.text('Region')
+  m.activate()
+  m.text('EU')
+  m.activate()
+  m.activate()
+  assert.ok(m.state().layout.rows[0]!.left.some(ref => ref.id === 'user:Region'))
+  assert.equal(m.customItemSettings().length, 4)
+})
+
+test('custom Text supports text/tone editing, rename, and referenced delete cleanup', () => {
+  const catalog = new FooterCustomItemCatalog([VALID_ENVIRONMENT])
+  const registry = new FooterItemRegistry()
+  const m = new FooterConfiguratorModel({
+    schemaVersion: 1,
+    rows: [{ left: [{ id: 'user:environment' }, { id: 'user:environment' }], right: [] }],
+  }, registry, catalog)
+  m.activate() // row
+  m.activate() // item
+
+  // Text: replace PROD with STAGE.
+  m.activate()
+  for (let i = 0; i < 'PROD'.length; i += 1) m.backspace()
+  m.text('STAGE')
+  m.activate()
+  assert.equal(m.customItem('user:environment')?.text, 'STAGE')
+
+  // Tone: choose Primary in the definition picker.
+  m.moveDown()
+  m.activate()
+  for (let i = 0; i < 5; i += 1) m.moveUp()
+  m.activate()
+  assert.equal(m.customItem('user:environment')?.tone, 'primary')
+
+  // Rename: all references receive the new canonical id.
+  m.moveDown()
+  m.moveDown()
+  m.activate()
+  for (let i = 0; i < 'environment'.length; i += 1) m.backspace()
+  m.text('stage')
+  m.activate()
+  assert.equal(m.customItem('user:stage')?.text, 'STAGE')
+  assert.equal(m.state().layout.rows[0]!.left.every(ref => ref.id === 'user:stage'), true)
+
+  // Delete: Enter opens confirmation, a second Enter removes both refs and
+  // the definition from the draft catalog.
+  m.moveDown()
+  m.activate()
+  assert.equal(m.state().mode, 'custom-delete')
+  m.activate()
+  assert.equal(m.state().mode, 'row')
+  assert.deepEqual(m.state().layout.rows[0]!.left, [])
+  assert.equal(m.customItem('user:stage'), undefined)
+})
+
+test('Custom Text creation is visible in the real configurator UI and saves both parts', async () => {
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const catalog = new FooterCustomItemCatalog()
+  const registry = new FooterItemRegistry(app.getFooterItemRegistry())
+  registry.setCustomSource(catalog)
+  const model = new FooterConfiguratorModel({ schemaVersion: 1, rows: [{ left: [], right: [] }] }, registry, catalog)
+  let saved: { layout: unknown; items: readonly unknown[] } | undefined
+  app.openFooterConfigurator({
+    model,
+    registry,
+    composer: new FooterComposer(registry),
+    onSave: (layout, items) => { saved = { layout, items: items ?? [] } },
+    onCancel: () => {},
+  })
+  await vt.waitForRender()
+  assert.ok(vt.getViewport().join('\n').includes('Configure Footer'))
+
+  vt.sendInput('\r') // row
+  vt.sendInput('a') // add picker
+  vt.sendInput('no-match') // make the create action the only option
+  await vt.waitForRender()
+  assert.ok(vt.getViewport().join('\n').includes('+ Create Custom Text'))
+  vt.sendInput('\r') // create name
+  vt.sendInput('Environment')
+  vt.sendInput('\r') // create text
+  vt.sendInput('PROD')
+  vt.sendInput('\r') // create tone
+  vt.sendInput('\r') // create with Auto
+  await vt.waitForRender()
+  assert.ok(vt.getViewport().join('\n').includes('PROD'))
+  vt.sendInput('\r') // item editor
+  await vt.waitForRender()
+  const itemView = vt.getViewport().join('\n')
+  assert.ok(itemView.includes('Text'), `custom item editor must expose Text:\n${itemView}`)
+  assert.ok(itemView.includes('Rename definition'), `custom item editor must expose rename:\n${itemView}`)
+  assert.ok(itemView.includes('Delete definition'), `custom item editor must expose delete:\n${itemView}`)
+  vt.sendInput('\x1b') // item -> row
+  vt.sendInput('\x1b') // row -> selector
+  vt.sendInput('s') // save
+  await vt.waitForRender()
+  assert.ok(saved)
+  assert.deepEqual(saved.items, [{ schemaVersion: 1, id: 'user:Environment', kind: 'text', text: 'PROD', tone: 'auto' }])
+  assert.deepEqual(saved.layout, {
+    schemaVersion: 1,
+    rows: [{ left: [{ id: 'user:Environment' }], right: [] }],
+  })
+  app.stop()
+})
+
+test('custom definitions do not change the existing FooterLayoutV1 shape or builtin output', () => {
+  const builtin = createBuiltinFooterRegistry()
+  const withCustom = new FooterItemRegistry(builtin)
+  withCustom.setCustomSource(new FooterCustomItemCatalog([VALID_ENVIRONMENT]))
+  const composer = new FooterComposer(withCustom)
+  const layout = { schemaVersion: 1 as const, rows: [{ left: [{ id: 'model' }], right: [] }] }
+  const snapshot = emptyStatusSnapshot()
+  assert.equal(
+    plain(composer.render({ snapshot, layout, width: 80, context: { taskBrowserAvailable: false, extensionFooterText: '' } })),
+    plain(new FooterComposer(builtin).render({ snapshot, layout, width: 80, context: { taskBrowserAvailable: false, extensionFooterText: '' } })),
+  )
+  assert.equal(layout.schemaVersion, 1)
+  assert.deepEqual(Object.keys(layout.rows[0]!), ['left', 'right'])
+})

--- a/test/home-end-keys.test.ts
+++ b/test/home-end-keys.test.ts
@@ -228,6 +228,7 @@ function setupSettings(options: { homeEndKeys?: string } = {}) {
     find: () => undefined,
     execute: async () => undefined,
   } as never)
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   const settings = fakeTuiSettings(options.homeEndKeys ?? 'input')
   const runner: TuiCommandRunner = {
     ctx,

--- a/test/icon-style-settings.test.ts
+++ b/test/icon-style-settings.test.ts
@@ -54,6 +54,7 @@ function setupSettings(options: { iconStyle?: string } = {}) {
     find: () => undefined,
     execute: async () => undefined,
   } as never)
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   // The fake document starts from the FULL default shape. When no
   // iconStyle is passed, the field is OMITTED entirely — the exact shape
   // of an old settings file written before the preference existed.

--- a/test/keybinding-ui-controller.test.ts
+++ b/test/keybinding-ui-controller.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../src/keybinding-ui/controller.ts'
 import { serializeTuiSettingsMutation, type TuiSettingsDoc } from '../src/runtime/config-port.ts'
 
-function settingsFixture(initialKeybindings: unknown): {
+function settingsFixture(initialKeybindings: unknown, footerCustomItems?: unknown): {
   settings: { get(): TuiSettingsDoc; replace(doc: TuiSettingsDoc): unknown }
   getCount: () => number
   replaceCount: () => number
@@ -24,6 +24,7 @@ function settingsFixture(initialKeybindings: unknown): {
     homeEndKeys: 'off',
     focusMode: 'off',
     footerCommand: { command: 'printf status', intervalMs: 1000 },
+    ...footerCustomItems === undefined ? {} : { footerCustomItems },
     unrelated: 'preserved',
     keybindings: initialKeybindings,
   } as unknown as TuiSettingsDoc
@@ -80,6 +81,44 @@ test('mutation performs one get, one replace, preserves unrelated fields, then p
       'app.todo.toggle': ['ctrl+t', 'ctrl+y'],
     })
     assert.equal(result.kind === 'applied' ? result.model.rows.find(row => row.id === 'app.todo.toggle')!.effective[0]!.key : '', 'ctrl+t')
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('keybinding writes project merged footer items back from the USER raw projection', async () => {
+  const userRaw = [
+    { schemaVersion: 1, id: 'user:mine', kind: 'text', text: 'USER', tone: 'default' },
+    { schemaVersion: 1, id: 'user:future', kind: 'command', command: 'future command', futureField: { version: 2 } },
+  ]
+  const projectRaw = [
+    { schemaVersion: 1, id: 'user:project', kind: 'text', text: 'PROJECT', tone: 'warning' },
+  ]
+  const fixture = settingsFixture(undefined, projectRaw)
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings(fixture.settings.get().keybindings))
+  const controller = new KeybindingEditorController({
+    settings: fixture.settings,
+    manager,
+    // This is the commands-side USER authority projector. The controller
+    // must call it after copying the merged document and before replace.
+    projectSettingsForWrite: doc => ({ ...doc, footerCustomItems: userRaw }),
+  })
+  try {
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'applied')
+    const persisted = fixture.latest()!
+    assert.deepEqual(persisted.footerCustomItems, userRaw, 'a keybinding write must persist the exact USER raw collection')
+    assert.equal(
+      (persisted.footerCustomItems as Array<{ id: string }>).some(item => item.id === 'user:project'),
+      false,
+      'a project definition must never be promoted into USER settings',
+    )
+    assert.deepEqual(persisted.keybindings, { 'app.todo.toggle': ['ctrl+t', 'ctrl+y'] })
   } finally {
     manager.dispose()
   }

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -236,6 +236,7 @@ function setup(options: {
   app.start()
   const commands = fakeCommands()
   ctx.provide('commands', commands.service as never)
+  if (options.settings === undefined) ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   const presets = presetService(options.rows ?? SHIPPED_ROWS)
   ctx.provide('agentPresets', presets.service as never)
   if (options.settings !== undefined) ctx.provide('settings', options.settings as never)

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -377,6 +377,16 @@ test('the runner cleanup closure never references a later-declared binding (TDZ 
   )
 })
 
+test('the restored fullscreen startup path initializes custom-item persistence before its callback can run', () => {
+  const source = readFileSync(join(srcDir, 'index.ts'), 'utf8')
+  const helper = source.indexOf('const userFooterCustomItemsForSave =')
+  const fullscreenBoot = source.indexOf("if (tuiSettings?.get().fullscreen === 'on') app.setFullscreen(true)")
+  assert.ok(helper >= 0, 'the custom-item save projection must exist')
+  assert.ok(fullscreenBoot >= 0, 'the restored fullscreen startup path must exist')
+  assert.ok(helper < fullscreenBoot,
+    'fullscreen startup can synchronously invoke its persistence callback; the custom-item save projection must be initialized first')
+})
+
 test('startup-eager callbacks of startProcessTui never reference a later-declared binding (TDZ guard)', () => {
   // Lifecycle regression (the footer-command startup ReferenceError):
   // `onTerminalResize` is invoked SYNCHRONOUSLY from TuiApp's render path —

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -387,6 +387,35 @@ test('the restored fullscreen startup path initializes custom-item persistence b
     'fullscreen startup can synchronously invoke its persistence callback; the custom-item save projection must be initialized first')
 })
 
+test('legacy history cleanup preserves the raw USER custom-item field', () => {
+  // The migration cleanup is another whole-document replace. Keep this
+  // source-level guard beside the startup-order guard: omitting the raw USER
+  // projection here would promote a merged/project footerCustomItems value or
+  // erase unknown/future definitions while deleting legacy history.
+  const source = readFileSync(join(srcDir, 'index.ts'), 'utf8')
+  const start = source.indexOf("runDetached('settings history cleanup'")
+  const end = source.indexOf("          }, {", start)
+  assert.ok(start >= 0, 'the legacy history cleanup write must exist')
+  assert.ok(end > start, 'the legacy history cleanup write must have options')
+  const cleanup = source.slice(start, end)
+  assert.match(cleanup, /doc\.footerCustomItems\s*=\s*userFooterCustomItemsForSave\(\)/,
+    'history cleanup must project the exact raw USER custom definitions before replace')
+  assert.match(cleanup, /delete doc\.history/, 'history cleanup must still remove the legacy field')
+
+  // Pin the ownership outcome represented by the production projection above:
+  // a merged project value is replaced by the raw USER value, including an
+  // entry this version intentionally cannot parse.
+  const userRaw = [
+    { schemaVersion: 1, id: 'user:known', kind: 'text', text: 'USER' },
+    { schemaVersion: 1, id: 'user:future', kind: 'command', command: 'date' },
+  ]
+  const merged = { footerCustomItems: [{ schemaVersion: 1, id: 'user:project', kind: 'text', text: 'PROJECT' }], history: { '/ws': ['old'] } }
+  const projected: { footerCustomItems: unknown; history?: unknown } = { ...merged, footerCustomItems: userRaw }
+  delete projected.history
+  assert.deepEqual(projected.footerCustomItems, userRaw,
+    'the cleanup projection must retain raw USER data rather than merged project data')
+})
+
 test('startup-eager callbacks of startProcessTui never reference a later-declared binding (TDZ guard)', () => {
   // Lifecycle regression (the footer-command startup ReferenceError):
   // `onTerminalResize` is invoked SYNCHRONOUSLY from TuiApp's render path —

--- a/test/runtime-backend.test.ts
+++ b/test/runtime-backend.test.ts
@@ -85,6 +85,9 @@ test('the Direct backend is the current production surface and serves EXACTLY th
       userFooterMode: undefined,
       command: undefined,
     },
+    footerCustomItems: {
+      get: () => ({ items: [], invalidCount: 0 }),
+    },
     providers: {
       available: () => true,
       listCredentialOptions: () => [],

--- a/test/runtime-backend.test.ts
+++ b/test/runtime-backend.test.ts
@@ -87,7 +87,7 @@ test('the Direct backend is the current production surface and serves EXACTLY th
     },
     footerCustomItems: {
       get: () => ({ items: [], invalidCount: 0 }),
-      rawForPersistence: () => undefined,
+      rawForPersistence: () => ({ kind: 'available' as const, value: undefined }),
     },
     providers: {
       available: () => true,

--- a/test/runtime-backend.test.ts
+++ b/test/runtime-backend.test.ts
@@ -87,6 +87,7 @@ test('the Direct backend is the current production surface and serves EXACTLY th
     },
     footerCustomItems: {
       get: () => ({ items: [], invalidCount: 0 }),
+      rawForPersistence: () => undefined,
     },
     providers: {
       available: () => true,

--- a/test/session-state.test.ts
+++ b/test/session-state.test.ts
@@ -813,14 +813,30 @@ test('/settings theme pick persists the BUILTIN choice too (review P1: the trans
   app.start()
   const services = fakeServices()
   ctx.provide('commands', services.commands as never)
+  const userFooterCustomItems: unknown[] = [
+    { schemaVersion: 1, id: 'user:prod', kind: 'text', text: 'PROD' },
+    { schemaVersion: 1, id: 'user:clock', kind: 'command', command: 'date' },
+  ]
+  const projectFooterCustomItems: unknown[] = [{ schemaVersion: 1, id: 'user:project', kind: 'text', text: 'PROJECT' }]
+  ctx.provide('settings', {
+    describe: () => [{
+      ns: 'dsh-pi-tui',
+      value: { footerCustomItems: projectFooterCustomItems },
+      user: { footerCustomItems: userFooterCustomItems },
+    }],
+  } as never)
   const runner = stubRunner(ctx, app, { agent: fakeAgent('session-a'), generation: 1 })
-  const doc: Record<string, unknown> = { theme: 'dark', iconStyle: 'emoji', footer: 'default', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off' }
-  const persisted: string[] = []
+  const doc: Record<string, unknown> = {
+    theme: 'dark', iconStyle: 'emoji', footer: 'default', fullscreen: 'off',
+    busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off',
+    footerCustomItems: projectFooterCustomItems,
+  }
+  const persisted: Array<{ theme: unknown; footerCustomItems: unknown }> = []
   Object.assign(runner, {
     tuiSettings: {
       get: () => doc as never,
       replace: (next: Record<string, unknown>) => {
-        persisted.push(next.theme as string)
+        persisted.push({ theme: next.theme, footerCustomItems: next.footerCustomItems })
         Object.assign(doc, next)
         return next
       },
@@ -841,8 +857,15 @@ test('/settings theme pick persists the BUILTIN choice too (review P1: the trans
   await vt.waitForRender()
   vt.sendInput('\r') // pick light
   await vt.waitForRender()
-  assert.deepEqual(persisted, ['light'],
+  assert.equal(persisted.length, 1)
+  assert.equal(persisted[0]?.theme, 'light',
     'a BUILTIN pick must persist through the same transactional commit as a plugin pick')
+  assert.deepEqual(persisted[0]?.footerCustomItems, userFooterCustomItems,
+    'an unrelated theme change must preserve the exact USER custom-item storage value')
+  assert.deepEqual(doc.footerCustomItems, userFooterCustomItems,
+    'a project-layer custom-item value must never be promoted by the theme write')
+  assert.deepEqual(runner.config.footerCustomItems.get().items, [userFooterCustomItems[0]],
+    'runtime resolution must still expose only the supported USER definition')
   // The committed choice marks the light row on a re-open.
   vt.sendInput('\r') // reopen the submenu
   await vt.waitForRender()

--- a/test/session-state.test.ts
+++ b/test/session-state.test.ts
@@ -875,6 +875,56 @@ test('/settings theme pick persists the BUILTIN choice too (review P1: the trans
   app.stop()
 })
 
+test('/settings theme write aborts when USER custom storage is unavailable', async () => {
+  // A whole-document settings write must not proceed when the Direct adapter
+  // cannot read the USER layer. Otherwise this fallback would write the merged
+  // document with footerCustomItems: undefined and erase the user's data.
+  const ctx = new Context()
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const services = fakeServices()
+  ctx.provide('commands', services.commands as never)
+  const runner = stubRunner(ctx, app, { agent: fakeAgent('session-a'), generation: 1 })
+  const projectFooterCustomItems = [{ schemaVersion: 1, id: 'user:project', kind: 'text', text: 'PROJECT' }]
+  const doc: Record<string, unknown> = {
+    theme: 'dark', iconStyle: 'emoji', footer: 'default', fullscreen: 'off',
+    busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off',
+    footerCustomItems: projectFooterCustomItems,
+  }
+  const persisted: Record<string, unknown>[] = []
+  Object.assign(runner, {
+    tuiSettings: {
+      get: () => doc as never,
+      replace: (next: Record<string, unknown>) => {
+        persisted.push(next)
+        Object.assign(doc, next)
+        return next
+      },
+    },
+  })
+  registerTuiCommands(runner)
+  const settingsDef = services.defs.find(def => def.name === 'settings')
+  assert.ok(settingsDef?.handler !== undefined, 'settings handler missing')
+  ;(settingsDef!.handler as () => unknown)()
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B') // → Theme row (approval is first; the doc starts dark)
+  await vt.waitForRender()
+  vt.sendInput('\r') // open the Theme submenu
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B') // dark
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B') // light
+  await vt.waitForRender()
+  vt.sendInput('\r') // attempt to pick light
+  await vt.waitForRender()
+  for (let spin = 0; spin < 50; spin += 1) await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(persisted, [], 'an unavailable USER projection must abort the unrelated settings write')
+  assert.equal(doc.theme, 'dark', 'the merged document must remain untouched when the write is aborted')
+  assert.deepEqual(doc.footerCustomItems, projectFooterCustomItems, 'the project value must not be promoted')
+  app.stop()
+})
+
 test('/settings theme STALE pick through the REAL handler rolls the row and the choice back (review P2: production-path failure)', async () => {
   // The miniature in theme-picker.test.ts pins the fork contract; THIS test
   // drives the REAL /settings handler (registerTuiCommands → app panel →


### PR DESCRIPTION
## Summary
- add persisted `user:<name>` Custom Text footer definitions independent from `FooterLayoutV1`
- add isolated `/footer` create, search, edit, rename, delete, tone, and reference-cleanup flows
- preserve custom definitions through startup, reload, settings, and atomic `/footer` saves
- keep layered registry behavior, fail-soft parsing, and public extension compatibility

## Verification
- bundle suite: 2812 passed
- vendored pi-tui suite: 985 passed
- typechecks and builds passed
- tarball and plugin smoke gates passed
- holistic review-fix loop: accepted

No changes were made to `packages/pi-tui` source.