### PR TITLE
feat(keybindings): add action-first shortcut editor

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -345,7 +345,13 @@ dsh-pi-tui:
   toggle trigger (Ctrl+T stops); `['ctrl+z', '<leader>s']` keeps both
   USER triggers; `false` removes every trigger of the action.
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores all user overrides (builtin
-  defaults only).
+  defaults only). The whole `/keybindings` editor is read-only while safe mode
+  is active, so it cannot save a configuration that is only checked after safe
+  mode is disabled.
+- In the editor, untouched default bindings are selectable. `Add shortcut`
+  materializes every displayed default plus the new key; replacing or removing
+  one default preserves its siblings. Once an action has a user declaration,
+  that declaration still replaces the builtin set as described above.
 - `/help` remains the key-first, read-only help surface; `/keybindings` is the
   action-first, editable Keyboard Shortcuts Editor: it groups actions by
   category, searches action IDs/descriptions/current keys/default keys, and
@@ -354,7 +360,11 @@ dsh-pi-tui:
   and persistence controller as `/keybindings`.
 - The recorder reads a real terminal key, parses it with `parseKey`, and stores
   the canonical `KeyId`; known dead, typing-swallowing, terminal-ambiguous, and
-  conflicting shortcuts are rejected before saving.
+  conflicting shortcuts are rejected before saving. Raw `Esc` cancels recording;
+  press `e` in a direct recording to explicitly bind the legal Escape key.
+- Conditional affordances are labeled separately in the editor (for example,
+  `Down (conditional)` for the empty-editor task browser) instead of appearing
+  as ordinary configured shortcuts.
 - `/keybindings conflicts` lists conflicts (same key + overlapping scope + same
   priority — never silent last-write-wins); `/keybindings reload` re-reads the
   settings (fail-soft: a bad entry is diagnosed and skipped, a throwing read

--- a/README.en.md
+++ b/README.en.md
@@ -361,7 +361,8 @@ dsh-pi-tui:
 - The recorder reads a real terminal key, parses it with `parseKey`, and stores
   the canonical `KeyId`; known dead, typing-swallowing, terminal-ambiguous, and
   conflicting shortcuts are rejected before saving. Raw `Esc` cancels recording;
-  press `e` in a direct recording to explicitly bind the legal Escape key.
+  press `e` while recording the Host interrupt action to explicitly retain its
+  legal Escape binding; physical Escape is reserved for Host lifecycle paths.
 - Conditional affordances are labeled separately in the editor (for example,
   `Down (conditional)` for the empty-editor task browser) instead of appearing
   as ordinary configured shortcuts.

--- a/README.en.md
+++ b/README.en.md
@@ -346,11 +346,19 @@ dsh-pi-tui:
   USER triggers; `false` removes every trigger of the action.
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores all user overrides (builtin
   defaults only).
-- `/keybindings` shows the effective table; `/keybindings conflicts`
-  lists conflicts (same key + overlapping scope + same priority — never
-  silent last-write-wins); `/keybindings reload` re-reads the settings
-  (fail-soft: a bad entry is diagnosed and skipped, a throwing read is an
-  error notice — never a crash; the keymap keeps the last-known-good
+- `/help` remains the key-first, read-only help surface; `/keybindings` is the
+  action-first, editable Keyboard Shortcuts Editor: it groups actions by
+  category, searches action IDs/descriptions/current keys/default keys, and
+  marks customized, conflict, Unbound, Disabled, and fixed states. A standalone Leader key row also configures the global leader key.
+- `/settings` has one `Keyboard shortcuts` launcher that opens the same editor
+  and persistence controller as `/keybindings`.
+- The recorder reads a real terminal key, parses it with `parseKey`, and stores
+  the canonical `KeyId`; known dead, typing-swallowing, terminal-ambiguous, and
+  conflicting shortcuts are rejected before saving.
+- `/keybindings conflicts` lists conflicts (same key + overlapping scope + same
+  priority — never silent last-write-wins); `/keybindings reload` re-reads the
+  settings (fail-soft: a bad entry is diagnosed and skipped, a throwing read
+  is an error notice — never a crash; the keymap keeps the last-known-good
   configuration); `/keybindings reset` clears the overrides through the
   settings service and rebuilds the running keymap immediately.
 - The subagent viewer blocks PARENT actions by action id, so a remapped

--- a/README.en.md
+++ b/README.en.md
@@ -351,10 +351,12 @@ dsh-pi-tui:
   defaults only). The whole `/keybindings` editor is read-only while safe mode
   is active, so it cannot save a configuration that is only checked after safe
   mode is disabled.
-- In the editor, untouched default bindings are selectable. `Add shortcut`
-  materializes every displayed default plus the new key; replacing or removing
-  one default preserves its siblings. Once an action has a user declaration,
-  that declaration still replaces the builtin set as described above.
+- In the editor, untouched default bindings that are still effective are
+  selectable. `Add shortcut` materializes those surviving defaults plus the new
+  key; shadowed definition defaults remain reference-only, and replacing or
+  removing one surviving default preserves its siblings. Once an action has a
+  user declaration, that declaration still replaces the builtin set as
+  described above.
 - `/help` remains the key-first, read-only help surface; `/keybindings` is the
   action-first, editable Keyboard Shortcuts Editor: it groups actions by
   category, searches action IDs/descriptions/current keys/default keys, and
@@ -363,9 +365,11 @@ dsh-pi-tui:
   and persistence controller as `/keybindings`.
 - The recorder reads a real terminal key, parses it with `parseKey`, and stores
   the canonical `KeyId`; known dead, typing-swallowing, terminal-ambiguous, and
-  conflicting shortcuts are rejected before saving. Raw `Esc` cancels recording;
-  press `e` while recording the Host interrupt action to explicitly retain its
-  legal Escape binding; physical Escape is reserved for Host lifecycle paths.
+  conflicting shortcuts are rejected before saving. Ordinary recording cancels
+  on `Esc`; the direct Host interrupt recorder uses a short double-press window:
+  one `Esc` cancels and two `Esc` press events assign physical Escape. Key
+  repeats/releases do not count, and there is no single-letter shortcut;
+  physical Escape remains reserved for Host lifecycle paths.
 - Conditional affordances are labeled separately in the editor (for example,
   `Down (conditional)` for the empty-editor task browser) instead of appearing
   as ordinary configured shortcuts.

--- a/README.en.md
+++ b/README.en.md
@@ -343,7 +343,10 @@ dsh-pi-tui:
   `app.input.steer: ctrl+x` makes Ctrl+X steer and Ctrl+S stop steering;
   a leader-only `app.todo.toggle: <leader>t` makes Leader T the only
   toggle trigger (Ctrl+T stops); `['ctrl+z', '<leader>s']` keeps both
-  USER triggers; `false` removes every trigger of the action.
+  USER triggers; `false` removes every trigger of the action. Leader
+  completions that the effective editor-owned submit key would consume (for
+  example, `<leader>enter`) are rejected instead of being advertised as dead
+  sequences.
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` ignores all user overrides (builtin
   defaults only). The whole `/keybindings` editor is read-only while safe mode
   is active, so it cannot save a configuration that is only checked after safe

--- a/README.md
+++ b/README.md
@@ -328,12 +328,19 @@ dsh-pi-tui:
   失效);`['ctrl+z', '<leader>s']` 同时保留两个用户触发;`false`
   移除该 action 的全部触发。
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。
-- `/keybindings` 显示生效表;`/keybindings conflicts` 列出冲突(同键 +
-  作用域重叠 + 同优先级——绝不静默 last-write-wins);`/keybindings
-  reload` 重新读取设置(fail-soft:坏配置会被诊断并跳过,读取异常才会
-  给出错误提示——都不会崩溃,keymap 保留 last-known-good 配置);
-  `/keybindings reset` 通过 settings 服务清除覆盖,并立即重建运行中的
-  keymap。
+- `/help` 仍是按键优先的只读帮助;`/keybindings` 是按 action 优先的
+  可编辑 Keyboard Shortcuts Editor:按类别分组,搜索 action ID/描述/当前键和
+  默认键,并标记 customized、conflict、Unbound、Disabled 和 fixed 状态。
+  独立的 Leader key 行还可设置全局 leader key。
+- `/settings` 只有一个 `Keyboard shortcuts` 入口,打开与 `/keybindings` 相同的
+  编辑器和持久化控制器。
+- 录制器读取真实终端按键,通过 `parseKey` 规范化为 `KeyId`;保存前会拒绝
+  无法匹配、吞输入、终端歧义或已知冲突的按键。
+- `/keybindings conflicts` 列出冲突(同键 + 作用域重叠 + 同优先级——绝不
+  静默 last-write-wins);`/keybindings reload` 重新读取设置(fail-soft:坏配置会
+  被诊断并跳过,读取异常才会给出错误提示——都不会崩溃,keymap 保留
+  last-known-good 配置);`/keybindings reset` 通过 settings 服务清除覆盖,并
+  立即重建运行中的 keymap。
 - 子代理查看器按 action id 阻止父级 action,因此改键后的父级快捷键
   在查看器内依然被阻止。
 - 条件 affordance 是**累加**的:绑定 `app.tasks.open: ctrl+x` 是**增加**

--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ dsh-pi-tui:
   编辑器和持久化控制器。
 - 录制器读取真实终端按键,通过 `parseKey` 规范化为 `KeyId`;保存前会拒绝
   无法匹配、吞输入、终端歧义或已知冲突的按键。裸 `Esc` 会取消录制;
-  direct 录制时按 `e` 可显式绑定合法的 Escape 键。
+  录制 Host interrupt action 时按 `e` 可显式保留合法的 Escape 绑定;
+  物理 Escape 保留给 Host 生命周期路径。
 - 条件 affordance 会在编辑器中单独标注(例如空编辑器任务浏览器的
   `Down (conditional)`),不会伪装成普通已配置快捷键。
 - `/keybindings conflicts` 列出冲突(同键 + 作用域重叠 + 同优先级——绝不

--- a/README.md
+++ b/README.md
@@ -332,9 +332,10 @@ dsh-pi-tui:
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。Safe mode
   开启时整个 `/keybindings` 编辑器只读,避免保存只会在关闭 safe mode 后才发现的
   冲突配置。
-- 编辑器中未自定义 action 的默认按键也可选择。`Add shortcut` 会把当前显示的
-  全部默认键与新键一起写入;替换或删除单个默认键会保留其余默认键。action 已有
-  用户声明后,仍按上文规则替换内置按键集合。
+- 编辑器中未自定义 action 且仍然 effective 的默认按键可选择。`Add shortcut` 会把
+  这些仍生效的默认键与新键一起写入;已被 shadow 的 definition default 仅作参考,替换
+  或删除一个仍生效的默认键会保留其余 sibling。action 已有用户声明后,仍按上文规则
+  替换内置按键集合。
 - `/help` 仍是按键优先的只读帮助;`/keybindings` 是按 action 优先的
   可编辑 Keyboard Shortcuts Editor:按类别分组,搜索 action ID/描述/当前键和
   默认键,并标记 customized、conflict、Unbound、Disabled 和 fixed 状态。
@@ -342,9 +343,10 @@ dsh-pi-tui:
 - `/settings` 只有一个 `Keyboard shortcuts` 入口,打开与 `/keybindings` 相同的
   编辑器和持久化控制器。
 - 录制器读取真实终端按键,通过 `parseKey` 规范化为 `KeyId`;保存前会拒绝
-  无法匹配、吞输入、终端歧义或已知冲突的按键。裸 `Esc` 会取消录制;
-  录制 Host interrupt action 时按 `e` 可显式保留合法的 Escape 绑定;
-  物理 Escape 保留给 Host 生命周期路径。
+  无法匹配、吞输入、终端歧义或已知冲突的按键。普通录制器按 `Esc` 立即取消;
+  Host interrupt action 的 direct recorder 使用短暂双击窗口:一次 `Esc` 取消,
+  两次 `Esc` press event 才录入物理 Escape。repeat/release 不算第二次,不再有单字母
+  快捷方式;物理 Escape 保留给 Host 生命周期路径。
 - 条件 affordance 会在编辑器中单独标注(例如空编辑器任务浏览器的
   `Down (conditional)`),不会伪装成普通已配置快捷键。
 - `/keybindings conflicts` 列出冲突(同键 + 作用域重叠 + 同优先级——绝不

--- a/README.md
+++ b/README.md
@@ -326,7 +326,9 @@ dsh-pi-tui:
   ctrl+x` 让 Ctrl+X steer、Ctrl+S 不再 steer;仅 leader 的
   `app.todo.toggle: <leader>t` 让 Leader T 成为唯一切换触发(Ctrl+T
   失效);`['ctrl+z', '<leader>s']` 同时保留两个用户触发;`false`
-  移除该 action 的全部触发。
+  移除该 action 的全部触发。若 effective editor-owned submit key 会在
+  leader machine 之前消费某个 completion(例如 `<leader>enter`),该死序列会被
+  拒绝而不会被展示。
 - `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。Safe mode
   开启时整个 `/keybindings` 编辑器只读,避免保存只会在关闭 safe mode 后才发现的
   冲突配置。

--- a/README.md
+++ b/README.md
@@ -327,7 +327,12 @@ dsh-pi-tui:
   `app.todo.toggle: <leader>t` 让 Leader T 成为唯一切换触发(Ctrl+T
   失效);`['ctrl+z', '<leader>s']` 同时保留两个用户触发;`false`
   移除该 action 的全部触发。
-- `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。
+- `DSH_PI_TUI_SAFE_KEYBINDINGS=1` 忽略所有用户覆盖(仅使用内置默认)。Safe mode
+  开启时整个 `/keybindings` 编辑器只读,避免保存只会在关闭 safe mode 后才发现的
+  冲突配置。
+- 编辑器中未自定义 action 的默认按键也可选择。`Add shortcut` 会把当前显示的
+  全部默认键与新键一起写入;替换或删除单个默认键会保留其余默认键。action 已有
+  用户声明后,仍按上文规则替换内置按键集合。
 - `/help` 仍是按键优先的只读帮助;`/keybindings` 是按 action 优先的
   可编辑 Keyboard Shortcuts Editor:按类别分组,搜索 action ID/描述/当前键和
   默认键,并标记 customized、conflict、Unbound、Disabled 和 fixed 状态。
@@ -335,7 +340,10 @@ dsh-pi-tui:
 - `/settings` 只有一个 `Keyboard shortcuts` 入口,打开与 `/keybindings` 相同的
   编辑器和持久化控制器。
 - 录制器读取真实终端按键,通过 `parseKey` 规范化为 `KeyId`;保存前会拒绝
-  无法匹配、吞输入、终端歧义或已知冲突的按键。
+  无法匹配、吞输入、终端歧义或已知冲突的按键。裸 `Esc` 会取消录制;
+  direct 录制时按 `e` 可显式绑定合法的 Escape 键。
+- 条件 affordance 会在编辑器中单独标注(例如空编辑器任务浏览器的
+  `Down (conditional)`),不会伪装成普通已配置快捷键。
 - `/keybindings conflicts` 列出冲突(同键 + 作用域重叠 + 同优先级——绝不
   静默 last-write-wins);`/keybindings reload` 重新读取设置(fail-soft:坏配置会
   被诊断并跳过,读取异常才会给出错误提示——都不会崩溃,keymap 保留

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -191,7 +191,9 @@ dsh-pi-tui:
 
 Semantics: string = one key; array = several; `false` = disable the
 action's effective binding; absent = builtin default; `<leader>X` = a
-leader sequence (requires `leader`). The validation pipeline is
+leader sequence (requires `leader`). Physical `Escape` is reserved for the
+Host lifecycle path and is accepted only for `app.agent.interrupt`; the
+runtime routes it before ordinary user action resolution. The validation pipeline is
 **grammar → canonicalize → policy → store** (round-9 finding): every
 policy check (printable, lifecycle collisions, editor-owned constraints)
 runs on the CANONICAL key, so an uppercase spelling (`SPACE`, `ctrl+A`)
@@ -472,7 +474,8 @@ Detail view: `Add shortcut` materializes the displayed defaults together with
 the new key, while replacing or removing one default preserves its siblings.
 Once an action has an explicit user declaration, the unified override contract
 still applies. Safe mode makes the entire editor read-only, and direct recording
-uses `e` as the explicit "use Escape" command because raw `Esc` remains cancel.
+uses `e` as the explicit "use Escape" command for the Host interrupt because raw
+`Esc` remains cancel. Physical Escape is never available to ordinary actions.
 Context-gated composition affordances are labeled separately from ordinary
 configured bindings (for example, `Down (conditional)` for the task browser).
 

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -445,3 +445,31 @@ Final gates: 2536 bundle tests, 985 fork tests, 11 docs tests,
 typecheck (fork + bundle), `check-host-keybindings` gate (all quote
 styles, either casing), `git diff --check` — all green. The latest
 external convergence review round was accepted with no findings.
+
+## Keyboard Shortcuts Editor
+
+`/help` remains the key-first, read-only help surface. `/keybindings` is the
+separate action-first editor: it groups definitions into non-selectable
+category sections, searches labels/descriptions/action IDs/categories/current
+keys/default keys, and marks `*` customized, `!` conflicts, `Unbound`,
+`Disabled`, fixed, and reserved actions. A standalone leader-key row also
+exposes the optional global leader key.
+
+The editor is client-local presentation and input handling. It reads and writes
+only through `TuiSettingsConfig.get()`/`replace()`, preserves the complete
+settings document, and projects the exact parsed candidate into
+`HostKeybindingManager` only after a successful write. A recorder accepts one
+raw terminal key, parses it with `parseKey`, canonicalizes it to `KeyId`, and
+reuses the shared runtime/text/terminal ambiguity policy. Interactive direct
+and leader mutations are preflighted against the live plugin rules and
+conflict diagnostics before persistence. Since `replace()` is a whole-document
+operation without a compare-and-swap token, all TUI settings writers use the
+shared transaction queue (including `/settings` and `/keybindings reset`), so
+editor controllers sharing a settings port serialize their `get` → candidate →
+`replace` transactions; late panel callbacks are generation-guarded and cannot
+repaint a disposed editor.
+
+`/settings` contains one `Keyboard shortcuts` launcher whose submenu uses the
+same controller and editor component. The diagnostic verbs
+`/keybindings conflicts`, `/keybindings reload`, and `/keybindings reset` stay
+available for inspection and recovery; no settings watch callback is used.

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -115,8 +115,8 @@ configurable action first (plan §3.3).
    host-reserved, so the key reaches the fork editor. User remaps/`false`
    sync into the fork editor's binding, conflict and shadow apply,
    fail-soft (a CONFLICTED direct submit override restores the builtin
-   Enter — convergence §4.5; a DEAD leader-only override stays inert,
-   never a fabricated restore; explicit `false` removes everything)
+   Enter — convergence §4.5; a DEAD leader-only completion is ignored and restores the action's builtin default,
+   explicit `false` removes everything)
    is evaluated on the EFFECTIVE rules — never the raw config, and a
    leader sequence NEVER clears the direct keys (`submit:
    ['ctrl+z', '<leader>s']` keeps BOTH triggers; only a truly leader-only
@@ -472,13 +472,16 @@ operation without a compare-and-swap token, all TUI settings writers use the
 shared transaction queue (including `/settings` and `/keybindings reset`), so
 editor controllers sharing a settings port serialize their `get` → candidate →
 `replace` transactions; late panel callbacks are generation-guarded and cannot
-repaint a disposed editor. Untouched builtin bindings are selectable in the
-Detail view: `Add shortcut` materializes the displayed defaults together with
-the new key, while replacing or removing one default preserves its siblings.
+repaint a disposed editor. Untouched builtin bindings that are still effective
+are selectable in the Detail view: `Add shortcut` materializes surviving defaults together with
+the new key; shadowed defaults remain reference-only, while replacing or
+removing one surviving default preserves its siblings.
 Once an action has an explicit user declaration, the unified override contract
-still applies. Safe mode makes the entire editor read-only, and direct recording
-uses `e` as the explicit "use Escape" command for the Host interrupt because raw
-`Esc` remains cancel. Physical Escape is never available to ordinary actions.
+still applies. Safe mode makes the entire editor read-only. Ordinary recording cancels on
+`Esc`; the direct Host interrupt recorder uses a short double-press window
+where one `Esc` cancels and two Escape press events assign physical Escape.
+Repeats and releases do not count, and there is no single-letter Escape
+shortcut. Physical Escape is never available to ordinary actions.
 Context-gated composition affordances are labeled separately from ordinary
 configured bindings (for example, `Down (conditional)` for the task browser).
 

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -192,8 +192,11 @@ dsh-pi-tui:
 Semantics: string = one key; array = several; `false` = disable the
 action's effective binding; absent = builtin default; `<leader>X` = a
 leader sequence (requires `leader`). Physical `Escape` is reserved for the
-Host lifecycle path and is accepted only for `app.agent.interrupt`; the
-runtime routes it before ordinary user action resolution. The validation pipeline is
+Host lifecycle path and is accepted only for `app.agent.interrupt`; the runtime
+routes it before ordinary user action resolution. A leader completion that the
+current editor-owned submit key would consume (for example,
+`<leader>enter`) is rejected rather than advertised as a dead sequence. The
+validation pipeline is
 **grammar → canonicalize → policy → store** (round-9 finding): every
 policy check (printable, lifecycle collisions, editor-owned constraints)
 runs on the CANONICAL key, so an uppercase spelling (`SPACE`, `ctrl+A`)

--- a/docs/keybinding-architecture.md
+++ b/docs/keybinding-architecture.md
@@ -467,7 +467,14 @@ operation without a compare-and-swap token, all TUI settings writers use the
 shared transaction queue (including `/settings` and `/keybindings reset`), so
 editor controllers sharing a settings port serialize their `get` → candidate →
 `replace` transactions; late panel callbacks are generation-guarded and cannot
-repaint a disposed editor.
+repaint a disposed editor. Untouched builtin bindings are selectable in the
+Detail view: `Add shortcut` materializes the displayed defaults together with
+the new key, while replacing or removing one default preserves its siblings.
+Once an action has an explicit user declaration, the unified override contract
+still applies. Safe mode makes the entire editor read-only, and direct recording
+uses `e` as the explicit "use Escape" command because raw `Esc` remains cancel.
+Context-gated composition affordances are labeled separately from ordinary
+configured bindings (for example, `Down (conditional)` for the task browser).
 
 `/settings` contains one `Keyboard shortcuts` launcher whose submenu uses the
 same controller and editor component. The diagnostic verbs

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,9 +28,11 @@ import { mergeDraft } from './steer.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
 import { iconStyleOf } from './icons.ts'
 import { parseUserKeybindings } from './keybindings/config.ts'
-import { APP_KEYBINDINGS } from './keybindings/definitions.ts'
-import { formatKeyId, formatLeaderSequence } from './keybindings/hints.ts'
+import { formatKeyId } from './keybindings/hints.ts'
 import type { AppKeybindingId } from './keybindings/types.ts'
+import { KeybindingEditorController } from './keybinding-ui/controller.ts'
+import { KeybindingEditorPanel, KeybindingEditorUnavailablePanel } from './keybinding-ui/list.ts'
+import type { KeybindingEditorModel } from './keybinding-ui/model.ts'
 import { parseFooterLayout, isFooterLayout } from './footer/layout.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
 import { FooterConfiguratorModel } from './footer/configurator-model.ts'
@@ -222,7 +224,7 @@ export function presetDisplayText(preset: {
  * an unknown-key pass-through in the config port's document schema — see
  * index.ts) ride along. */
 export type { TuiSettingsLike, TuiSettingsDoc } from './runtime/config-port.ts'
-import type { TuiSettingsLike } from './runtime/config-port.ts'
+import { serializeTuiSettingsMutation, type TuiSettingsDoc, type TuiSettingsLike } from './runtime/config-port.ts'
 
 
 /** The minimal commands-registry surface the TUI command surface needs
@@ -985,6 +987,49 @@ export function registerTuiCommands(
       recoverable: options.notify === true ? () => true : undefined,
     })
   }
+
+  /** Build the one editor used by /keybindings and the /settings submenu.
+   * The settings row is only a launcher; all reads/writes still go through
+   * the controller and the same panel state machine. */
+  const createKeybindingEditorPanel = (
+    onClose: () => void,
+    onModelChange: (model: KeybindingEditorModel) => void = () => {},
+  ): KeybindingEditorPanel | undefined => {
+    const settings = runner.tuiSettings
+    if (settings === undefined) return undefined
+    const controller = new KeybindingEditorController({
+      settings,
+      manager: app.keybindingsManager(),
+      onDiagnostic: diagnostic => runner.diag.debug('keybinding configuration', { error: diagnostic }),
+    })
+    let panel: KeybindingEditorPanel | undefined
+    try {
+      const model = controller.readModel()
+      let unregister = (): void => {}
+      panel = new KeybindingEditorPanel({
+        model,
+        onClose,
+        onModelChange,
+        onDispose: () => unregister(),
+        maxRows: () => app.keybindingEditorMaxRows(),
+        requestRender: () => app.requestRender(),
+        runMutation: (mutation, onResult, onError) => {
+          runOwned('keybinding editor mutation', () => controller.mutate(mutation), {
+            diag: runner.diag,
+            sessionId: () => runner.liveAgent?.session.id,
+            onResult,
+            onError,
+          })
+        },
+      })
+      unregister = app.trackKeybindingEditor(panel)
+      return panel
+    } catch (error) {
+      app.notify(`Could not open keyboard shortcuts: ${safeErrorMessage(error)}`, 'error')
+      return undefined
+    }
+  }
+
   /** Switch sessions with full rejection handling (the runner resolves an
    * error STRING for user-facing failures, but an unexpected rejection must
    * not become an unhandled rejection either). An owned workflow: the
@@ -1190,7 +1235,17 @@ export function registerTuiCommands(
     handler: () => {
       const liveAgent = runner.liveAgent
       const tuiSettings = runner.tuiSettings
-      const theme = tuiSettings?.get().theme ?? 'auto'
+      let settingsDoc: TuiSettingsDoc | undefined
+      if (tuiSettings !== undefined) {
+        try {
+          settingsDoc = tuiSettings.get()
+        } catch (error) {
+          // A present but temporarily unreadable settings service must degrade
+          // to the same unavailable keyboard-shortcuts fallback as absence.
+          runner.diag.warn('settings read failed', { error: safeErrorMessage(error) })
+        }
+      }
+      const theme = settingsDoc?.theme ?? 'auto'
       // The DISPLAYED current theme: the friendly name (the persisted
       // value may still be the legacy `custom:<name>` / bare-name form —
       // the display derives from it, the /settings handler reads and
@@ -1216,6 +1271,29 @@ export function registerTuiCommands(
       // Before the first session (deferred start) the session-scoped rows —
       // approval policy and the read-only session facts — do not exist yet;
       // everything process-wide stays available.
+      const keyboardShortcutsRow: SettingItem = {
+        id: 'keyboard-shortcuts',
+        label: 'Keyboard shortcuts',
+        description: 'Browse and customize action shortcuts, leader keys, and conflict-safe bindings',
+        currentValue: 'Unavailable',
+      }
+      if (runner.tuiSettings !== undefined && settingsDoc !== undefined) {
+        try {
+          const model = new KeybindingEditorController({
+            settings: runner.tuiSettings,
+            manager: app.keybindingsManager(),
+          }).readModel()
+          keyboardShortcutsRow.currentValue = model.summary
+        } catch {
+          keyboardShortcutsRow.currentValue = 'Unavailable'
+        }
+      }
+      keyboardShortcutsRow.submenu = (_currentValue, done) => createKeybindingEditorPanel(
+        done,
+        model => {
+          keyboardShortcutsRow.currentValue = model.summary
+        },
+      ) ?? new KeybindingEditorUnavailablePanel(done)
       app.openSettings(
         [
           ...liveAgent === undefined ? [] : [{
@@ -1266,7 +1344,7 @@ export function registerTuiCommands(
             description: 'Choose between emoji, compact symbols, or minimal structural markers',
             // The fallback applies HERE too: an invalid/missing persisted
             // value must never render as a row outside the values list.
-            currentValue: iconStyleOf(tuiSettings?.get().iconStyle),
+            currentValue: iconStyleOf(settingsDoc?.iconStyle),
             values: ['emoji', 'symbols', 'minimal'],
           },
           {
@@ -1294,14 +1372,14 @@ export function registerTuiCommands(
             id: 'busy-enter',
             label: 'Submit while busy',
             description: `Steer injects the draft into the running turn; ${keyHint('app.input.queue')} uses the other behavior`,
-            currentValue: tuiSettings?.get().busyEnter ?? 'queue',
+            currentValue: settingsDoc?.busyEnter ?? 'queue',
             values: ['queue', 'steer'],
           },
           {
             id: 'local-shell-sandbox',
             label: 'Local shell sandbox',
             description: '! / !! commands run outside the dsh sandbox (bypass, default) or under the sandbox policy',
-            currentValue: tuiSettings?.get().localShellSandbox ?? 'bypass',
+            currentValue: settingsDoc?.localShellSandbox ?? 'bypass',
             values: ['bypass', 'sandbox'],
           },
           {
@@ -1311,7 +1389,7 @@ export function registerTuiCommands(
             // The fallback applies HERE too: an invalid persisted value
             // must never render as a row outside the values list (round-1
             // finding).
-            currentValue: homeEndKeysModeOf(tuiSettings?.get().homeEndKeys),
+            currentValue: homeEndKeysModeOf(settingsDoc?.homeEndKeys),
             values: ['input', 'viewport'],
           },
           {
@@ -1360,6 +1438,7 @@ export function registerTuiCommands(
             description: color.textDim('The live session workspace (follows session switches)'),
             currentValue: color.textDim(runner.sessionCwd()),
           },
+          keyboardShortcutsRow,
           // ── M5: plugin-registered settings rows ───────────────────
           ...(runner.extensions?.settings.rows() ?? []).map(row => ({
             id: `ext-setting:${row.id}`,
@@ -1416,7 +1495,10 @@ export function registerTuiCommands(
                   // Spread the current doc: a replace is wholesale, so the
                   // other preference keys must ride along. The persisted
                   // value IS the source-qualified identity.
-                  detach('settings theme write', () => settings.replace({ ...settings.get(), theme: qualified }) as Promise<unknown>, { notify: true })
+                  detach('settings theme write', () => serializeTuiSettingsMutation(
+                    settings,
+                    () => settings.replace({ ...settings.get(), theme: qualified }),
+                  ), { notify: true })
                 }
                 lastThemeChoice = qualified
                 revert(themeDisplayNameOf(qualified, runner.extensions?.themes))
@@ -1540,25 +1622,30 @@ export function registerTuiCommands(
             if (value === 'default' || value === 'compact' || value === 'custom') {
               const settings = tuiSettings
               if (settings !== undefined) {
-                const doc = settings.get()
-                // Selecting custom with no (valid) layout initializes an
-                // editable copy of the default layout (plan §14.8).
-                const nextLayout = value === 'custom'
-                  ? !isFooterLayout(parseFooterLayout(doc.footerLayout))
-                    ? DEFAULT_FOOTER_LAYOUT
-                    : doc.footerLayout
-                  : doc.footerLayout
                 // footerFallbackMode records the LAST NATIVE mode (M5):
                 // `footer` is overwritten by 'command' when the command
                 // surface arms, so the command failure fallback must be
                 // able to recover THIS choice (a compact user's fallback
-                // survives a restart).
+                // survives a restart). Read and replace inside the shared
+                // transaction so a concurrent whole-document writer cannot
+                // be overwritten by this stale panel snapshot.
                 // PERSIST FIRST (the configurator's discipline): the app
                 // applies only from the successful write — a failed
                 // settings write must not leave the live layout ahead of
                 // the document (the next reload would silently revert).
                 detach('settings footer write', async () => {
-                  await settings.replace({ ...doc, footer: value, footerLayout: nextLayout, footerFallbackMode: value })
+                  const nextLayout = await serializeTuiSettingsMutation(settings, async () => {
+                    const doc = settings.get()
+                    // Selecting custom with no (valid) layout initializes an
+                    // editable copy of the default layout (plan §14.8).
+                    const layout = value === 'custom'
+                      ? !isFooterLayout(parseFooterLayout(doc.footerLayout))
+                        ? DEFAULT_FOOTER_LAYOUT
+                        : doc.footerLayout
+                      : doc.footerLayout
+                    await settings.replace({ ...doc, footer: value, footerLayout: layout, footerFallbackMode: value })
+                    return layout
+                  })
                   runner.applyFooterSettings({ footer: value, footerLayout: nextLayout })
                 }, { notify: true })
               } else {
@@ -1569,7 +1656,10 @@ export function registerTuiCommands(
             if (value === 'queue' || value === 'steer') {
               const settings = tuiSettings
               if (settings !== undefined) {
-                detach('settings busy enter write', () => settings.replace({ ...settings.get(), busyEnter: value }) as Promise<unknown>, { notify: true })
+                detach('settings busy enter write', () => serializeTuiSettingsMutation(
+                   settings,
+                   () => settings.replace({ ...settings.get(), busyEnter: value }),
+                 ), { notify: true })
               }
             }
           } else if (id === 'icon-style') {
@@ -1582,14 +1672,20 @@ export function registerTuiCommands(
               app.setIconStyle(value)
               const settings = tuiSettings
               if (settings !== undefined) {
-                detach('settings icon style write', () => settings.replace({ ...settings.get(), iconStyle: value }) as Promise<unknown>, { notify: true })
+                detach('settings icon style write', () => serializeTuiSettingsMutation(
+                   settings,
+                   () => settings.replace({ ...settings.get(), iconStyle: value }),
+                 ), { notify: true })
               }
             }
           } else if (id === 'local-shell-sandbox') {
             if (value === 'bypass' || value === 'sandbox') {
               const settings = tuiSettings
               if (settings !== undefined) {
-                detach('settings local shell sandbox write', () => settings.replace({ ...settings.get(), localShellSandbox: value }) as Promise<unknown>, { notify: true })
+                detach('settings local shell sandbox write', () => serializeTuiSettingsMutation(
+                   settings,
+                   () => settings.replace({ ...settings.get(), localShellSandbox: value }),
+                 ), { notify: true })
               }
             }
           } else if (id === 'home-end-keys') {
@@ -1599,7 +1695,10 @@ export function registerTuiCommands(
               applyHomeEndKeyMode(value)
               const settings = tuiSettings
               if (settings !== undefined) {
-                detach('settings home end keys write', () => settings.replace({ ...settings.get(), homeEndKeys: value }) as Promise<unknown>, { notify: true })
+                detach('settings home end keys write', () => serializeTuiSettingsMutation(
+                   settings,
+                   () => settings.replace({ ...settings.get(), homeEndKeys: value }),
+                 ), { notify: true })
               }
             }
           } else if (id === 'focus-mode') {
@@ -1681,7 +1780,12 @@ export function registerTuiCommands(
             // surface's restart fallback must resolve to THIS custom
             // layout, not the mode the user had before opening /footer.
             detach('footer configurator write', async () => {
-              await settings.replace({ ...settings.get(), footer: 'custom', footerFallbackMode: 'custom', footerLayout: parsed })
+              await serializeTuiSettingsMutation(settings, () => settings.replace({
+                ...settings.get(),
+                footer: 'custom',
+                footerFallbackMode: 'custom',
+                footerLayout: parsed,
+              }))
               runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed })
               app.notify('footer layout saved', 'info')
             }, { notify: true })
@@ -3154,13 +3258,12 @@ export function registerTuiCommands(
     },
   })
 
-  // M4: the keybinding diagnostics command (plan §19). The panel is
-  // read-only (no key recorder in the first version); reload re-reads the
-  // settings document, reset clears the user overrides THROUGH the
-  // settings service (never a direct settings.yaml write).
+  // M4: the keybinding command. Bare /keybindings opens the action-first
+  // Keyboard Shortcuts Editor; conflicts/reload/reset remain read-only or
+  // explicit diagnostics seams and persist only through the settings port.
   commands.register({
     name: 'keybindings',
-    description: 'Show effective keybindings (conflicts / reload / reset)',
+    description: 'Edit keyboard shortcuts (conflicts / reload / reset)',
     input: { hint: '[conflicts|reload|reset]' },
     handler: (invocation) => {
       const verb = invocation.rawInput.trim().split(/\s+/)[0]?.toLowerCase() ?? ''
@@ -3201,18 +3304,20 @@ export function registerTuiCommands(
         // Neither class may throw out of the handler
         // (review round 28: reload is now the ONLY reload seam, so its
         // fail-soft contract must match the startup application).
-        try {
-          const parsed = parseUserKeybindings(settings.get().keybindings)
-          for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
-          keybindings.setUserConfiguration(parsed)
-        } catch (error: unknown) {
-          const message = safeErrorMessage(error)
-          runner.diag.warn('keybindings', { error: message, message: 'keybindings reload failed — the error may come from the post-rebuild UI invalidation, so the keymap may already be rebuilt' })
-          app.notify(`keybindings reload failed: ${message}`, 'error')
-          return { kind: 'error', text: `keybindings reload failed: ${message}` }
-        }
-        app.notify('Keybindings reloaded.', 'info')
-        return { kind: 'success', text: 'Keybindings reloaded.' }
+        return serializeTuiSettingsMutation(settings, (): CommandResult => {
+          try {
+            const parsed = parseUserKeybindings(settings.get().keybindings)
+            for (const message of parsed.diagnostics) runner.diag.warn('keybindings', { message })
+            keybindings.setUserConfiguration(parsed)
+          } catch (error: unknown) {
+            const message = safeErrorMessage(error)
+            runner.diag.warn('keybindings', { error: message, message: 'keybindings reload failed — the error may come from the post-rebuild UI invalidation, so the keymap may already be rebuilt' })
+            app.notify(`keybindings reload failed: ${message}`, 'error')
+            return { kind: 'error', text: `keybindings reload failed: ${message}` }
+          }
+          app.notify('Keybindings reloaded.', 'info')
+          return { kind: 'success', text: 'Keybindings reloaded.' }
+        })
       }
       if (verb === 'reset') {
         const settings = runner.tuiSettings
@@ -3220,7 +3325,7 @@ export function registerTuiCommands(
         // The whole reset is guarded — INCLUDING the initial read (review
         // round 30): a throwing first `get()` must not escape the handler;
         // it reports an error and the running keymap stays untouched.
-        return (async (): Promise<CommandResult> => {
+        return serializeTuiSettingsMutation(settings, async (): Promise<CommandResult> => {
           try {
             const doc = { ...settings.get() } as Record<string, unknown>
             delete doc.keybindings
@@ -3254,36 +3359,14 @@ export function registerTuiCommands(
             app.notify(`keybindings reset failed: ${message}`, 'error')
             return { kind: 'error', text: `keybindings reset failed: ${message}` }
           }
-        })()
-      }
-      // The full effective table, grouped by category (plan §19).
-      const snapshot = keybindings.snapshot()
-      const categories = new Map<string, SettingItem[]>()
-      for (const binding of snapshot.bindings) {
-        const definition = APP_KEYBINDINGS[binding.action as AppKeybindingId]
-        const category = definition?.category ?? 'Other'
-        const list = categories.get(category) ?? []
-        list.push({
-          id: `kb-${binding.action}`,
-          label: [ ...binding.keys.map(key => formatKeyId(key)), ...(binding.leaderKeys ?? []).map(key => formatLeaderSequence(key)) ].join(' / ') || '—',
-          description: `${binding.action} — ${definition?.description ?? ''} (${binding.scope}, ${binding.source})`,
-          currentValue: '',
         })
-        categories.set(category, list)
       }
-      const rows: SettingItem[] = []
-      for (const [category, list] of categories) {
-        rows.push({ id: `sep-${category}`, label: color.border(`── ${category} ──`), currentValue: '' })
-        rows.push(...list)
-      }
-      const diagnostics = keybindings.diagnosticsList()
-      if (diagnostics.length > 0) {
-        rows.push({ id: 'sep-diag', label: color.border('── diagnostics ──'), currentValue: '' })
-        for (const message of diagnostics) {
-          rows.push({ id: `diag-${rows.length}`, label: color.warning('⚠'), description: message, currentValue: '' })
-        }
-      }
-      app.openSettings(rows, () => {}, () => {})
+      // Bare /keybindings opens the action-first editor. The historical
+      // conflicts/reload/reset verbs above remain explicit diagnostics seams.
+      let closeEditor: () => void = () => {}
+      const panel = createKeybindingEditorPanel(() => closeEditor())
+      if (panel === undefined) return { kind: 'error', text: 'settings service unavailable' }
+      closeEditor = app.openKeybindingEditor(panel)
       return { kind: 'success' }
     },
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,7 @@ import { DirectSessionLifecycle } from './runtime/direct/session-lifecycle-direc
 import { DirectInteractionPort } from './runtime/direct/interaction-direct.ts'
 import { DirectCatalogPort } from './runtime/direct/catalog-direct.ts'
 import { DirectConfigPort } from './runtime/direct/config-direct.ts'
+import { serializeTuiSettingsMutation } from './runtime/config-port.ts'
 import { DirectHostFilePort } from './runtime/direct/host-file-direct.ts'
 import type { SubagentFollowupContext } from './runtime/subagent-port.ts'
 import { directAgentOf, ownerHandleOf, type CreateSessionRequest, type ResumeSessionRequest, type SessionHandle } from './runtime/session-lifecycle-port.ts'
@@ -4421,7 +4422,10 @@ export function apply(ctx: Context, config: Config): void {
       onFullscreenChange: (fullscreen) => {
         const settings = tuiSettings
         if (settings !== undefined) {
-          runDetached('settings fullscreen write', () => settings.replace({ ...settings.get(), fullscreen: fullscreen ? 'on' : 'off' }), {
+          runDetached('settings fullscreen write', () => serializeTuiSettingsMutation(
+             settings,
+             () => settings.replace({ ...settings.get(), fullscreen: fullscreen ? 'on' : 'off' }),
+           ), {
             diag,
             notify: (message) => app.notify(message, 'error'),
             recoverable: () => true,
@@ -5272,9 +5276,11 @@ export function apply(ctx: Context, config: Config): void {
           // them), so the resolved doc still carries `history`: delete it
           // explicitly, or the replace would write it right back.
           runDetached('settings history cleanup', () => {
-            const doc = { ...tuiSettings.get() } as Record<string, unknown>
-            delete doc.history
-            tuiSettings.replace(doc)
+            return serializeTuiSettingsMutation(tuiSettings, () => {
+              const doc = { ...tuiSettings.get() } as Record<string, unknown>
+              delete doc.history
+              return tuiSettings.replace(doc)
+            })
           }, {
             diag,
             notify: (message) => app.notify(message, 'error'),
@@ -5780,7 +5786,10 @@ export function apply(ctx: Context, config: Config): void {
       refreshStatus()
       const settings = tuiSettings
       if (settings !== undefined) {
-        runDetached('settings focus write', () => settings.replace({ ...settings.get(), focusMode: enabled ? 'on' : 'off' }) as Promise<unknown>, {
+        runDetached('settings focus write', () => serializeTuiSettingsMutation(
+           settings,
+           () => settings.replace({ ...settings.get(), focusMode: enabled ? 'on' : 'off' }),
+         ), {
           diag,
           notify: (message) => app.notify(`focus mode persistence failed: ${message}`, 'error'),
           recoverable: () => true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ const LOCAL_SHELL_TAIL_FLUSH_MS = 200
  */
 export const SESSIONLESS_COMMANDS = new Set([
   'exit', 'focus', 'footer', 'settings', 'help', 'image', 'login', 'logout', 'model', 'reload',
-  'sessions', 'resume', 'search', 'new', 'fork', 'rewind', 'preset',
+  'sessions', 'resume', 'search', 'new', 'fork', 'rewind', 'preset', 'keybindings',
   // `/statusline` is the approved alias of `/footer` (same configurator,
   // other-agent muscle memory) — it rides the same ownership sets, so it
   // executes locally, never steers, and works before any session exists.

--- a/src/keybinding-ui/action-editor.ts
+++ b/src/keybinding-ui/action-editor.ts
@@ -139,12 +139,12 @@ export class ActionEditorPanel implements Component {
     lines.push('')
 
     const configured = this.row.customized ? this.row.configured : []
-    const editable = this.row.customized ? this.row.configured : this.row.defaults
+    const editable = this.row.customized ? this.row.configured : this.row.editableDefaults
     lines.push(color.textStrong(this.row.customized ? 'Configured shortcuts' : 'Shortcuts'))
     if (this.row.customized && configured.length === 0) {
       lines.push(color.textDim(this.row.disabled ? '  Disabled' : '  Unbound'))
     }
-    if (!this.row.customized && this.row.defaults.length === 0 && this.row.conditional.length === 0) {
+    if (!this.row.customized && editable.length === 0 && this.row.conditional.length === 0) {
       lines.push(color.textDim('  Unbound'))
     }
     const canEdit = this.row.configurable && !this.row.reserved && !this.row.safeMode
@@ -180,7 +180,8 @@ export class ActionEditorPanel implements Component {
     }
     const effectiveOrdinary = ordinaryBindings(this.row, this.row.effective)
     const configuredOrdinary = ordinaryBindings(this.row, configured)
-    if (this.row.customized && effectiveOrdinary.length > 0 && !sameBindingList(effectiveOrdinary, configuredOrdinary)) {
+    const baselineOrdinary = this.row.customized ? configuredOrdinary : this.row.defaults
+    if (this.row.configurable && !sameBindingList(effectiveOrdinary, baselineOrdinary)) {
       lines.push(color.textDim(`Effective now: ${formatEditorBindings(effectiveOrdinary)}`))
     }
     if (this.row.diagnostics.length > 0) {
@@ -203,6 +204,7 @@ export class ActionEditorPanel implements Component {
     if (this.disposed) return
     this.disposed = true
     this.mutationGeneration += 1
+    this.recorder?.dispose()
     this.recorder = undefined
   }
 
@@ -241,7 +243,7 @@ export class ActionEditorPanel implements Component {
     }
     if (this.row.fixed || this.row.reserved) return
     const configured = this.row.customized ? this.row.configured : []
-    const editable = this.row.customized ? this.row.configured : this.row.defaults
+    const editable = this.row.customized ? this.row.configured : this.row.editableDefaults
     const total = editable.length + 1
     if (matchesKey(data, 'up')) {
       this.selectedIndex = (this.selectedIndex + total - 1) % total
@@ -391,7 +393,7 @@ export class ActionEditorPanel implements Component {
     const next = result.model.rows.find(row => row.id === this.row.id)
     if (next !== undefined) this.row = next
     this.model = result.model
-    const editableCount = this.row.customized ? this.row.configured.length : this.row.defaults.length
+    const editableCount = this.row.customized ? this.row.configured.length : this.row.editableDefaults.length
     this.selectedIndex = Math.min(this.selectedIndex, editableCount)
     this.message = result.message
     this.onModelChange(result.model)

--- a/src/keybinding-ui/action-editor.ts
+++ b/src/keybinding-ui/action-editor.ts
@@ -54,6 +54,33 @@ function selectedLine(label: string, selected: boolean, width: number): string {
   return truncateToWidth(text, Math.max(1, width))
 }
 
+/** Keep the selected binding visible in a short terminal while retaining the
+ * detail footer. The first/last visible content lines double as scroll
+ * markers when they are not the selected line. */
+function actionViewport(
+  lines: readonly string[],
+  selectedLineIndex: number | undefined,
+  maxRows: number,
+): string[] {
+  const limit = Math.max(1, maxRows)
+  if (lines.length <= limit) return [...lines]
+  const footer = lines[lines.length - 1]!
+  if (limit === 1) return [footer]
+  const content = lines.slice(0, -1)
+  if (content.length === 0) return [footer]
+  const windowSize = Math.max(1, limit - 1)
+  const selected = selectedLineIndex === undefined
+    ? Math.min(content.length - 1, Math.floor(windowSize / 2))
+    : Math.min(content.length - 1, Math.max(0, selectedLineIndex))
+  const maxStart = Math.max(0, content.length - windowSize)
+  const start = Math.min(maxStart, Math.max(0, selected - Math.floor(windowSize / 2)))
+  const end = Math.min(content.length, start + windowSize)
+  const viewport = content.slice(start, end)
+  if (start > 0 && selected > start) viewport[0] = color.textDim(`↑ ${start} more lines`)
+  if (end < content.length && selected < end - 1) viewport[viewport.length - 1] = color.textDim(`↓ ${content.length - end} more lines`)
+  return [...viewport, footer]
+}
+
 export class ActionEditorPanel implements Component {
   private model: KeybindingEditorModel
   private row: KeybindingEditorRow
@@ -89,33 +116,49 @@ export class ActionEditorPanel implements Component {
       color.textStrong(`Keyboard shortcuts › ${this.row.label}`),
       '',
     ]
+    const selectableLineIndices: number[] = []
     lines.push(...wrapTextWithAnsi(this.row.description, safeWidth).map(line => color.text(line)))
     lines.push('')
     lines.push(color.textDim(`Action ID: ${this.row.id}`))
     lines.push(color.textDim(`Scope: ${this.row.scope} · Source: ${this.row.source}`))
     lines.push(color.textDim(`Status: ${statusLabel(this.row)}`))
+    if (this.row.safeMode) {
+      lines.push(color.warning('Safe mode is active. Custom shortcuts are ignored.'))
+      lines.push(color.textDim('Editing is disabled until safe mode is turned off.'))
+    }
     if (this.row.reserved) lines.push(color.warning('This action is reserved and has no runtime implementation.'))
     if (this.row.fixed) lines.push(color.textDim('This action is fixed by the application and cannot be edited.'))
     lines.push('')
 
     const configured = this.row.customized ? this.row.configured : []
+    const editable = this.row.customized ? this.row.configured : this.row.defaults
     lines.push(color.textStrong(this.row.customized ? 'Configured shortcuts' : 'Shortcuts'))
     if (this.row.customized && configured.length === 0) {
       lines.push(color.textDim(this.row.disabled ? '  Disabled' : '  Unbound'))
     }
-    if (!this.row.customized && this.row.defaults.length === 0) {
+    if (!this.row.customized && this.row.defaults.length === 0 && this.row.conditional.length === 0) {
       lines.push(color.textDim('  Unbound'))
     }
-    const canEdit = this.row.configurable && !this.row.reserved
+    const canEdit = this.row.configurable && !this.row.reserved && !this.row.safeMode
     if (canEdit) {
-      for (let index = 0; index < configured.length; index += 1) {
-        const binding = configured[index]!
-        const suffix = this.row.conflict ? color.warning(' !') : ''
-        lines.push(selectedLine(`${bindingLabel(binding)}${suffix}`, this.selectedIndex === index, safeWidth))
+      for (let index = 0; index < editable.length; index += 1) {
+        const binding = editable[index]!
+        const defaultSuffix = this.row.customized ? '' : ' (default)'
+        const conflictSuffix = this.row.conflict ? color.warning(' !') : ''
+        selectableLineIndices.push(lines.length)
+        lines.push(selectedLine(`${bindingLabel(binding)}${defaultSuffix}${conflictSuffix}`, this.selectedIndex === index, safeWidth))
       }
-      lines.push(selectedLine('+ Add shortcut', this.selectedIndex === configured.length, safeWidth))
+      selectableLineIndices.push(lines.length)
+      lines.push(selectedLine('+ Add shortcut', this.selectedIndex === editable.length, safeWidth))
     } else if (this.row.defaults.length > 0) {
       for (const binding of this.row.defaults) lines.push(`  ${bindingLabel(binding)}`)
+    }
+
+    if (this.row.conditional.length > 0) {
+      lines.push(color.textStrong('Conditional shortcuts'))
+      for (const binding of this.row.conditional) {
+        lines.push(color.textDim(`  ${bindingLabel(binding)} (${this.row.conditionalDescription ?? 'when its context is active'})`))
+      }
     }
 
     if (!this.row.customized && this.row.defaults.length > 0) {
@@ -130,10 +173,10 @@ export class ActionEditorPanel implements Component {
     if (this.message !== undefined) lines.push(color.error(truncateToWidth(this.message, safeWidth)))
     if (this.pending) lines.push(color.accent('Saving…'))
     lines.push('')
-    lines.push(color.textDim(this.row.fixed
+    lines.push(color.textDim(this.row.fixed || this.row.reserved || this.row.safeMode
       ? 'Esc: back'
       : 'Enter: edit · a: add · Delete: remove · r: reset · d: disable · Esc: back'))
-    return lines.slice(0, Math.max(1, this.maxRows()))
+    return actionViewport(lines, selectableLineIndices[this.selectedIndex], this.maxRows())
   }
 
   invalidate(): void {
@@ -150,10 +193,21 @@ export class ActionEditorPanel implements Component {
   handleInput(data: string): void {
     if (this.disposed) return
     if (this.recorder !== undefined) {
-      this.recorder.handleInput(data)
+      if (this.row.safeMode) {
+        this.recorder.handleInput('\x1b')
+      } else {
+        this.recorder.handleInput(data)
+      }
       return
     }
     if (this.pending) {
+      if (matchesKey(data, 'escape')) {
+        this.dispose()
+        this.onBack()
+      }
+      return
+    }
+    if (this.row.safeMode) {
       if (matchesKey(data, 'escape')) {
         this.dispose()
         this.onBack()
@@ -171,7 +225,8 @@ export class ActionEditorPanel implements Component {
     }
     if (this.row.fixed || this.row.reserved) return
     const configured = this.row.customized ? this.row.configured : []
-    const total = configured.length + 1
+    const editable = this.row.customized ? this.row.configured : this.row.defaults
+    const total = editable.length + 1
     if (matchesKey(data, 'up')) {
       this.selectedIndex = (this.selectedIndex + total - 1) % total
       this.message = undefined
@@ -186,6 +241,7 @@ export class ActionEditorPanel implements Component {
     }
     if (commandKey(data, 'a')) {
       this.mode = 'choose-binding'
+      this.selectedIndex = 0
       this.message = undefined
       this.requestRender()
       return
@@ -199,18 +255,19 @@ export class ActionEditorPanel implements Component {
       return
     }
     if (matchesKey(data, 'delete') || matchesKey(data, 'backspace')) {
-      if (this.selectedIndex < configured.length) {
-        this.startMutation({ kind: 'remove', action: this.row.id, binding: configured[this.selectedIndex]! })
+      if (this.selectedIndex < editable.length) {
+        this.startMutation({ kind: 'remove', action: this.row.id, binding: editable[this.selectedIndex]! })
       }
       return
     }
     if (matchesKey(data, 'enter') || data === '\n' || data === '\r') {
-      if (this.selectedIndex >= configured.length) {
+      if (this.selectedIndex >= editable.length) {
         this.mode = 'choose-binding'
+        this.selectedIndex = 0
         this.message = undefined
         this.requestRender()
       } else {
-        this.startRecorder(configured[this.selectedIndex]!.kind, configured[this.selectedIndex])
+        this.startRecorder(editable[this.selectedIndex]!.kind, editable[this.selectedIndex])
       }
     }
   }
@@ -318,7 +375,8 @@ export class ActionEditorPanel implements Component {
     const next = result.model.rows.find(row => row.id === this.row.id)
     if (next !== undefined) this.row = next
     this.model = result.model
-    this.selectedIndex = Math.min(this.selectedIndex, (this.row.customized ? this.row.configured.length : 0))
+    const editableCount = this.row.customized ? this.row.configured.length : this.row.defaults.length
+    this.selectedIndex = Math.min(this.selectedIndex, editableCount)
     this.message = result.message
     this.onModelChange(result.model)
     this.requestRender()

--- a/src/keybinding-ui/action-editor.ts
+++ b/src/keybinding-ui/action-editor.ts
@@ -1,0 +1,347 @@
+/**
+ * Detail and mutation view for one keyboard shortcut action.
+ */
+
+import { matchesKey, truncateToWidth, wrapTextWithAnsi, type Component, type KeyId } from '@xmoon76/pi-tui'
+import { color } from '../theme.ts'
+import { formatKeyId, formatLeaderSequence } from '../keybindings/hints.ts'
+import type {
+  KeybindingEditorBinding,
+  KeybindingEditorBindingKind,
+  KeybindingEditorModel,
+  KeybindingEditorRow,
+} from './model.ts'
+import { formatEditorBindings } from './model.ts'
+import type { KeybindingMutation, KeybindingMutationResult, KeybindingMutationRunner } from './controller.ts'
+import { KeyRecorder } from './recorder.ts'
+
+export interface ActionEditorOptions {
+  readonly model: KeybindingEditorModel
+  readonly action: KeybindingEditorRow
+  readonly runMutation: KeybindingMutationRunner
+  readonly onModelChange: (model: KeybindingEditorModel) => void
+  readonly onBack: () => void
+  readonly requestRender?: () => void
+  readonly maxRows?: () => number
+}
+
+type ActionEditorMode = 'edit' | 'choose-binding'
+
+function commandKey(data: string, key: string): boolean {
+  return matchesKey(data, key as KeyId) || (data.length === 1 && data.toLowerCase() === key.toLowerCase())
+}
+
+function bindingLabel(binding: KeybindingEditorBinding): string {
+  return binding.kind === 'leader' ? formatLeaderSequence(binding.key) : formatKeyId(binding.key)
+}
+
+function statusLabel(row: KeybindingEditorRow): string {
+  switch (row.status) {
+    case 'customized': return 'Customized'
+    case 'disabled': return 'Disabled'
+    case 'conflict': return 'Conflict'
+    case 'fixed': return 'Fixed (not configurable)'
+    case 'reserved': return 'Reserved (not implemented)'
+    case 'safe-mode': return 'Customized (safe mode is using defaults)'
+    case 'unbound': return 'Unbound'
+    case 'default': return 'Default'
+  }
+}
+
+function selectedLine(label: string, selected: boolean, width: number): string {
+  const marker = selected ? color.primary('›') : ' '
+  const text = `${marker} ${label}`
+  return truncateToWidth(text, Math.max(1, width))
+}
+
+export class ActionEditorPanel implements Component {
+  private model: KeybindingEditorModel
+  private row: KeybindingEditorRow
+  private readonly runMutation: KeybindingMutationRunner
+  private readonly onModelChange: (model: KeybindingEditorModel) => void
+  private readonly onBack: () => void
+  private readonly requestRender: () => void
+  private readonly maxRows: () => number
+  private mode: ActionEditorMode = 'edit'
+  private selectedIndex = 0
+  private recorder: KeyRecorder | undefined
+  private pending = false
+  private mutationGeneration = 0
+  private disposed = false
+  private message: string | undefined
+
+  constructor(options: ActionEditorOptions) {
+    this.model = options.model
+    this.row = options.action
+    this.runMutation = options.runMutation
+    this.onModelChange = options.onModelChange
+    this.onBack = options.onBack
+    this.requestRender = options.requestRender ?? (() => {})
+    this.maxRows = options.maxRows ?? (() => 18)
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width)
+    if (this.recorder !== undefined) return this.recorder.render(safeWidth)
+    if (this.mode === 'choose-binding') return this.renderBindingChoice(safeWidth)
+
+    const lines: string[] = [
+      color.textStrong(`Keyboard shortcuts › ${this.row.label}`),
+      '',
+    ]
+    lines.push(...wrapTextWithAnsi(this.row.description, safeWidth).map(line => color.text(line)))
+    lines.push('')
+    lines.push(color.textDim(`Action ID: ${this.row.id}`))
+    lines.push(color.textDim(`Scope: ${this.row.scope} · Source: ${this.row.source}`))
+    lines.push(color.textDim(`Status: ${statusLabel(this.row)}`))
+    if (this.row.reserved) lines.push(color.warning('This action is reserved and has no runtime implementation.'))
+    if (this.row.fixed) lines.push(color.textDim('This action is fixed by the application and cannot be edited.'))
+    lines.push('')
+
+    const configured = this.row.customized ? this.row.configured : []
+    lines.push(color.textStrong(this.row.customized ? 'Configured shortcuts' : 'Shortcuts'))
+    if (this.row.customized && configured.length === 0) {
+      lines.push(color.textDim(this.row.disabled ? '  Disabled' : '  Unbound'))
+    }
+    if (!this.row.customized && this.row.defaults.length === 0) {
+      lines.push(color.textDim('  Unbound'))
+    }
+    const canEdit = this.row.configurable && !this.row.reserved
+    if (canEdit) {
+      for (let index = 0; index < configured.length; index += 1) {
+        const binding = configured[index]!
+        const suffix = this.row.conflict ? color.warning(' !') : ''
+        lines.push(selectedLine(`${bindingLabel(binding)}${suffix}`, this.selectedIndex === index, safeWidth))
+      }
+      lines.push(selectedLine('+ Add shortcut', this.selectedIndex === configured.length, safeWidth))
+    } else if (this.row.defaults.length > 0) {
+      for (const binding of this.row.defaults) lines.push(`  ${bindingLabel(binding)}`)
+    }
+
+    if (!this.row.customized && this.row.defaults.length > 0) {
+      lines.push(color.textDim(`Default: ${formatEditorBindings(this.row.defaults)}`))
+    }
+    if (this.row.customized && this.row.effective.length > 0 && !sameBindingList(this.row.effective, configured)) {
+      lines.push(color.textDim(`Effective now: ${formatEditorBindings(this.row.effective)}`))
+    }
+    if (this.row.diagnostics.length > 0) {
+      for (const diagnostic of this.row.diagnostics.slice(0, 2)) lines.push(color.warning(truncateToWidth(diagnostic, safeWidth)))
+    }
+    if (this.message !== undefined) lines.push(color.error(truncateToWidth(this.message, safeWidth)))
+    if (this.pending) lines.push(color.accent('Saving…'))
+    lines.push('')
+    lines.push(color.textDim(this.row.fixed
+      ? 'Esc: back'
+      : 'Enter: edit · a: add · Delete: remove · r: reset · d: disable · Esc: back'))
+    return lines.slice(0, Math.max(1, this.maxRows()))
+  }
+
+  invalidate(): void {
+    this.recorder?.invalidate()
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.mutationGeneration += 1
+    this.recorder = undefined
+  }
+
+  handleInput(data: string): void {
+    if (this.disposed) return
+    if (this.recorder !== undefined) {
+      this.recorder.handleInput(data)
+      return
+    }
+    if (this.pending) {
+      if (matchesKey(data, 'escape')) {
+        this.dispose()
+        this.onBack()
+      }
+      return
+    }
+    if (this.mode === 'choose-binding') {
+      this.handleBindingChoice(data)
+      return
+    }
+    if (matchesKey(data, 'escape')) {
+      this.dispose()
+      this.onBack()
+      return
+    }
+    if (this.row.fixed || this.row.reserved) return
+    const configured = this.row.customized ? this.row.configured : []
+    const total = configured.length + 1
+    if (matchesKey(data, 'up')) {
+      this.selectedIndex = (this.selectedIndex + total - 1) % total
+      this.message = undefined
+      this.requestRender()
+      return
+    }
+    if (matchesKey(data, 'down')) {
+      this.selectedIndex = (this.selectedIndex + 1) % total
+      this.message = undefined
+      this.requestRender()
+      return
+    }
+    if (commandKey(data, 'a')) {
+      this.mode = 'choose-binding'
+      this.message = undefined
+      this.requestRender()
+      return
+    }
+    if (commandKey(data, 'r')) {
+      this.startMutation({ kind: 'reset-action', action: this.row.id })
+      return
+    }
+    if (commandKey(data, 'd')) {
+      this.startMutation({ kind: 'disable-action', action: this.row.id })
+      return
+    }
+    if (matchesKey(data, 'delete') || matchesKey(data, 'backspace')) {
+      if (this.selectedIndex < configured.length) {
+        this.startMutation({ kind: 'remove', action: this.row.id, binding: configured[this.selectedIndex]! })
+      }
+      return
+    }
+    if (matchesKey(data, 'enter') || data === '\n' || data === '\r') {
+      if (this.selectedIndex >= configured.length) {
+        this.mode = 'choose-binding'
+        this.message = undefined
+        this.requestRender()
+      } else {
+        this.startRecorder(configured[this.selectedIndex]!.kind, configured[this.selectedIndex])
+      }
+    }
+  }
+
+  private renderBindingChoice(width: number): string[] {
+    const lines = [
+      color.textStrong(`Add shortcut › ${this.row.label}`),
+      '',
+      color.text('Choose what to record:'),
+      selectedLine('Direct shortcut', this.selectedIndex === 0, width),
+      selectedLine('Leader completion', this.selectedIndex === 1, width),
+    ]
+    if (this.model.leader.key === undefined) {
+      lines.push(color.textDim('Leader completion is unavailable until a leader key is configured.'))
+    } else {
+      lines.push(color.textDim(`Leader prefix: ${formatKeyId(this.model.leader.key)}`))
+    }
+    if (this.message !== undefined) lines.push(color.error(truncateToWidth(this.message, width)))
+    lines.push('', color.textDim('Enter: choose · d/l: choose directly · Esc: back'))
+    return lines.slice(0, Math.max(1, this.maxRows()))
+  }
+
+  private handleBindingChoice(data: string): void {
+    if (matchesKey(data, 'escape')) {
+      this.mode = 'edit'
+      this.requestRender()
+      return
+    }
+    if (matchesKey(data, 'up') || commandKey(data, 'k')) {
+      this.selectedIndex = (this.selectedIndex + 2 - 1) % 2
+      this.requestRender()
+      return
+    }
+    if (matchesKey(data, 'down') || commandKey(data, 'j')) {
+      this.selectedIndex = (this.selectedIndex + 1) % 2
+      this.requestRender()
+      return
+    }
+    if (commandKey(data, 'd')) {
+      this.selectedIndex = 0
+    } else if (commandKey(data, 'l')) {
+      this.selectedIndex = 1
+    } else if (!matchesKey(data, 'enter') && data !== '\n' && data !== '\r') {
+      return
+    }
+    if (this.selectedIndex === 1 && this.model.leader.key === undefined) {
+      this.message = 'Configure a leader key before adding a leader completion.'
+      this.mode = 'edit'
+      this.requestRender()
+      return
+    }
+    this.startRecorder(this.selectedIndex === 1 ? 'leader' : 'direct')
+  }
+
+  private startRecorder(kind: KeybindingEditorBindingKind, previous?: KeybindingEditorBinding): void {
+    this.mode = 'edit'
+    this.message = undefined
+    this.recorder = new KeyRecorder({
+      purpose: kind === 'leader' ? 'leader-completion' : 'direct',
+      action: this.row.id,
+      label: kind === 'leader' ? 'the leader completion' : this.row.label,
+      onCapture: (key) => {
+        if (this.disposed) return
+        this.recorder = undefined
+        const binding: KeybindingEditorBinding = { kind, key }
+        const mutation: KeybindingMutation = previous === undefined
+          ? { kind: 'add', action: this.row.id, binding }
+          : { kind: 'replace', action: this.row.id, previous, binding }
+        this.startMutation(mutation)
+      },
+      onCancel: () => {
+        this.recorder = undefined
+        if (!this.disposed) this.requestRender()
+      },
+      requestRender: this.requestRender,
+    })
+    this.requestRender()
+  }
+
+  private startMutation(mutation: KeybindingMutation): void {
+    if (this.disposed) return
+    const generation = ++this.mutationGeneration
+    this.pending = true
+    this.message = undefined
+    this.requestRender()
+    try {
+      this.runMutation(
+        mutation,
+        result => this.applyMutationResult(generation, result),
+        error => this.applyMutationError(generation, error),
+      )
+    } catch (error) {
+      this.applyMutationError(generation, error)
+    }
+  }
+
+  private applyMutationResult(generation: number, result: KeybindingMutationResult): void {
+    if (this.disposed || generation !== this.mutationGeneration) return
+    this.pending = false
+    if (result.kind !== 'applied') {
+      this.message = result.message
+      this.requestRender()
+      return
+    }
+    const next = result.model.rows.find(row => row.id === this.row.id)
+    if (next !== undefined) this.row = next
+    this.model = result.model
+    this.selectedIndex = Math.min(this.selectedIndex, (this.row.customized ? this.row.configured.length : 0))
+    this.message = result.message
+    this.onModelChange(result.model)
+    this.requestRender()
+  }
+
+  private applyMutationError(generation: number, error: unknown): void {
+    if (this.disposed || generation !== this.mutationGeneration) return
+    this.pending = false
+    this.message = error instanceof Error ? error.message : 'Could not save keyboard shortcuts.'
+    this.requestRender()
+  }
+}
+
+function sameBindingList(
+  left: readonly KeybindingEditorBinding[],
+  right: readonly KeybindingEditorBinding[],
+): boolean {
+  return left.length === right.length && left.every((binding, index) => {
+    const other = right[index]
+    return other !== undefined && binding.kind === other.kind && binding.key === other.key
+  })
+}
+
+export function bindingKey(binding: KeybindingEditorBinding): string {
+  return `${binding.kind}:${binding.key}`
+}

--- a/src/keybinding-ui/action-editor.ts
+++ b/src/keybinding-ui/action-editor.ts
@@ -35,6 +35,21 @@ function bindingLabel(binding: KeybindingEditorBinding): string {
   return binding.kind === 'leader' ? formatLeaderSequence(binding.key) : formatKeyId(binding.key)
 }
 
+function isConditionalBinding(row: KeybindingEditorRow, binding: KeybindingEditorBinding): boolean {
+  return row.conditional.some(candidate => candidate.kind === binding.kind && candidate.key === binding.key)
+}
+
+function formatVisibleBindings(row: KeybindingEditorRow, bindings: readonly KeybindingEditorBinding[]): string {
+  const ordinary = bindings.filter(binding => !isConditionalBinding(row, binding))
+  const conditional = bindings
+    .filter(binding => isConditionalBinding(row, binding))
+    .map(binding => `${bindingLabel(binding)} (conditional)`)
+  return [
+    ordinary.length > 0 ? formatEditorBindings(ordinary) : '',
+    conditional.join(' / '),
+  ].filter(part => part !== '').join(' / ') || 'Unbound'
+}
+
 function statusLabel(row: KeybindingEditorRow): string {
   switch (row.status) {
     case 'customized': return 'Customized'
@@ -144,9 +159,13 @@ export class ActionEditorPanel implements Component {
       for (let index = 0; index < editable.length; index += 1) {
         const binding = editable[index]!
         const defaultSuffix = this.row.customized ? '' : ' (default)'
+        const conditionalSuffix = isConditionalBinding(this.row, binding) ? ' (conditional)' : ''
         const conflictSuffix = this.row.conflict ? color.warning(' !') : ''
         selectableLineIndices.push(lines.length)
-        lines.push(selectedLine(`${bindingLabel(binding)}${defaultSuffix}${conflictSuffix}`, this.selectedIndex === index, safeWidth))
+        lines.push(selectedLine(`${bindingLabel(binding)}${defaultSuffix}${conditionalSuffix}${conflictSuffix}`, this.selectedIndex === index, safeWidth))
+      }
+      if (editable.some(binding => isConditionalBinding(this.row, binding))) {
+        lines.push(color.textDim(`  Conditional: ${this.row.conditionalDescription ?? 'when its context is active'}`))
       }
       selectableLineIndices.push(lines.length)
       lines.push(selectedLine('+ Add shortcut', this.selectedIndex === editable.length, safeWidth))
@@ -154,9 +173,11 @@ export class ActionEditorPanel implements Component {
       for (const binding of this.row.defaults) lines.push(`  ${bindingLabel(binding)}`)
     }
 
-    if (this.row.conditional.length > 0) {
+    const conditionalOnly = this.row.conditional.filter(binding => !editable.some(candidate =>
+      candidate.kind === binding.kind && candidate.key === binding.key))
+    if (conditionalOnly.length > 0) {
       lines.push(color.textStrong('Conditional shortcuts'))
-      for (const binding of this.row.conditional) {
+      for (const binding of conditionalOnly) {
         lines.push(color.textDim(`  ${bindingLabel(binding)} (${this.row.conditionalDescription ?? 'when its context is active'})`))
       }
     }
@@ -165,7 +186,7 @@ export class ActionEditorPanel implements Component {
       lines.push(color.textDim(`Default: ${formatEditorBindings(this.row.defaults)}`))
     }
     if (this.row.customized && this.row.effective.length > 0 && !sameBindingList(this.row.effective, configured)) {
-      lines.push(color.textDim(`Effective now: ${formatEditorBindings(this.row.effective)}`))
+      lines.push(color.textDim(`Effective now: ${formatVisibleBindings(this.row, this.row.effective)}`))
     }
     if (this.row.diagnostics.length > 0) {
       for (const diagnostic of this.row.diagnostics.slice(0, 2)) lines.push(color.warning(truncateToWidth(diagnostic, safeWidth)))

--- a/src/keybinding-ui/action-editor.ts
+++ b/src/keybinding-ui/action-editor.ts
@@ -39,15 +39,8 @@ function isConditionalBinding(row: KeybindingEditorRow, binding: KeybindingEdito
   return row.conditional.some(candidate => candidate.kind === binding.kind && candidate.key === binding.key)
 }
 
-function formatVisibleBindings(row: KeybindingEditorRow, bindings: readonly KeybindingEditorBinding[]): string {
-  const ordinary = bindings.filter(binding => !isConditionalBinding(row, binding))
-  const conditional = bindings
-    .filter(binding => isConditionalBinding(row, binding))
-    .map(binding => `${bindingLabel(binding)} (conditional)`)
-  return [
-    ordinary.length > 0 ? formatEditorBindings(ordinary) : '',
-    conditional.join(' / '),
-  ].filter(part => part !== '').join(' / ') || 'Unbound'
+function ordinaryBindings(row: KeybindingEditorRow, bindings: readonly KeybindingEditorBinding[]): KeybindingEditorBinding[] {
+  return bindings.filter(binding => !isConditionalBinding(row, binding))
 }
 
 function statusLabel(row: KeybindingEditorRow): string {
@@ -185,8 +178,10 @@ export class ActionEditorPanel implements Component {
     if (!this.row.customized && this.row.defaults.length > 0) {
       lines.push(color.textDim(`Default: ${formatEditorBindings(this.row.defaults)}`))
     }
-    if (this.row.customized && this.row.effective.length > 0 && !sameBindingList(this.row.effective, configured)) {
-      lines.push(color.textDim(`Effective now: ${formatVisibleBindings(this.row, this.row.effective)}`))
+    const effectiveOrdinary = ordinaryBindings(this.row, this.row.effective)
+    const configuredOrdinary = ordinaryBindings(this.row, configured)
+    if (this.row.customized && effectiveOrdinary.length > 0 && !sameBindingList(effectiveOrdinary, configuredOrdinary)) {
+      lines.push(color.textDim(`Effective now: ${formatEditorBindings(effectiveOrdinary)}`))
     }
     if (this.row.diagnostics.length > 0) {
       for (const diagnostic of this.row.diagnostics.slice(0, 2)) lines.push(color.warning(truncateToWidth(diagnostic, safeWidth)))

--- a/src/keybinding-ui/controller.ts
+++ b/src/keybinding-ui/controller.ts
@@ -114,6 +114,25 @@ function actionBindings(
   return [...editorBindingsFor(action, parsed)]
 }
 
+function defaultBindings(action: AppKeybindingId): KeybindingEditorBinding[] {
+  return APP_KEYBINDINGS[action]!.defaultKeys.map(key => ({ kind: 'direct' as const, key }))
+}
+
+/**
+ * The first edit of an untouched action starts from its editable effective
+ * defaults. Once the action has a user declaration, user bindings remain the
+ * complete source of truth because a declaration intentionally replaces the
+ * builtin set.
+ */
+function mutationBindings(
+  action: AppKeybindingId,
+  parsed: ParsedUserKeybindings,
+): KeybindingEditorBinding[] {
+  return hasOwn(parsed.bindings, action)
+    ? actionBindings(action, parsed)
+    : defaultBindings(action)
+}
+
 function sameBinding(left: KeybindingEditorBinding, right: KeybindingEditorBinding): boolean {
   return left.kind === right.kind && left.key === right.key
 }
@@ -188,17 +207,17 @@ function applyMutation(
 ): Record<string, unknown> | undefined {
   switch (mutation.kind) {
     case 'add': {
-      const bindings = actionBindings(mutation.action, current)
+      const bindings = mutationBindings(mutation.action, current)
       writeActionDeclarations(raw, mutation.action, [...bindings, mutation.binding])
       return raw
     }
     case 'replace': {
-      const bindings = actionBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.previous))
+      const bindings = mutationBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.previous))
       writeActionDeclarations(raw, mutation.action, [...bindings, mutation.binding])
       return raw
     }
     case 'remove': {
-      const bindings = actionBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.binding))
+      const bindings = mutationBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.binding))
       writeActionDeclarations(raw, mutation.action, bindings)
       return raw
     }
@@ -260,6 +279,9 @@ export class KeybindingEditorController {
     const settings = this.settings
     return serializeTuiSettingsMutation(settings, async () => {
       try {
+        if (this.manager.isSafeMode()) {
+          return { kind: 'rejected', message: 'Keyboard shortcuts cannot be edited while safe mode is active.' }
+        }
         const currentDoc = settings.get()
         const raw = cloneKeybindings(currentDoc.keybindings)
         const current = parseUserKeybindings(raw)

--- a/src/keybinding-ui/controller.ts
+++ b/src/keybinding-ui/controller.ts
@@ -1,0 +1,329 @@
+/**
+ * Persistence and runtime projection for the Keyboard Shortcuts Editor.
+ *
+ * The controller is deliberately narrow: settings are accessed through the
+ * get/replace ConfigPort surface, while runtime state is projected through
+ * HostKeybindingManager. It never watches settings and never writes a file.
+ */
+
+import { APP_KEYBINDINGS } from '../keybindings/definitions.ts'
+import { parseUserKeybindings } from '../keybindings/config.ts'
+import { formatKeyId } from '../keybindings/hints.ts'
+import type { HostKeybindingManager } from '../keybindings/manager.ts'
+import { serializeTuiSettingsMutation, type TuiSettingsDoc, type TuiSettingsConfig } from '../runtime/config-port.ts'
+import type { KeyId } from '@xmoon76/pi-tui'
+import type { AppKeybindingId } from '../keybindings/types.ts'
+import {
+  buildKeybindingEditorModel,
+  editorBindingsFor,
+  type KeybindingEditorBinding,
+  type KeybindingEditorModel,
+} from './model.ts'
+import { safeErrorMessage } from '../error-boundary.ts'
+import type { ParsedUserKeybindings } from '../keybindings/config.ts'
+
+export type KeybindingMutation =
+  | {
+      readonly kind: 'add'
+      readonly action: AppKeybindingId
+      readonly binding: KeybindingEditorBinding
+    }
+  | {
+      readonly kind: 'replace'
+      readonly action: AppKeybindingId
+      readonly previous: KeybindingEditorBinding
+      readonly binding: KeybindingEditorBinding
+    }
+  | {
+      readonly kind: 'remove'
+      readonly action: AppKeybindingId
+      readonly binding: KeybindingEditorBinding
+    }
+  | {
+      readonly kind: 'set-action'
+      readonly action: AppKeybindingId
+      readonly bindings: readonly KeybindingEditorBinding[]
+    }
+  | {
+      readonly kind: 'reset-action'
+      readonly action: AppKeybindingId
+    }
+  | {
+      readonly kind: 'disable-action'
+      readonly action: AppKeybindingId
+    }
+  | {
+      readonly kind: 'set-leader'
+      readonly key: KeyId | undefined
+    }
+  | {
+      readonly kind: 'reset-all'
+    }
+
+export type KeybindingMutationResult =
+  | {
+      readonly kind: 'applied'
+      readonly model: KeybindingEditorModel
+      readonly parsed: ParsedUserKeybindings
+      readonly message: string
+    }
+  | {
+      readonly kind: 'rejected' | 'error'
+      readonly message: string
+    }
+
+export type KeybindingMutationRunner = (
+  mutation: KeybindingMutation,
+  onResult: (result: KeybindingMutationResult) => void,
+  onError: (error: unknown) => void,
+) => void
+
+export interface KeybindingEditorControllerOptions {
+  readonly settings: TuiSettingsConfig | undefined
+  readonly manager: HostKeybindingManager
+  readonly onDiagnostic?: (message: string) => void
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cloneKeybindings(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {}
+  const clone: Record<string, unknown> = { ...raw }
+  if (isRecord(raw.bindings)) clone.bindings = { ...raw.bindings }
+  return clone
+}
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function removeActionDeclarations(raw: Record<string, unknown>, action: AppKeybindingId): void {
+  delete raw[action]
+  if (!isRecord(raw.bindings)) return
+  const bindings = { ...raw.bindings }
+  delete bindings[action]
+  raw.bindings = bindings
+}
+
+function actionBindings(
+  action: AppKeybindingId,
+  parsed: ParsedUserKeybindings,
+): KeybindingEditorBinding[] {
+  return [...editorBindingsFor(action, parsed)]
+}
+
+function sameBinding(left: KeybindingEditorBinding, right: KeybindingEditorBinding): boolean {
+  return left.kind === right.kind && left.key === right.key
+}
+
+function dedupeBindings(bindings: readonly KeybindingEditorBinding[]): KeybindingEditorBinding[] {
+  const result: KeybindingEditorBinding[] = []
+  for (const binding of bindings) {
+    if (!result.some(existing => sameBinding(existing, binding))) result.push(binding)
+  }
+  return result
+}
+
+function writeActionDeclarations(
+  raw: Record<string, unknown>,
+  action: AppKeybindingId,
+  bindings: readonly KeybindingEditorBinding[],
+): void {
+  removeActionDeclarations(raw, action)
+  const values = dedupeBindings(bindings).map(binding => binding.kind === 'leader' ? `<leader>${binding.key}` : binding.key)
+  // An empty declaration means "no override" in the parser (and therefore
+  // restores the builtin). `false` is reserved for the explicit Disable
+  // command and must not be conflated with removing the final shortcut.
+  raw[action] = values.length === 0 ? [] : values.length === 1 ? values[0]! : values
+}
+
+function actionFromMutation(mutation: KeybindingMutation): AppKeybindingId | undefined {
+  switch (mutation.kind) {
+    case 'add':
+    case 'replace':
+    case 'remove':
+    case 'set-action':
+    case 'reset-action':
+    case 'disable-action':
+      return mutation.action
+    case 'set-leader':
+    case 'reset-all':
+      return undefined
+  }
+}
+
+function isBenignParserDiagnostic(message: string): boolean {
+  // This warning describes a scoped overlay precedence rule. The action still
+  // works outside that overlay, so the editor may persist it after showing the
+  // warning instead of treating it as a dead binding.
+  return message.includes('non-configurable overlay owns while it is open')
+}
+
+function conflictSignature(conflict: {
+  readonly key: KeyId
+  readonly actions: readonly { readonly action: string; readonly scope: string; readonly source: string }[]
+}): string {
+  return `${conflict.key}\u0000${conflict.actions.map(action => `${action.action}:${action.scope}:${action.source}`).sort().join('|')}`
+}
+
+function affectedActions(mutation: KeybindingMutation): readonly AppKeybindingId[] {
+  const action = actionFromMutation(mutation)
+  return action === undefined ? [] : [action]
+}
+
+function describeConflict(conflict: {
+  readonly key: KeyId
+  readonly actions: readonly { readonly action: string }[]
+}): string {
+  const actions = conflict.actions.map(action => action.action).join(', ')
+  return `Cannot save: ${formatKeyId(conflict.key)} conflicts with ${actions}. Choose another shortcut.`
+}
+
+function applyMutation(
+  raw: Record<string, unknown>,
+  current: ParsedUserKeybindings,
+  mutation: KeybindingMutation,
+): Record<string, unknown> | undefined {
+  switch (mutation.kind) {
+    case 'add': {
+      const bindings = actionBindings(mutation.action, current)
+      writeActionDeclarations(raw, mutation.action, [...bindings, mutation.binding])
+      return raw
+    }
+    case 'replace': {
+      const bindings = actionBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.previous))
+      writeActionDeclarations(raw, mutation.action, [...bindings, mutation.binding])
+      return raw
+    }
+    case 'remove': {
+      const bindings = actionBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.binding))
+      writeActionDeclarations(raw, mutation.action, bindings)
+      return raw
+    }
+    case 'set-action':
+      writeActionDeclarations(raw, mutation.action, mutation.bindings)
+      return raw
+    case 'reset-action':
+      removeActionDeclarations(raw, mutation.action)
+      return raw
+    case 'disable-action':
+      removeActionDeclarations(raw, mutation.action)
+      raw[mutation.action] = false
+      return raw
+    case 'set-leader':
+      if (mutation.key === undefined) {
+        delete raw.leader
+        // Clearing the prefix also removes its completions. Leaving inert
+        // <leader> entries behind would make the next parse warn and would
+        // not be a useful state for an interactive editor.
+        for (const definition of Object.values(APP_KEYBINDINGS)) {
+          const bindings = actionBindings(definition.id, current)
+          if (!bindings.some(binding => binding.kind === 'leader')) continue
+          const direct = bindings.filter(binding => binding.kind === 'direct')
+          if (direct.length === 0) removeActionDeclarations(raw, definition.id)
+          else writeActionDeclarations(raw, definition.id, direct)
+        }
+      } else {
+        raw.leader = mutation.key
+      }
+      return raw
+    case 'reset-all':
+      return undefined
+  }
+}
+
+export class KeybindingEditorController {
+  private readonly settings: TuiSettingsConfig | undefined
+  private readonly manager: HostKeybindingManager
+  private readonly onDiagnostic: (message: string) => void
+
+  constructor(options: KeybindingEditorControllerOptions) {
+    this.settings = options.settings
+    this.manager = options.manager
+    this.onDiagnostic = options.onDiagnostic ?? (() => {})
+  }
+
+  readModel(): KeybindingEditorModel {
+    if (this.settings === undefined) throw new Error('Keyboard shortcuts are unavailable because settings are not connected.')
+    const doc = this.settings.get()
+    const parsed = parseUserKeybindings(doc.keybindings)
+    for (const diagnostic of parsed.diagnostics) this.onDiagnostic(diagnostic)
+    return buildKeybindingEditorModel(this.manager, parsed)
+  }
+
+  async mutate(mutation: KeybindingMutation): Promise<KeybindingMutationResult> {
+    if (this.settings === undefined) {
+      return { kind: 'error', message: 'Keyboard shortcuts are unavailable because settings are not connected.' }
+    }
+    const settings = this.settings
+    return serializeTuiSettingsMutation(settings, async () => {
+      try {
+        const currentDoc = settings.get()
+        const raw = cloneKeybindings(currentDoc.keybindings)
+        const current = parseUserKeybindings(raw)
+        const definition = actionFromMutation(mutation)
+        if (definition !== undefined && !APP_KEYBINDINGS[definition]!.configurable) {
+          return { kind: 'rejected', message: 'This shortcut is fixed by the application and cannot be changed.' }
+        }
+        const nextRaw = applyMutation(raw, current, mutation)
+        const parsed = parseUserKeybindings(nextRaw)
+        for (const diagnostic of parsed.diagnostics) this.onDiagnostic(diagnostic)
+
+        const previousDiagnostics = new Set(current.diagnostics)
+        const newHardDiagnostics = parsed.diagnostics.filter(diagnostic => !previousDiagnostics.has(diagnostic) && !isBenignParserDiagnostic(diagnostic))
+        if (newHardDiagnostics.length > 0) {
+          return { kind: 'rejected', message: `Cannot save: ${newHardDiagnostics[0]}` }
+        }
+
+        const preflight = this.manager.preflight(parsed)
+        const currentManagerDiagnostics = new Set(this.manager.diagnosticsList())
+        const newManagerDiagnostics = preflight.diagnostics.filter(diagnostic => !currentManagerDiagnostics.has(diagnostic))
+        // Any mutation can make an existing leader prefix unusable (for
+        // example, adding a direct binding on the prefix key). Reject only a
+        // newly introduced diagnostic so an unrelated edit can still repair a
+        // configuration that was already persisted with a warning.
+        const leaderProblem = newManagerDiagnostics.find(diagnostic => diagnostic.includes('leader key') || diagnostic.includes('ambiguous leader sequence'))
+        if (leaderProblem !== undefined) {
+          return { kind: 'rejected', message: `Cannot save: ${leaderProblem}` }
+        }
+
+        const affected = new Set(affectedActions(mutation))
+        const currentConflictSet = new Set(this.manager.snapshot().conflicts.map(conflictSignature))
+        const newConflict = preflight.snapshot.conflicts.find(conflict =>
+          conflict.actions.some(action => affected.has(action.action as AppKeybindingId))
+          && !currentConflictSet.has(conflictSignature(conflict)),
+        )
+        if (newConflict !== undefined) return { kind: 'rejected', message: describeConflict(newConflict) }
+
+        const nextDoc = { ...currentDoc } as TuiSettingsDoc
+        if (nextRaw === undefined) delete nextDoc.keybindings
+        else nextDoc.keybindings = nextRaw
+        // The transaction intentionally has one replace and only projects the
+        // same parsed candidate after persistence succeeds.
+        await Promise.resolve(settings.replace(nextDoc))
+        this.manager.setUserConfiguration(parsed)
+        return {
+          kind: 'applied',
+          model: buildKeybindingEditorModel(this.manager, parsed),
+          parsed,
+          message: 'Keyboard shortcut settings saved.',
+        }
+      } catch (error) {
+        return { kind: 'error', message: `Could not save keyboard shortcuts: ${safeErrorMessage(error)}` }
+      }
+    })
+  }
+}
+
+export function keybindingSummary(model: KeybindingEditorModel): string {
+  return model.summary
+}
+
+export function hasDeclaredAction(
+  parsed: ParsedUserKeybindings,
+  action: AppKeybindingId,
+): boolean {
+  return hasOwn(parsed.bindings, action)
+}

--- a/src/keybinding-ui/controller.ts
+++ b/src/keybinding-ui/controller.ts
@@ -114,23 +114,34 @@ function actionBindings(
   return [...editorBindingsFor(action, parsed)]
 }
 
-function defaultBindings(action: AppKeybindingId): KeybindingEditorBinding[] {
-  return APP_KEYBINDINGS[action]!.defaultKeys.map(key => ({ kind: 'direct' as const, key }))
+/** Builtin defaults that are still visible in the manager's effective
+ * direct projection. Composition/conditional affordances are intentionally
+ * absent because they are not definition defaults and must never be
+ * materialized as ordinary user declarations. */
+function editableEffectiveDefaults(
+  action: AppKeybindingId,
+  manager: HostKeybindingManager,
+): KeybindingEditorBinding[] {
+  const effective = new Set(manager.keysFor(action))
+  return APP_KEYBINDINGS[action]!.defaultKeys
+    .filter(key => effective.has(key))
+    .map(key => ({ kind: 'direct' as const, key }))
 }
 
 /**
- * The first edit of an untouched action starts from its editable effective
- * defaults. Once the action has a user declaration, user bindings remain the
- * complete source of truth because a declaration intentionally replaces the
- * builtin set.
+ * The first edit of an untouched action starts from its surviving effective
+ * builtin defaults. Once the action has a user declaration, user bindings
+ * remain the complete source of truth because a declaration intentionally
+ * replaces the builtin set.
  */
 function mutationBindings(
   action: AppKeybindingId,
   parsed: ParsedUserKeybindings,
+  manager: HostKeybindingManager,
 ): KeybindingEditorBinding[] {
   return hasOwn(parsed.bindings, action)
     ? actionBindings(action, parsed)
-    : defaultBindings(action)
+    : editableEffectiveDefaults(action, manager)
 }
 
 function sameBinding(left: KeybindingEditorBinding, right: KeybindingEditorBinding): boolean {
@@ -204,20 +215,21 @@ function applyMutation(
   raw: Record<string, unknown>,
   current: ParsedUserKeybindings,
   mutation: KeybindingMutation,
+  manager: HostKeybindingManager,
 ): Record<string, unknown> | undefined {
   switch (mutation.kind) {
     case 'add': {
-      const bindings = mutationBindings(mutation.action, current)
+      const bindings = mutationBindings(mutation.action, current, manager)
       writeActionDeclarations(raw, mutation.action, [...bindings, mutation.binding])
       return raw
     }
     case 'replace': {
-      const bindings = mutationBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.previous))
+      const bindings = mutationBindings(mutation.action, current, manager).filter(binding => !sameBinding(binding, mutation.previous))
       writeActionDeclarations(raw, mutation.action, [...bindings, mutation.binding])
       return raw
     }
     case 'remove': {
-      const bindings = mutationBindings(mutation.action, current).filter(binding => !sameBinding(binding, mutation.binding))
+      const bindings = mutationBindings(mutation.action, current, manager).filter(binding => !sameBinding(binding, mutation.binding))
       writeActionDeclarations(raw, mutation.action, bindings)
       return raw
     }
@@ -289,7 +301,7 @@ export class KeybindingEditorController {
         if (definition !== undefined && !APP_KEYBINDINGS[definition]!.configurable) {
           return { kind: 'rejected', message: 'This shortcut is fixed by the application and cannot be changed.' }
         }
-        const nextRaw = applyMutation(raw, current, mutation)
+        const nextRaw = applyMutation(raw, current, mutation, this.manager)
         const parsed = parseUserKeybindings(nextRaw)
         for (const diagnostic of parsed.diagnostics) this.onDiagnostic(diagnostic)
 
@@ -306,7 +318,9 @@ export class KeybindingEditorController {
         // example, adding a direct binding on the prefix key). Reject only a
         // newly introduced diagnostic so an unrelated edit can still repair a
         // configuration that was already persisted with a warning.
-        const leaderProblem = newManagerDiagnostics.find(diagnostic => diagnostic.includes('leader key') || diagnostic.includes('ambiguous leader sequence'))
+        const leaderProblem = newManagerDiagnostics.find(diagnostic => diagnostic.includes('leader key')
+          || diagnostic.includes('ambiguous leader sequence')
+          || diagnostic.includes('effective editor submit key'))
         if (leaderProblem !== undefined) {
           return { kind: 'rejected', message: `Cannot save: ${leaderProblem}` }
         }

--- a/src/keybinding-ui/list.ts
+++ b/src/keybinding-ui/list.ts
@@ -1,0 +1,462 @@
+/**
+ * Keyboard Shortcuts Editor: searchable action-first list, leader setup, and
+ * the shared detail/editor child view.
+ */
+
+import { decodePrintableKey, matchesKey, truncateToWidth, visibleWidth, type Component } from '@xmoon76/pi-tui'
+import { color } from '../theme.ts'
+import { formatKeyId } from '../keybindings/hints.ts'
+import type { KeyId } from '@xmoon76/pi-tui'
+import {
+  formatEditorBindings,
+  searchKeybindingRows,
+  searchMatchesLeader,
+  type KeybindingEditorModel,
+  type KeybindingEditorRow,
+} from './model.ts'
+import type { KeybindingMutation, KeybindingMutationResult, KeybindingMutationRunner } from './controller.ts'
+import { ActionEditorPanel } from './action-editor.ts'
+import { KeyRecorder } from './recorder.ts'
+
+export interface KeybindingEditorPanelOptions {
+  readonly model: KeybindingEditorModel
+  readonly runMutation: KeybindingMutationRunner
+  readonly onClose: () => void
+  readonly onModelChange?: (model: KeybindingEditorModel) => void
+  readonly onDispose?: () => void
+  readonly requestRender?: () => void
+  readonly maxRows?: () => number
+}
+
+type ListEntry =
+  | { readonly kind: 'header'; readonly label: string }
+  | { readonly kind: 'leader'; readonly id: 'leader' }
+  | { readonly kind: 'action'; readonly row: KeybindingEditorRow }
+
+function commandKey(data: string, key: string): boolean {
+  return matchesKey(data, key as KeyId) || (data.length === 1 && data.toLowerCase() === key.toLowerCase())
+}
+
+function printableChunk(data: string): string | undefined {
+  const decoded = decodePrintableKey(data)
+  if (decoded !== undefined) return decoded
+  if (data === '' || data.includes('\x1b')) return undefined
+  for (const character of data) {
+    if (character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127) return undefined
+  }
+  return data
+}
+
+function statusMarkers(row: KeybindingEditorRow): string {
+  const markers: string[] = []
+  if (row.customized) markers.push('*')
+  if (row.conflict) markers.push('!')
+  if (row.fixed) markers.push('fixed')
+  if (row.reserved) markers.push('reserved')
+  return markers.length === 0 ? '' : ` [${markers.join(', ')}]`
+}
+
+function renderActionRow(row: KeybindingEditorRow, selected: boolean, width: number): string {
+  const marker = selected ? color.primary('›') : ' '
+  const labelText = `${row.label}${statusMarkers(row)}`
+  const valueText = row.disabled ? 'Disabled' : formatEditorBindings(row.effective)
+  const available = Math.max(1, width - 2)
+  const leftWidth = Math.min(available, Math.max(18, Math.floor(available * 0.57)))
+  const left = truncateToWidth(labelText, leftWidth)
+  const right = truncateToWidth(valueText, Math.max(1, available - visibleWidth(left) - 2))
+  const gap = ' '.repeat(Math.max(2, available - visibleWidth(left) - visibleWidth(right)))
+  const styledLeft = selected ? color.textStrong(left) : color.text(left)
+  const styledRight = row.conflict ? color.warning(right) : color.textDim(right)
+  return truncateToWidth(`${marker} ${styledLeft}${gap}${styledRight}`, Math.max(1, width))
+}
+
+function renderLeaderRow(model: KeybindingEditorModel, selected: boolean, width: number): string {
+  const marker = selected ? color.primary('›') : ' '
+  const ignored = model.leader.safeMode && model.leader.customized
+  const value = ignored
+    ? 'Ignored by safe mode'
+    : model.leader.key === undefined
+      ? 'Not configured'
+      : formatKeyId(model.leader.key)
+  const suffix = model.leader.customized ? ' *' : ''
+  const text = `${marker} ${selected ? color.textStrong('Leader key') : color.text('Leader key')}${suffix}  ${color.textDim(value)}`
+  return truncateToWidth(text, Math.max(1, width))
+}
+
+export class KeybindingEditorPanel implements Component {
+  private model: KeybindingEditorModel
+  private readonly runMutation: KeybindingMutationRunner
+  private readonly onClose: () => void
+  private readonly onModelChange: (model: KeybindingEditorModel) => void
+  private readonly onDispose: () => void
+  private readonly requestRender: () => void
+  private readonly maxRows: () => number
+  private query = ''
+  private selectedId = 'leader'
+  private selectedIndex = 0
+  private actionEditor: ActionEditorPanel | undefined
+  private leaderRecorder: KeyRecorder | undefined
+  private leaderEditing = false
+  private leaderPending = false
+  private mutationGeneration = 0
+  private disposed = false
+  private message: string | undefined
+
+  constructor(options: KeybindingEditorPanelOptions) {
+    this.model = options.model
+    this.runMutation = options.runMutation
+    this.onClose = options.onClose
+    this.onModelChange = options.onModelChange ?? (() => {})
+    this.onDispose = options.onDispose ?? (() => {})
+    this.requestRender = options.requestRender ?? (() => {})
+    this.maxRows = options.maxRows ?? (() => 18)
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width)
+    if (this.actionEditor !== undefined) return this.actionEditor.render(safeWidth)
+    if (this.leaderEditing) return this.renderLeaderEditor(safeWidth)
+
+    const lines: string[] = [
+      color.textStrong('Keyboard shortcuts'),
+      color.textDim(`Search actions, descriptions, IDs, categories, or keys · ${this.model.summary}`),
+      `${color.text('Search: ')}${this.query === '' ? color.textDim('type to filter') : color.text(this.query)}`,
+      '',
+    ]
+    const entries = this.displayEntries()
+    const selectable = this.selectableEntries(entries)
+    this.ensureSelection(selectable)
+    const selectedDisplayIndex = entries.findIndex(entry => this.isSelectedEntry(entry))
+    // Reserve space for the bottom hint and both possible scroll markers;
+    // the hint must remain visible even when the list is longer than the
+    // terminal viewport.
+    const listBudget = Math.max(1, this.maxRows() - lines.length - 4)
+    const start = Math.max(0, Math.min(
+      Math.max(0, selectedDisplayIndex - Math.floor(listBudget / 2)),
+      Math.max(0, entries.length - listBudget),
+    ))
+    const end = Math.min(entries.length, start + listBudget)
+    if (entries.length === 0) {
+      lines.push(color.textDim('No matching shortcuts.'))
+    } else {
+      for (const entry of entries.slice(start, end)) {
+        if (entry.kind === 'header') lines.push(color.textStrong(entry.label))
+        else if (entry.kind === 'leader') lines.push(renderLeaderRow(this.model, this.selectedId === 'leader', safeWidth))
+        else lines.push(renderActionRow(entry.row, this.selectedId === entry.row.id, safeWidth))
+      }
+    }
+    if (start > 0) lines.push(color.textDim(`↑ ${start} more`))
+    if (end < entries.length) lines.push(color.textDim(`↓ ${entries.length - end} more`))
+    if (this.message !== undefined) lines.push(color.error(truncateToWidth(this.message, safeWidth)))
+    lines.push('', color.textDim('Enter: details · type: search · ↑↓: move · Esc: close'))
+    return lines.slice(0, Math.max(1, this.maxRows()))
+  }
+
+  handleInput(data: string): void {
+    if (this.disposed) return
+    if (this.actionEditor !== undefined) {
+      this.actionEditor.handleInput(data)
+      return
+    }
+    if (this.leaderEditing) {
+      this.handleLeaderInput(data)
+      return
+    }
+    if (matchesKey(data, 'escape')) {
+      if (this.query !== '') {
+        this.query = ''
+        this.selectedId = 'leader'
+        this.selectedIndex = 0
+        this.message = undefined
+        this.requestRender()
+      } else {
+        this.dispose()
+        this.onClose()
+      }
+      return
+    }
+    const selectable = this.selectableEntries(this.displayEntries())
+    this.ensureSelection(selectable)
+    if (matchesKey(data, 'up')) {
+      this.moveSelection(-1, selectable)
+      return
+    }
+    if (matchesKey(data, 'down')) {
+      this.moveSelection(1, selectable)
+      return
+    }
+    if (matchesKey(data, 'pageUp')) {
+      this.moveSelection(-Math.max(1, this.maxRows() - 6), selectable)
+      return
+    }
+    if (matchesKey(data, 'pageDown')) {
+      this.moveSelection(Math.max(1, this.maxRows() - 6), selectable)
+      return
+    }
+    if (matchesKey(data, 'backspace')) {
+      if (this.query !== '') {
+        this.query = this.query.slice(0, -1)
+        this.selectedId = 'leader'
+        this.selectedIndex = 0
+        this.requestRender()
+      }
+      return
+    }
+    if (matchesKey(data, 'enter') || data === '\n' || data === '\r') {
+      this.openSelected(selectable)
+      return
+    }
+    const chunk = printableChunk(data)
+    if (chunk !== undefined) {
+      this.query += chunk
+      this.selectedId = 'leader'
+      this.selectedIndex = 0
+      this.message = undefined
+      this.requestRender()
+    }
+  }
+
+  invalidate(): void {
+    this.actionEditor?.invalidate?.()
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.mutationGeneration += 1
+    this.actionEditor?.dispose?.()
+    this.actionEditor = undefined
+    this.leaderRecorder = undefined
+    this.onDispose()
+  }
+
+  private displayEntries(): readonly ListEntry[] {
+    const matches = searchKeybindingRows(this.model.rows, this.query)
+    const matchedRows = new Set(matches.map(match => match.row.id))
+    const entries: ListEntry[] = []
+    if (searchMatchesLeader(this.model.leader, this.query)) entries.push({ kind: 'leader', id: 'leader' })
+    for (const section of this.model.sections) {
+      const rows = section.rows.filter(row => matchedRows.has(row.id))
+      if (rows.length === 0) continue
+      entries.push({ kind: 'header', label: section.category })
+      for (const row of rows) entries.push({ kind: 'action', row })
+    }
+    return entries
+  }
+
+  private selectableEntries(entries: readonly ListEntry[]): readonly ListEntry[] {
+    return entries.filter(entry => entry.kind !== 'header')
+  }
+
+  private isSelectedEntry(entry: ListEntry): boolean {
+    return entry.kind === 'leader' ? this.selectedId === 'leader' : entry.kind === 'action' && this.selectedId === entry.row.id
+  }
+
+  private ensureSelection(selectable: readonly ListEntry[]): void {
+    if (selectable.length === 0) {
+      this.selectedIndex = 0
+      return
+    }
+    const existing = selectable.findIndex(entry => this.isSelectedEntry(entry))
+    if (existing >= 0) {
+      this.selectedIndex = existing
+      return
+    }
+    this.selectedIndex = Math.min(this.selectedIndex, selectable.length - 1)
+    this.selectedId = this.entryId(selectable[this.selectedIndex]!)
+  }
+
+  private entryId(entry: ListEntry): string {
+    return entry.kind === 'leader' ? 'leader' : entry.kind === 'action' ? entry.row.id : ''
+  }
+
+  private moveSelection(delta: number, selectable: readonly ListEntry[]): void {
+    if (selectable.length === 0) return
+    this.ensureSelection(selectable)
+    const next = (this.selectedIndex + delta) % selectable.length
+    this.selectedIndex = next < 0 ? next + selectable.length : next
+    this.selectedId = this.entryId(selectable[this.selectedIndex]!)
+    this.message = undefined
+    this.requestRender()
+  }
+
+  private openSelected(selectable: readonly ListEntry[]): void {
+    this.ensureSelection(selectable)
+    const selected = selectable[this.selectedIndex]
+    if (selected === undefined) return
+    if (selected.kind === 'leader') {
+      this.leaderEditing = true
+      this.message = undefined
+      this.requestRender()
+      return
+    }
+    if (selected.kind !== 'action') return
+    this.actionEditor = new ActionEditorPanel({
+      model: this.model,
+      action: selected.row,
+      runMutation: this.runMutation,
+      onModelChange: model => this.applyModel(model),
+      onBack: () => {
+        this.actionEditor?.dispose()
+        this.actionEditor = undefined
+        this.requestRender()
+      },
+      requestRender: this.requestRender,
+      maxRows: this.maxRows,
+    })
+    this.requestRender()
+  }
+
+  private renderLeaderEditor(width: number): string[] {
+    if (this.leaderRecorder !== undefined) return this.leaderRecorder.render(width)
+    const safeMode = this.model.leader.safeMode
+    const ignored = safeMode && this.model.leader.customized
+    const current = ignored
+      ? 'Ignored by safe mode'
+      : this.model.leader.key === undefined
+        ? 'Not configured'
+        : formatKeyId(this.model.leader.key)
+    const lines = [
+      color.textStrong('Keyboard shortcuts › Leader key'),
+      '',
+      color.text('A leader key prefixes multi-key shortcuts.'),
+      color.textDim(`Current: ${current}`),
+      ...(safeMode
+        ? [color.warning(ignored
+          ? 'Safe mode ignores persisted keyboard shortcuts.'
+          : 'Safe mode disables leader shortcut editing.')]
+        : []),
+      '',
+      ...(safeMode
+        ? [color.textDim('Esc: back')]
+        : [color.accent('Enter: record a new leader key'), color.textDim('r: reset leader key · Esc: back')]),
+    ]
+    if (this.leaderPending) lines.push(color.accent('Saving…'))
+    if (this.message !== undefined) lines.push(color.error(truncateToWidth(this.message, width)))
+    return lines.slice(0, Math.max(1, this.maxRows()))
+  }
+
+  private handleLeaderInput(data: string): void {
+    if (this.leaderRecorder !== undefined) {
+      this.leaderRecorder.handleInput(data)
+      return
+    }
+    if (this.leaderPending) return
+    if (matchesKey(data, 'escape')) {
+      this.leaderEditing = false
+      this.message = undefined
+      this.requestRender()
+      return
+    }
+    if (this.model.leader.safeMode) {
+      this.message = 'Safe mode ignores persisted keyboard shortcuts.'
+      this.requestRender()
+      return
+    }
+    if (commandKey(data, 'r')) {
+      this.startLeaderMutation({ kind: 'set-leader', key: undefined })
+      return
+    }
+    if (matchesKey(data, 'enter') || data === '\n' || data === '\r') {
+      this.leaderRecorder = new KeyRecorder({
+        purpose: 'leader-key',
+        label: 'the global leader key',
+        onCapture: key => {
+          this.leaderRecorder = undefined
+          if (!this.disposed) this.startLeaderMutation({ kind: 'set-leader', key })
+        },
+        onCancel: () => {
+          this.leaderRecorder = undefined
+          if (!this.disposed) this.requestRender()
+        },
+        requestRender: this.requestRender,
+      })
+      this.message = undefined
+      this.requestRender()
+    }
+  }
+
+  private startLeaderMutation(mutation: KeybindingMutation): void {
+    if (this.disposed) return
+    if (this.model.leader.safeMode) {
+      this.message = 'Safe mode ignores persisted keyboard shortcuts.'
+      this.requestRender()
+      return
+    }
+    const generation = ++this.mutationGeneration
+    this.leaderPending = true
+    this.message = undefined
+    this.requestRender()
+    try {
+      this.runMutation(
+        mutation,
+        result => this.applyLeaderResult(generation, result),
+        error => this.applyLeaderError(generation, error),
+      )
+    } catch (error) {
+      this.applyLeaderError(generation, error)
+    }
+  }
+
+  private applyLeaderResult(generation: number, result: KeybindingMutationResult): void {
+    if (this.disposed || generation !== this.mutationGeneration) return
+    this.leaderPending = false
+    if (result.kind !== 'applied') {
+      this.message = result.message
+      this.requestRender()
+      return
+    }
+    this.applyModel(result.model)
+    this.message = result.message
+    this.requestRender()
+  }
+
+  private applyLeaderError(generation: number, error: unknown): void {
+    if (this.disposed || generation !== this.mutationGeneration) return
+    this.leaderPending = false
+    this.message = error instanceof Error ? error.message : 'Could not save keyboard shortcuts.'
+    this.requestRender()
+  }
+
+  private applyModel(model: KeybindingEditorModel): void {
+    this.model = model
+    this.onModelChange(model)
+    this.requestRender()
+  }
+}
+
+export function keybindingEditorLeaderKey(model: KeybindingEditorModel): KeyId | undefined {
+  return model.leader.key
+}
+
+export function keybindingEditorSummary(model: KeybindingEditorModel): string {
+  return model.summary
+}
+
+export function keybindingEditorMutationResultMessage(result: KeybindingMutationResult): string {
+  return result.kind === 'applied' ? result.message : result.message
+}
+
+/** A safe submenu fallback when the ConfigPort cannot be read. */
+export class KeybindingEditorUnavailablePanel implements Component {
+  private readonly onClose: () => void
+
+  constructor(onClose: () => void) {
+    this.onClose = onClose
+  }
+
+  render(width: number): string[] {
+    return [
+      truncateToWidth(color.textStrong('Keyboard shortcuts unavailable'), Math.max(1, width)),
+      '',
+      truncateToWidth(color.error('The settings service could not be read.'), Math.max(1, width)),
+      truncateToWidth(color.textDim('Esc: back'), Math.max(1, width)),
+    ]
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, 'escape')) this.onClose()
+  }
+
+  invalidate(): void {}
+}

--- a/src/keybinding-ui/list.ts
+++ b/src/keybinding-ui/list.ts
@@ -50,16 +50,31 @@ function printableChunk(data: string): string | undefined {
 function statusMarkers(row: KeybindingEditorRow): string {
   const markers: string[] = []
   if (row.customized) markers.push('*')
+  if (row.status === 'safe-mode') markers.push('safe mode')
+  if (row.status === 'unbound') markers.push('unbound')
   if (row.conflict) markers.push('!')
   if (row.fixed) markers.push('fixed')
   if (row.reserved) markers.push('reserved')
   return markers.length === 0 ? '' : ` [${markers.join(', ')}]`
 }
 
+function rowBindingText(row: KeybindingEditorRow): string {
+  const ordinary = row.effective.filter(binding => !row.conditional.some(candidate =>
+    candidate.kind === binding.kind && candidate.key === binding.key))
+  const parts: string[] = []
+  if (ordinary.length > 0) parts.push(formatEditorBindings(ordinary))
+  if (row.conditional.length > 0) {
+    parts.push(row.conditional
+      .map(binding => `${formatKeyId(binding.key)} (conditional)`)
+      .join(' / '))
+  }
+  return parts.join(' / ') || 'Unbound'
+}
+
 function renderActionRow(row: KeybindingEditorRow, selected: boolean, width: number): string {
   const marker = selected ? color.primary('›') : ' '
   const labelText = `${row.label}${statusMarkers(row)}`
-  const valueText = row.disabled ? 'Disabled' : formatEditorBindings(row.effective)
+  const valueText = row.disabled ? 'Disabled' : rowBindingText(row)
   const available = Math.max(1, width - 2)
   const leftWidth = Math.min(available, Math.max(18, Math.floor(available * 0.57)))
   const left = truncateToWidth(labelText, leftWidth)
@@ -119,6 +134,12 @@ export class KeybindingEditorPanel implements Component {
 
     const lines: string[] = [
       color.textStrong('Keyboard shortcuts'),
+      ...(this.model.leader.safeMode
+        ? [
+          color.warning('Safe mode is active. Custom shortcuts are ignored.'),
+          color.textDim('Editing is disabled until safe mode is turned off.'),
+        ]
+        : []),
       color.textDim(`Search actions, descriptions, IDs, categories, or keys · ${this.model.summary}`),
       `${color.text('Search: ')}${this.query === '' ? color.textDim('type to filter') : color.text(this.query)}`,
       '',

--- a/src/keybinding-ui/list.ts
+++ b/src/keybinding-ui/list.ts
@@ -247,6 +247,7 @@ export class KeybindingEditorPanel implements Component {
     this.mutationGeneration += 1
     this.actionEditor?.dispose?.()
     this.actionEditor = undefined
+    this.leaderRecorder?.dispose()
     this.leaderRecorder = undefined
     this.onDispose()
   }

--- a/src/keybinding-ui/model.ts
+++ b/src/keybinding-ui/model.ts
@@ -43,6 +43,9 @@ export interface KeybindingEditorRow {
   readonly configured: readonly KeybindingEditorBinding[]
   readonly effective: readonly KeybindingEditorBinding[]
   readonly defaults: readonly KeybindingEditorBinding[]
+  /** Context-gated composition affordances, not ordinary direct defaults. */
+  readonly conditional: readonly KeybindingEditorBinding[]
+  readonly conditionalDescription: string | undefined
   readonly diagnostics: readonly string[]
   /** Search fields retain their semantic origin so tests and future UI can
    * explain why a row matched without re-parsing its display text. */
@@ -199,10 +202,11 @@ export function buildKeybindingEditorModel(
     const userValue = parsed.bindings[definition.id]
     const customized = owns(parsed.bindings, definition.id)
     const disabled = !safeMode && userValue === false
-    const direct = manager.keysFor(definition.id)
+    const directKeys = manager.keysFor(definition.id)
+    const conditionalKeys = manager.conditionalKeysFor(definition.id)
     const leader = manager.leaderKeysFor(definition.id)
     const effective: KeybindingEditorBinding[] = [
-      ...direct.map(key => ({ kind: 'direct' as const, key })),
+      ...directKeys.map(key => ({ kind: 'direct' as const, key })),
       ...leader.map(key => ({ kind: 'leader' as const, key })),
     ]
     const configured = directBindings(userValue).concat(
@@ -210,6 +214,12 @@ export function buildKeybindingEditorModel(
         .filter(binding => binding.action === definition.id)
         .map(binding => ({ kind: 'leader' as const, key: binding.key })),
     )
+    const configuredDirectKeys = new Set(
+      configured.filter(binding => binding.kind === 'direct').map(binding => binding.key),
+    )
+    const conditional = conditionalKeys
+      .filter(key => !configuredDirectKeys.has(key))
+      .map(key => ({ kind: 'direct' as const, key }))
     // Capturing-scope fixed actions are deliberately absent from the Host
     // keymap. Their defaults remain their effective fixed triggers.
     if (!disabled && !definition.configurable && effective.length === 0) {
@@ -254,6 +264,12 @@ export function buildKeybindingEditorModel(
       configured,
       effective,
       defaults,
+      conditional,
+      conditionalDescription: conditional.length === 0
+        ? undefined
+        : definition.id === 'app.tasks.open'
+          ? 'when the editor is empty and tasks are active'
+          : 'when its context is active',
       diagnostics,
       searchFields: {
         label: labelFor(definition),

--- a/src/keybinding-ui/model.ts
+++ b/src/keybinding-ui/model.ts
@@ -214,11 +214,7 @@ export function buildKeybindingEditorModel(
         .filter(binding => binding.action === definition.id)
         .map(binding => ({ kind: 'leader' as const, key: binding.key })),
     )
-    const configuredDirectKeys = new Set(
-      configured.filter(binding => binding.kind === 'direct').map(binding => binding.key),
-    )
     const conditional = conditionalKeys
-      .filter(key => !configuredDirectKeys.has(key))
       .map(key => ({ kind: 'direct' as const, key }))
     // Capturing-scope fixed actions are deliberately absent from the Host
     // keymap. Their defaults remain their effective fixed triggers.

--- a/src/keybinding-ui/model.ts
+++ b/src/keybinding-ui/model.ts
@@ -42,7 +42,11 @@ export interface KeybindingEditorRow {
    * editor never treats an untouched builtin as a removable override. */
   readonly configured: readonly KeybindingEditorBinding[]
   readonly effective: readonly KeybindingEditorBinding[]
+  /** All definition defaults, retained for reset/reference/search display. */
   readonly defaults: readonly KeybindingEditorBinding[]
+  /** Definition defaults that are still effective direct runtime keys and can
+   * be materialized safely by the first edit of an untouched action. */
+  readonly editableDefaults: readonly KeybindingEditorBinding[]
   /** Context-gated composition affordances, not ordinary direct defaults. */
   readonly conditional: readonly KeybindingEditorBinding[]
   readonly conditionalDescription: string | undefined
@@ -216,6 +220,8 @@ export function buildKeybindingEditorModel(
     )
     const conditional = conditionalKeys
       .map(key => ({ kind: 'direct' as const, key }))
+    const ordinaryEffective = effective.filter(binding => !conditional.some(candidate =>
+      candidate.kind === binding.kind && candidate.key === binding.key))
     // Capturing-scope fixed actions are deliberately absent from the Host
     // keymap. Their defaults remain their effective fixed triggers.
     if (!disabled && !definition.configurable && effective.length === 0) {
@@ -225,6 +231,11 @@ export function buildKeybindingEditorModel(
     const diagnostics = manager.diagnosticsList().filter(message => message.includes(definition.id))
     const conflict = conflictFor(definition.id, snapshot, diagnostics)
     const reserved = definition.availability === 'reserved'
+    const editableDefaults = !customized && definition.configurable
+      ? definition.defaultKeys
+        .filter(key => directKeys.includes(key))
+        .map(key => ({ kind: 'direct' as const, key }))
+      : []
     const status: KeybindingEditorRowStatus = safeMode && customized
       ? 'safe-mode'
       : disabled
@@ -235,7 +246,7 @@ export function buildKeybindingEditorModel(
             ? 'reserved'
             : !definition.configurable
               ? 'fixed'
-              : configured.length === 0 && definition.defaultKeys.length === 0
+              : !customized && ordinaryEffective.length === 0
                 ? 'unbound'
                 : customized
                   ? 'customized'
@@ -260,6 +271,7 @@ export function buildKeybindingEditorModel(
       configured,
       effective,
       defaults,
+      editableDefaults,
       conditional,
       conditionalDescription: conditional.length === 0
         ? undefined

--- a/src/keybinding-ui/model.ts
+++ b/src/keybinding-ui/model.ts
@@ -1,0 +1,353 @@
+/**
+ * Presentation-only model for the Keyboard Shortcuts Editor.
+ *
+ * The effective keymap remains owned by HostKeybindingManager. This module
+ * combines that runtime projection with the raw parsed user declaration so a
+ * UI can distinguish defaults, overrides, disabled actions, and conflicts
+ * without guessing from effective keys alone.
+ */
+
+import { APP_KEYBINDINGS } from '../keybindings/definitions.ts'
+import { formatKeyId, formatLeaderSequence } from '../keybindings/hints.ts'
+import type { HostKeybindingManager } from '../keybindings/manager.ts'
+import type { ParsedUserKeybindings } from '../keybindings/config.ts'
+import type { KeyId } from '@xmoon76/pi-tui'
+import type { AppKeybindingDefinition, AppKeybindingId, KeybindingSource } from '../keybindings/types.ts'
+
+export type KeybindingEditorBindingKind = 'direct' | 'leader'
+
+export interface KeybindingEditorBinding {
+  readonly kind: KeybindingEditorBindingKind
+  readonly key: KeyId
+}
+
+export type KeybindingEditorRowStatus = 'default' | 'customized' | 'disabled' | 'conflict' | 'fixed' | 'reserved' | 'safe-mode' | 'unbound'
+
+export interface KeybindingEditorRow {
+  readonly id: AppKeybindingId
+  readonly label: string
+  readonly description: string
+  readonly category: string
+  readonly scope: AppKeybindingDefinition['scope']
+  readonly configurable: boolean
+  readonly fixed: boolean
+  readonly reserved: boolean
+  readonly customized: boolean
+  readonly disabled: boolean
+  readonly safeMode: boolean
+  readonly conflict: boolean
+  readonly status: KeybindingEditorRowStatus
+  readonly source: KeybindingSource
+  /** Parsed user declarations, kept separate from effective defaults so the
+   * editor never treats an untouched builtin as a removable override. */
+  readonly configured: readonly KeybindingEditorBinding[]
+  readonly effective: readonly KeybindingEditorBinding[]
+  readonly defaults: readonly KeybindingEditorBinding[]
+  readonly diagnostics: readonly string[]
+  /** Search fields retain their semantic origin so tests and future UI can
+   * explain why a row matched without re-parsing its display text. */
+  readonly searchFields: Readonly<{
+    readonly label: string
+    readonly description: string
+    readonly action: string
+    readonly category: string
+    readonly effective: string
+    readonly defaults: string
+  }>
+}
+
+export interface KeybindingEditorSection {
+  readonly category: string
+  readonly rows: readonly KeybindingEditorRow[]
+}
+
+export interface KeybindingEditorLeader {
+  readonly key: KeyId | undefined
+  readonly customized: boolean
+  readonly safeMode: boolean
+}
+
+export interface KeybindingEditorModel {
+  readonly available: true
+  readonly rows: readonly KeybindingEditorRow[]
+  readonly sections: readonly KeybindingEditorSection[]
+  readonly leader: KeybindingEditorLeader
+  readonly diagnostics: readonly string[]
+  readonly customizedCount: number
+  readonly disabledCount: number
+  readonly conflictCount: number
+  readonly summary: string
+}
+
+const LABELS: Readonly<Partial<Record<AppKeybindingId, string>>> = {
+  'app.input.submit': 'Submit draft',
+  'app.input.steer': 'Steer running turn',
+  'app.input.queue': 'Queue draft while busy',
+  'app.input.dequeue': 'Pull queued draft back',
+  'app.agent.interrupt': 'Interrupt active turn',
+  'app.exit.request': 'Quit the TUI',
+  'app.transcript.search': 'Search transcript',
+  'app.transcript.search.next': 'Next search match',
+  'app.transcript.search.previous': 'Previous search match',
+  'app.transcript.search.close': 'Close transcript search',
+  'app.transcript.toggleExpand': 'Expand or collapse recent output',
+  'app.transcript.toggleThinking': 'Show or hide thinking blocks',
+  'app.transcript.toggleFullscreen': 'Toggle fullscreen mode',
+  'app.editor.external': 'Edit draft in external editor',
+  'app.clipboard.pasteMedia': 'Paste media from clipboard',
+  'app.permission.cycle': 'Cycle permission preset',
+  'app.todo.toggle': 'Toggle todo panel',
+  'app.tasks.open': 'Open task browser',
+  'app.history.search': 'Search input history',
+  'app.shell.dismissSettled': 'Dismiss settled shell cards',
+  'app.model.open': 'Open model picker',
+  'question.confirm': 'Confirm question',
+  'question.cancel': 'Cancel question',
+  'question.cursorUp': 'Move question selection up',
+  'question.cursorDown': 'Move question selection down',
+  'question.pageUp': 'Page question list up',
+  'question.pageDown': 'Page question list down',
+  'question.toggleExpand': 'Expand question details',
+  'tasks.confirm': 'Confirm selected task',
+  'tasks.cancel': 'Close task browser',
+  'tasks.cursorUp': 'Move task selection up',
+  'tasks.cursorDown': 'Move task selection down',
+  'tasks.pageUp': 'Page task list up',
+  'tasks.pageDown': 'Page task list down',
+  'tasks.cycleType': 'Cycle task type filter',
+  'tasks.interrupt': 'Interrupt selected task',
+}
+
+function labelFor(definition: AppKeybindingDefinition): string {
+  return LABELS[definition.id] ?? definition.id
+}
+
+function owns<T extends object>(object: T, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function directBindings(value: unknown): KeybindingEditorBinding[] {
+  if (value === false || value === undefined) return []
+  const values = Array.isArray(value) ? value : [value]
+  return values
+    .filter((value): value is KeyId => typeof value === 'string')
+    .map(key => ({ kind: 'direct' as const, key }))
+}
+
+function sourceFor(
+  definition: AppKeybindingDefinition,
+  snapshot: ReturnType<HostKeybindingManager['snapshot']>,
+  effective: readonly KeybindingEditorBinding[],
+  customized: boolean,
+): KeybindingSource {
+  const snapshotBinding = snapshot.bindings.find(binding => binding.action === definition.id)
+  if (snapshotBinding !== undefined) return snapshotBinding.source
+  if (effective.some(binding => binding.kind === 'leader') || customized) return 'user'
+  return 'builtin'
+}
+
+function displayBindings(bindings: readonly KeybindingEditorBinding[]): string {
+  return bindings
+    .map(binding => binding.kind === 'leader' ? formatLeaderSequence(binding.key) : formatKeyId(binding.key))
+    .join(' / ')
+}
+
+function searchValue(bindings: readonly KeybindingEditorBinding[]): string {
+  return bindings
+    .flatMap(binding => [binding.key, binding.kind, binding.kind === 'leader' ? formatLeaderSequence(binding.key) : formatKeyId(binding.key)])
+    .join(' ')
+}
+
+function conflictFor(
+  action: AppKeybindingId,
+  snapshot: ReturnType<HostKeybindingManager['snapshot']>,
+  diagnostics: readonly string[],
+): boolean {
+  if (snapshot.conflicts.some(conflict => conflict.actions.some(entry => entry.action === action))) return true
+  return diagnostics.some(message => message.includes(action) && (message.includes('conflict') || message.includes('ambiguous')))
+}
+
+function sectionize(rows: readonly KeybindingEditorRow[]): KeybindingEditorSection[] {
+  const sections: KeybindingEditorSection[] = []
+  const byCategory = new Map<string, KeybindingEditorRow[]>()
+  for (const row of rows) {
+    const existing = byCategory.get(row.category)
+    if (existing === undefined) {
+      const next: KeybindingEditorRow[] = [row]
+      byCategory.set(row.category, next)
+      sections.push({ category: row.category, rows: next })
+    } else {
+      existing.push(row)
+    }
+  }
+  return sections
+}
+
+export function formatEditorBindings(bindings: readonly KeybindingEditorBinding[]): string {
+  return displayBindings(bindings) || 'Unbound'
+}
+
+export function buildKeybindingEditorModel(
+  manager: HostKeybindingManager,
+  parsed: ParsedUserKeybindings,
+): KeybindingEditorModel {
+  const snapshot = manager.snapshot()
+  const safeMode = manager.isSafeMode()
+  const rows: KeybindingEditorRow[] = []
+
+  for (const definition of Object.values(APP_KEYBINDINGS)) {
+    const userValue = parsed.bindings[definition.id]
+    const customized = owns(parsed.bindings, definition.id)
+    const disabled = !safeMode && userValue === false
+    const direct = manager.keysFor(definition.id)
+    const leader = manager.leaderKeysFor(definition.id)
+    const effective: KeybindingEditorBinding[] = [
+      ...direct.map(key => ({ kind: 'direct' as const, key })),
+      ...leader.map(key => ({ kind: 'leader' as const, key })),
+    ]
+    const configured = directBindings(userValue).concat(
+      parsed.leaderBindings
+        .filter(binding => binding.action === definition.id)
+        .map(binding => ({ kind: 'leader' as const, key: binding.key })),
+    )
+    // Capturing-scope fixed actions are deliberately absent from the Host
+    // keymap. Their defaults remain their effective fixed triggers.
+    if (!disabled && !definition.configurable && effective.length === 0) {
+      effective.push(...definition.defaultKeys.map(key => ({ kind: 'direct' as const, key })))
+    }
+    const defaults = definition.defaultKeys.map(key => ({ kind: 'direct' as const, key }))
+    const diagnostics = manager.diagnosticsList().filter(message => message.includes(definition.id))
+    const conflict = conflictFor(definition.id, snapshot, diagnostics)
+    const reserved = definition.availability === 'reserved'
+    const status: KeybindingEditorRowStatus = safeMode && customized
+      ? 'safe-mode'
+      : disabled
+        ? 'disabled'
+        : conflict
+          ? 'conflict'
+          : reserved
+            ? 'reserved'
+            : !definition.configurable
+              ? 'fixed'
+              : configured.length === 0 && definition.defaultKeys.length === 0
+                ? 'unbound'
+                : customized
+                  ? 'customized'
+                  : 'default'
+    const effectiveText = searchValue(effective)
+    const defaultText = searchValue(defaults)
+    rows.push({
+      id: definition.id,
+      label: labelFor(definition),
+      description: definition.description,
+      category: definition.category,
+      scope: definition.scope,
+      configurable: definition.configurable,
+      fixed: !definition.configurable,
+      reserved,
+      customized,
+      disabled,
+      safeMode,
+      conflict,
+      status,
+      source: sourceFor(definition, snapshot, effective, customized),
+      configured,
+      effective,
+      defaults,
+      diagnostics,
+      searchFields: {
+        label: labelFor(definition),
+        description: definition.description,
+        action: definition.id,
+        category: definition.category,
+        effective: effectiveText,
+        defaults: defaultText,
+      },
+    })
+  }
+
+  const leader: KeybindingEditorLeader = {
+    // Safe mode intentionally ignores the persisted leader together with all
+    // other user bindings; exposing it as current would invite an edit that
+    // cannot affect runtime dispatch.
+    key: safeMode ? undefined : parsed.leader?.key,
+    customized: parsed.leader !== undefined,
+    safeMode,
+  }
+  const sections = sectionize(rows)
+  const customizedCount = rows.filter(row => row.customized).length
+  const disabledCount = rows.filter(row => row.disabled).length
+  const conflictCount = rows.filter(row => row.conflict).length
+  const summaryParts: string[] = []
+  if (customizedCount > 0) summaryParts.push(`${customizedCount} customized`)
+  if (disabledCount > 0) summaryParts.push(`${disabledCount} disabled`)
+  if (conflictCount > 0) summaryParts.push(`${conflictCount} conflict${conflictCount === 1 ? '' : 's'}`)
+  const summary = summaryParts.length > 0 ? summaryParts.join(' · ') : 'Defaults'
+
+  return {
+    available: true,
+    rows,
+    sections,
+    leader,
+    diagnostics: [...parsed.diagnostics, ...manager.diagnosticsList()],
+    customizedCount,
+    disabledCount,
+    conflictCount,
+    summary,
+  }
+}
+
+export interface KeybindingSearchMatch {
+  readonly row: KeybindingEditorRow
+  readonly fields: readonly string[]
+}
+
+/** Search labels, descriptions, action IDs, categories, effective keys, and
+ * defaults. All terms must match, while the original definition order stays
+ * stable. */
+export function searchKeybindingRows(
+  rows: readonly KeybindingEditorRow[],
+  query: string,
+): readonly KeybindingSearchMatch[] {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+  if (terms.length === 0) return rows.map(row => ({ row, fields: [] }))
+  const fieldsFor = (row: KeybindingEditorRow): Readonly<Record<string, string>> => ({
+    label: row.searchFields.label,
+    description: row.searchFields.description,
+    action: row.searchFields.action,
+    category: row.searchFields.category,
+    effective: row.searchFields.effective,
+    defaults: row.searchFields.defaults,
+  })
+  const matches: KeybindingSearchMatch[] = []
+  for (const row of rows) {
+    const fields = fieldsFor(row)
+    const matchedFields = Object.entries(fields)
+      .filter(([, value]) => terms.some(term => value.toLowerCase().includes(term)))
+      .map(([name]) => name)
+    const matchesAllTerms = terms.every(term => Object.values(fields).some(value => value.toLowerCase().includes(term)))
+    if (matchesAllTerms) matches.push({ row, fields: matchedFields })
+  }
+  return matches
+}
+
+export function searchMatchesLeader(
+  leader: KeybindingEditorLeader,
+  query: string,
+): boolean {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+  if (terms.length === 0) return true
+  const text = ['leader', 'leader key', leader.key === undefined ? 'unbound' : leader.key, leader.key === undefined ? '' : formatKeyId(leader.key)].join(' ').toLowerCase()
+  return terms.every(term => text.includes(term))
+}
+
+export function editorBindingsFor(
+  action: AppKeybindingId,
+  parsed: ParsedUserKeybindings,
+): readonly KeybindingEditorBinding[] {
+  const direct = directBindings(parsed.bindings[action])
+  const leader = parsed.leaderBindings
+    .filter(binding => binding.action === action)
+    .map(binding => ({ kind: 'leader' as const, key: binding.key }))
+  return [...direct, ...leader]
+}

--- a/src/keybinding-ui/recorder.ts
+++ b/src/keybinding-ui/recorder.ts
@@ -2,7 +2,7 @@
 
 import { isKeyRelease, isKeyRepeat, matchesKey, parseKey, truncateToWidth, type Component } from '@xmoon76/pi-tui'
 import { canonicalizeKeyId, isRuntimeBindableKeyId, isTextProducingKeyId, isValidKeyId } from '../keybindings/key-identity.ts'
-import { isEditorSubmitPreSubmitKey, isTerminalAmbiguousKeyId } from '../keybindings/config.ts'
+import { isEditorSubmitPreSubmitKey, isPhysicalEscapeAction, isTerminalAmbiguousKeyId } from '../keybindings/config.ts'
 import type { KeyId } from '@xmoon76/pi-tui'
 import type { AppKeybindingId } from '../keybindings/types.ts'
 import { color } from '../theme.ts'
@@ -45,6 +45,9 @@ export function validateRecordedKey(
   }
   if (options.purpose === 'leader-completion' && key === 'escape') {
     return { key: undefined, message: 'Escape cancels a leader sequence and cannot be a completion.' }
+  }
+  if (key === 'escape' && (options.action === undefined || !isPhysicalEscapeAction(options.action))) {
+    return { key: undefined, message: 'Physical Escape is reserved for the Host lifecycle path.' }
   }
   if (options.action === 'app.input.submit' && options.purpose !== 'leader-completion') {
     if (key === 'shift+enter') {
@@ -91,7 +94,9 @@ export class KeyRecorder implements Component {
         ? color.accent('Waiting for one key…')
         : color.error(this.error),
       '',
-      color.textDim(this.purpose === 'direct' ? 'Esc: cancel · e: use Escape' : 'Esc: cancel'),
+      color.textDim(this.purpose === 'direct' && this.action === 'app.agent.interrupt'
+        ? 'Esc: cancel · e: use Escape'
+        : 'Esc: cancel'),
     ]
     return lines.map(line => truncateToWidth(line, safeWidth))
   }
@@ -104,11 +109,18 @@ export class KeyRecorder implements Component {
     // the active editor overlay and must never reach the host editor.
     if (isKeyRelease(data) || isKeyRepeat(data)) return
     // Raw Escape is the recorder's cancel gesture. Offer an explicit
-    // disambiguated command so a direct action can still express the legal
-    // unmodified Escape KeyId without making the cancel path unreachable.
-    if (this.purpose === 'direct' && data.length === 1 && data.toLowerCase() === 'e') {
+    // disambiguated command so the lifecycle interrupt action can retain its
+    // legal unmodified Escape KeyId without making the cancel path unreachable.
+    if (this.purpose === 'direct' && this.action === 'app.agent.interrupt'
+      && data.length === 1 && data.toLowerCase() === 'e') {
+      const validation = validateRecordedKey('escape', { purpose: this.purpose, action: this.action })
+      if (validation.key === undefined) {
+        this.error = validation.message
+        this.requestRender()
+        return
+      }
       try {
-        this.onCapture('escape')
+        this.onCapture(validation.key)
       } catch {
         this.error = 'The shortcut could not be recorded. Try again.'
         this.requestRender()

--- a/src/keybinding-ui/recorder.ts
+++ b/src/keybinding-ui/recorder.ts
@@ -1,0 +1,134 @@
+/** A focused raw-input recorder for one semantic keybinding. */
+
+import { isKeyRelease, isKeyRepeat, matchesKey, parseKey, truncateToWidth, type Component } from '@xmoon76/pi-tui'
+import { canonicalizeKeyId, isRuntimeBindableKeyId, isTextProducingKeyId, isValidKeyId } from '../keybindings/key-identity.ts'
+import { isEditorSubmitPreSubmitKey, isTerminalAmbiguousKeyId } from '../keybindings/config.ts'
+import type { KeyId } from '@xmoon76/pi-tui'
+import type { AppKeybindingId } from '../keybindings/types.ts'
+import { color } from '../theme.ts'
+
+export type KeyRecorderPurpose = 'direct' | 'leader-completion' | 'leader-key'
+
+export interface KeyRecorderOptions {
+  readonly purpose: KeyRecorderPurpose
+  readonly action?: AppKeybindingId
+  readonly label: string
+  readonly onCapture: (key: KeyId) => void
+  readonly onCancel: () => void
+  readonly requestRender?: () => void
+}
+
+export interface KeyRecorderValidation {
+  readonly key: KeyId | undefined
+  readonly message: string | undefined
+}
+
+/** Validate the canonical key policy shared by the config parser and the
+ * plugin registry before a recorded value reaches the mutation controller. */
+export function validateRecordedKey(
+  rawKey: string,
+  options: { readonly purpose: KeyRecorderPurpose; readonly action?: AppKeybindingId },
+): KeyRecorderValidation {
+  if (!isValidKeyId(rawKey)) return { key: undefined, message: 'This key combination is not recognized.' }
+  const key = canonicalizeKeyId(rawKey as KeyId)
+  if (!isRuntimeBindableKeyId(key)) {
+    return { key: undefined, message: 'This key cannot be matched reliably by the current terminal.' }
+  }
+  // A completion is read only after the leader prefix has armed the
+  // state-machine, so printable letters are safe there. Direct bindings and
+  // the prefix itself must still never swallow ordinary typing.
+  if (options.purpose !== 'leader-completion' && isTextProducingKeyId(key)) {
+    return { key: undefined, message: 'Printable keys are reserved for typing.' }
+  }
+  if (isTerminalAmbiguousKeyId(key)) {
+    return { key: undefined, message: 'This key is indistinguishable from a fixed terminal key on legacy terminals.' }
+  }
+  if (options.purpose === 'leader-completion' && key === 'escape') {
+    return { key: undefined, message: 'Escape cancels a leader sequence and cannot be a completion.' }
+  }
+  if (options.action === 'app.input.submit' && options.purpose !== 'leader-completion') {
+    if (key === 'shift+enter') {
+      return { key: undefined, message: 'Shift+Enter is reserved for inserting a newline.' }
+    }
+    if (isEditorSubmitPreSubmitKey(key)) {
+      return { key: undefined, message: 'The editor consumes this key before submit can see it.' }
+    }
+  }
+  return { key, message: undefined }
+}
+
+export class KeyRecorder implements Component {
+  private readonly purpose: KeyRecorderPurpose
+  private readonly action: AppKeybindingId | undefined
+  private readonly label: string
+  private readonly onCapture: (key: KeyId) => void
+  private readonly onCancel: () => void
+  private readonly requestRender: () => void
+  private error: string | undefined
+
+  constructor(options: KeyRecorderOptions) {
+    this.purpose = options.purpose
+    this.action = options.action
+    this.label = options.label
+    this.onCapture = options.onCapture
+    this.onCancel = options.onCancel
+    this.requestRender = options.requestRender ?? (() => {})
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, width)
+    const lines = [
+      color.textStrong('Record shortcut'),
+      '',
+      color.text(`Press a key for ${this.label}.`),
+      color.textDim(this.purpose === 'leader-key'
+        ? 'This key becomes the global leader prefix.'
+        : this.purpose === 'leader-completion'
+          ? 'This key completes the leader sequence.'
+          : 'The key is parsed from the terminal and stored canonically.'),
+      '',
+      this.error === undefined
+        ? color.accent('Waiting for one key…')
+        : color.error(this.error),
+      '',
+      color.textDim('Esc: cancel'),
+    ]
+    return lines.map(line => truncateToWidth(line, safeWidth))
+  }
+
+  invalidate(): void {}
+
+  handleInput(data: string): void {
+    if (data === '') return
+    // Release/repeat reports are not a second binding. They are consumed by
+    // the active editor overlay and must never reach the host editor.
+    if (isKeyRelease(data) || isKeyRepeat(data)) return
+    if (matchesKey(data, 'escape')) {
+      this.onCancel()
+      return
+    }
+    let parsed: string | undefined
+    try {
+      parsed = parseKey(data)
+    } catch {
+      parsed = undefined
+    }
+    if (parsed === undefined) {
+      this.error = 'Press one recognizable shortcut, not text or a pasted sequence.'
+      this.requestRender()
+      return
+    }
+    const validation = validateRecordedKey(parsed, { purpose: this.purpose, action: this.action })
+    if (validation.key === undefined) {
+      this.error = validation.message
+      this.requestRender()
+      return
+    }
+    try {
+      this.onCapture(validation.key)
+    } catch {
+      this.error = 'The shortcut could not be recorded. Try again.'
+      this.requestRender()
+    }
+  }
+}

--- a/src/keybinding-ui/recorder.ts
+++ b/src/keybinding-ui/recorder.ts
@@ -9,6 +9,20 @@ import { color } from '../theme.ts'
 
 export type KeyRecorderPurpose = 'direct' | 'leader-completion' | 'leader-key'
 
+/** The short disambiguation window for assigning physical Escape. */
+export const DOUBLE_ESCAPE_MS = 300
+
+/** Injectable timer operations keep recorder lifecycle tests deterministic. */
+export interface KeyRecorderTimer {
+  readonly set: (callback: () => void, delayMs: number) => unknown
+  readonly clear: (handle: unknown) => void
+}
+
+const DEFAULT_TIMER: KeyRecorderTimer = {
+  set: (callback, delayMs) => setTimeout(callback, delayMs),
+  clear: handle => clearTimeout(handle as ReturnType<typeof setTimeout>),
+}
+
 export interface KeyRecorderOptions {
   readonly purpose: KeyRecorderPurpose
   readonly action?: AppKeybindingId
@@ -16,6 +30,7 @@ export interface KeyRecorderOptions {
   readonly onCapture: (key: KeyId) => void
   readonly onCancel: () => void
   readonly requestRender?: () => void
+  readonly timer?: KeyRecorderTimer
 }
 
 export interface KeyRecorderValidation {
@@ -67,7 +82,11 @@ export class KeyRecorder implements Component {
   private readonly onCapture: (key: KeyId) => void
   private readonly onCancel: () => void
   private readonly requestRender: () => void
+  private readonly timer: KeyRecorderTimer
   private error: string | undefined
+  private escapePending = false
+  private escapeTimer: unknown
+  private disposed = false
 
   constructor(options: KeyRecorderOptions) {
     this.purpose = options.purpose
@@ -76,10 +95,12 @@ export class KeyRecorder implements Component {
     this.onCapture = options.onCapture
     this.onCancel = options.onCancel
     this.requestRender = options.requestRender ?? (() => {})
+    this.timer = options.timer ?? DEFAULT_TIMER
   }
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width)
+    const interruptDirect = this.purpose === 'direct' && this.action === 'app.agent.interrupt'
     const lines = [
       color.textStrong('Record shortcut'),
       '',
@@ -91,11 +112,13 @@ export class KeyRecorder implements Component {
           : 'The key is parsed from the terminal and stored canonically.'),
       '',
       this.error === undefined
-        ? color.accent('Waiting for one key…')
+        ? color.accent(interruptDirect && this.escapePending
+          ? 'Esc again to assign Escape…'
+          : 'Waiting for one key…')
         : color.error(this.error),
       '',
-      color.textDim(this.purpose === 'direct' && this.action === 'app.agent.interrupt'
-        ? 'Esc: cancel · e: use Escape'
+      color.textDim(interruptDirect
+        ? 'Esc: cancel · double-Esc: assign Escape'
         : 'Esc: cancel'),
     ]
     return lines.map(line => truncateToWidth(line, safeWidth))
@@ -103,34 +126,83 @@ export class KeyRecorder implements Component {
 
   invalidate(): void {}
 
+  /** Stop the pending Escape disambiguation callback before the parent panel
+   * is torn down. Timer callbacks also check this flag for late safety. */
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.clearEscapeTimer()
+    this.escapePending = false
+  }
+
+  private isInterruptDirect(): boolean {
+    return this.purpose === 'direct' && this.action === 'app.agent.interrupt'
+  }
+
+  private clearEscapeTimer(): void {
+    if (this.escapeTimer !== undefined) this.timer.clear(this.escapeTimer)
+    this.escapeTimer = undefined
+  }
+
+  private expirePendingEscape(): void {
+    this.escapeTimer = undefined
+    if (this.disposed || !this.escapePending) return
+    this.escapePending = false
+    this.onCancel()
+  }
+
+  private capture(key: KeyId): void {
+    try {
+      this.onCapture(key)
+    } catch {
+      this.error = 'The shortcut could not be recorded. Try again.'
+      this.requestRender()
+    }
+  }
+
+  private beginEscapeDisambiguation(): void {
+    this.error = undefined
+    this.escapePending = true
+    this.escapeTimer = this.timer.set(() => this.expirePendingEscape(), DOUBLE_ESCAPE_MS)
+    this.requestRender()
+  }
+
   handleInput(data: string): void {
-    if (data === '') return
+    if (this.disposed || data === '') return
     // Release/repeat reports are not a second binding. They are consumed by
     // the active editor overlay and must never reach the host editor.
     if (isKeyRelease(data) || isKeyRepeat(data)) return
-    // Raw Escape is the recorder's cancel gesture. Offer an explicit
-    // disambiguated command so the lifecycle interrupt action can retain its
-    // legal unmodified Escape KeyId without making the cancel path unreachable.
-    if (this.purpose === 'direct' && this.action === 'app.agent.interrupt'
-      && data.length === 1 && data.toLowerCase() === 'e') {
-      const validation = validateRecordedKey('escape', { purpose: this.purpose, action: this.action })
-      if (validation.key === undefined) {
-        this.error = validation.message
-        this.requestRender()
+
+    if (matchesKey(data, 'escape')) {
+      if (!this.isInterruptDirect()) {
+        this.onCancel()
         return
       }
-      try {
-        this.onCapture(validation.key)
-      } catch {
-        this.error = 'The shortcut could not be recorded. Try again.'
-        this.requestRender()
+      if (this.escapePending) {
+        this.clearEscapeTimer()
+        this.escapePending = false
+        const validation = validateRecordedKey('escape', { purpose: this.purpose, action: this.action })
+        if (validation.key === undefined) {
+          this.error = validation.message
+          this.requestRender()
+          return
+        }
+        this.capture(validation.key)
+      } else {
+        this.beginEscapeDisambiguation()
       }
       return
     }
-    if (matchesKey(data, 'escape')) {
+
+    // The first Escape expresses cancel intent. Any other key during its
+    // short pending window cancels the recorder and is not captured.
+    if (this.escapePending) {
+      this.clearEscapeTimer()
+      this.escapePending = false
       this.onCancel()
       return
     }
+
     let parsed: string | undefined
     try {
       parsed = parseKey(data)
@@ -148,11 +220,6 @@ export class KeyRecorder implements Component {
       this.requestRender()
       return
     }
-    try {
-      this.onCapture(validation.key)
-    } catch {
-      this.error = 'The shortcut could not be recorded. Try again.'
-      this.requestRender()
-    }
+    this.capture(validation.key)
   }
 }

--- a/src/keybinding-ui/recorder.ts
+++ b/src/keybinding-ui/recorder.ts
@@ -91,7 +91,7 @@ export class KeyRecorder implements Component {
         ? color.accent('Waiting for one key…')
         : color.error(this.error),
       '',
-      color.textDim('Esc: cancel'),
+      color.textDim(this.purpose === 'direct' ? 'Esc: cancel · e: use Escape' : 'Esc: cancel'),
     ]
     return lines.map(line => truncateToWidth(line, safeWidth))
   }
@@ -103,6 +103,18 @@ export class KeyRecorder implements Component {
     // Release/repeat reports are not a second binding. They are consumed by
     // the active editor overlay and must never reach the host editor.
     if (isKeyRelease(data) || isKeyRepeat(data)) return
+    // Raw Escape is the recorder's cancel gesture. Offer an explicit
+    // disambiguated command so a direct action can still express the legal
+    // unmodified Escape KeyId without making the cancel path unreachable.
+    if (this.purpose === 'direct' && data.length === 1 && data.toLowerCase() === 'e') {
+      try {
+        this.onCapture('escape')
+      } catch {
+        this.error = 'The shortcut could not be recorded. Try again.'
+        this.requestRender()
+      }
+      return
+    }
     if (matchesKey(data, 'escape')) {
       this.onCancel()
       return

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -372,32 +372,6 @@ export function parseUserKeybindings(
     }
   }
 
-  // The leader machine runs after the editor-owned submit seam for focused
-  // editors. Reject completions that the current effective submit binding
-  // would consume before the machine can see them (Enter by default, or a
-  // parsed user remap). This is done after all entries are parsed so nested
-  // and top-level declarations share the same policy.
-  const submitValue = bindings['app.input.submit']
-  const submitKeys = submitValue === false
-    ? new Set<KeyId>()
-    : submitValue === undefined
-      ? leaderOnlyActions.has('app.input.submit')
-        ? new Set<KeyId>()
-        : new Set(APP_KEYBINDINGS['app.input.submit'].defaultKeys)
-      : new Set(Array.isArray(submitValue) ? submitValue : [submitValue])
-  const usableLeaderBindings = leaderBindings.filter(binding => {
-    if (!submitKeys.has(binding.key)) return true
-    diagnostics.push(`keybindings: "${binding.action}" binds a "<leader>${binding.key}" sequence, but ${binding.key} is an editor-owned submit key — ignored`)
-    return false
-  })
-  if (usableLeaderBindings.length !== leaderBindings.length) {
-    leaderBindings.length = 0
-    leaderBindings.push(...usableLeaderBindings)
-    for (const action of leaderOnlyActions) {
-      if (!leaderBindings.some(binding => binding.action === action)) leaderOnlyActions.delete(action)
-    }
-  }
-
   // A leader sequence without a leader key is inert: warn once.
   if (leaderBindings.length > 0 && leader === undefined) {
     diagnostics.push('keybindings: leader sequences configured but no "leader" key — the sequences are ignored')

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -61,6 +61,12 @@ const EDITOR_PRE_SUBMIT_KEYS = new Set(
   [...EDITOR_OWNED_KEY_IDS].filter(key => !EDITOR_POST_SUBMIT_KEYS.has(key)),
 )
 
+/** Whether the fork editor consumes a key before the submit action can see
+ * it. The interactive editor shares this derived inventory with the parser. */
+export function isEditorSubmitPreSubmitKey(key: KeyId): boolean {
+  return EDITOR_PRE_SUBMIT_KEYS.has(canonicalizeKeyId(key))
+}
+
 /** Whether a key is a PLAIN (unmodified) printable — the strict subset of
  * {@link isTextProducingKeyId} with no modifier at all (plan §14). The
  * parser rejects the BROADER text-producing set (shift-only printables
@@ -222,7 +228,7 @@ export function parseUserKeybindings(
   }
 
   for (const [actionId, value] of entries) {
-    if (!(actionId in APP_KEYBINDINGS)) {
+    if (!Object.prototype.hasOwnProperty.call(APP_KEYBINDINGS, actionId)) {
       diagnostics.push(`keybindings: unknown action "${actionId}" — ignored`)
       continue
     }

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -381,7 +381,9 @@ export function parseUserKeybindings(
   const submitKeys = submitValue === false
     ? new Set<KeyId>()
     : submitValue === undefined
-      ? new Set(APP_KEYBINDINGS['app.input.submit'].defaultKeys)
+      ? leaderOnlyActions.has('app.input.submit')
+        ? new Set<KeyId>()
+        : new Set(APP_KEYBINDINGS['app.input.submit'].defaultKeys)
       : new Set(Array.isArray(submitValue) ? submitValue : [submitValue])
   const usableLeaderBindings = leaderBindings.filter(binding => {
     if (!submitKeys.has(binding.key)) return true

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -44,6 +44,13 @@ export const LEADER_PREFIX = '<leader>'
  * for callers of the parser module). */
 export { isValidKeyId }
 
+/** Physical Escape is reserved for the Host lifecycle path (overlay close,
+ * shell exit, interrupt/double-cancel). Only the lifecycle action itself may
+ * declare it; every other action would otherwise steal that path. */
+export function isPhysicalEscapeAction(action: string): boolean {
+  return action === 'app.agent.interrupt'
+}
+
 /** The FORK EDITOR's UNCONDITIONAL PRE-SUBMIT keys — DERIVED from the
  * shared {@link EDITOR_OWNED_KEY_IDS} inventory minus the POST-SUBMIT
  * keys (packages/pi-tui components/editor.ts handleInput dispatch
@@ -185,6 +192,8 @@ export function parseUserKeybindings(
         diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — the runtime can never match this modifier combination (F-keys and Escape take no modifiers; Clear takes only Shift/Ctrl) — ignored`)
       } else if (isTextProducingKeyId(canonicalLeader)) {
         diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — a text-producing leader would swallow typing — ignored`)
+      } else if (canonicalLeader === 'escape') {
+        diagnostics.push(`keybindings: invalid leader key "${String(leaderValue)}" — physical Escape is reserved for the Host lifecycle path — ignored`)
       } else if (TERMINAL_AMBIGUOUS_KEY_IDS.has(canonicalLeader)) {
         // Legacy terminal collisions are REJECTED for the leader prefix too
         // (convergence finding): a leader on ctrl+[ / ctrl+j / ctrl+m would
@@ -293,6 +302,10 @@ export function parseUserKeybindings(
       // never bypass the printable guard or the collision sets — the raw
       // spelling is only used in the diagnostic text.
       const canonicalEntry = canonicalizeKeyId(entry as KeyId)
+      if (canonicalEntry === 'escape' && !isPhysicalEscapeAction(actionId)) {
+        diagnostics.push(`keybindings: "${actionId}" cannot bind "${entry}" — physical Escape is reserved for the Host lifecycle path — ignored`)
+        continue
+      }
       // RUNTIME-BINDABLE GATE (round-22/24 finding): the fork matcher
       // can never match certain modifier combinations (F-keys/Escape
       // take no modifiers — keys.ts `modifier !== 0` → false; Clear
@@ -340,7 +353,8 @@ export function parseUserKeybindings(
       // while that overlay is open (e.g. the search toggle remapped to
       // Enter collides with search.next). The binding still works
       // outside the overlay; warned, never silently dropped.
-      if (FIXED_OVERLAY_KEYS.has(canonicalEntry)) {
+      if (FIXED_OVERLAY_KEYS.has(canonicalEntry)
+        && !(canonicalEntry === 'escape' && isPhysicalEscapeAction(actionId))) {
         diagnostics.push(`keybindings: "${actionId}" binds "${entry}", which a non-configurable overlay owns while it is open — the overlay wins there`)
       }
       keys.push(canonicalEntry)

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -372,6 +372,30 @@ export function parseUserKeybindings(
     }
   }
 
+  // The leader machine runs after the editor-owned submit seam for focused
+  // editors. Reject completions that the current effective submit binding
+  // would consume before the machine can see them (Enter by default, or a
+  // parsed user remap). This is done after all entries are parsed so nested
+  // and top-level declarations share the same policy.
+  const submitValue = bindings['app.input.submit']
+  const submitKeys = submitValue === false
+    ? new Set<KeyId>()
+    : submitValue === undefined
+      ? new Set(APP_KEYBINDINGS['app.input.submit'].defaultKeys)
+      : new Set(Array.isArray(submitValue) ? submitValue : [submitValue])
+  const usableLeaderBindings = leaderBindings.filter(binding => {
+    if (!submitKeys.has(binding.key)) return true
+    diagnostics.push(`keybindings: "${binding.action}" binds a "<leader>${binding.key}" sequence, but ${binding.key} is an editor-owned submit key — ignored`)
+    return false
+  })
+  if (usableLeaderBindings.length !== leaderBindings.length) {
+    leaderBindings.length = 0
+    leaderBindings.push(...usableLeaderBindings)
+    for (const action of leaderOnlyActions) {
+      if (!leaderBindings.some(binding => binding.action === action)) leaderOnlyActions.delete(action)
+    }
+  }
+
   // A leader sequence without a leader key is inert: warn once.
   if (leaderBindings.length > 0 && leader === undefined) {
     diagnostics.push('keybindings: leader sequences configured but no "leader" key — the sequences are ignored')

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -556,6 +556,14 @@ export class EffectiveKeymap {
       rule.action === action && rule.owner === 'editor' && rule.source === 'user')
   }
 
+  /** The visible conditional/composition keys of one action. These are
+   * context-gated affordances rather than ordinary user-editable defaults. */
+  conditionalKeysFor(action: string): KeyId[] {
+    return [...new Set(this.visibleRules
+      .filter(rule => rule.action === action && rule.source === 'composition')
+      .map(rule => rule.key))]
+  }
+
   /** The primary (first) effective key of one action, or undefined. */
   primaryKeyFor(action: string): KeyId | undefined {
     const keys = this.keysFor(action)

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -442,6 +442,19 @@ export class EffectiveKeymap {
     return [...keys]
   }
 
+  /** Every ACTIVE key of one action, including a lower-priority rule that is
+   * shadowed in the ordinary read projection. The physical Escape lifecycle
+   * seam uses this to remain enabled when malformed injected state contains
+   * an ordinary Escape binding; parser-valid user remaps still remove the
+   * builtin rule from this active set. */
+  activeKeysFor(action: string): KeyId[] {
+    const keys = new Set<KeyId>()
+    for (const rule of this.activeRules) {
+      if (rule.action === action) keys.add(rule.key)
+    }
+    return [...keys]
+  }
+
   /** Every ACTIVE key of the HOST-owned sources only (builtin / user /
    * composition — PLUGIN and EDITOR rules excluded). The runtime
    * reservation and the leader-prefix collision check must consider only

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -557,10 +557,19 @@ export class EffectiveKeymap {
   }
 
   /** The visible conditional/composition keys of one action. These are
-   * context-gated affordances rather than ordinary user-editable defaults. */
+   * context-gated affordances rather than ordinary user-editable defaults.
+   * A user rule inherits its action's composition predicate, and may dedupe
+   * the synthesized composition rule when it uses the same key, so source
+   * alone cannot identify every conditional trigger. */
   conditionalKeysFor(action: string): KeyId[] {
+    const compositionKeys = new Set(this.compositionRules
+      .filter(composition => composition.action === action)
+      .map(composition => canonicalizeKeyId(composition.key)))
+    if (compositionKeys.size === 0) return []
     return [...new Set(this.visibleRules
-      .filter(rule => rule.action === action && rule.source === 'composition')
+      .filter(rule => rule.action === action
+        && compositionKeys.has(rule.key)
+        && (rule.source === 'composition' || rule.predicate !== undefined))
       .map(rule => rule.key))]
   }
 

--- a/src/keybindings/effective-keymap.ts
+++ b/src/keybindings/effective-keymap.ts
@@ -556,21 +556,21 @@ export class EffectiveKeymap {
       rule.action === action && rule.owner === 'editor' && rule.source === 'user')
   }
 
-  /** The visible conditional/composition keys of one action. These are
-   * context-gated affordances rather than ordinary user-editable defaults.
-   * A user rule inherits its action's composition predicate, and may dedupe
-   * the synthesized composition rule when it uses the same key, so source
-   * alone cannot identify every conditional trigger. */
+  /** The conditional/composition keys of one action. These are context-gated
+   * affordance metadata rather than ordinary user-editable defaults. Keep the
+   * projection independent of active rules: a conflicting user rule can
+   * deactivate both the user and synthesized composition rules, but the UI
+   * still needs to explain that the declared Down trigger is conditional.
+   * Explicit `false` remains the sole way to remove the affordance. */
   conditionalKeysFor(action: string): KeyId[] {
-    const compositionKeys = new Set(this.compositionRules
+    const definition = this.definitions[action]
+    if (definition === undefined) return []
+    if (this.includeScopes !== undefined && !this.includeScopes.has(definition.scope)) return []
+    const userValue = this.safeMode ? undefined : this.userBindings[action as AppKeybindingId]
+    if (userValue === false) return []
+    return [...new Set(this.compositionRules
       .filter(composition => composition.action === action)
-      .map(composition => canonicalizeKeyId(composition.key)))
-    if (compositionKeys.size === 0) return []
-    return [...new Set(this.visibleRules
-      .filter(rule => rule.action === action
-        && compositionKeys.has(rule.key)
-        && (rule.source === 'composition' || rule.predicate !== undefined))
-      .map(rule => rule.key))]
+      .map(composition => canonicalizeKeyId(composition.key)))]
   }
 
   /** The primary (first) effective key of one action, or undefined. */

--- a/src/keybindings/key-identity.ts
+++ b/src/keybindings/key-identity.ts
@@ -66,11 +66,12 @@ export function isValidKeyId(value: string): value is KeyId {
   if (parts.length === 0) return false
   const base = parts[parts.length - 1]!
   if (!BASE_KEYS_LOWER.has(base.toLowerCase())) return false
-  for (let index = 0; index < parts.length - 1; index += 1) {
-    if (!KEY_ID_MODIFIERS.has(parts[index]!)) return false
+  const modifiers = parts.slice(0, -1).map(modifier => modifier.toLowerCase())
+  for (const modifier of modifiers) {
+    if (!KEY_ID_MODIFIERS.has(modifier)) return false
   }
-  // No duplicate modifiers.
-  return new Set(parts.slice(0, -1)).size === parts.length - 1
+  // No duplicate modifiers (case-insensitively).
+  return new Set(modifiers).size === modifiers.length
 }
 
 /** Whether a key is TEXT-PRODUCING — it types a character into the

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -121,10 +121,13 @@ export class HostKeybindingManager {
     this.onEditorSubmitSync(this.editorSubmitKeysFor())
   }
 
-  private buildKeymap(): EffectiveKeymap {
+  private buildKeymap(
+    userBindings: UserKeybindingsConfig = this.userBindings,
+    onDiagnostic: (message: string) => void = message => this.diagnostics.push(message),
+  ): EffectiveKeymap {
     return new EffectiveKeymap({
       definitions: APP_KEYBINDINGS,
-      userBindings: this.safeMode ? {} : this.userBindings,
+      userBindings: this.safeMode ? {} : userBindings,
       pluginRules: this.pluginRules,
       compositionRules: [TASKS_OPEN_AFFORDANCE],
       safeMode: this.safeMode,
@@ -133,7 +136,7 @@ export class HostKeybindingManager {
       // overlay keys live in their own contexts (plan §3.3) and must never
       // resolve in the host ladder.
       includeScopes: new Set(['global', 'editor', 'agent-running']),
-      onDiagnostic: (message) => this.diagnostics.push(message),
+      onDiagnostic,
     })
   }
 
@@ -145,9 +148,61 @@ export class HostKeybindingManager {
     // including the leader key and its sequences (a leader sequence is a
     // user override; safe mode must restore the builtin surface).
     const effectiveLeaderConfig = this.safeMode ? undefined : this.leaderConfig
-    const effectiveLeaderBindings = this.safeMode
+    const configuredLeaderBindings = this.safeMode
       ? []
       : this.leaderBindings.filter(binding => this.userBindings[binding.action] !== false)
+
+    // Build a provisional map before creating the leader machine. The editor
+    // submit seam is an EFFECTIVE projection: it already accounts for user
+    // rules that are live, conflicted, shadowed, or absent. Do not infer this
+    // from the raw submit declaration (a conflicted remap can fall back to
+    // builtin Enter, while a shadowed builtin can disappear).
+    const provisionalDiagnostics: string[] = []
+    const provisionalKeymap = this.buildKeymap(
+      this.userBindings,
+      message => provisionalDiagnostics.push(message),
+    )
+    const provisionalSubmitKeys = new Set(provisionalKeymap.editorKeysFor('app.input.submit'))
+    const deadLeaderOnlyActions = new Set<AppKeybindingId>()
+    const deadLeaderPairs = new Set<string>()
+    const filteredLeaderBindings = configuredLeaderBindings.filter(binding => {
+      if (!provisionalSubmitKeys.has(binding.key)) return true
+      const pair = `${binding.action}\u0000${binding.key}`
+      if (!deadLeaderPairs.has(pair)) {
+        deadLeaderPairs.add(pair)
+        this.diagnostics.push(
+          `keybinding: <leader>${formatKeyId(binding.key)} for ${binding.action} is unavailable because ${formatKeyId(binding.key)} is an effective editor submit key — ignored`,
+        )
+      }
+      return false
+    })
+    for (const action of new Set(configuredLeaderBindings.map(binding => binding.action))) {
+      const configured = this.userBindings[action]
+      if (Array.isArray(configured) && configured.length === 0
+        && configuredLeaderBindings.some(binding => binding.action === action)
+        && !filteredLeaderBindings.some(binding => binding.action === action)) {
+        // A leader-only marker is a full replacement declaration. If every
+        // completion is dead because the effective submit seam consumes it,
+        // remove the marker for the final map so the builtin survives.
+        deadLeaderOnlyActions.add(action)
+      }
+    }
+
+    let finalKeymap = provisionalKeymap
+    let finalDiagnostics = provisionalDiagnostics
+    if (deadLeaderOnlyActions.size > 0) {
+      const restoredUserBindings = { ...this.userBindings }
+      for (const action of deadLeaderOnlyActions) delete restoredUserBindings[action]
+      const rebuiltDiagnostics: string[] = []
+      finalKeymap = this.buildKeymap(
+        restoredUserBindings,
+        message => rebuiltDiagnostics.push(message),
+      )
+      finalDiagnostics = rebuiltDiagnostics
+    }
+    this.keymap = finalKeymap
+    this.diagnostics.push(...finalDiagnostics)
+
     // Leader bindings: a duplicate completing key across DIFFERENT
     // actions is ambiguous — neither fires (plan §6 M6: ambiguous prefix
     // is a diagnostic). Identical (action, key) pairs are DEDUPED first
@@ -156,7 +211,7 @@ export class HostKeybindingManager {
     // never fires either.
     const seenPairs = new Set<string>()
     const byKey = new Map<KeyId, LeaderBinding[]>()
-    for (const binding of effectiveLeaderBindings) {
+    for (const binding of filteredLeaderBindings) {
       const pair = `${binding.action}\u0000${binding.key}`
       if (seenPairs.has(pair)) continue
       seenPairs.add(pair)
@@ -174,7 +229,6 @@ export class HostKeybindingManager {
       }
       leaderBindings.push(list[0]!)
     }
-    this.keymap = this.buildKeymap()
     this.effectiveLeaderBindings = leaderBindings
     // Leader PREFIX collision (PR review finding + round-12 finding): the
     // leader key is fed BEFORE the host ladder AND before the plugin

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -397,6 +397,12 @@ export class HostKeybindingManager {
     return this.keymap.keysFor(action)
   }
 
+  /** The visible context-gated composition keys of one action, kept
+   * separate by the editor from ordinary direct bindings. */
+  conditionalKeysFor(action: AppKeybindingId): KeyId[] {
+    return this.keymap.conditionalKeysFor(action)
+  }
+
   /** Whether one raw input resolves to a HOST-owned action (PLUGIN rules
    * excluded — a plugin binding is not a Host action and must reach the
    * plugin dispatch stage; PR review finding). */

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -397,16 +397,13 @@ export class HostKeybindingManager {
     return this.safeMode
   }
 
-  /** Whether physical Escape should run the Host lifecycle seam. A malformed
-   * lower-priority/ordinary action must not shadow the builtin lifecycle key;
-   * only an explicit interrupt remap or disable changes this decision. */
+  /** Whether physical Escape should run the Host lifecycle seam. Derive this
+   * from the final effective map so fail-soft builtin restoration (including a
+   * dead leader-only interrupt declaration) cannot leave runtime and hints at
+   * odds. The active projection deliberately retains a reserved lifecycle
+   * builtin when malformed injected ordinary state shadows it. */
   physicalEscapeEnabled(): boolean {
-    if (this.safeMode) return true
-    const configured = this.userBindings['app.agent.interrupt']
-    if (configured === false) return false
-    if (configured === undefined) return true
-    const keys = Array.isArray(configured) ? configured : [configured]
-    return keys.includes('escape')
+    return this.keymap.activeKeysFor('app.agent.interrupt').includes('escape')
   }
 
   /** Replace the plugin contributions (the runner wires the keybinding

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -343,6 +343,18 @@ export class HostKeybindingManager {
     return this.safeMode
   }
 
+  /** Whether physical Escape should run the Host lifecycle seam. A malformed
+   * lower-priority/ordinary action must not shadow the builtin lifecycle key;
+   * only an explicit interrupt remap or disable changes this decision. */
+  physicalEscapeEnabled(): boolean {
+    if (this.safeMode) return true
+    const configured = this.userBindings['app.agent.interrupt']
+    if (configured === false) return false
+    if (configured === undefined) return true
+    const keys = Array.isArray(configured) ? configured : [configured]
+    return keys.includes('escape')
+  }
+
   /** Replace the plugin contributions (the runner wires the keybinding
    * registry's snapshot). A no-op when the rules are unchanged (the
    * runner may call this on every registry invalidation). */

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -45,6 +45,13 @@ const TASKS_OPEN_AFFORDANCE: CompositionRule = {
     && context.editorPromptMode && context.tasksActive,
 }
 
+export interface HostKeybindingPreflight {
+  /** The candidate's effective host projection, including conflicts. */
+  readonly snapshot: KeymapSnapshot
+  /** Diagnostics emitted while compiling the candidate. */
+  readonly diagnostics: readonly string[]
+}
+
 export interface HostKeybindingManagerOptions {
   /** Called after every rebuild (the app repaints hints/footer). */
   readonly onInvalidate?: () => void
@@ -295,6 +302,31 @@ export class HostKeybindingManager {
     this.leaderConfig = config.leader
     this.leaderBindings = config.leaderBindings
     this.rebuild()
+  }
+
+  /**
+   * Compile a candidate without changing this manager. This is the
+   * side-effect-free preflight used by the interactive editor: it carries
+   * over the live plugin rules and safe-mode policy, then disposes the
+   * temporary leader machine before returning.
+   */
+  preflight(config: {
+    readonly bindings: UserKeybindingsConfig
+    readonly leader: LeaderConfig | undefined
+    readonly leaderBindings: readonly LeaderBinding[]
+  }): HostKeybindingPreflight {
+    const preview = new HostKeybindingManager({ leaderTimeoutMs: this.leaderTimeoutMs })
+    try {
+      preview.setPluginRules(this.pluginRules)
+      preview.setSafeMode(this.safeMode)
+      preview.setUserConfiguration(config)
+      return {
+        snapshot: preview.snapshot(),
+        diagnostics: preview.diagnosticsList(),
+      }
+    } finally {
+      preview.dispose()
+    }
   }
 
   /** Safe mode (plan §17): ignore user overrides, keep builtin defaults.

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -73,6 +73,30 @@ export interface TuiSettingsDoc {
 export interface TuiSettingsConfig {
   get(): TuiSettingsDoc
   replace(doc: TuiSettingsDoc): unknown
+  /** Optional stable identity when several wrappers share one backend. */
+  readonly mutationQueueKey?: object
+}
+
+/**
+ * Serialize every whole-document TUI-settings transaction in this process.
+ * The port has no compare-and-swap token, so a queue keyed only by one wrapper
+ * object would still allow two adapters around the same backend to lose a
+ * get → modify → replace update. The shared fallback key closes that gap;
+ * future adapters may expose a stable object as `mutationQueueKey` when they
+ * need independent settings stores while preserving the same queue contract.
+ */
+const sharedTuiSettingsMutationKey = {}
+const tuiSettingsMutationQueues = new WeakMap<object, Promise<void>>()
+
+export function serializeTuiSettingsMutation<T>(
+  settings: TuiSettingsConfig,
+  task: () => T | PromiseLike<T>,
+): Promise<T> {
+  const key = settings.mutationQueueKey ?? sharedTuiSettingsMutationKey
+  const previous = tuiSettingsMutationQueues.get(key) ?? Promise.resolve()
+  const current = previous.catch(() => undefined).then(task)
+  tuiSettingsMutationQueues.set(key, current.then(() => undefined, () => undefined))
+  return current
 }
 
 /** The USER-layer footer-command trust read (M5, plan §17.4): whether the
@@ -95,6 +119,8 @@ export interface FooterCommandTrust {
 export interface TuiSettingsLike {
   get(): TuiSettingsDoc
   replace(doc: TuiSettingsDoc): unknown
+  /** Optional stable identity for shared-backend wrappers. */
+  readonly mutationQueueKey?: object
 }
 
 /** One /login credential target as the CLIENT sees it — a detached DTO

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -3191,9 +3191,11 @@ export class TuiApp {
         this.lastEscapeAt = undefined
         return routed
       }
-      // The plugin DECLINED Esc: continue through the host Esc fallback
-      // (shell-mode exit, double-Esc cancel) instead of dropping the
-      // key — a dropped Esc would never arm the cancel.
+      // The plugin DECLINED Esc. With an effective interrupt, continue
+      // through the Host fallback below; with a remapped interrupt, the
+      // replacement already received the event and it must not be delivered
+      // a second time by TuiBase's focused-component dispatch.
+      if (!includeInterrupt) return { consume: true }
     }
     // Shell-mode exit: the host editor in a shell mode with an EMPTY
     // body owns Esc — it cancels the shell mode (the double-Esc cancel

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2767,15 +2767,20 @@ export class TuiApp {
     // of Esc would trip the double-Esc cancel. The framework already filters
     // releases for the focused component; listeners are on their own.
     if (isKeyRelease(data) || isKeyRepeat(data)) return undefined
+    const physicalEscape = matchesKey(data, 'escape')
     // The double-action window is a CONSECUTIVE-press chord of the
     // EFFECTIVE interrupt trigger: any OTHER key between the two presses
-    // disarms it (review E12 — `Esc → Left → Esc` must not rewind;
-    // convergence §4 finding — after a remap, the physical Esc is just
-    // another key, so `Ctrl+X → Esc → Ctrl+X` must NOT fire the double
-    // action; the default Escape matches app.agent.interrupt naturally).
+    // disarms it (review E12 — `Esc → Left → Esc` must not rewind). Physical
+    // Escape is a lifecycle seam only while it remains effective for
+    // app.agent.interrupt; after a remap it is an intervening key and must
+    // disarm the remapped interrupt's double-action window.
     // Releases/repeats already returned above, so only genuine presses
     // reach this line.
-    if (!this.keybindings.matches(data, 'app.agent.interrupt')) this.lastEscapeAt = undefined
+    if (physicalEscape
+      ? !this.keybindings.physicalEscapeEnabled()
+      : !this.keybindings.matches(data, 'app.agent.interrupt')) {
+      this.lastEscapeAt = undefined
+    }
     if (this.activeQuestions !== undefined) {
       return this.handleQuestionKey(data)
     }
@@ -2890,6 +2895,7 @@ export class TuiApp {
     // owns it — so this seam stays physical: it is the focused-editor
     // contract, not a host shortcut.)
     if (this.seatEditor().handleInput !== undefined
+      && !matchesKey(data, 'escape')
       && this.isSubmitKey(data)) {
       this.editorSeatHolder.handleHostFallbackInput(data)
       return { consume: true }
@@ -2902,7 +2908,10 @@ export class TuiApp {
     // callback ALREADY dispatched the action (the manager wires it to
     // dispatchResolvedAction) — this branch only consumes the key.
     const leader = this.keybindings.leaderMachine()
-    if (leader !== undefined) {
+    // Physical Escape is reserved even against a malformed/injected leader
+    // configuration: an idle leader must not arm on Escape. A pending leader
+    // still receives Escape so its documented cancel-consume behavior wins.
+    if (leader !== undefined && !(physicalEscape && !leader.pending)) {
       const outcome = leader.feed(data)
       if (outcome.kind === 'consumed' || outcome.kind === 'cancelled-consume') {
         return { consume: true }
@@ -2915,6 +2924,17 @@ export class TuiApp {
       }
       // cancelled-pass: the pending state was cancelled; the key is
       // processed normally below.
+    }
+
+    // Physical Escape is a reserved lifecycle path, not a normal user action:
+    // route it after leader cancellation but before user keymap resolution.
+    // This keeps idle/busy/replacement-editor Escape behavior intact even if
+    // malformed or future state injects an ordinary action at the same key.
+    // If an editor seam declines it, returning undefined deliberately hands
+    // Escape to the focused component; it must never fall through to a user
+    // action that could steal lifecycle handling.
+    if (physicalEscape) {
+      return this.handleEscapeKey(data, this.keybindings.physicalEscapeEnabled())
     }
 
     // M1/M2: the host semantic action ladder. The keymap resolves the raw
@@ -3034,8 +3054,10 @@ export class TuiApp {
 
   /** Dispatch one resolved semantic action (plan §9). The Esc and exit
    * paths are the two context-heavy host paths and stay host methods,
-   * keyed by the ACTION — a user remap of app.agent.interrupt moves the
-   * whole Esc path to the new key. Returns whether the key was consumed. */
+   * keyed by the ACTION. Physical Escape always takes its lifecycle path;
+   * a user remap of app.agent.interrupt adds a semantic interrupt trigger
+   * whose remapped key bypasses physical-editor Escape seams. Returns whether
+   * the key was consumed. */
   private dispatchResolvedAction(action: AppKeybindingId, data: string, key?: KeyId): boolean {
     if (action === 'app.agent.interrupt') {
       // Convergence §5: the PHYSICAL Escape key runs the full
@@ -3129,20 +3151,19 @@ export class TuiApp {
     return { consume: true }
   }
 
-  /** The PHYSICAL Escape path (app.agent.interrupt on the escape key):
+  /** The PHYSICAL Escape path (when Escape is the effective interrupt key):
    * the editor-owned Escape seams (overlay pass-through, autocomplete
    * pass-through, replacement-editor Esc, shell-mode exit) run FIRST,
-   * then the semantic interrupt core. A REMAPPED interrupt key bypasses
-   * this and goes straight to {@link handleInterruptAction} (convergence
-   * §5 — only physical Escape owns the Escape-specific editor behavior).
-   * Returns undefined when the key must fall through. */
-  private handleEscapeKey(data: string): TuiInputListenerResult | undefined {
-    // The BUSY cancel keeps its Host-owned priority over EVERY physical
-    // Escape seam (shell-mode exit, replacement-editor Esc): a busy Esc
-    // must stop the agent, never vanish into a shell-mode exit or a
-    // plugin's modal handling (convergence §5 — the priority order is
-    // preserved from the pre-split ladder).
-    if (this.busy) {
+   * then the semantic interrupt core. When app.agent.interrupt is remapped,
+   * the same seams still get first refusal but the semantic core is skipped,
+   * preserving the remapped trigger's consecutive-press contract. Returns
+   * undefined when the key must fall through. */
+  private handleEscapeKey(data: string, includeInterrupt = true): TuiInputListenerResult | undefined {
+    // While Escape is the effective interrupt trigger, BUSY cancel keeps its
+    // Host-owned priority over EVERY physical Escape seam (shell-mode exit,
+    // replacement-editor Esc). A remapped interrupt intentionally bypasses
+    // this semantic core, just like its other physical-key distinctions.
+    if (includeInterrupt && this.busy) {
       this.lastEscapeAt = undefined
       this.events.onCancel?.()
       return { consume: true }
@@ -3183,7 +3204,9 @@ export class TuiApp {
     if (this.seatEditor().id === 'host' && this.editor.getInputMode() !== 'prompt' && this.seatEditor().getText() === '') {
       return undefined
     }
-    // After the physical-Escape editor seams, the semantic core runs.
+    // After the physical-Escape editor seams, the semantic core runs only
+    // while Escape is the effective interrupt trigger.
+    if (!includeInterrupt) return undefined
     return this.handleInterruptAction(data)
   }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1775,6 +1775,9 @@ export class TuiApp {
    * The broker owns the modal-stacking + question-suspension rules; the
    * host keeps the physical screen mounts. */
   private readonly overlayBroker: OverlayBroker
+  /** Client-local editor panels need explicit disposal when the physical
+   * overlay stack is torn down for a screen swap or final surface dispose. */
+  private readonly keybindingEditorPanels = new Set<Component>()
   /** M8: still-owned plugin overlay leases (closed by the final dispose —
    * plan §13.3: leases are generation-scoped). */
   private readonly extensionOverlayLeases = new Set<import('./extension/public-types.ts').TuiOverlayHandle>()
@@ -2518,6 +2521,7 @@ export class TuiApp {
     for (const pending of [...this.approvalQueue]) this.settleApproval(pending, 'cancelled')
     this.approvalQueue.length = 0
     if (this.activeApproval !== undefined) this.settleApproval(this.activeApproval, 'cancelled')
+    this.disposeTrackedKeybindingEditors()
     this.stop()
     this.generation += 1
     this.clearNotify()
@@ -3768,6 +3772,7 @@ export class TuiApp {
     if (enabled === active) return
     const pending = this.activeApproval
     pending?.handle?.hide()
+    this.disposeTrackedKeybindingEditors()
     // overlayHandles holds RAW handles (showOverlayOnHost stores them before
     // wrapping), so this loop calls the pi-tui hide directly: it removes
     // every overlay from the OLD screen's stack. The tracking graph below
@@ -9623,6 +9628,48 @@ export class TuiApp {
     }, { enableSearch: true })
     handle = this.showOverlayOnHost(new Frame(settings, true), { width: 72, maxHeight: 28 })
     return () => handle?.hide()
+  }
+
+  /** Track an action-first editor even when it is nested inside the
+   * SettingsList submenu rather than mounted as a standalone overlay. The
+   * returned unregister callback is idempotent. */
+  trackKeybindingEditor(panel: Component): () => void {
+    this.keybindingEditorPanels.add(panel)
+    let active = true
+    return () => {
+      if (!active) return
+      active = false
+      this.keybindingEditorPanels.delete(panel)
+    }
+  }
+
+  private disposeTrackedKeybindingEditors(): void {
+    const panels = [...this.keybindingEditorPanels]
+    this.keybindingEditorPanels.clear()
+    for (const panel of panels) panel.dispose?.()
+  }
+
+  /** Open the action-first Keyboard Shortcuts Editor in the standard overlay
+   * lifecycle. The panel owns its Esc hierarchy; this method owns the Frame
+   * mount and the final disposal. */
+  openKeybindingEditor(panel: Component): () => void {
+    let handle: OverlayHandle | undefined
+    const unregister = this.trackKeybindingEditor(panel)
+    const close = (): void => {
+      panel.dispose?.()
+      unregister()
+      handle?.hide()
+    }
+    handle = this.showOverlayOnHost(new Frame(panel, true), {
+      width: 88,
+      maxHeight: '100%',
+    })
+    return close
+  }
+
+  /** Content-row budget used by client-local editor overlays. */
+  keybindingEditorMaxRows(): number {
+    return Math.max(1, this.terminal.rows - 4)
   }
 
   /**

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -203,6 +203,20 @@ test('the space key is printable: rejected as a leader and as a direct binding',
   assert.deepEqual(chord.bindings, { 'app.todo.toggle': 'ctrl+space' })
 })
 
+test('physical Escape stays reserved for the Host lifecycle action', () => {
+  const stolen = parseUserKeybindings({ 'app.todo.toggle': 'escape' })
+  assert.deepEqual(stolen.bindings, {})
+  assert.ok(stolen.diagnostics.some(message => message.includes('physical Escape')))
+
+  const lifecycle = parseUserKeybindings({ 'app.agent.interrupt': 'escape' })
+  assert.deepEqual(lifecycle.bindings, { 'app.agent.interrupt': 'escape' })
+  assert.deepEqual(lifecycle.diagnostics, [])
+
+  const leader = parseUserKeybindings({ leader: 'escape', 'app.todo.toggle': '<leader>t' })
+  assert.equal(leader.leader, undefined)
+  assert.ok(leader.diagnostics.some(message => message.includes('physical Escape')))
+})
+
 test('legacy terminal collisions are REJECTED bindings', () => {
   // Convergence §4.5: a key indistinguishable from a lifecycle key on
   // legacy terminals is unsupported — rejected with a diagnostic.

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -24,6 +24,13 @@ test('KeyId validation accepts the fork grammar', () => {
   assert.ok(!isValidKeyId('ctrl+shift+'))
 })
 
+test('uppercase modifiers canonicalize before parser validation', () => {
+  assert.ok(isValidKeyId('SHIFT+CTRL+RETURN'))
+  const parsed = parseUserKeybindings({ 'app.input.steer': 'SHIFT+CTRL+P' })
+  assert.deepEqual(parsed.bindings, { 'app.input.steer': 'ctrl+shift+p' })
+  assert.deepEqual(parsed.diagnostics, [])
+})
+
 test('plain printable detection', () => {
   assert.ok(isPlainPrintableKey('a'))
   assert.ok(isPlainPrintableKey('1'))

--- a/test/keybinding-config.test.ts
+++ b/test/keybinding-config.test.ts
@@ -56,6 +56,17 @@ test('unknown action → diagnostic + ignore', () => {
   assert.ok(parsed.diagnostics[0]!.includes('unknown action'))
 })
 
+test('prototype property names are unknown actions, never inherited definitions', () => {
+  const raw = Object.create(null) as Record<string, unknown>
+  raw['toString'] = 'ctrl+x'
+  raw['constructor'] = 'ctrl+y'
+  raw['__proto__'] = 'ctrl+z'
+  const parsed = parseUserKeybindings(raw)
+  assert.deepEqual(parsed.bindings, {})
+  assert.equal(parsed.diagnostics.length, 3)
+  assert.ok(parsed.diagnostics.every(message => message.includes('unknown action')))
+})
+
 test('invalid key → diagnostic + ignore', () => {
   const parsed = parseUserKeybindings({ 'app.input.steer': 'ctrl+zzz' })
   assert.deepEqual(parsed.bindings, {})

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -178,6 +178,22 @@ test('4.1h a shadowed builtin submit permits leader Enter', () => {
   assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), ['enter'])
 })
 
+test('4.1i a dead leader-only interrupt restores the physical Escape lifecycle', () => {
+  const manager = new HostKeybindingManager()
+  try {
+    manager.setUserConfiguration(parseUserKeybindings({
+      leader: 'ctrl+x',
+      'app.agent.interrupt': '<leader>enter',
+    }))
+    assert.deepEqual(manager.leaderKeysFor('app.agent.interrupt'), [])
+    assert.deepEqual(manager.keysFor('app.agent.interrupt'), ['escape'])
+    assert.equal(manager.keyHint('app.agent.interrupt'), 'Esc')
+    assert.equal(manager.physicalEscapeEnabled(), true)
+  } finally {
+    manager.dispose()
+  }
+})
+
 // ── 4.2 duplicate direct key ──────────────────────────────────────────────
 
 test('4.2a a duplicate direct key dedupes (no self-conflict)', () => {

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -34,21 +34,20 @@ const editorContext = deriveKeybindingContext({ focusedSeat: 'editor' })
 
 // ── 4.1 canonical identity ────────────────────────────────────────────────
 
-test('4.1a esc and escape are the SAME physical key (conflict)', () => {
+test('4.1a physical Escape aliases are reserved for the lifecycle path', () => {
   const manager = new HostKeybindingManager()
-  manager.setUserConfiguration(parseUserKeybindings({
+  const parsed = parseUserKeybindings({
     'app.history.search': 'escape',
     'app.todo.toggle': 'esc',
-  }))
-  // The two USER rules collide on the canonical escape key and are
-  // deactivated — neither action may fire on Esc. (The BUILTIN
-  // app.agent.interrupt on escape legitimately survives.)
+  })
+  manager.setUserConfiguration(parsed)
+  // User actions cannot take over the physical Escape lifecycle path; both
+  // aliases are rejected before they can enter the effective keymap.
   assert.equal(manager.resolve('\x1b', editorContext)?.action, 'app.agent.interrupt',
-    'the conflicting aliases must not fire — only the surviving builtin interrupt may')
-  assert.deepEqual(manager.keysFor('app.history.search'), [], 'the conflicted history must not keep escape')
-  assert.deepEqual(manager.keysFor('app.todo.toggle'), [], 'the conflicted todo must not keep esc')
-  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')),
-    `no conflict diagnostic for aliases: ${manager.diagnosticsList().join(' | ')}`)
+    'only the lifecycle interrupt may resolve physical Escape')
+  assert.deepEqual(manager.keysFor('app.history.search'), ['ctrl+r'], 'history must retain its builtin after rejection')
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'], 'todo must retain its builtin after rejection')
+  assert.equal(parsed.diagnostics.filter(message => message.includes('physical Escape')).length, 2)
 })
 
 test('4.1b enter and return are the SAME physical key (conflict)', () => {
@@ -80,16 +79,17 @@ test('4.1c modifier order is canonicalized (ctrl+shift+p == shift+ctrl+p)', () =
   assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
 })
 
-test('4.1d leader prefix alias (leader: esc) collides with the escape interrupt', () => {
+test('4.1d leader prefix alias (leader: esc) is lifecycle-reserved', () => {
   const manager = new HostKeybindingManager()
-  manager.setUserConfiguration(parseUserKeybindings({
+  const parsed = parseUserKeybindings({
     leader: 'esc',
     bindings: { 'app.tasks.open': '<leader>t' },
-  }))
+  })
+  manager.setUserConfiguration(parsed)
   assert.equal(manager.leaderMachine(), undefined,
-    'leader: esc must collide with the default escape interrupt and be disabled')
-  assert.ok(manager.diagnosticsList().some(message => message.includes('active host key')),
-    `no leader collision diagnostic: ${manager.diagnosticsList().join(' | ')}`)
+    'leader: esc must be rejected before it can take over physical Escape')
+  assert.ok(parsed.diagnostics.some(message => message.includes('physical Escape')),
+    `no Escape reservation diagnostic: ${parsed.diagnostics.join(' | ')}`)
 })
 
 test('4.1e leader completion aliases are ambiguous (enter vs return)', () => {
@@ -744,11 +744,13 @@ test('5.13 uppercase aliases canonicalize to the same key (ESC/escape, RETURN/en
   assert.equal(canonicalizeKeyId('RETURN' as never), 'enter')
   assert.equal(canonicalizeKeyId('CTRL+RETURN' as never), 'ctrl+enter')
   assert.equal(canonicalizeKeyId('Shift+Ctrl+ESC' as never), 'ctrl+shift+escape')
-  // An uppercase-alias config conflicts with the canonical spelling.
+  // Uppercase aliases still canonicalize before the lifecycle reservation.
   const manager = new HostKeybindingManager()
-  manager.setUserConfiguration(parseUserKeybindings({ 'app.history.search': 'ESC', 'app.todo.toggle': 'escape' }))
-  assert.deepEqual(manager.keysFor('app.history.search'), [], 'ESC and escape must conflict as one key')
-  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
+  const parsed = parseUserKeybindings({ 'app.history.search': 'ESC', 'app.todo.toggle': 'escape' })
+  manager.setUserConfiguration(parsed)
+  assert.deepEqual(manager.keysFor('app.history.search'), ['ctrl+r'], 'rejected ESC must leave the builtin intact')
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'], 'rejected escape must leave the builtin intact')
+  assert.equal(parsed.diagnostics.filter(message => message.includes('physical Escape')).length, 2)
 })
 
 test('5.14 the leader prefix and completions reject legacy lifecycle collisions', () => {

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -92,20 +92,90 @@ test('4.1d leader prefix alias (leader: esc) is lifecycle-reserved', () => {
     `no Escape reservation diagnostic: ${parsed.diagnostics.join(' | ')}`)
 })
 
-test('4.1e leader completion aliases on Enter are rejected by the editor submit seam', () => {
+test('4.1e default effective submit blocks ordinary leader Enter completions', () => {
   const manager = new HostKeybindingManager()
   const parsed = parseUserKeybindings({
     leader: 'ctrl+x',
     bindings: {
-      'app.history.search': '<leader>enter',
-      'app.todo.toggle': '<leader>return',
+      'app.todo.toggle': ['<leader>enter', '<leader>return'],
+    },
+  })
+  // Parsing is static: both alias spellings survive canonical parsing.
+  assert.deepEqual(parsed.leaderBindings, [
+    { action: 'app.todo.toggle', key: 'enter' },
+    { action: 'app.todo.toggle', key: 'enter' },
+  ])
+  manager.setUserConfiguration(parsed)
+  // The provisional EffectiveKeymap sees builtin Enter as the effective
+  // editor submit key, so the manager drops both dead completions and
+  // restores the leader-only action's builtin default.
+  assert.equal(manager.leaderMachine(), undefined,
+    'Enter/Return completions must not arm a dead leader machine')
+  assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), [])
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
+  assert.equal(manager.diagnosticsList().filter(message => message.includes('effective editor submit key')).length, 1,
+    'duplicate aliases should produce one dead-key diagnostic')
+})
+
+test('4.1f a working submit remap permits and runs leader Enter', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const parsed = parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.input.submit': 'ctrl+z',
+      'app.todo.toggle': '<leader>enter',
+    },
+  })
+  app.keybindingsManager().setUserConfiguration(parsed)
+  assert.deepEqual(app.keybindingsManager().editorSubmitKeysFor(), ['ctrl+z'])
+  assert.deepEqual(app.keybindingsManager().leaderKeysFor('app.todo.toggle'), ['enter'])
+  assert.deepEqual(app.keybindingsManager().keysFor('app.todo.toggle'), [])
+  assert.equal(app.keybindingsManager().diagnosticsList().some(message => message.includes('effective editor submit key')), false)
+  await vt.waitForRender()
+  vt.sendInput('\x18') // leader
+  await vt.waitForRender()
+  vt.sendInput('\r') // leader completion; Enter is not submit after the remap
+  await vt.waitForRender()
+  assert.equal(app.isTodoPanelVisible(), true, 'Leader Enter must activate todo after submit moves to Ctrl+Z')
+  app.stop()
+})
+
+test('4.1g a conflicted submit remap falls back to Enter and blocks leader Enter', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.input.submit': 'ctrl+z',
+      'app.history.search': 'ctrl+z',
+      'app.todo.toggle': '<leader>enter',
     },
   })
   manager.setUserConfiguration(parsed)
-  assert.equal(manager.leaderMachine(), undefined,
-    'Enter/Return completions must not arm a dead leader machine')
-  assert.equal(parsed.leaderBindings.length, 0)
-  assert.equal(parsed.diagnostics.filter(message => message.includes('editor-owned submit')).length, 2)
+  assert.deepEqual(manager.editorSubmitKeysFor(), ['enter'])
+  assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), [])
+  assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'],
+    'a dead leader-only declaration must not suppress the builtin')
+  assert.ok(manager.diagnosticsList().some(message => message.includes('effective editor submit key')))
+  assert.ok(manager.diagnosticsList().some(message => message.includes('conflict')))
+})
+
+test('4.1h a shadowed builtin submit permits leader Enter', () => {
+  const manager = new HostKeybindingManager()
+  manager.setUserConfiguration(parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: {
+      'app.history.search': 'enter',
+      'app.todo.toggle': '<leader>enter',
+    },
+  }))
+  // The user history rule shadows the builtin editor-owned Enter, so Enter
+  // is no longer an effective submit key and the leader completion remains
+  // live rather than being rejected from the raw default assumption.
+  assert.deepEqual(manager.editorSubmitKeysFor(), [])
+  assert.deepEqual(manager.keysFor('app.history.search'), ['enter'])
+  assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), ['enter'])
 })
 
 // ── 4.2 duplicate direct key ──────────────────────────────────────────────

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -92,18 +92,20 @@ test('4.1d leader prefix alias (leader: esc) is lifecycle-reserved', () => {
     `no Escape reservation diagnostic: ${parsed.diagnostics.join(' | ')}`)
 })
 
-test('4.1e leader completion aliases are ambiguous (enter vs return)', () => {
+test('4.1e leader completion aliases on Enter are rejected by the editor submit seam', () => {
   const manager = new HostKeybindingManager()
-  manager.setUserConfiguration(parseUserKeybindings({
+  const parsed = parseUserKeybindings({
     leader: 'ctrl+x',
     bindings: {
       'app.history.search': '<leader>enter',
       'app.todo.toggle': '<leader>return',
     },
-  }))
-  assert.equal(manager.leaderMachine()?.leaderBindings.length ?? 0, 0,
-    'enter/return completions must be ambiguous — neither fires')
-  assert.ok(manager.diagnosticsList().some(message => message.includes('ambiguous')))
+  })
+  manager.setUserConfiguration(parsed)
+  assert.equal(manager.leaderMachine(), undefined,
+    'Enter/Return completions must not arm a dead leader machine')
+  assert.equal(parsed.leaderBindings.length, 0)
+  assert.equal(parsed.diagnostics.filter(message => message.includes('editor-owned submit')).length, 2)
 })
 
 // ── 4.2 duplicate direct key ──────────────────────────────────────────────

--- a/test/keybinding-convergence.test.ts
+++ b/test/keybinding-convergence.test.ts
@@ -1074,6 +1074,19 @@ test('6.6c leader-only submit: the unified model carries NO Enter (resolve/match
   const binding = manager.snapshot().bindings.find(entry => entry.action === 'app.input.submit')
   assert.ok(binding !== undefined)
   assert.deepEqual(binding!.keys, [], 'the snapshot carries no Enter')
+  // Enter remains a valid leader completion when the submit action itself is
+  // leader-only: the editor submit seam is empty, so this is not a dead key.
+  const enterLeader = new HostKeybindingManager()
+  const enterParsed = parseUserKeybindings({
+    leader: 'ctrl+x',
+    bindings: { 'app.input.submit': '<leader>enter' },
+  })
+  enterLeader.setUserConfiguration(enterParsed)
+  assert.deepEqual(enterParsed.bindings, { 'app.input.submit': [] })
+  assert.deepEqual(enterParsed.leaderBindings, [{ action: 'app.input.submit', key: 'enter' }])
+  assert.equal(enterLeader.leaderMachine()?.leaderBindings[0]?.key, 'enter')
+  assert.deepEqual(enterLeader.editorSubmitKeysFor(), [])
+  enterLeader.dispose()
   // A direct+leader mix keeps the direct key AND the leader (both user
   // triggers; the builtin is removed).
   const mixed = new HostKeybindingManager()

--- a/test/keybinding-editor.test.ts
+++ b/test/keybinding-editor.test.ts
@@ -95,6 +95,68 @@ test('untouched defaults are selectable and recorder replacement names the defau
   }
 })
 
+test('shadowed defaults are reference-only and Add does not select them', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings({ 'app.history.search': 'ctrl+t' })
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.todo.toggle')!
+  const mutations: Array<{ kind: string; binding?: { key: string } }> = []
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: mutation => { mutations.push(mutation as unknown as { kind: string; binding?: { key: string } }) },
+    onModelChange: () => {},
+    onBack: () => {},
+    maxRows: () => 30,
+  })
+  try {
+    const view = plain(editor.render(88).join('\n'))
+    assert.match(view, /Default: Ctrl\+T/)
+    assert.match(view, /Effective now: Unbound/)
+    assert.doesNotMatch(view, /› Ctrl\+T \(default\)/)
+    assert.match(view, /› \+ Add shortcut/)
+    editor.handleInput('\r')
+    editor.handleInput('\r')
+    editor.handleInput('\x1b[121;5u')
+    assert.deepEqual(mutations, [{ kind: 'add', action: 'app.todo.toggle', binding: { kind: 'direct', key: 'ctrl+y' } }])
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
+test('interrupt action detail assigns Escape with double-Esc', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings({ 'app.agent.interrupt': 'ctrl+x' })
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.agent.interrupt')!
+  const mutations: Array<{ kind: string; previous?: { key: string }; binding?: { key: string } }> = []
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: mutation => { mutations.push(mutation as unknown as { kind: string; previous?: { key: string }; binding?: { key: string } }) },
+    onModelChange: () => {},
+    onBack: () => {},
+  })
+  try {
+    editor.handleInput('\r')
+    assert.match(plain(editor.render(88).join('\n')), /double-Esc: assign Escape/)
+    editor.handleInput('\x1b')
+    editor.handleInput('\x1b')
+    assert.deepEqual(mutations, [{
+      kind: 'replace',
+      action: 'app.agent.interrupt',
+      previous: { kind: 'direct', key: 'ctrl+x' },
+      binding: { kind: 'direct', key: 'escape' },
+    }])
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
 test('short action details keep the selected binding in the viewport', () => {
   const manager = new HostKeybindingManager()
   const parsed = parseUserKeybindings(undefined)

--- a/test/keybinding-editor.test.ts
+++ b/test/keybinding-editor.test.ts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { HostKeybindingManager } from '../src/keybindings/manager.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+import { ActionEditorPanel } from '../src/keybinding-ui/action-editor.ts'
+import { KeybindingEditorPanel, KeybindingEditorUnavailablePanel } from '../src/keybinding-ui/list.ts'
+import type { KeybindingMutationResult } from '../src/keybinding-ui/controller.ts'
+import { buildKeybindingEditorModel } from '../src/keybinding-ui/model.ts'
+
+function plain(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, '')
+}
+
+function makePanel(onClose: () => void) {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const panel = new KeybindingEditorPanel({
+    model,
+    onClose,
+    runMutation: () => {},
+    maxRows: () => 30,
+  })
+  return { manager, panel }
+}
+
+test('editor renders an action-first list with a non-selectable leader row and category headers', () => {
+  let closed = 0
+  const { manager, panel } = makePanel(() => { closed += 1 })
+  try {
+    const view = panel.render(88).join('\n')
+    assert.match(view, /Keyboard shortcuts/)
+    assert.match(view, /Leader key/)
+    assert.match(view, /Input/)
+    assert.match(view, /Submit draft/)
+    assert.match(view, /fixed/)
+    assert.match(view, /Enter: details/)
+    assert.equal(closed, 0)
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('action details label an unbound configurable action distinctly', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.transcript.toggleFullscreen')!
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: () => {},
+    onModelChange: () => {},
+    onBack: () => {},
+  })
+  try {
+    assert.match(plain(editor.render(88).join('\\n')), /Status: Unbound/)
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
+test('editor search is cleared by the first Escape and closes on the second', () => {
+  let closed = 0
+  const { manager, panel } = makePanel(() => { closed += 1 })
+  try {
+    panel.handleInput('todo')
+    const filtered = panel.render(88).join('\n')
+    assert.match(filtered, /Toggle todo panel/)
+    assert.doesNotMatch(filtered, /Submit draft/)
+    panel.handleInput('\x1b')
+    assert.match(panel.render(88).join('\n'), /Submit draft/)
+    assert.equal(closed, 0)
+    panel.handleInput('\x1b')
+    assert.equal(closed, 1)
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('binding choice arrows move in their named direction', () => {
+  const { manager, panel } = makePanel(() => {})
+  try {
+    panel.handleInput('\x1b[B')
+    panel.handleInput('\r')
+    panel.handleInput('\r')
+    let view = plain(panel.render(88).join('\n'))
+    assert.match(view, /› Direct shortcut/)
+    panel.handleInput('\x1b[B')
+    view = plain(panel.render(88).join('\n'))
+    assert.match(view, /› Leader completion/)
+    panel.handleInput('\x1b[A')
+    view = plain(panel.render(88).join('\n'))
+    assert.match(view, /› Direct shortcut/)
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('late action results are ignored after a newer mutation or disposal', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.todo.toggle')!
+  const results: Array<(result: KeybindingMutationResult) => void> = []
+  let changes = 0
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: (_mutation, onResult) => { results.push(onResult) },
+    onModelChange: () => { changes += 1 },
+    onBack: () => {},
+  })
+  const applied: KeybindingMutationResult = {
+    kind: 'applied',
+    model,
+    parsed,
+    message: 'saved',
+  }
+  try {
+    editor.handleInput('\r')
+    editor.handleInput('d')
+    editor.handleInput('\x1b[115;5u')
+    assert.equal(results.length, 1)
+    results[0]!(applied)
+    assert.equal(changes, 1)
+
+    editor.handleInput('r')
+    assert.equal(results.length, 2)
+    results[0]!(applied)
+    assert.equal(changes, 1)
+
+    editor.dispose()
+    results[1]!(applied)
+    assert.equal(changes, 1)
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
+test('a late action recorder cancel after disposal cannot repaint the panel', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.todo.toggle')!
+  let renders = 0
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: () => {},
+    onModelChange: () => {},
+    onBack: () => {},
+    requestRender: () => { renders += 1 },
+  })
+  try {
+    editor.handleInput('\r')
+    editor.handleInput('\r')
+    const recorder = (editor as unknown as {
+      recorder?: { handleInput(data: string): void }
+    }).recorder!
+    const beforeDispose = renders
+    editor.dispose()
+    recorder.handleInput('\x1b')
+    assert.equal(renders, beforeDispose)
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
+test('late leader results are ignored after the editor is disposed', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const results: Array<(result: KeybindingMutationResult) => void> = []
+  let changes = 0
+  const panel = new KeybindingEditorPanel({
+    model,
+    runMutation: (_mutation, onResult) => { results.push(onResult) },
+    onClose: () => {},
+    onModelChange: () => { changes += 1 },
+  })
+  try {
+    panel.handleInput('\r')
+    panel.handleInput('\r')
+    panel.handleInput('\x1b[120;5u')
+    assert.equal(results.length, 1)
+    panel.dispose()
+    results[0]!(
+      { kind: 'applied', model, parsed, message: 'saved' },
+    )
+    assert.equal(changes, 0)
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('a late leader capture after disposal cannot start a mutation', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const results: Array<(result: KeybindingMutationResult) => void> = []
+  const panel = new KeybindingEditorPanel({
+    model,
+    runMutation: (_mutation, onResult) => { results.push(onResult) },
+    onClose: () => {},
+  })
+  try {
+    panel.handleInput('\r')
+    panel.handleInput('\r')
+    const recorder = (panel as unknown as {
+      leaderRecorder?: { handleInput(data: string): void }
+    }).leaderRecorder!
+    panel.dispose()
+    recorder.handleInput('\x1b[120;5u')
+    assert.equal(results.length, 0)
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('safe mode presents an ignored leader and never starts its recorder', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings({ leader: 'ctrl+q' })
+  manager.setSafeMode(true)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const results: Array<(result: KeybindingMutationResult) => void> = []
+  const panel = new KeybindingEditorPanel({
+    model,
+    runMutation: (_mutation, onResult) => { results.push(onResult) },
+    onClose: () => {},
+  })
+  try {
+    assert.equal(model.leader.key, undefined)
+    assert.equal(model.leader.customized, true)
+    assert.match(plain(panel.render(88).join('\n')), /Ignored by safe mode/)
+    panel.handleInput('\r')
+    assert.match(plain(panel.render(88).join('\n')), /Safe mode ignores persisted keyboard shortcuts/)
+    panel.handleInput('\r')
+    assert.equal(results.length, 0)
+    assert.doesNotMatch(plain(panel.render(88).join('\n')), /record a new leader key/)
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('fullscreen teardown disposes a pending tracked editor before late results can repaint it', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const results: Array<(result: KeybindingMutationResult) => void> = []
+  let changes = 0
+  const panel = new KeybindingEditorPanel({
+    model,
+    runMutation: (_mutation, onResult) => { results.push(onResult) },
+    onClose: () => {},
+    onModelChange: () => { changes += 1 },
+  })
+  const app = new TuiApp(new VirtualTerminal(80, 24), { onSubmit: () => {}, onExit: () => {} })
+  try {
+    app.start()
+    app.trackKeybindingEditor(panel)
+    panel.handleInput('\r')
+    panel.handleInput('\r')
+    panel.handleInput('\x1b[120;5u')
+    assert.equal(results.length, 1)
+    app.setFullscreen(true)
+    results[0]({ kind: 'applied', model, parsed, message: 'saved' })
+    assert.equal(changes, 0)
+  } finally {
+    app.dispose()
+    manager.dispose()
+  }
+})
+
+test('unavailable settings render a closable fallback instead of a dead row', () => {
+  let closed = 0
+  const panel = new KeybindingEditorUnavailablePanel(() => { closed += 1 })
+  assert.match(panel.render(40).join('\n'), /Keyboard shortcuts unavailable/)
+  panel.handleInput('\x1b')
+  assert.equal(closed, 1)
+})
+
+test('Enter opens the selected action detail without making category headers selectable', () => {
+  const { manager, panel } = makePanel(() => {})
+  try {
+    panel.handleInput('\x1b[B')
+    panel.handleInput('\r')
+    const view = panel.render(88).join('\n')
+    assert.match(view, /Keyboard shortcuts › Submit draft/)
+    assert.match(view, /Action ID: app\.input\.submit/)
+    assert.match(view, /Default: Enter/)
+  } finally {
+    manager.dispose()
+  }
+})

--- a/test/keybinding-editor.test.ts
+++ b/test/keybinding-editor.test.ts
@@ -135,6 +135,31 @@ test('conditional task affordances are labeled separately from configured shortc
   }
 })
 
+test('a configured Down task shortcut is still rendered as conditional', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings({ 'app.tasks.open': 'down' })
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.tasks.open')!
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: () => {},
+    onModelChange: () => {},
+    onBack: () => {},
+    maxRows: () => 30,
+  })
+  try {
+    const view = plain(editor.render(88).join('\n'))
+    assert.match(view, /Configured shortcuts/)
+    assert.match(view, /Down \(conditional\)/)
+    assert.match(view, /when the editor is empty and tasks are active/)
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
 test('editor search is cleared by the first Escape and closes on the second', () => {
   let closed = 0
   const { manager, panel } = makePanel(() => { closed += 1 })

--- a/test/keybinding-editor.test.ts
+++ b/test/keybinding-editor.test.ts
@@ -65,6 +65,76 @@ test('action details label an unbound configurable action distinctly', () => {
   }
 })
 
+test('untouched defaults are selectable and recorder replacement names the default', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.todo.toggle')!
+  const mutations: Array<{ kind: string; previous?: { key: string } }> = []
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: mutation => { mutations.push(mutation as unknown as { kind: string; previous?: { key: string } }) },
+    onModelChange: () => {},
+    onBack: () => {},
+  })
+  try {
+    assert.match(plain(editor.render(88).join('\n')), /Ctrl\+T \(default\)/)
+    editor.handleInput('\r')
+    editor.handleInput('\x1b[121;5u')
+    assert.deepEqual(mutations, [{
+      kind: 'replace',
+      action: 'app.todo.toggle',
+      previous: { kind: 'direct', key: 'ctrl+t' },
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    }])
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
+test('short action details keep the selected binding in the viewport', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(undefined)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.transcript.search')!
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: () => {},
+    onModelChange: () => {},
+    onBack: () => {},
+    maxRows: () => 8,
+  })
+  try {
+    const view = plain(editor.render(88).join('\n'))
+    assert.match(view, /› Ctrl\+F \(default\)/)
+    assert.match(view, /Esc: back/)
+  } finally {
+    editor.dispose()
+    manager.dispose()
+  }
+})
+
+test('conditional task affordances are labeled separately from configured shortcuts', () => {
+  const { manager, panel } = makePanel(() => {})
+  try {
+    panel.handleInput('tasks')
+    assert.match(plain(panel.render(88).join('\n')), /Down \(conditional\)/)
+    panel.handleInput('\r')
+    const detail = plain(panel.render(88).join('\n'))
+    assert.match(detail, /Conditional shortcuts/)
+    assert.match(detail, /Down \(when the editor is empty and tasks are active\)/)
+    assert.doesNotMatch(detail, /Shortcuts\n  Unbound/)
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
 test('editor search is cleared by the first Escape and closes on the second', () => {
   let closed = 0
   const { manager, panel } = makePanel(() => { closed += 1 })
@@ -88,6 +158,7 @@ test('binding choice arrows move in their named direction', () => {
   try {
     panel.handleInput('\x1b[B')
     panel.handleInput('\r')
+    panel.handleInput('\x1b[B')
     panel.handleInput('\r')
     let view = plain(panel.render(88).join('\n'))
     assert.match(view, /› Direct shortcut/)
@@ -161,6 +232,7 @@ test('a late action recorder cancel after disposal cannot repaint the panel', ()
     requestRender: () => { renders += 1 },
   })
   try {
+    editor.handleInput('\x1b[B')
     editor.handleInput('\r')
     editor.handleInput('\r')
     const recorder = (editor as unknown as {
@@ -254,6 +326,36 @@ test('safe mode presents an ignored leader and never starts its recorder', () =>
     assert.doesNotMatch(plain(panel.render(88).join('\n')), /record a new leader key/)
   } finally {
     panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('safe mode makes action details read-only', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+y' })
+  manager.setSafeMode(true)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  const row = model.rows.find(candidate => candidate.id === 'app.todo.toggle')!
+  const mutations: string[] = []
+  const editor = new ActionEditorPanel({
+    model,
+    action: row,
+    runMutation: mutation => { mutations.push(mutation.kind) },
+    onModelChange: () => {},
+    onBack: () => {},
+  })
+  try {
+    const view = plain(editor.render(88).join('\n'))
+    assert.match(view, /Editing is disabled until safe mode is turned off/)
+    assert.doesNotMatch(view, /Add shortcut/)
+    editor.handleInput('a')
+    editor.handleInput('r')
+    editor.handleInput('d')
+    editor.handleInput('\x1b[3~')
+    assert.deepEqual(mutations, [])
+  } finally {
+    editor.dispose()
     manager.dispose()
   }
 })

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -8,6 +8,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { EditorRegistry } from '../src/editor-registry.ts'
 import { TuiApp } from '../src/tui-app.ts'
 import { parseUserKeybindings } from '../src/keybindings/config.ts'
 import { HostKeybindingManager } from '../src/keybindings/manager.ts'
@@ -35,6 +36,16 @@ function managerWith(config: Record<string, unknown>): (manager: HostKeybindingM
   }
 }
 
+/** Inject the formerly possible bad state to prove the runtime lifecycle
+ * guard independently of the parser's Escape reservation. */
+function injectEscapeSteal(manager: HostKeybindingManager): void {
+  manager.setUserConfiguration({
+    bindings: { 'app.todo.toggle': 'escape' },
+    leader: undefined,
+    leaderBindings: [],
+  })
+}
+
 test('user remap: ctrl+x steers, ctrl+s no longer does', async () => {
   const steered: string[] = []
   const { vt, app } = startApp({ onSteer: (text: string) => steered.push(text) }, managerWith({ 'app.input.steer': 'ctrl+x' }))
@@ -44,6 +55,80 @@ test('user remap: ctrl+x steers, ctrl+s no longer does', async () => {
   vt.sendInput('\x13') // ctrl+s
   await vt.waitForRender()
   assert.deepEqual(steered, [''], 'the old key must no longer steer')
+  app.stop()
+})
+
+test('physical idle Escape keeps the Host lifecycle path ahead of an action binding', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let singleEscapes = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSingleEscape: () => { singleEscapes += 1; return true },
+  })
+  app.start()
+  injectEscapeSteal(app.keybindingsManager())
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(singleEscapes, 1, 'physical idle Escape must reach the lifecycle handler')
+  assert.equal(app.isTodoPanelVisible(), false, 'an injected action binding must not steal Escape')
+  app.stop()
+})
+
+test('physical busy Escape cancels before an action binding can dispatch', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let cancels = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => { cancels += 1 },
+  })
+  app.start()
+  injectEscapeSteal(app.keybindingsManager())
+  app.setBusy(true)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(cancels, 1, 'physical busy Escape must cancel the active work')
+  assert.equal(app.isTodoPanelVisible(), false, 'busy Escape must not dispatch the injected action')
+  app.stop()
+})
+
+test('physical Escape reaches a replacement editor before user action resolution', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(80, 24)
+  let pluginEscapes = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+  }, { editorRegistry: registry })
+  app.start()
+  const handle = registry.register({
+    id: 'escape-guard-plugin',
+    priority: 0,
+    create: () => ({
+      component: { kind: 'text', spans: [{ text: '' }] },
+      getText: () => '',
+      setText: () => {},
+      getCursor: () => 0,
+      setCursor: () => {},
+      get focused() { return false },
+      borderColor: (text: string) => text,
+      handleInput: () => {
+        pluginEscapes += 1
+        return true
+      },
+      dispose: () => {},
+    }),
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  injectEscapeSteal(app.keybindingsManager())
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(pluginEscapes, 1, 'the replacement editor must receive physical Escape')
+  assert.equal(app.isTodoPanelVisible(), false, 'the action binding must not steal replacement Escape')
+  handle.dispose()
+  app.reconcileEditorNow()
   app.stop()
 })
 

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -132,6 +132,51 @@ test('physical Escape reaches a replacement editor before user action resolution
   app.stop()
 })
 
+test('a declined replacement Escape is consumed once after the interrupt is remapped', async () => {
+  const registry = new EditorRegistry()
+  const vt = new VirtualTerminal(80, 24)
+  let pluginEscapes = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+  }, { editorRegistry: registry })
+  app.start()
+  const handle = registry.register({
+    id: 'declining-escape-plugin',
+    priority: 0,
+    create: () => ({
+      component: { kind: 'text', spans: [{ text: '' }] },
+      getText: () => '',
+      setText: () => {},
+      getCursor: () => 0,
+      setCursor: () => {},
+      focused: false,
+      borderColor: (text: string) => text,
+      handleInput: () => {
+        pluginEscapes += 1
+        return false
+      },
+      dispose: () => {},
+    }),
+  }, 'plugin')
+  app.reconcileEditorNow()
+  await vt.waitForRender()
+  // Bypass the parser to exercise the runtime guard against the old bad
+  // shadowing state, while remapping the real interrupt away from Escape.
+  app.keybindingsManager().setUserConfiguration({
+    bindings: { 'app.todo.toggle': 'escape', 'app.agent.interrupt': 'ctrl+x' },
+    leader: undefined,
+    leaderBindings: [],
+  })
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(pluginEscapes, 1, 'a declining replacement must receive Escape exactly once')
+  assert.equal(app.isTodoPanelVisible(), false, 'a declining replacement must not expose the shadowing action')
+  handle.dispose()
+  app.reconcileEditorNow()
+  app.stop()
+})
+
 test('the viewer guard follows the remap: ctrl+x is blocked inside the continuable viewer', async () => {
   // The plan's key test: the user remaps app.input.steer to ctrl+x; the
   // viewer receives ctrl+x — the PARENT must still NOT be steered (the

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -93,6 +93,25 @@ test('physical busy Escape cancels before an action binding can dispatch', async
   app.stop()
 })
 
+test('dead leader-only interrupt restores busy physical Escape cancellation', async () => {
+  let cancels = 0
+  const { vt, app } = startApp(
+    { onCancel: () => { cancels += 1 } },
+    managerWith({
+      leader: 'ctrl+x',
+      'app.agent.interrupt': '<leader>enter',
+    }),
+  )
+  app.setBusy(true)
+  assert.deepEqual(app.keybindingsManager().keysFor('app.agent.interrupt'), ['escape'])
+  assert.equal(app.keybindingsManager().keyHint('app.agent.interrupt'), 'Esc')
+  assert.equal(app.keybindingsManager().physicalEscapeEnabled(), true)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  assert.equal(cancels, 1, 'restored builtin Escape must cancel busy work')
+  app.stop()
+})
+
 test('physical Escape reaches a replacement editor before user action resolution', async () => {
   const registry = new EditorRegistry()
   const vt = new VirtualTerminal(80, 24)

--- a/test/keybinding-ui-controller.test.ts
+++ b/test/keybinding-ui-controller.test.ts
@@ -85,6 +85,66 @@ test('mutation performs one get, one replace, preserves unrelated fields, then p
   }
 })
 
+test('adding to an untouched action does not resurrect a shadowed builtin shortcut', async () => {
+  const fixture = settingsFixture({ 'app.history.search': 'ctrl+t' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), [], 'the todo builtin is shadowed before editing')
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'applied')
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+y'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      'app.history.search': 'ctrl+t',
+      'app.todo.toggle': 'ctrl+y',
+    })
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('adding to a partially shadowed multi-default keeps only surviving defaults', async () => {
+  const fixture = settingsFixture({ 'app.todo.toggle': 'ctrl+f' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    assert.deepEqual(manager.keysFor('app.transcript.search'), ['ctrl+shift+f'])
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.transcript.search',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'applied')
+    assert.deepEqual(manager.keysFor('app.transcript.search'), ['ctrl+shift+f', 'ctrl+y'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      'app.todo.toggle': 'ctrl+f',
+      'app.transcript.search': ['ctrl+shift+f', 'ctrl+y'],
+    })
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('adding to the conditional task affordance never materializes Down', async () => {
+  const fixture = settingsFixture(undefined)
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.tasks.open',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'applied')
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      'app.tasks.open': 'ctrl+y',
+    })
+  } finally {
+    manager.dispose()
+  }
+})
+
 test('adding to an untouched action retains every builtin shortcut', async () => {
   const fixture = settingsFixture(undefined)
   const { controller, manager } = controllerFor(fixture)
@@ -191,6 +251,24 @@ test('a direct binding cannot newly shadow an already configured leader prefix',
     })
     assert.equal(result.kind, 'rejected')
     assert.match(result.message, /leader key/i)
+    assert.equal(fixture.replaceCount(), 0)
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('interactive preflight rejects a leader completion consumed by effective submit', async () => {
+  const fixture = settingsFixture({ leader: 'ctrl+x' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'leader', key: 'enter' },
+    })
+    assert.equal(result.kind, 'rejected')
+    assert.match(result.message, /effective editor submit key/i)
     assert.equal(fixture.replaceCount(), 0)
     assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
   } finally {

--- a/test/keybinding-ui-controller.test.ts
+++ b/test/keybinding-ui-controller.test.ts
@@ -1,0 +1,308 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { HostKeybindingManager } from '../src/keybindings/manager.ts'
+import {
+  KeybindingEditorController,
+  type KeybindingMutation,
+} from '../src/keybinding-ui/controller.ts'
+import { serializeTuiSettingsMutation, type TuiSettingsDoc } from '../src/runtime/config-port.ts'
+
+function settingsFixture(initialKeybindings: unknown): {
+  settings: { get(): TuiSettingsDoc; replace(doc: TuiSettingsDoc): unknown }
+  getCount: () => number
+  replaceCount: () => number
+  latest: () => TuiSettingsDoc | undefined
+} {
+  let doc: TuiSettingsDoc = {
+    theme: 'auto',
+    iconStyle: 'symbols',
+    footer: 'default',
+    fullscreen: 'off',
+    busyEnter: 'queue',
+    localShellSandbox: 'off',
+    homeEndKeys: 'off',
+    focusMode: 'off',
+    footerCommand: { command: 'printf status', intervalMs: 1000 },
+    unrelated: 'preserved',
+    keybindings: initialKeybindings,
+  } as unknown as TuiSettingsDoc
+  let gets = 0
+  let replaces = 0
+  let latest: TuiSettingsDoc | undefined
+  return {
+    settings: {
+      get: () => {
+        gets += 1
+        return doc
+      },
+      replace: next => {
+        replaces += 1
+        latest = next
+        doc = next
+      },
+    },
+    getCount: () => gets,
+    replaceCount: () => replaces,
+    latest: () => latest,
+  }
+}
+
+function controllerFor(fixture: ReturnType<typeof settingsFixture>, manager = new HostKeybindingManager()) {
+  manager.setUserConfiguration(parseUserKeybindings(fixture.settings.get().keybindings))
+  return { controller: new KeybindingEditorController({ settings: fixture.settings, manager }), manager }
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>(settle => { resolve = settle })
+  return { promise, resolve }
+}
+
+test('mutation performs one get, one replace, preserves unrelated fields, then projects the same candidate', async () => {
+  const fixture = settingsFixture(undefined)
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const mutation: KeybindingMutation = {
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    }
+    const result = await controller.mutate(mutation)
+    assert.equal(result.kind, 'applied')
+    assert.equal(fixture.getCount(), 2)
+    assert.equal(fixture.replaceCount(), 1)
+    assert.equal((fixture.latest() as unknown as Record<string, unknown>).unrelated, 'preserved')
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).footerCommand, { command: 'printf status', intervalMs: 1000 })
+    assert.equal((fixture.latest() as TuiSettingsDoc).keybindings && typeof (fixture.latest() as TuiSettingsDoc).keybindings, 'object')
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+y'])
+    assert.equal(result.kind === 'applied' ? result.model.rows.find(row => row.id === 'app.todo.toggle')!.effective[0]!.key : '', 'ctrl+y')
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('interactive preflight rejects a new direct conflict without persistence or runtime mutation', async () => {
+  const fixture = settingsFixture({ 'app.transcript.toggleExpand': 'ctrl+y' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.history.search',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'rejected')
+    assert.match(result.message, /conflicts/i)
+    assert.equal(fixture.replaceCount(), 0)
+    assert.deepEqual(manager.keysFor('app.history.search'), ['ctrl+r'])
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('a direct binding cannot newly shadow an already configured leader prefix', async () => {
+  const fixture = settingsFixture({ leader: 'ctrl+q' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+q' },
+    })
+    assert.equal(result.kind, 'rejected')
+    assert.match(result.message, /leader key/i)
+    assert.equal(fixture.replaceCount(), 0)
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('shared settings mutations serialize and preserve both concurrent edits', async () => {
+  let doc: TuiSettingsDoc = {
+    theme: 'auto',
+    iconStyle: 'symbols',
+    footer: 'default',
+    fullscreen: 'off',
+    busyEnter: 'queue',
+    localShellSandbox: 'off',
+    homeEndKeys: 'off',
+    focusMode: 'off',
+  }
+  let gets = 0
+  let replaces = 0
+  const firstReplaceStarted = deferred<void>()
+  const releaseFirstReplace = deferred<void>()
+  const settings = {
+    get: () => {
+      gets += 1
+      return doc
+    },
+    replace: async (next: TuiSettingsDoc) => {
+      replaces += 1
+      if (replaces === 1) {
+        firstReplaceStarted.resolve(undefined)
+        await releaseFirstReplace.promise
+      }
+      doc = next
+    },
+  }
+  const manager1 = new HostKeybindingManager()
+  const manager2 = new HostKeybindingManager()
+  const controller1 = new KeybindingEditorController({ settings, manager: manager1 })
+  const controller2 = new KeybindingEditorController({ settings, manager: manager2 })
+  try {
+    const first = controller1.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    await firstReplaceStarted.promise
+    const second = controller2.mutate({
+      kind: 'add',
+      action: 'app.input.steer',
+      binding: { kind: 'direct', key: 'ctrl+z' },
+    })
+    releaseFirstReplace.resolve(undefined)
+    const results = await Promise.all([first, second])
+    assert.equal(results[0]!.kind, 'applied')
+    assert.equal(results[1]!.kind, 'applied')
+    assert.equal(gets, 2)
+    assert.equal(replaces, 2)
+    assert.deepEqual(doc.keybindings, {
+      'app.todo.toggle': 'ctrl+y',
+      'app.input.steer': 'ctrl+z',
+    })
+  } finally {
+    manager1.dispose()
+    manager2.dispose()
+  }
+})
+
+test('the shared queue also preserves an unrelated whole-document settings writer', async () => {
+  let doc: TuiSettingsDoc = {
+    theme: 'auto',
+    iconStyle: 'symbols',
+    footer: 'default',
+    fullscreen: 'off',
+    busyEnter: 'queue',
+    localShellSandbox: 'off',
+    homeEndKeys: 'off',
+    focusMode: 'off',
+  }
+  let replaces = 0
+  const firstReplaceStarted = deferred<void>()
+  const releaseFirstReplace = deferred<void>()
+  const settings = {
+    get: () => doc,
+    replace: async (next: TuiSettingsDoc) => {
+      replaces += 1
+      if (replaces === 1) {
+        firstReplaceStarted.resolve(undefined)
+        await releaseFirstReplace.promise
+      }
+      doc = next
+    },
+  }
+  const manager = new HostKeybindingManager()
+  const controller = new KeybindingEditorController({ settings, manager })
+  try {
+    const keybindingWrite = controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    await firstReplaceStarted.promise
+    // Use a distinct wrapper around the same backend to prove the shared
+    // fallback queue is logical-port scoped, not wrapper-object scoped.
+    const unrelatedSettings = { get: settings.get, replace: settings.replace }
+    const unrelatedWrite = serializeTuiSettingsMutation(unrelatedSettings, async () => {
+      const current = unrelatedSettings.get()
+      await unrelatedSettings.replace({ ...current, theme: 'dark' })
+    })
+    releaseFirstReplace.resolve(undefined)
+    const [keybindingResult] = await Promise.all([keybindingWrite, unrelatedWrite])
+    assert.equal(keybindingResult.kind, 'applied')
+    assert.equal(doc.theme, 'dark')
+    assert.deepEqual(doc.keybindings, { 'app.todo.toggle': 'ctrl+y' })
+    assert.equal(replaces, 2)
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('leader setup and completion use the same persisted candidate', async () => {
+  const fixture = settingsFixture(undefined)
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const leader = await controller.mutate({ kind: 'set-leader', key: 'ctrl+q' })
+    assert.equal(leader.kind, 'applied')
+    const completion = await controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'leader', key: 't' },
+    })
+    assert.equal(completion.kind, 'applied')
+    assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), ['t'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      leader: 'ctrl+q',
+      'app.todo.toggle': '<leader>t',
+    })
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('removing the last custom shortcut restores the builtin instead of disabling the action', async () => {
+  const fixture = settingsFixture({ 'app.todo.toggle': 'ctrl+y' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'remove',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'applied')
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, { 'app.todo.toggle': [] })
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('reset all removes only keybinding data and restores runtime defaults', async () => {
+  const fixture = settingsFixture({ leader: 'ctrl+q', 'app.todo.toggle': 'ctrl+y' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+y'])
+    const result = await controller.mutate({ kind: 'reset-all' })
+    assert.equal(result.kind, 'applied')
+    assert.equal('keybindings' in (fixture.latest() as object), false)
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
+    assert.equal(fixture.replaceCount(), 1)
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('a failed settings replace leaves the last-known runtime map untouched', async () => {
+  const fixture = settingsFixture(undefined)
+  const { controller, manager } = controllerFor(fixture)
+  const failing = {
+    get: fixture.settings.get,
+    replace: () => { throw new Error('disk unavailable') },
+  }
+  const failingController = new KeybindingEditorController({ settings: failing, manager })
+  try {
+    const result = await failingController.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'error')
+    assert.match(result.message, /disk unavailable/)
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
+  } finally {
+    manager.dispose()
+  }
+})

--- a/test/keybinding-ui-controller.test.ts
+++ b/test/keybinding-ui-controller.test.ts
@@ -75,8 +75,88 @@ test('mutation performs one get, one replace, preserves unrelated fields, then p
     assert.equal((fixture.latest() as unknown as Record<string, unknown>).unrelated, 'preserved')
     assert.deepEqual((fixture.latest() as TuiSettingsDoc).footerCommand, { command: 'printf status', intervalMs: 1000 })
     assert.equal((fixture.latest() as TuiSettingsDoc).keybindings && typeof (fixture.latest() as TuiSettingsDoc).keybindings, 'object')
-    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+y'])
-    assert.equal(result.kind === 'applied' ? result.model.rows.find(row => row.id === 'app.todo.toggle')!.effective[0]!.key : '', 'ctrl+y')
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t', 'ctrl+y'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      'app.todo.toggle': ['ctrl+t', 'ctrl+y'],
+    })
+    assert.equal(result.kind === 'applied' ? result.model.rows.find(row => row.id === 'app.todo.toggle')!.effective[0]!.key : '', 'ctrl+t')
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('adding to an untouched action retains every builtin shortcut', async () => {
+  const fixture = settingsFixture(undefined)
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.transcript.search',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'applied')
+    assert.deepEqual(manager.keysFor('app.transcript.search'), ['ctrl+f', 'ctrl+shift+f', 'ctrl+y'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      'app.transcript.search': ['ctrl+f', 'ctrl+shift+f', 'ctrl+y'],
+    })
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('replacing one untouched builtin shortcut preserves its siblings', async () => {
+  const fixture = settingsFixture(undefined)
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'replace',
+      action: 'app.transcript.search',
+      previous: { kind: 'direct', key: 'ctrl+f' },
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    assert.equal(result.kind, 'applied')
+    assert.deepEqual(manager.keysFor('app.transcript.search'), ['ctrl+shift+f', 'ctrl+y'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      'app.transcript.search': ['ctrl+shift+f', 'ctrl+y'],
+    })
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('removing one untouched builtin shortcut preserves its siblings', async () => {
+  const fixture = settingsFixture(undefined)
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    const result = await controller.mutate({
+      kind: 'remove',
+      action: 'app.transcript.search',
+      binding: { kind: 'direct', key: 'ctrl+f' },
+    })
+    assert.equal(result.kind, 'applied')
+    assert.deepEqual(manager.keysFor('app.transcript.search'), ['ctrl+shift+f'])
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
+      'app.transcript.search': 'ctrl+shift+f',
+    })
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('safe mode rejects action mutations before they reach persistence', async () => {
+  const fixture = settingsFixture({ 'app.todo.toggle': 'ctrl+y' })
+  const { controller, manager } = controllerFor(fixture)
+  manager.setSafeMode(true)
+  try {
+    const result = await controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+z' },
+    })
+    assert.equal(result.kind, 'rejected')
+    assert.match(result.message, /safe mode/i)
+    assert.equal(fixture.replaceCount(), 0)
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
   } finally {
     manager.dispose()
   }
@@ -170,8 +250,8 @@ test('shared settings mutations serialize and preserve both concurrent edits', a
     assert.equal(gets, 2)
     assert.equal(replaces, 2)
     assert.deepEqual(doc.keybindings, {
-      'app.todo.toggle': 'ctrl+y',
-      'app.input.steer': 'ctrl+z',
+      'app.todo.toggle': ['ctrl+t', 'ctrl+y'],
+      'app.input.steer': ['ctrl+s', 'ctrl+z'],
     })
   } finally {
     manager1.dispose()
@@ -224,7 +304,7 @@ test('the shared queue also preserves an unrelated whole-document settings write
     const [keybindingResult] = await Promise.all([keybindingWrite, unrelatedWrite])
     assert.equal(keybindingResult.kind, 'applied')
     assert.equal(doc.theme, 'dark')
-    assert.deepEqual(doc.keybindings, { 'app.todo.toggle': 'ctrl+y' })
+    assert.deepEqual(doc.keybindings, { 'app.todo.toggle': ['ctrl+t', 'ctrl+y'] })
     assert.equal(replaces, 2)
   } finally {
     manager.dispose()
@@ -246,7 +326,7 @@ test('leader setup and completion use the same persisted candidate', async () =>
     assert.deepEqual(manager.leaderKeysFor('app.todo.toggle'), ['t'])
     assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {
       leader: 'ctrl+q',
-      'app.todo.toggle': '<leader>t',
+      'app.todo.toggle': ['ctrl+t', '<leader>t'],
     })
   } finally {
     manager.dispose()

--- a/test/keybinding-ui-model.test.ts
+++ b/test/keybinding-ui-model.test.ts
@@ -41,6 +41,34 @@ test('editor model preserves defaults and exposes real category sections', () =>
   }
 })
 
+test('untouched rows expose only surviving effective defaults for editing', () => {
+  const { manager, model } = modelFor({ 'app.history.search': 'ctrl+t' })
+  try {
+    const todo = model.rows.find(row => row.id === 'app.todo.toggle')!
+    assert.deepEqual(todo.defaults, [{ kind: 'direct', key: 'ctrl+t' }])
+    assert.deepEqual(todo.editableDefaults, [])
+    assert.deepEqual(todo.effective, [])
+    assert.equal(todo.status, 'unbound')
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('partial default shadowing leaves only the surviving default editable', () => {
+  const { manager, model } = modelFor({ 'app.todo.toggle': 'ctrl+f' })
+  try {
+    const search = model.rows.find(row => row.id === 'app.transcript.search')!
+    assert.deepEqual(search.defaults, [
+      { kind: 'direct', key: 'ctrl+f' },
+      { kind: 'direct', key: 'ctrl+shift+f' },
+    ])
+    assert.deepEqual(search.editableDefaults, [{ kind: 'direct', key: 'ctrl+shift+f' }])
+    assert.deepEqual(search.effective, [{ kind: 'direct', key: 'ctrl+shift+f' }])
+  } finally {
+    manager.dispose()
+  }
+})
+
 test('a Down remap of the task browser keeps its conditional metadata', () => {
   const { manager, model } = modelFor({ 'app.tasks.open': 'down' })
   try {

--- a/test/keybinding-ui-model.test.ts
+++ b/test/keybinding-ui-model.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { HostKeybindingManager } from '../src/keybindings/manager.ts'
+import {
+  buildKeybindingEditorModel,
+  searchKeybindingRows,
+} from '../src/keybinding-ui/model.ts'
+
+function modelFor(raw: unknown) {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings(raw)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  return { manager, model }
+}
+
+test('editor model preserves defaults and exposes real category sections', () => {
+  const { manager, model } = modelFor(undefined)
+  try {
+    const submit = model.rows.find(row => row.id === 'app.input.submit')!
+    assert.equal(submit.customized, false)
+    assert.deepEqual(submit.effective.map(binding => binding.key), ['enter'])
+    assert.equal(submit.status, 'default')
+    const unbound = model.rows.find(row => row.id === 'app.tasks.open')!
+    assert.deepEqual(unbound.defaults, [])
+    assert.deepEqual(unbound.effective, [{ kind: 'direct', key: 'down' }])
+    assert.equal(unbound.status, 'unbound')
+    const trulyUnbound = model.rows.find(row => row.id === 'app.transcript.toggleFullscreen')!
+    assert.deepEqual(trulyUnbound.effective, [])
+    assert.equal(trulyUnbound.status, 'unbound')
+    assert.deepEqual(model.sections.map(section => section.category), [
+      'Input', 'Agent', 'Transcript', 'Editor', 'Permission', 'Panels', 'Session', 'Question', 'Tasks',
+    ])
+    assert.ok(model.sections.every(section => section.rows.length > 0))
+    assert.equal(model.leader.key, undefined)
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('search matches action ids, effective keys, and replaced defaults', () => {
+  const { manager, model } = modelFor({ 'app.todo.toggle': 'ctrl+y' })
+  try {
+    const oldKeyMatches = searchKeybindingRows(model.rows, 'ctrl+t')
+    assert.ok(oldKeyMatches.some(match => match.row.id === 'app.todo.toggle'))
+    assert.ok(oldKeyMatches.find(match => match.row.id === 'app.todo.toggle')!.fields.includes('defaults'))
+
+    const actionMatches = searchKeybindingRows(model.rows, 'todo ctrl+y')
+    assert.deepEqual(actionMatches.map(match => match.row.id), ['app.todo.toggle'])
+    assert.equal(model.rows.find(row => row.id === 'app.todo.toggle')!.status, 'customized')
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('model marks disabled, fixed, leader, and conflicting states distinctly', () => {
+  const { manager, model } = modelFor({
+    leader: 'ctrl+q',
+    'app.todo.toggle': false,
+    'app.transcript.toggleExpand': 'ctrl+y',
+    'app.history.search': 'ctrl+y',
+    'app.input.steer': '<leader>t',
+  })
+  try {
+    const disabled = model.rows.find(row => row.id === 'app.todo.toggle')!
+    const fixed = model.rows.find(row => row.id === 'question.confirm')!
+    const conflict = model.rows.find(row => row.id === 'app.transcript.toggleExpand')!
+    const leader = model.rows.find(row => row.id === 'app.input.steer')!
+    assert.equal(disabled.status, 'disabled')
+    assert.deepEqual(disabled.effective, [])
+    assert.equal(fixed.status, 'fixed')
+    assert.equal(fixed.fixed, true)
+    assert.equal(conflict.conflict, true)
+    assert.equal(conflict.status, 'conflict')
+    assert.deepEqual(leader.effective, [{ kind: 'leader', key: 't' }])
+    assert.equal(model.leader.key, 'ctrl+q')
+    assert.match(model.summary, /customized/)
+    assert.match(model.summary, /disabled/)
+    assert.match(model.summary, /conflict/)
+  } finally {
+    manager.dispose()
+  }
+})

--- a/test/keybinding-ui-model.test.ts
+++ b/test/keybinding-ui-model.test.ts
@@ -25,6 +25,8 @@ test('editor model preserves defaults and exposes real category sections', () =>
     const unbound = model.rows.find(row => row.id === 'app.tasks.open')!
     assert.deepEqual(unbound.defaults, [])
     assert.deepEqual(unbound.effective, [{ kind: 'direct', key: 'down' }])
+    assert.deepEqual(unbound.conditional, [{ kind: 'direct', key: 'down' }])
+    assert.equal(unbound.conditionalDescription, 'when the editor is empty and tasks are active')
     assert.equal(unbound.status, 'unbound')
     const trulyUnbound = model.rows.find(row => row.id === 'app.transcript.toggleFullscreen')!
     assert.deepEqual(trulyUnbound.effective, [])
@@ -34,6 +36,23 @@ test('editor model preserves defaults and exposes real category sections', () =>
     ])
     assert.ok(model.sections.every(section => section.rows.length > 0))
     assert.equal(model.leader.key, undefined)
+  } finally {
+    manager.dispose()
+  }
+})
+
+test('safe mode marks persisted action overrides as ignored defaults', () => {
+  const manager = new HostKeybindingManager()
+  const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+y' })
+  manager.setSafeMode(true)
+  manager.setUserConfiguration(parsed)
+  const model = buildKeybindingEditorModel(manager, parsed)
+  try {
+    const row = model.rows.find(candidate => candidate.id === 'app.todo.toggle')!
+    assert.equal(row.safeMode, true)
+    assert.equal(row.status, 'safe-mode')
+    assert.equal(row.customized, true)
+    assert.deepEqual(row.effective, [{ kind: 'direct', key: 'ctrl+t' }])
   } finally {
     manager.dispose()
   }

--- a/test/keybinding-ui-model.test.ts
+++ b/test/keybinding-ui-model.test.ts
@@ -53,6 +53,21 @@ test('a Down remap of the task browser keeps its conditional metadata', () => {
   }
 })
 
+test('a conflicted Down task binding keeps its conditional metadata', () => {
+  const { manager, model } = modelFor({
+    'app.tasks.open': 'down',
+    'app.todo.toggle': 'down',
+  })
+  try {
+    const row = model.rows.find(candidate => candidate.id === 'app.tasks.open')!
+    assert.equal(row.conflict, true)
+    assert.deepEqual(row.effective, [])
+    assert.deepEqual(row.conditional, [{ kind: 'direct', key: 'down' }])
+  } finally {
+    manager.dispose()
+  }
+})
+
 test('safe mode marks persisted action overrides as ignored defaults', () => {
   const manager = new HostKeybindingManager()
   const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+y' })

--- a/test/keybinding-ui-model.test.ts
+++ b/test/keybinding-ui-model.test.ts
@@ -41,6 +41,18 @@ test('editor model preserves defaults and exposes real category sections', () =>
   }
 })
 
+test('a Down remap of the task browser keeps its conditional metadata', () => {
+  const { manager, model } = modelFor({ 'app.tasks.open': 'down' })
+  try {
+    const row = model.rows.find(candidate => candidate.id === 'app.tasks.open')!
+    assert.deepEqual(row.effective, [{ kind: 'direct', key: 'down' }])
+    assert.deepEqual(row.conditional, [{ kind: 'direct', key: 'down' }])
+    assert.equal(row.conditionalDescription, 'when the editor is empty and tasks are active')
+  } finally {
+    manager.dispose()
+  }
+})
+
 test('safe mode marks persisted action overrides as ignored defaults', () => {
   const manager = new HostKeybindingManager()
   const parsed = parseUserKeybindings({ 'app.todo.toggle': 'ctrl+y' })

--- a/test/keybinding-ui-recorder.test.ts
+++ b/test/keybinding-ui-recorder.test.ts
@@ -38,14 +38,15 @@ test('direct recorder can explicitly capture the legal Escape binding', () => {
   let captured: string | undefined
   const recorder = new KeyRecorder({
     purpose: 'direct',
-    action: 'app.todo.toggle',
-    label: 'todo panel',
+    action: 'app.agent.interrupt',
+    label: 'interrupt',
     onCapture: key => { captured = key },
     onCancel: noop,
   })
   assert.match(recorder.render(88).join('\n'), /e: use Escape/)
   recorder.handleInput('e')
   assert.equal(captured, 'escape')
+  assert.match(validateRecordedKey('escape', { purpose: 'direct', action: 'app.todo.toggle' }).message!, /reserved/i)
 })
 
 test('Escape cancels recording and never captures a binding', () => {

--- a/test/keybinding-ui-recorder.test.ts
+++ b/test/keybinding-ui-recorder.test.ts
@@ -1,8 +1,43 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { KeyRecorder, validateRecordedKey } from '../src/keybinding-ui/recorder.ts'
+import {
+  DOUBLE_ESCAPE_MS,
+  KeyRecorder,
+  type KeyRecorderTimer,
+  validateRecordedKey,
+} from '../src/keybinding-ui/recorder.ts'
 
 function noop(): void {}
+
+function fakeTimer(): {
+  readonly timer: KeyRecorderTimer
+  readonly fire: () => void
+  readonly delay: () => number | undefined
+} {
+  let callback: (() => void) | undefined
+  let scheduledDelay: number | undefined
+  const timer: KeyRecorderTimer = {
+    set: (next, delay) => {
+      callback = next
+      scheduledDelay = delay
+      return Symbol('escape-timer')
+    },
+    clear: () => {
+      callback = undefined
+      scheduledDelay = undefined
+    },
+  }
+  return {
+    timer,
+    fire: () => {
+      const next = callback
+      callback = undefined
+      scheduledDelay = undefined
+      next?.()
+    },
+    delay: () => scheduledDelay,
+  }
+}
 
 test('recorder parses terminal input and returns the canonical KeyId', () => {
   let captured: string | undefined
@@ -34,31 +69,134 @@ test('recorder rejects dead, text-producing, and terminal-ambiguous keys', () =>
   assert.match(validateRecordedKey('escape', { purpose: 'leader-completion' }).message!, /cancel/i)
 })
 
-test('direct recorder can explicitly capture the legal Escape binding', () => {
-  let captured: string | undefined
-  const recorder = new KeyRecorder({
-    purpose: 'direct',
-    action: 'app.agent.interrupt',
-    label: 'interrupt',
-    onCapture: key => { captured = key },
-    onCancel: noop,
-  })
-  assert.match(recorder.render(88).join('\n'), /e: use Escape/)
-  recorder.handleInput('e')
-  assert.equal(captured, 'escape')
-  assert.match(validateRecordedKey('escape', { purpose: 'direct', action: 'app.todo.toggle' }).message!, /reserved/i)
-})
-
-test('Escape cancels recording and never captures a binding', () => {
+test('ordinary recorder cancels immediately on Escape', () => {
   let captures = 0
   let cancels = 0
   const recorder = new KeyRecorder({
-    purpose: 'leader-key',
-    label: 'global leader key',
+    purpose: 'direct',
+    action: 'app.todo.toggle',
+    label: 'todo panel',
     onCapture: () => { captures += 1 },
     onCancel: () => { cancels += 1 },
   })
   recorder.handleInput('\x1b')
   assert.equal(captures, 0)
   assert.equal(cancels, 1)
+})
+
+test('interrupt recorder assigns Escape only on double-Esc', () => {
+  let captured: string | undefined
+  let cancels = 0
+  let renders = 0
+  const clock = fakeTimer()
+  const recorder = new KeyRecorder({
+    purpose: 'direct',
+    action: 'app.agent.interrupt',
+    label: 'interrupt',
+    onCapture: key => { captured = key },
+    onCancel: () => { cancels += 1 },
+    requestRender: () => { renders += 1 },
+    timer: clock.timer,
+  })
+  const initial = recorder.render(88).join('\n')
+  assert.match(initial, /double-Esc: assign Escape/)
+  assert.doesNotMatch(initial, /e: use Escape/)
+  recorder.handleInput('e')
+  assert.equal(captured, undefined, 'the removed e shortcut must not assign Escape')
+  recorder.handleInput('\x1b')
+  assert.equal(clock.delay(), DOUBLE_ESCAPE_MS)
+  assert.equal(cancels, 0)
+  assert.equal(renders, 2, 'invalid e and the pending Escape each request a repaint')
+  assert.match(recorder.render(88).join('\n'), /Esc again to assign Escape/)
+  recorder.handleInput('\x1b')
+  assert.equal(captured, 'escape')
+  assert.equal(cancels, 0)
+  clock.fire()
+  assert.equal(cancels, 0, 'a captured Escape must clear the timeout')
+  assert.match(validateRecordedKey('escape', { purpose: 'direct', action: 'app.todo.toggle' }).message!, /reserved/i)
+})
+
+test('a single interrupt Escape cancels after the double-press window', () => {
+  let captures = 0
+  let cancels = 0
+  const clock = fakeTimer()
+  const recorder = new KeyRecorder({
+    purpose: 'direct',
+    action: 'app.agent.interrupt',
+    label: 'interrupt',
+    onCapture: () => { captures += 1 },
+    onCancel: () => { cancels += 1 },
+    timer: clock.timer,
+  })
+  recorder.handleInput('\x1b')
+  assert.equal(cancels, 0)
+  clock.fire()
+  assert.equal(captures, 0)
+  assert.equal(cancels, 1)
+})
+
+test('Escape repeat and release do not count as the second press', () => {
+  let captures = 0
+  let cancels = 0
+  const clock = fakeTimer()
+  const recorder = new KeyRecorder({
+    purpose: 'direct',
+    action: 'app.agent.interrupt',
+    label: 'interrupt',
+    onCapture: () => { captures += 1 },
+    onCancel: () => { cancels += 1 },
+    timer: clock.timer,
+  })
+  recorder.handleInput('\x1b')
+  recorder.handleInput('\x1b[27;1:3u')
+  recorder.handleInput('\x1b[27;1:2u')
+  assert.equal(captures, 0)
+  assert.equal(cancels, 0)
+  clock.fire()
+  assert.equal(cancels, 1)
+})
+
+test('a non-Escape key during pending Escape cancels without capturing it', () => {
+  let captures = 0
+  let cancels = 0
+  const clock = fakeTimer()
+  const recorder = new KeyRecorder({
+    purpose: 'direct',
+    action: 'app.agent.interrupt',
+    label: 'interrupt',
+    onCapture: () => { captures += 1 },
+    onCancel: () => { cancels += 1 },
+    timer: clock.timer,
+  })
+  recorder.handleInput('\x1b')
+  recorder.handleInput('\x18')
+  assert.equal(captures, 0)
+  assert.equal(cancels, 1)
+  clock.fire()
+  assert.equal(cancels, 1)
+})
+
+test('dispose clears pending Escape and blocks late callbacks or repaint', () => {
+  let captures = 0
+  let cancels = 0
+  let renders = 0
+  const clock = fakeTimer()
+  const recorder = new KeyRecorder({
+    purpose: 'direct',
+    action: 'app.agent.interrupt',
+    label: 'interrupt',
+    onCapture: () => { captures += 1 },
+    onCancel: () => { cancels += 1 },
+    requestRender: () => { renders += 1 },
+    timer: clock.timer,
+  })
+  recorder.handleInput('\x1b')
+  assert.equal(renders, 1)
+  recorder.dispose()
+  clock.fire()
+  assert.equal(captures, 0)
+  assert.equal(cancels, 0)
+  assert.equal(renders, 1)
+  recorder.handleInput('\x1b')
+  assert.equal(cancels, 0)
 })

--- a/test/keybinding-ui-recorder.test.ts
+++ b/test/keybinding-ui-recorder.test.ts
@@ -34,6 +34,20 @@ test('recorder rejects dead, text-producing, and terminal-ambiguous keys', () =>
   assert.match(validateRecordedKey('escape', { purpose: 'leader-completion' }).message!, /cancel/i)
 })
 
+test('direct recorder can explicitly capture the legal Escape binding', () => {
+  let captured: string | undefined
+  const recorder = new KeyRecorder({
+    purpose: 'direct',
+    action: 'app.todo.toggle',
+    label: 'todo panel',
+    onCapture: key => { captured = key },
+    onCancel: noop,
+  })
+  assert.match(recorder.render(88).join('\n'), /e: use Escape/)
+  recorder.handleInput('e')
+  assert.equal(captured, 'escape')
+})
+
 test('Escape cancels recording and never captures a binding', () => {
   let captures = 0
   let cancels = 0

--- a/test/keybinding-ui-recorder.test.ts
+++ b/test/keybinding-ui-recorder.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { KeyRecorder, validateRecordedKey } from '../src/keybinding-ui/recorder.ts'
+
+function noop(): void {}
+
+test('recorder parses terminal input and returns the canonical KeyId', () => {
+  let captured: string | undefined
+  const recorder = new KeyRecorder({
+    purpose: 'direct',
+    action: 'app.todo.toggle',
+    label: 'todo panel',
+    onCapture: key => { captured = key },
+    onCancel: noop,
+  })
+  recorder.handleInput('\x1b[115;5u')
+  assert.equal(captured, 'ctrl+s')
+})
+
+test('leader completions allow printable keys after the prefix', () => {
+  assert.deepEqual(validateRecordedKey('t', { purpose: 'leader-completion', action: 'app.todo.toggle' }), {
+    key: 't',
+    message: undefined,
+  })
+  assert.equal(validateRecordedKey('t', { purpose: 'direct', action: 'app.todo.toggle' }).key, undefined)
+})
+
+test('recorder rejects dead, text-producing, and terminal-ambiguous keys', () => {
+  assert.match(validateRecordedKey('shift+f5', { purpose: 'direct' }).message!, /cannot be matched/i)
+  assert.match(validateRecordedKey('a', { purpose: 'direct' }).message!, /typing/i)
+  assert.match(validateRecordedKey('ctrl+j', { purpose: 'direct' }).message!, /legacy terminals/i)
+  assert.match(validateRecordedKey('shift+enter', { purpose: 'direct', action: 'app.input.submit' }).message!, /newline/i)
+  assert.match(validateRecordedKey('tab', { purpose: 'direct', action: 'app.input.submit' }).message!, /before submit/i)
+  assert.match(validateRecordedKey('escape', { purpose: 'leader-completion' }).message!, /cancel/i)
+})
+
+test('Escape cancels recording and never captures a binding', () => {
+  let captures = 0
+  let cancels = 0
+  const recorder = new KeyRecorder({
+    purpose: 'leader-key',
+    label: 'global leader key',
+    onCapture: () => { captures += 1 },
+    onCancel: () => { cancels += 1 },
+  })
+  recorder.handleInput('\x1b')
+  assert.equal(captures, 0)
+  assert.equal(cancels, 1)
+})

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -16,6 +16,7 @@ import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { CommandInvocation } from '@deepseek-ai/dsh-commands'
 import { CommandId } from '@deepseek-ai/dsh-commands'
 import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from '../src/commands.ts'
+import { KeybindingEditorController } from '../src/keybinding-ui/controller.ts'
 import { parseUserKeybindings } from '../src/keybindings/config.ts'
 import type { CatalogRefreshOutcome, CatalogRefreshRequest } from '../src/skill-catalog-refresh.ts'
 import { SESSIONLESS_COMMANDS } from '../src/index.ts'
@@ -682,6 +683,123 @@ test('/keybindings reload re-reads the settings document LAZILY (the explicit re
   t.app.stop()
 })
 
+test('/keybindings reload queues behind an editor write and applies the latest document', async () => {
+  let settingsDoc: TuiSettingsLike['get'] extends () => infer T ? T : never = {
+    theme: 'auto',
+    footer: 'full',
+    fullscreen: 'off',
+    busyEnter: 'queue',
+    localShellSandbox: 'bypass',
+    homeEndKeys: 'viewport',
+    focusMode: 'off',
+    iconStyle: 'emoji',
+    keybindings: { 'app.input.steer': 'ctrl+x' },
+  }
+  let writes = 0
+  let firstWriteStarted!: () => void
+  const firstStarted = new Promise<void>(resolve => { firstWriteStarted = resolve })
+  let releaseFirst!: () => void
+  const release = new Promise<void>(resolve => { releaseFirst = resolve })
+  const tuiSettings: TuiSettingsLike = {
+    get: () => settingsDoc,
+    replace: async next => {
+      writes += 1
+      if (writes === 1) {
+        firstWriteStarted()
+        await release
+      }
+      settingsDoc = next
+    },
+  }
+  const t = setup({ tuiSettings })
+  const manager = t.app.keybindingsManager()
+  manager.setUserConfiguration(parseUserKeybindings(settingsDoc.keybindings))
+  const controller = new KeybindingEditorController({ settings: tuiSettings, manager })
+  try {
+    const editorWrite = controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    await firstStarted
+    let reloadSettled = false
+    const reload = t.runCommand('keybindings', 'reload').then(result => {
+      reloadSettled = true
+      return result
+    })
+    await Promise.resolve()
+    assert.equal(reloadSettled, false, 'reload must wait for the in-flight whole-document write')
+    releaseFirst()
+    const [editorResult, reloadResult] = await Promise.all([editorWrite, reload])
+    assert.equal(editorResult.kind, 'applied')
+    assert.equal((reloadResult as { kind: string }).kind, 'success')
+    assert.equal(writes, 1)
+    assert.deepEqual(settingsDoc.keybindings, {
+      'app.input.steer': 'ctrl+x',
+      'app.todo.toggle': 'ctrl+y',
+    })
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+y'])
+  } finally {
+    releaseFirst()
+    t.app.stop()
+    manager.dispose()
+  }
+})
+
+test('/keybindings reset queues behind an editor write and keeps the final reset authoritative', async () => {
+  let settingsDoc: TuiSettingsLike['get'] extends () => infer T ? T : never = {
+    theme: 'auto',
+    footer: 'full',
+    fullscreen: 'off',
+    busyEnter: 'queue',
+    localShellSandbox: 'bypass',
+    homeEndKeys: 'viewport',
+    focusMode: 'off',
+    iconStyle: 'emoji',
+    keybindings: undefined,
+  }
+  let writes = 0
+  let firstWriteStarted!: () => void
+  const firstStarted = new Promise<void>(resolve => { firstWriteStarted = resolve })
+  let releaseFirst!: () => void
+  const release = new Promise<void>(resolve => { releaseFirst = resolve })
+  const tuiSettings: TuiSettingsLike = {
+    get: () => settingsDoc,
+    replace: async next => {
+      writes += 1
+      if (writes === 1) {
+        firstWriteStarted()
+        await release
+      }
+      settingsDoc = next
+    },
+  }
+  const t = setup({ tuiSettings })
+  const manager = t.app.keybindingsManager()
+  manager.setUserConfiguration(parseUserKeybindings(settingsDoc.keybindings))
+  const controller = new KeybindingEditorController({ settings: tuiSettings, manager })
+  try {
+    const editorWrite = controller.mutate({
+      kind: 'add',
+      action: 'app.todo.toggle',
+      binding: { kind: 'direct', key: 'ctrl+y' },
+    })
+    await firstStarted
+    const reset = t.runCommand('keybindings', 'reset')
+    releaseFirst()
+    const [editorResult, resetResult] = await Promise.all([editorWrite, reset])
+    assert.equal(editorResult.kind, 'applied')
+    assert.equal((resetResult as { kind: string }).kind, 'success')
+    assert.equal('keybindings' in settingsDoc, false)
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t'])
+    assert.equal(writes, 2)
+  } finally {
+    releaseFirst()
+    t.app.stop()
+    manager.dispose()
+  }
+})
+
 test('/keybindings reset awaits the settings write, applies the cleared config, and reports its real outcome', async () => {
   // Review finding: the reset must not report success before the async
   // persistence write resolves — a failed write is an error result.
@@ -747,6 +865,26 @@ test('/keybindings reset awaits the settings write, applies the cleared config, 
   assert.ok((readFailed as { text: string }).text.includes('failed'), `error text missing: ${JSON.stringify(readFailed)}`)
   assert.equal(readsFailing, 1, 'the initial read must be attempted once')
   assert.deepEqual(t.app.keybindingsManager().keysFor('app.input.steer'), ['ctrl+x'], 'a failed reset must keep the running keymap')
+  t.app.stop()
+})
+
+test('/settings keeps the keyboard-shortcuts fallback when the settings read throws', async () => {
+  let reads = 0
+  const tuiSettings: TuiSettingsLike = {
+    get: () => {
+      reads += 1
+      throw new Error('settings read exploded')
+    },
+    replace: async () => {},
+  }
+  const t = setup({ tuiSettings })
+  const result = await t.runCommand('settings')
+  assert.equal((result as { kind: string }).kind, 'success')
+  t.vt.sendInput('keyboard')
+  const view = await t.view()
+  assert.match(view, /Keyboard shortcuts/)
+  assert.match(view, /Unavailable/)
+  assert.equal(reads, 1, 'the settings command should make one guarded initial read')
   t.app.stop()
 })
 

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -290,6 +290,33 @@ test('/preset is in the sessionless dispatch gate', () => {
   assert.ok(SESSIONLESS_COMMANDS.has('preset'), 'SESSIONLESS_COMMANDS must keep /preset sessionless')
 })
 
+test('/keybindings opens sessionless without creating a session', async () => {
+  const tuiSettings: TuiSettingsLike = {
+    get: () => ({
+      theme: 'auto',
+      footer: 'full',
+      fullscreen: 'off',
+      busyEnter: 'queue',
+      localShellSandbox: 'bypass',
+      homeEndKeys: 'viewport',
+      focusMode: 'off',
+      iconStyle: 'emoji',
+      keybindings: undefined,
+    }),
+    replace: async () => {},
+  }
+  const t = setup({ tuiSettings })
+  try {
+    const result = await t.runCommand('keybindings')
+    assert.deepEqual(result, { kind: 'success' })
+    assert.deepEqual(t.ensureCalls, [], '/keybindings must not create a session')
+    const view = await t.view()
+    assert.match(view, /Keyboard shortcuts/)
+  } finally {
+    t.app.stop()
+  }
+})
+
 test('/preset with no session opens the English roster and creates nothing', async () => {
   const t = setup({})
   const result = await t.run('')
@@ -736,9 +763,9 @@ test('/keybindings reload queues behind an editor write and applies the latest d
     assert.equal(writes, 1)
     assert.deepEqual(settingsDoc.keybindings, {
       'app.input.steer': 'ctrl+x',
-      'app.todo.toggle': 'ctrl+y',
+      'app.todo.toggle': ['ctrl+t', 'ctrl+y'],
     })
-    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+y'])
+    assert.deepEqual(manager.keysFor('app.todo.toggle'), ['ctrl+t', 'ctrl+y'])
   } finally {
     releaseFirst()
     t.app.stop()


### PR DESCRIPTION
## Summary
- add the action-first `/keybindings` editor with search, detail views, direct/leader recording, mutations, statuses, diagnostics, and safe-mode handling
- share the editor from `/settings` with an unavailable fallback while keeping `/help` key-first and read-only
- preserve complete settings documents, serialize whole-document mutations, preflight conflicts/leader ambiguity, and project runtime state only after persistence succeeds
- document the architecture and add focused regressions for model, recorder, persistence, concurrency, lifecycle, teardown, and command integration

## Verification
- `pnpm test`
- `node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm build`
- naming, client-boundary, and host-keybinding gates
- `git diff --check`

All checks pass. `packages/pi-tui` is unchanged.