### PR TITLE
fix(transcript): ignore model-only surface replacements (ghost compaction cards)

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -220,6 +220,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   executed only when it lives in the USER layer of your settings document
   — a repository/project-supplied `footerCommand` is never executed.
 
+### Fixed
+
+- **Ghost Tool Cards after `compaction/prune` are gone.** After
+  tool-result pruning (or a summary-compaction checkpoint) in a long
+  session, Harness appends model-only copy events carrying
+  `surfaceOp: { op: 'replace' }`; the Human Transcript used to render
+  those copies as new messages, so a batch of duplicate "ghost Tool
+  Cards" appeared at the transcript tail and the original full result
+  was replaced by the pruned truncated text. `TranscriptFolder` now
+  filters every explicit surface replacement at its unified entry point
+  (user/message, assistant/message and tool/result alike) — append-origin
+  history survives untouched, unmarked legacy sessions stay fully
+  compatible, and `/export md` follows the same contract.
+
 ## [0.3.4] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,18 @@
   擦掉。**安全:** 只有当命令位于你的设置文档的 USER 层时才会被执行
   ——仓库/项目提供的 `footerCommand` 永远不会被执行。
 
+### 修复
+
+- **compaction/prune 后的幽灵 Tool Card 不再出现。** 长会话发生
+  工具结果剪枝(或 summary compaction 生成检查点)后,Harness 会追加
+  携带 `surfaceOp: { op: 'replace' }` 的模型专用副本事件;Human
+  Transcript 之前会把这些副本当成新消息渲染,导致 transcript 末尾
+  突然出现一批重复的“幽灵 Tool Card”,并把原始完整结果替换成剪枝
+  后的截断文本。现在 `TranscriptFolder` 在统一入口过滤所有明确的
+  surface replacement(user/message、assistant/message、tool/result
+  一视同仁)——append-origin 历史原样保留,未标记 surfaceOp 的旧
+  session 完全兼容,`/export md` 导出采用同一契约。
+
 ## [0.3.4] - 2026-08-25
 
 ### 新增

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -16,6 +16,7 @@
  * @module @xmoon76/dsh-pi-tui/transcript
  */
 
+import { isReplacementSurfaceEvent } from '@deepseek-ai/dsh-session'
 import type { SessionEvent, SessionHeader, JsonValue } from '@deepseek-ai/dsh-session'
 import type { ContentBlock } from '@deepseek-ai/dsh-llm'
 import { contextIconSemantic, contextProvenance, contextSummary } from './context.ts'
@@ -910,6 +911,17 @@ export class TranscriptFolder {
   }
 
   private applyEvent(event: SessionEvent): void {
+    // The human transcript keeps append-origin history. Surface
+    // replacements are model-only rewrites (tool-result pruning,
+    // compaction summary checkpoints) and must never be replayed as new
+    // visible messages or mutate any projection (items, Focus activity,
+    // tool counts, grouping, usage). Replaced history may ALSO arrive as
+    // user/message or assistant/message, so this is a unified gate before
+    // the compaction lifecycle and the switch — not a per-case guard.
+    // Only an EXPLICIT replacement is filtered; unmarked legacy events
+    // keep their current behavior (no surfaceOp = not a surface event at
+    // all — the helper requires the event type AND the marker).
+    if (isReplacementSurfaceEvent(event)) return
     // Compaction lifecycle events are typed STRUCTURALLY: dsh-compaction
     // is not a peer dependency, so its session-event augmentation never
     // enters our type graph (the same pattern as the structural service
@@ -1483,6 +1495,12 @@ export function renderTranscriptMarkdown(session: {
     '',
   ]
   for (const event of session.events) {
+    // The same append-origin contract as the transcript fold: a surface
+    // replacement is a model-only rewrite (pruned tool result, compaction
+    // summary checkpoint) and must never be replayed in a human-facing
+    // export — the append-origin original is already rendered at its log
+    // position. Unmarked legacy events keep their current behavior.
+    if (isReplacementSurfaceEvent(event)) continue
     switch (event.type) {
       case 'user/message': {
         const text = markdownContent(event.data.content)

--- a/test/folding.test.ts
+++ b/test/folding.test.ts
@@ -256,3 +256,55 @@ test('renderTranscriptMarkdown projects image blocks (review finding 4)', () => 
   assert.ok(md.includes('> 🖼️ image · 640×480 · attachment `att-10`'), 'image-only message renders')
   assert.ok(md.includes('分析这张图:'), 'text rides along')
 })
+
+test('renderTranscriptMarkdown never replays surface replacements', () => {
+  // A pruned tool result + a summary compaction checkpoint must stay out
+  // of the human-facing export: the append-origin originals already render
+  // at their log positions (same contract as the transcript fold).
+  const session = {
+    header: { id: 'session-2' as never, cwd: '/ws', version: 1, createdAt: 0 },
+    events: [
+      {
+        type: 'tool/call',
+        seq: 0,
+        time: 1,
+        data: { turn: 0, step: 0, callId: 'call-1' as never, name: 'bash', arguments: '{}' },
+      },
+      {
+        type: 'tool/result',
+        seq: 1,
+        time: 2,
+        data: {
+          turn: 0,
+          step: 0,
+          message: {
+            id: 'msg-1' as never,
+            role: 'user',
+            content: [{ type: 'tool-result', toolCallId: 'call-1' as never, content: [{ type: 'text', text: 'ORIGINAL RESULT' }] }],
+            source: { kind: 'tool', callId: 'call-1' as never },
+          },
+        },
+        surfaceOp: 'append',
+      },
+      {
+        type: 'tool/result',
+        seq: 2,
+        time: 3,
+        data: {
+          turn: 0,
+          step: 0,
+          message: {
+            id: 'msg-2' as never,
+            role: 'user',
+            content: [{ type: 'tool-result', toolCallId: 'call-1' as never, content: [{ type: 'text', text: 'PRUNED RESULT' }] }],
+            source: { kind: 'tool', callId: 'call-1' as never },
+          },
+        },
+        surfaceOp: { op: 'replace', start: 1, end: 1 },
+      },
+    ],
+  }
+  const md = renderTranscriptMarkdown(session as never)
+  assert.ok(md.includes('ORIGINAL RESULT'), 'the append-origin result renders')
+  assert.ok(!md.includes('PRUNED RESULT'), 'the pruned replacement must never render in the export')
+})

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -26,6 +26,52 @@ function rawEvent(type: string, data: Record<string, unknown>, seq: number): Ses
   return { type, seq, time: 1_700_000_000_000 + seq, data } as SessionEvent
 }
 
+/** Build a surface event carrying its surface metadata marker. */
+function surfaceEvent<K extends SessionEvent['type']>(
+  type: K,
+  data: SessionEvent<K>['data'],
+  seq: number,
+  surfaceOp: 'append' | { op: 'replace'; start: number; end: number },
+): SessionEvent {
+  return { type, seq, time: 1_700_000_000_000 + seq, data, surfaceOp } as SessionEvent
+}
+
+/** One append-origin tool result for `callId` (surfaceOp=append). */
+function toolResult(seq: number, callId: string, text: string, name = 'bash'): SessionEvent {
+  return surfaceEvent('tool/result', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`msg-${seq}`),
+      role: 'user',
+      content: [{
+        type: 'tool-result',
+        toolCallId: CallId(callId),
+        content: [{ type: 'text', text }],
+      }],
+      source: { kind: 'tool', callId: CallId(callId) },
+    },
+  }, seq, 'append')
+}
+
+/** One prune replacement of tool/result `callId` (surfaceOp=replace). */
+function pruneReplacement(seq: number, callId: string, text: string, originalSeq: number): SessionEvent {
+  return surfaceEvent('tool/result', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`msg-prune-${seq}`),
+      role: 'user',
+      content: [{
+        type: 'tool-result',
+        toolCallId: CallId(callId),
+        content: [{ type: 'text', text }],
+      }],
+      source: { kind: 'tool', callId: CallId(callId) },
+    },
+  }, seq, { op: 'replace', start: originalSeq, end: originalSeq })
+}
+
 /** The message list shape expected by assertions. */
 function kinds(messages: readonly TranscriptMessage[]): string[] {
   return messages.map(message => message.kind)
@@ -914,6 +960,284 @@ test('injected context rows carry a source-kind icon SEMANTIC (never a glyph)', 
     // The fold NEVER stores a concrete glyph.
     assert.equal('emoji' in (message as Record<string, unknown>), false, `folded system rows must not carry a glyph field:\n${JSON.stringify(message)}`)
   })
+})
+
+// ---------------------------------------------------------------------------
+// Human-transcript append-origin contract: model-only surface replacements
+// (tool-result pruning after compaction/prune, summary compaction
+// checkpoints) must never be replayed as new visible messages.
+// ---------------------------------------------------------------------------
+
+test('Test A: an append-origin tool call/result pair folds into one ok card', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('a1'), name: 'bash', arguments: '{"command":"echo"}' }, 1),
+    toolResult(2, 'a1', 'ORIGINAL FULL RESULT'),
+  ])
+  assert.deepEqual(kinds(messages), ['tool'])
+  const tool = messages[0]
+  assert.ok(tool !== undefined && tool.kind === 'tool')
+  assert.equal(tool.status, 'ok')
+  assert.equal(tool.result, 'ORIGINAL FULL RESULT')
+  // The running → ok pairing is unchanged (verified via the folder).
+  const folder = new TranscriptFolder()
+  folder.apply([event('turn/start', { turn: 0 }, 0), event('tool/call', { turn: 0, step: 0, callId: CallId('a1'), name: 'bash', arguments: '{}' }, 1)])
+  const running = folder.messages()[0]
+  assert.ok(running !== undefined && running.kind === 'tool')
+  assert.equal(running.status, 'running')
+  folder.apply([toolResult(2, 'a1', 'done')])
+  const settled = folder.messages()[0]
+  assert.ok(settled !== undefined && settled.kind === 'tool')
+  assert.equal(settled.status, 'ok')
+})
+
+test('Test B: a post-prune replacement tool/result must not add a ghost card', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('a1'), name: 'bash', arguments: '{}' }, 1),
+    toolResult(2, 'a1', 'ORIGINAL FULL RESULT'),
+    // compaction/prune then the replacement copy of the SAME call.
+    rawEvent('compaction/prune', {
+      shadowedRange: { start: 2, end: 2 },
+      shadowedSeqs: [2],
+      shadowedTokenCount: 4200,
+    }, 3),
+    pruneReplacement(4, 'a1', 'PRUNED RESULT', 2),
+  ])
+  assert.deepEqual(kinds(messages), ['tool'], 'exactly one tool card expected')
+  const tool = messages[0]
+  assert.ok(tool !== undefined && tool.kind === 'tool')
+  assert.equal(tool.result, 'ORIGINAL FULL RESULT', 'the append-origin result must survive pruned replacement')
+  assert.notEqual(tool.result, 'PRUNED RESULT')
+})
+
+test('Test C: many prune replacements never change the transcript tail', () => {
+  const events: SessionEvent[] = [event('turn/start', { turn: 0 }, 0)]
+  let seq = 1
+  const originalSeqs: number[] = []
+  for (let index = 0; index < 13; index += 1) {
+    const callId = `call-${index}`
+    events.push(event('tool/call', { turn: 0, step: 0, callId: CallId(callId), name: 'bash', arguments: `{"cmd":"${index}"}` }, seq++))
+    const originalSeq = seq
+    originalSeqs.push(originalSeq)
+    events.push(toolResult(seq++, callId, `ORIGINAL ${index}`))
+  }
+  const before = foldTranscript(events)
+  const beforeTools = before.filter(message => message.kind === 'tool')
+  assert.equal(beforeTools.length, 13)
+  // Every original gets a prune + replacement, at the tail of the log.
+  for (let index = 0; index < 13; index += 1) {
+    const callId = `call-${index}`
+    events.push(rawEvent('compaction/prune', {
+      shadowedRange: { start: originalSeqs[index]!, end: originalSeqs[index]! },
+      shadowedSeqs: [originalSeqs[index]!],
+      shadowedTokenCount: 100,
+    }, seq++))
+    events.push(pruneReplacement(seq++, callId, `PRUNED ${index}`, originalSeqs[index]!))
+  }
+  const after = foldTranscript(events)
+  assert.deepEqual(kinds(after), kinds(before), 'transcript kinds must be identical before/after pruning')
+  const afterTools = after.filter(message => message.kind === 'tool')
+  assert.equal(afterTools.length, 13, 'no ghost tool cards after 13 prunes')
+  afterTools.forEach((tool, index) => {
+    assert.ok(tool !== undefined && tool.kind === 'tool')
+    assert.equal(tool.result, `ORIGINAL ${index}`, `tool ${index} result must keep the append-origin text`)
+  })
+})
+
+test('Test D: a replacement user/message does not enter the transcript', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    surfaceEvent('user/message', {
+      id: MessageId('msg-orig'),
+      role: 'user',
+      content: [{ type: 'text', text: 'original' }],
+      source: { kind: 'user' },
+    }, 1, 'append'),
+    // The summary compaction checkpoint replaces the range with one node.
+    surfaceEvent('user/message', {
+      id: MessageId('msg-summary'),
+      role: 'user',
+      content: [{ type: 'text', text: 'summary of earlier turns' }],
+      source: { kind: 'user' },
+    }, 2, { op: 'replace', start: 0, end: 1 }),
+  ])
+  assert.deepEqual(kinds(messages), ['user'], 'no user or system card for the replacement')
+  const only = messages[0]
+  assert.ok(only !== undefined && only.kind === 'user')
+  assert.equal(only.text, 'original')
+})
+
+test('Test E: a replacement assistant/message does not enter the transcript', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    surfaceEvent('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('msg-ans'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'the original answer' }],
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+      },
+    }, 1, 'append'),
+    surfaceEvent('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('msg-ans2'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'rewritten answer' }],
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+      },
+    }, 2, { op: 'replace', start: 1, end: 1 }),
+  ])
+  assert.deepEqual(kinds(messages), ['assistant'], 'no assistant card for the replacement')
+  const only = messages[0]
+  assert.ok(only !== undefined && only.kind === 'assistant')
+  assert.equal(only.text, 'the original answer', 'the append-origin assistant history must not be overwritten')
+})
+
+test('Test F: legacy unmarked sessions keep their current behavior', () => {
+  // tool/call + tool/result WITHOUT surfaceOp (a legacy Harness log).
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('legacy-1'), name: 'bash', arguments: '{}' }, 1),
+    event('tool/result', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('msg-legacy'),
+        role: 'user',
+        content: [{
+          type: 'tool-result',
+          toolCallId: CallId('legacy-1'),
+          content: [{ type: 'text', text: 'legacy result' }],
+        }],
+        source: { kind: 'tool', callId: CallId('legacy-1') },
+      },
+    }, 2),
+  ])
+  assert.deepEqual(kinds(messages), ['tool'])
+  const tool = messages[0]
+  assert.ok(tool !== undefined && tool.kind === 'tool')
+  assert.equal(tool.status, 'ok')
+  assert.equal(tool.result, 'legacy result')
+  // Legacy user/assistant messages without surfaceOp also survive.
+  const legacyUser = foldTranscript([
+    event('user/message', {
+      id: MessageId('msg-lu'), role: 'user',
+      content: [{ type: 'text', text: 'hello legacy' }],
+      source: { kind: 'user' },
+    }, 0),
+  ])
+  assert.deepEqual(kinds(legacyUser), ['user'])
+})
+
+test('Test G: cold replay and incremental replay agree on replacement logs', () => {
+  const events: SessionEvent[] = [
+    event('turn/start', { turn: 0 }, 0),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('a1'), name: 'bash', arguments: '{}' }, 1),
+    toolResult(2, 'a1', 'ORIGINAL'),
+    rawEvent('compaction/prune', { shadowedRange: { start: 2, end: 2 }, shadowedSeqs: [2], shadowedTokenCount: 1 }, 3),
+    pruneReplacement(4, 'a1', 'PRUNED', 2),
+  ]
+  const cold = foldTranscript(events)
+  const folder = new TranscriptFolder()
+  for (const eventOne of events) folder.apply([eventOne])
+  const incremental = folder.messages()
+  assert.deepEqual(incremental, cold, 'incremental replay must match the one-shot cold fold')
+  // Windowing must agree too: a window containing the turn keeps one tool.
+  const coldWindowed = foldTranscript(events, { maxTurns: 5 })
+  const warmWindowed = folder.messages({ maxTurns: 5 })
+  assert.deepEqual(warmWindowed, coldWindowed, 'windowed projections must match')
+})
+
+test('a replacement does not disturb consecutive-read grouping or the window summary', () => {
+  const readResult = (seq: number, callId: string, text: string): SessionEvent => surfaceEvent('tool/result', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`msg-${seq}`),
+      role: 'user',
+      content: [{
+        type: 'tool-result',
+        toolCallId: CallId(callId),
+        content: [{ type: 'text', text }],
+      }],
+      source: { kind: 'tool', callId: CallId(callId) },
+    },
+  }, seq, 'append')
+  const events: SessionEvent[] = [
+    event('turn/start', { turn: 0 }, 0),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('r1'), name: 'read', arguments: '{"file":"a.ts"}' }, 1),
+    readResult(2, 'r1', 'aaa'),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('r2'), name: 'read', arguments: '{"file":"b.ts"}' }, 3),
+    readResult(4, 'r2', 'bbb'),
+  ]
+  const before = foldTranscript(events)
+  const beforeTools = before.filter(message => message.kind === 'tool')
+  assert.equal(beforeTools.length, 1)
+  assert.equal(beforeTools[0]?.args, '2 files')
+  assert.ok((beforeTools[0]?.result ?? '').includes('aaa') && (beforeTools[0]?.result ?? '').includes('bbb'))
+  // A prune replacement of the FIRST read lands after the pair.
+  const after = foldTranscript([
+    ...events,
+    rawEvent('compaction/prune', { shadowedRange: { start: 2, end: 2 }, shadowedSeqs: [2], shadowedTokenCount: 1 }, 5),
+    pruneReplacement(6, 'r1', 'aaa-pruned', 2),
+  ])
+  const afterTools = after.filter(message => message.kind === 'tool')
+  assert.equal(afterTools.length, 1, 'the group must not gain a member')
+  assert.equal(afterTools[0]?.args, '2 files', 'the group card must keep "2 files"')
+  assert.ok((afterTools[0]?.result ?? '').includes('aaa') && (afterTools[0]?.result ?? '').includes('bbb'), 'the grouped result must keep both originals')
+  // The window summary counts grouped cards, and the replacement must not
+  // change the collapsed history's tool count.
+  const windowed = foldTranscript([...events, rawEvent('compaction/prune', { shadowedRange: { start: 2, end: 2 }, shadowedSeqs: [2], shadowedTokenCount: 1 }, 5), pruneReplacement(6, 'r1', 'aaa-pruned', 2)], { maxTurns: 5 })
+  assert.equal(windowed[0]?.kind, 'tool', 'one recent turn fits the window; no summary noise')
+  assert.equal(windowed.filter(message => message.kind === 'tool').length, 1, 'the windowed view keeps exactly the grouped read card')
+})
+
+test('a replacement assistant/message does not mutate Focus activity', () => {
+  const folder = new TranscriptFolder()
+  const events: SessionEvent[] = [
+    event('turn/start', { turn: 0 }, 0),
+    surfaceEvent('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('msg-1'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'first answer' }],
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+      },
+    }, 1, 'append'),
+  ]
+  folder.apply(events)
+  const before = folder.turnActivity(0)
+  assert.ok(before !== undefined)
+  const beforeMessages = before.assistantMessages
+  const beforeRevision = before.revision
+  // A replacement assistant/message for the same step lands.
+  folder.apply([surfaceEvent('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId('msg-2'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'rewritten' }],
+      source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+    },
+  }, 2, { op: 'replace', start: 1, end: 1 })])
+  const after = folder.turnActivity(0)
+  assert.ok(after !== undefined)
+  assert.equal(after.assistantMessages, beforeMessages, 'replacement must not bump assistantMessages')
+  assert.equal(after.revision, beforeRevision, 'replacement must not bump the Focus revision')
+  // And the transcript itself still holds the append-origin answer.
+  const messages = folder.messages()
+  assert.deepEqual(kinds(messages), ['assistant'])
+  const assistant = messages[0]
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, 'first answer', 'append-origin assistant text must survive')
 })
 
 

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -1190,11 +1190,54 @@ test('a replacement does not disturb consecutive-read grouping or the window sum
   assert.equal(afterTools.length, 1, 'the group must not gain a member')
   assert.equal(afterTools[0]?.args, '2 files', 'the group card must keep "2 files"')
   assert.ok((afterTools[0]?.result ?? '').includes('aaa') && (afterTools[0]?.result ?? '').includes('bbb'), 'the grouped result must keep both originals')
-  // The window summary counts grouped cards, and the replacement must not
-  // change the collapsed history's tool count.
-  const windowed = foldTranscript([...events, rawEvent('compaction/prune', { shadowedRange: { start: 2, end: 2 }, shadowedSeqs: [2], shadowedTokenCount: 1 }, 5), pruneReplacement(6, 'r1', 'aaa-pruned', 2)], { maxTurns: 5 })
-  assert.equal(windowed[0]?.kind, 'tool', 'one recent turn fits the window; no summary noise')
-  assert.equal(windowed.filter(message => message.kind === 'tool').length, 1, 'the windowed view keeps exactly the grouped read card')
+})
+
+test('window summaries stay identical across a prune replacement', () => {
+  const readResult = (seq: number, callId: string, text: string): SessionEvent => surfaceEvent('tool/result', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`msg-${seq}`),
+      role: 'user',
+      content: [{
+        type: 'tool-result',
+        toolCallId: CallId(callId),
+        content: [{ type: 'text', text }],
+      }],
+      source: { kind: 'tool', callId: CallId(callId) },
+    },
+  }, seq, 'append')
+  // Three turns: turn 0 = one grouped read pair, turn 1 = a bash call,
+  // turn 2 = a user prompt. A maxTurns=2 window collapses turn 0.
+  const events: SessionEvent[] = [
+    event('turn/start', { turn: 0 }, 0),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('r1'), name: 'read', arguments: '{"file":"a.ts"}' }, 1),
+    readResult(2, 'r1', 'aaa'),
+    event('tool/call', { turn: 0, step: 0, callId: CallId('r2'), name: 'read', arguments: '{"file":"b.ts"}' }, 3),
+    readResult(4, 'r2', 'bbb'),
+    event('turn/start', { turn: 1 }, 5),
+    event('tool/call', { turn: 1, step: 0, callId: CallId('b1'), name: 'bash', arguments: '{}' }, 6),
+    toolResult(7, 'b1', 'bash result'),
+    event('turn/start', { turn: 2 }, 8),
+    surfaceEvent('user/message', {
+      id: MessageId('msg-9'), role: 'user',
+      content: [{ type: 'text', text: 'newest question' }],
+      source: { kind: 'user' },
+    }, 9, 'append'),
+  ]
+  const before = foldTranscript(events, { maxTurns: 2 })
+  const summary = before[0]
+  assert.ok(summary !== undefined && summary.kind === 'summary', `expected a leading summary:\n${JSON.stringify(before)}`)
+  assert.ok(summary.text.includes('1 earlier turn'), `summary text:\n${summary.text}`)
+  assert.ok(summary.text.includes('1 tool call'), `summary must collapse the grouped read pair as ONE card:\n${summary.text}`)
+  // A prune replacement of the first read lands at the tail (the original
+  // accident's shape — the ghost card appears at the transcript tail).
+  const after = foldTranscript([
+    ...events,
+    rawEvent('compaction/prune', { shadowedRange: { start: 2, end: 2 }, shadowedSeqs: [2], shadowedTokenCount: 1 }, 10),
+    pruneReplacement(11, 'r1', 'aaa-pruned', 2),
+  ], { maxTurns: 2 })
+  assert.deepEqual(after, before, 'the windowed projection must be byte-identical after a replacement')
 })
 
 test('a replacement assistant/message does not mutate Focus activity', () => {


### PR DESCRIPTION
## 问题

长会话发生 `compaction/prune`(工具结果剪枝)或 summary compaction 后,transcript 末尾会突然出现一批“幽灵 Tool Card”。

根因:Harness 的 tool-result pruner 会追加一个 `tool/result`,携带 `surfaceOp: { op: 'replace', start, end }` —— 这是**模型专用**的副本(把原始完整结果替换成剪枝后的截断文本)。`TranscriptFolder` 按 callId 查 `pendingCalls` 找不到(原调用早已被 append-origin 结果 settle),于是落入 **Unknown call fallback** → `appendItem()` → 幽灵卡片。同类事件还可能以 `user/message`(summary 检查点)/ `assistant/message` 形式到达,同样会被重放或污染投影。

```text
compaction/prune → replacement tool/result { surfaceOp: replace }
  → pendingCalls 不存在 → Unknown call fallback → appendItem() → 幽灵卡片
```

## 修复(小范围,仅 transcript projection contract + 回归测试)

**统一入口过滤显式 surface replacement**(`TranscriptFolder.applyEvent` 最前):

- `surfaceOp === { op: 'replace', ... }` → 完全不进入 Human Transcript(所有投影:items / Focus activity / tool counts / grouping / usage 都不被污染)
- `surfaceOp === 'append'` → 行为完全不变
- **无 `surfaceOp`(legacy 旧 session)→ 保持现有兼容行为**

不根据 callId 去重、不猜 tool name、不按 sourceEventSeqs 判断 prune、不删除 orphan fallback(它继续负责合法的 partial-replay 片段)、不改 compaction UI(`compaction/prune` 依旧 silent,`start/summary/end` 卡片不变)、不改 Harness session log。`/export md` 采用同一契约。

**用官方 helper**:`@deepseek-ai/dsh-session@^0.1.1-rc.1`(当前兼容下限,startup gate 即此版本)已在主入口导出 `isReplacementSurfaceEvent` —— 无需 structural shim,未提升 Harness 最低版本。

## 测试(7 个新回归,已证实:在父提交 39a3bd1 上全部 FAIL,修复后 PASS)

- A:append-origin tool call/result → 1 张 ok 卡
- B:prune 后 replacement 不产生幽灵卡,保留 `ORIGINAL FULL RESULT`
- C:13 × (prune + replacement) 事故规模,卡片数量/内容不变
- D/E:replacement `user/message` / `assistant/message` 不进入 transcript、不覆盖 append-origin 历史
- F:legacy 无 `surfaceOp` 完全兼容
- G:cold 一次性折叠 vs 增量逐条 apply 输出一致(含窗口化)
- 附加:连续 read 分组不受 replacement 影响、窗口摘要字节级一致、Focus `assistantMessages`/`revision` 不变、`/export md` 不重放剪枝副本

## 验证

- `pnpm build` PASS
- `pnpm typecheck` PASS
- `pnpm test` PASS(2746 个 bundle 测试 + fork 套件 + docs 测试)
- `git diff --check` PASS
- pre-push gate(typecheck)PASS

## 兼容性

- append-origin 事件:不变
- legacy 无标记事件:保留
- 模型 replacement:从 human transcript 隐藏
- compaction lifecycle UI:不变
- Harness 最低版本:未提升