### PR TITLE
fix(settings): default Home/End keys to input

### DIFF
--- a/src/home-end-keys.ts
+++ b/src/home-end-keys.ts
@@ -14,10 +14,10 @@
  * cursorLineStart/cursorLineEnd. So the preset only remaps the two
  * viewport bindings:
  *
- * - `viewport` (default, unchanged behavior): top=`home`, bottom=`end` —
- *   Home/End scroll, Ctrl+Home/End reach the editor.
- * - `input`: top=`ctrl+home`, bottom=`ctrl+end` — Home/End reach the
- *   editor, Ctrl+Home/End scroll.
+ * - `input` (default): top=`ctrl+home`, bottom=`ctrl+end` — Home/End
+ *   reach the editor, Ctrl+Home/End scroll.
+ * - `viewport`: top=`home`, bottom=`end` — Home/End scroll, Ctrl+Home/End
+ *   reach the editor (unchanged legacy behavior).
  *
  * Precedence (plan §4.7): explicit user keybindings > this preset >
  * vendor default. There is no independent user keybinding persistence
@@ -34,10 +34,10 @@ import { getKeybindings } from '@xmoon76/pi-tui'
 /** The two Home/End navigation behaviors. */
 export type HomeEndKeysMode = 'input' | 'viewport'
 
-/** Read the persisted mode with a `viewport` fallback for invalid values
+/** Read the persisted mode with an `input` fallback for invalid values
  * (a stale or hand-edited settings document must never crash the boot). */
 export function homeEndKeysModeOf(value: string | undefined): HomeEndKeysMode {
-  return value === 'input' ? 'input' : 'viewport'
+  return value === 'viewport' ? 'viewport' : 'input'
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1505,9 +1505,9 @@ export function apply(ctx: Context, config: Config): void {
         // user's own), 'sandbox' routes them through the dsh shell
         // capability's policy for deployments that want it applied.
         localShellSandbox: z.string(),
-        // Home/End navigation behavior (issue #9): 'viewport' (default)
-        // keeps Home/End scrolling the fullscreen conversation; 'input'
-        // makes Home/End move within the input (Ctrl+Home/End scroll).
+        // Home/End navigation behavior (issue #9): 'input' (default)
+        // makes Home/End move within the input (Ctrl+Home/End scroll);
+        // 'viewport' keeps Home/End scrolling the fullscreen conversation.
         homeEndKeys: z.string(),
         // Focus Mode: 'on' collapses turn-intermediate activity into a
         // live Thought block (default 'off' — Focus OFF == current UI).
@@ -1530,7 +1530,7 @@ export function apply(ctx: Context, config: Config): void {
       // The base layout is the builtin default; the schemastery output
       // type is fully-populated, so the cast bridges the sparse literal
       // (the runtime validation accepts missing optional fields).
-      { base: { theme: 'auto', iconStyle: 'emoji', footer: 'full', footerFallbackMode: 'default', footerLayout: DEFAULT_FOOTER_LAYOUT as never, footerCommand: undefined as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' } },
+      { base: { theme: 'auto', iconStyle: 'emoji', footer: 'full', footerFallbackMode: 'default', footerLayout: DEFAULT_FOOTER_LAYOUT as never, footerCommand: undefined as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off' } },
     )
     // The ONE authoritative Focus runtime state (plan §5): restored from
     // the persisted document BEFORE the first compose/resume below, mutated

--- a/test/home-end-keys.test.ts
+++ b/test/home-end-keys.test.ts
@@ -40,7 +40,7 @@ function viewportHasLine(vt: VirtualTerminal, text: string): boolean {
 
 // ── the preset itself ────────────────────────────────────────────────────
 
-test('applyHomeEndKeyMode viewport: top=home, bottom=end (default behavior)', () => {
+test('applyHomeEndKeyMode viewport: top=home, bottom=end', () => {
   resetKeybindings()
   applyHomeEndKeyMode('viewport')
   const resolved = getKeybindings().getResolvedBindings()
@@ -66,12 +66,12 @@ test('applyHomeEndKeyMode keeps every other user binding', () => {
   assert.equal(user['tui.altScreen.bottom'], 'ctrl+end')
 })
 
-test('homeEndKeysModeOf falls back to viewport for invalid values', () => {
+test('homeEndKeysModeOf falls back to input for invalid values', () => {
   assert.equal(homeEndKeysModeOf('input'), 'input')
   assert.equal(homeEndKeysModeOf('viewport'), 'viewport')
-  assert.equal(homeEndKeysModeOf(undefined), 'viewport')
-  assert.equal(homeEndKeysModeOf(''), 'viewport')
-  assert.equal(homeEndKeysModeOf('pi'), 'viewport')
+  assert.equal(homeEndKeysModeOf(undefined), 'input')
+  assert.equal(homeEndKeysModeOf(''), 'input')
+  assert.equal(homeEndKeysModeOf('pi'), 'input')
 })
 
 // ── fullscreen behavior ─────────────────────────────────────────────────
@@ -90,7 +90,7 @@ function startFullscreenApp(): { vt: VirtualTerminal; app: TuiApp } {
   return { vt, app }
 }
 
-test('viewport mode (default): Home scrolls to the top, End to the bottom', async () => {
+test('viewport mode: Home scrolls to the top, End to the bottom', async () => {
   resetKeybindings()
   applyHomeEndKeyMode('viewport')
   const { vt, app } = startFullscreenApp()
@@ -228,7 +228,7 @@ function setupSettings(options: { homeEndKeys?: string } = {}) {
     find: () => undefined,
     execute: async () => undefined,
   } as never)
-  const settings = fakeTuiSettings(options.homeEndKeys ?? 'viewport')
+  const settings = fakeTuiSettings(options.homeEndKeys ?? 'input')
   const runner: TuiCommandRunner = {
     ctx,
     app,
@@ -316,7 +316,7 @@ function setupSettings(options: { homeEndKeys?: string } = {}) {
   return { vt, app, run, view, settings }
 }
 
-test('/settings shows the Home/End keys row; an invalid persisted value falls back to viewport', async () => {
+test('/settings shows the Home/End keys row; an invalid persisted value falls back to input', async () => {
   resetKeybindings()
   const t = setupSettings({ homeEndKeys: 'garbage' })
   await t.run()
@@ -327,8 +327,13 @@ test('/settings shows the Home/End keys row; an invalid persisted value falls ba
   // visible fold.
   for (let i = 0; i < 7; i += 1) t.vt.sendInput('\x1b[B')
   const view = await t.view()
-  assert.ok(view.includes('Home/End keys'), `row missing:\n${view}`)
-  assert.ok(view.includes('viewport'), `an invalid persisted value must fall back to viewport:\n${view}`)
+  const row = view.split('\n').find(line => line.includes('Home/End keys')) ?? ''
+  assert.ok(row !== '', `row missing:\n${view}`)
+  // The row line carries only the label and the current value (the
+  // description is a separate line), so the value can be matched on the
+  // row itself.
+  assert.ok(row.includes('input'), `an invalid persisted value must fall back to input:\n${view}`)
+  assert.ok(!row.includes('viewport'), `an invalid persisted value must not fall back to viewport:\n${view}`)
   assert.ok(!view.includes('garbage'), `the raw invalid value must never render:\n${view}`)
   t.app.stop()
 })


### PR DESCRIPTION
## 变更

把 `Home/End keys` 的默认值从 `viewport` 改为 `input`，保留已有用户显式配置不变。

- **`src/home-end-keys.ts`**: `homeEndKeysModeOf()` fallback 从 `viewport` 改成 `input`;模块头注释同步更新(`input` 现在标为 default)
- **`src/index.ts`**: TUI settings schema base 默认值 `homeEndKeys: 'viewport'` → `'input'`;附近注释同步
- **`test/home-end-keys.test.ts`**: fallback 断言(undefined/''/pi → input)、fixture 默认值、涉及 "viewport default" 的测试名;顺带把 /settings 回退断言从弱匹配(`view.includes('viewport')`,描述文本也含该词)改成按行精确匹配

## 行为

```
无配置     -> input
非法配置   -> input
input      -> input
viewport   -> viewport   (显式持久化的用户配置,不变)
```

## 未改动

- `/settings` 行逻辑:`values: ['input', 'viewport']` 不变
- **无配置迁移**:已保存 `viewport` 的用户继续用 `viewport`
- pi-tui vendor 和 editor 未碰

## 门禁

- `node --test test/home-end-keys.test.ts` ✅ 10/10
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test`(完整套件:fork 2948 + bundle + docs)✅ 全绿
- push 前 pre-push gate(typecheck)✅

Closes #9