### PR TITLE
fix(completion): converge @ and /image file completion

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,7 @@ import { color, loadCustomTheme, customThemeNames, settingsListTheme } from './t
 import { ThemeSubmenu, themeDisplayName as themeDisplayNameOf } from './theme-menu.ts'
 import { resolveThemeSelection, normalizePersistedTheme } from './theme-source.ts'
 import { suggestPathArgument } from './mentions.ts'
+import { FILE_ARGUMENT_COMMANDS } from './file-completion/context.ts'
 import { ModelSubmenu } from './model-menu.ts'
 import { computeStats, formatStats } from './stats.ts'
 import { renderTranscriptMarkdown, textOf } from './transcript.ts'
@@ -1025,9 +1026,10 @@ export function registerTuiCommands(
   /** The advertised names of the currently installed completion list. */
   let claims = new Set<string>()
   /** Slash commands whose single argument is a path: the fork's
-   * `getArgumentCompletions` extension point completes it against the LIVE
-   * session cwd (natural typing shows candidates, Tab accepts them). */
-  const PATH_ARGUMENT_COMMANDS = new Set(['image'])
+   * `getArgumentCompletions` extension point completes it against the
+   * Client-local cwd (natural typing shows candidates, Tab accepts them).
+   * Host session cwd remains reserved for `@` via HostFilePort. */
+  const PATH_ARGUMENT_COMMANDS = FILE_ARGUMENT_COMMANDS
   /**
    * Install one completion list (sorted, claims refreshed). The single
    * synchronous seam every catalog commit funnels through.
@@ -1044,7 +1046,7 @@ export function registerTuiCommands(
         description: command.description,
         argumentHint: command.input?.hint,
         ...(PATH_ARGUMENT_COMMANDS.has(command.name)
-          ? { getArgumentCompletions: (argument: string) => suggestPathArgument(argument, runner.sessionCwd()) }
+          ? { getArgumentCompletions: (argument: string) => suggestPathArgument(argument, runner.cwd) }
           : {}),
       })),
       runner.sessionCwd(),
@@ -1072,6 +1074,9 @@ export function registerTuiCommands(
       () => runner.liveAgent === undefined
         ? { kind: 'workspace', cwd: runner.sessionCwd() }
         : { kind: 'session', sessionId: runner.liveAgent.session.id },
+      // `/image` is Client-local. Direct mode uses the process cwd; a remote
+      // adapter can keep this independent from the Host session scope.
+      () => runner.cwd,
     )
     claims = new Set(sorted.map(command => command.name))
   }

--- a/src/file-completion/context.ts
+++ b/src/file-completion/context.ts
@@ -1,0 +1,164 @@
+/**
+ * The file-completion context classifier (plan §4): the ONLY place that
+ * decides whether the cursor sits in a file-completion context. File
+ * completion is allowed in exactly two contexts:
+ *
+ * - `mention` — an `@` token at a real token boundary (start of text, after
+ *   a delimiter, or glued to CJK text — so emails `a@b.com` and `pkg@1.0.0`
+ *   never qualify);
+ * - `image-argument` — the argument of a command EXPLICITLY declared as
+ *   file-argument (`/image`), never `getArgumentCompletions !== undefined`
+ *   (plan §4.2: file commands must be explicit).
+ *
+ * Everywhere else (`none`) ordinary text AND ordinary paths — `./foo`,
+ * `../foo`, `/tmp/foo`, `foo` — must neither naturally trigger a file
+ * dropdown nor open one on Tab.
+ * @module @xmoon76/dsh-pi-tui/file-completion/context
+ */
+
+import type { FileCompletionContext } from './types.ts'
+
+/** The EXPLICIT file-argument command set (plan §4.2 — never derived from
+ * `getArgumentCompletions !== undefined`): ONLY these command names make
+ * their argument position a file-completion context. `image` today; a new
+ * path-argument command must be added here AND get the matching
+ * getArgumentCompletions wiring. */
+export const FILE_ARGUMENT_COMMANDS: ReadonlySet<string> = new Set(['image'])
+
+/** Token separators: `@` must sit at the start of the current token. */
+const PATH_DELIMITERS = new Set([' ', '\t', '"', "'", '='])
+
+/** Whether the char is CJK (ideographs, kana, hangul, CJK punctuation,
+ * full-width forms): a mention may sit DIRECTLY against CJK text without
+ * a delimiter — CJK sentences glue the mention to the previous character —
+ * while ASCII words keep the strict boundary rule (emails, `pkg@1.0.0`). */
+export function isCjkChar(char: string): boolean {
+  const code = char.codePointAt(0) ?? 0
+  return (code >= 0x3000 && code <= 0x303f) // CJK punctuation
+    || (code >= 0x3040 && code <= 0x30ff) // hiragana + katakana
+    || (code >= 0x3400 && code <= 0x4dbf) // CJK extension A
+    || (code >= 0x4e00 && code <= 0x9fff) // CJK unified ideographs
+    || (code >= 0xac00 && code <= 0xd7af) // hangul
+    || (code >= 0xf900 && code <= 0xfaff) // compatibility ideographs
+    || (code >= 0xff00 && code <= 0xffef) // full-width forms
+}
+
+/** The position of an UNCLOSED `"` (null when every quote is closed):
+ * the completion cursor sits inside a quoted token exactly when a quote
+ * is open at the end of the text. */
+function findUnclosedQuote(text: string): number | null {
+  let inQuotes = false
+  let quoteStart = -1
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === '"') {
+      inQuotes = !inQuotes
+      if (inQuotes) quoteStart = index
+    }
+  }
+  return inQuotes ? quoteStart : null
+}
+
+/**
+ * The `@` mention prefix of the text before the cursor: `@query`,
+ * `@"quoted query"` (the unclosed quoted form), or null when the cursor
+ * is not inside a mention. Token grammar: `@` must sit at a token
+ * boundary — start-of-text, after a delimiter, or glued to CJK text — so
+ * emails (`a@b.com`) and `pkg@1.0.0` are never mentions.
+ * @param text - the line content before the cursor.
+ */
+export function extractAtPrefix(text: string): string | null {
+  // Quoted form: an unclosed `"` immediately after an `@` whose own
+  // position is a valid token start (`@"my file` while typing inside the
+  // quotes).
+  const quoteStart = findUnclosedQuote(text)
+  if (quoteStart !== null && text[quoteStart - 1] === '@') {
+    const at = quoteStart - 1
+    const before = at === 0 ? '' : text[at - 1] ?? ''
+    if (before === '' || PATH_DELIMITERS.has(before) || isCjkChar(before)) return text.slice(at)
+  }
+  // Bare form: the current token (after the last delimiter)...
+  let tokenStart = 0
+  for (let index = text.length - 1; index >= 0; index -= 1) {
+    if (PATH_DELIMITERS.has(text[index] ?? '')) {
+      tokenStart = index + 1
+      break
+    }
+  }
+  const token = text.slice(tokenStart)
+  if (token.startsWith('@')) return token
+  // ...or a CJK-glued `@` INSIDE the token (the character right before the
+  // `@` is a CJK code point, e.g. `\u770b\u770b@foo`): the LAST such `@`
+  // is the mention start (a CJK sentence glues the mention to the
+  // previous character — the same rule findFileMentions applies).
+  for (let index = token.length - 1; index >= 1; index -= 1) {
+    if (token[index] === '@' && isCjkChar(token[index - 1] ?? '')) return token.slice(index)
+  }
+  return null
+}
+
+/** The whitespace separator between a slash command name and its argument
+ * (the fork's argument branch passes everything after the FIRST space). */
+const SLASH_SEPARATOR = /[ \t]/
+
+/**
+ * Whether the text before the cursor is the ARGUMENT of a named command
+ * that is explicitly declared as file-argument completable.
+ * @param textBeforeCursor - the line content before the cursor.
+ * @param pathArgumentCommands - the explicit file-argument command set
+ *   (plan §4.2 — never derived from `getArgumentCompletions`).
+ * @returns the argument text (INCLUDING leftover separator whitespace, so
+ *   a multi-space separator survives the fork's whole-range apply), or
+ *   undefined when the position is not a declared file-argument position.
+ */
+export function imageArgumentOf(
+  textBeforeCursor: string,
+  pathArgumentCommands: ReadonlySet<string>,
+): string | undefined {
+  const trimmedStart = textBeforeCursor.trimStart()
+  if (!trimmedStart.startsWith('/')) return undefined
+  const separatorIndex = trimmedStart.search(SLASH_SEPARATOR)
+  if (separatorIndex <= 0) return undefined
+  const commandName = trimmedStart.slice(1, separatorIndex)
+  if (!pathArgumentCommands.has(commandName)) return undefined
+  // The argument is everything after the FIRST separator character. The
+  // fork's combined provider hands the argument branch the same slice
+  // (textBeforeCursor.slice(spaceIndex + 1)), so leading separator
+  // whitespace belongs to the ARGUMENT and the completed value keeps it.
+  // The textBeforeCursor is trimmed at the start, but the argument slice
+  // must start at the ORIGINAL separator (first whitespace of the ORIGINAL
+  // line, not the trimmed one) — the separator search above ran on the
+  // trimmed string, so re-find it on the original.
+  const originalSeparator = textBeforeCursor.search(SLASH_SEPARATOR)
+  if (originalSeparator <= 0) return undefined
+  return textBeforeCursor.slice(originalSeparator + 1)
+}
+
+/**
+ * Classify the file-completion context at the cursor (plan §4.1): exactly
+ * one of `mention`, `image-argument`, or `none`.
+ * @param textBeforeCursor - the line content before the cursor.
+ * @param pathArgumentCommands - the EXPLICIT file-argument command set
+ *   (`/image` today; never derived from `getArgumentCompletions`).
+ */
+export function classifyFileCompletionContext(
+  textBeforeCursor: string,
+  pathArgumentCommands: ReadonlySet<string>,
+): FileCompletionContext {
+  const atPrefix = extractAtPrefix(textBeforeCursor)
+  if (atPrefix !== null) {
+    return {
+      kind: 'mention',
+      query: atPrefix,
+      range: { start: textBeforeCursor.length - atPrefix.length, end: textBeforeCursor.length },
+    }
+  }
+  const argument = imageArgumentOf(textBeforeCursor, pathArgumentCommands)
+  if (argument !== undefined) {
+    return {
+      kind: 'image-argument',
+      query: argument,
+      range: { start: textBeforeCursor.length - argument.length, end: textBeforeCursor.length },
+    }
+  }
+  return { kind: 'none' }
+}

--- a/src/file-completion/context.ts
+++ b/src/file-completion/context.ts
@@ -120,16 +120,16 @@ export function imageArgumentOf(
   if (separatorIndex <= 0) return undefined
   const commandName = trimmedStart.slice(1, separatorIndex)
   if (!pathArgumentCommands.has(commandName)) return undefined
-  // The argument is everything after the FIRST separator character. The
-  // fork's combined provider hands the argument branch the same slice
+  // The argument is everything after the FIRST separator character AFTER
+  // THE COMMAND NAME — i.e. on the TRIMMED string, then translated back to
+  // the ORIGINAL line (leading whitespace before `/image` is indentation,
+  // not a separator; searching the original string for the first
+  // whitespace would match that indentation and fail the <= 0 guard).
+  // The fork's combined provider hands the argument branch the same slice
   // (textBeforeCursor.slice(spaceIndex + 1)), so leading separator
   // whitespace belongs to the ARGUMENT and the completed value keeps it.
-  // The textBeforeCursor is trimmed at the start, but the argument slice
-  // must start at the ORIGINAL separator (first whitespace of the ORIGINAL
-  // line, not the trimmed one) — the separator search above ran on the
-  // trimmed string, so re-find it on the original.
-  const originalSeparator = textBeforeCursor.search(SLASH_SEPARATOR)
-  if (originalSeparator <= 0) return undefined
+  const trimOffset = textBeforeCursor.length - textBeforeCursor.trimStart().length
+  const originalSeparator = trimOffset + separatorIndex
   return textBeforeCursor.slice(originalSeparator + 1)
 }
 

--- a/src/file-completion/context.ts
+++ b/src/file-completion/context.ts
@@ -26,7 +26,7 @@ import type { FileCompletionContext } from './types.ts'
 export const FILE_ARGUMENT_COMMANDS: ReadonlySet<string> = new Set(['image'])
 
 /** Token separators: `@` must sit at the start of the current token. */
-const PATH_DELIMITERS = new Set([' ', '\t', '"', "'", '='])
+const PATH_DELIMITERS = new Set([' ', '\t', '\n', '\r', '"', "'", '='])
 
 /** Whether the char is CJK (ideographs, kana, hangul, CJK punctuation,
  * full-width forms): a mention may sit DIRECTLY against CJK text without
@@ -144,20 +144,22 @@ export function classifyFileCompletionContext(
   textBeforeCursor: string,
   pathArgumentCommands: ReadonlySet<string>,
 ): FileCompletionContext {
-  const atPrefix = extractAtPrefix(textBeforeCursor)
-  if (atPrefix !== null) {
-    return {
-      kind: 'mention',
-      query: atPrefix,
-      range: { start: textBeforeCursor.length - atPrefix.length, end: textBeforeCursor.length },
-    }
-  }
+  // A declared command argument owns the whole command line. In particular,
+  // `/image @foo` is still a Client-local image path, not a Host mention.
   const argument = imageArgumentOf(textBeforeCursor, pathArgumentCommands)
   if (argument !== undefined) {
     return {
       kind: 'image-argument',
       query: argument,
       range: { start: textBeforeCursor.length - argument.length, end: textBeforeCursor.length },
+    }
+  }
+  const atPrefix = extractAtPrefix(textBeforeCursor)
+  if (atPrefix !== null) {
+    return {
+      kind: 'mention',
+      query: atPrefix,
+      range: { start: textBeforeCursor.length - atPrefix.length, end: textBeforeCursor.length },
     }
   }
   return { kind: 'none' }

--- a/src/file-completion/discovery.ts
+++ b/src/file-completion/discovery.ts
@@ -10,7 +10,7 @@
  */
 
 import { accessSync, constants as fsConstants, readdirSync, statSync } from 'node:fs'
-import { join } from 'node:path'
+import { delimiter, join } from 'node:path'
 import { spawn } from 'node:child_process'
 import type { PathCandidate, PathCompletionQuery } from './types.ts'
 
@@ -27,17 +27,23 @@ const MAX_FD_RESULTS = 100
 /** Locate an executable file-finder on PATH: `fd` preferred, `fdfind`
  * (Debian/Ubuntu's fd-find) second (plan §12 — kimi parity). Bare command
  * names resolve through PATH at spawn time; absolute/relative entries must
- * exist and be X_OK. POSIX PATH separators only (this deployment targets
- * POSIX hosts; a Windows Host would need a platform-aware probe, recorded
- * as a portability note, not a behavior change). */
+ * exist and be X_OK. The platform PATH delimiter is used so the same probe
+ * remains correct on Windows hosts too. */
 export function resolveFdPath(): string | null {
-  const pathEntries = process.env.PATH?.split(':').filter(entry => entry !== '') ?? []
+  const pathEntries = process.env.PATH?.split(delimiter) ?? []
   for (const name of ['fd', 'fdfind']) {
-    for (const dir of pathEntries) {
+    for (const entry of pathEntries) {
+      // An empty POSIX PATH component means the current directory. Keep it
+      // rather than silently changing the shell's lookup semantics.
+      const dir = entry === '' ? '.' : entry
       const candidate = join(dir, name)
       try {
-        accessSync(candidate, fsConstants.X_OK)
-        return candidate
+        // X_OK alone also succeeds for a directory on POSIX. Only return a
+        // regular file that is executable; a directory named `fd` must not
+        // poison discovery before the fallback gets a chance to run.
+        if (statSync(candidate).isFile() && accessSync(candidate, fsConstants.X_OK) === undefined) {
+          return candidate
+        }
       } catch {
         // Not here; keep scanning.
       }
@@ -81,7 +87,8 @@ function entryIsDirectory(
  * bare entry names. `.git` is skipped (consistent with fd and the
  * recursive scan — a `@` or `/image` listing never presents VCS
  * internals). A missing/unreadable directory yields [] (never a crash). */
-export function listDirectChildren(baseDir: string): RawDiscoveryEntry[] {
+export function listDirectChildren(baseDir: string, signal?: AbortSignal): RawDiscoveryEntry[] {
+  if (signal?.aborted ?? false) return []
   let entries
   try {
     entries = readdirSync(baseDir, { withFileTypes: true })
@@ -90,10 +97,11 @@ export function listDirectChildren(baseDir: string): RawDiscoveryEntry[] {
   }
   const out: RawDiscoveryEntry[] = []
   for (const entry of entries) {
+    if (signal?.aborted ?? false) return []
     if (entry.name === '.git') continue
     out.push({ path: entry.name, isDirectory: entryIsDirectory(baseDir, entry.name, entry) })
   }
-  return out
+  return (signal?.aborted ?? false) ? [] : out
 }
 
 /** The bounded recursive scan of one directory's SUBTREE: the root's
@@ -115,6 +123,7 @@ export async function scanSubtree(baseDir: string, signal?: AbortSignal): Promis
   } catch {
     return []
   }
+  if (signal?.aborted ?? false) return []
   // Depth 0: complete, uncapped.
   const stack: string[] = []
   for (const entry of firstEntries) {
@@ -176,19 +185,25 @@ export function discoverWithFd(
     // aligned with the ranking model: @FOO finds foo.txt, exactly like the
     // bounded-scan fallback path.
     '-i',
+    '--full-path',
+    '--print0',
     '--type', 'f',
     '--type', 'd',
-    '--follow',
+    // Include symlinks as candidates but do not follow them during descent;
+    // the bounded fallback exposes symlink entries and classifies a symlink
+    // to a directory as a directory without traversing it.
+    '--type', 'l',
     '--hidden',
     '--exclude', '.git',
     '--exclude', '.git/*',
     '--exclude', '.git/**',
   ]
-  // fd matches the query against the basename by default (substring,
-  // smart-case): for a basename term that is exactly the scoring model's
-  // input. A scoped query runs inside its own baseDir, so the term never
-  // contains a separator here — no --full-path needed. fd's default
-  // pattern is a REGEX — a user's literal term containing regex
+  // fd matches the query against the FULL relative path. This is important
+  // for parity with the fallback scorer: an unscoped `@src` must also see a
+  // candidate such as `src/readme`, not only an entry whose basename is
+  // `src`. A scoped query still runs inside its own baseDir, so the term is
+  // normally a basename substring. fd's pattern is a REGEX — a user's literal
+  // term containing regex
   // metacharacters (`foo[1].ts`, `a+b.ts`) would silently match nothing,
   // so the term is escaped to its literal form (the completion contract
   // is substring matching of the literal text, not regex). The filenames
@@ -199,10 +214,18 @@ export function discoverWithFd(
       resolve([])
       return
     }
-    const child = spawn(fdPath, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let child
+    try {
+      // stderr is intentionally ignored: discovery treats every non-zero exit
+      // as a fallback signal, and a pipe that is never drained can deadlock a
+      // noisy finder before it reaches its close event.
+      child = spawn(fdPath, args, { stdio: ['ignore', 'pipe', 'ignore'] })
+    } catch {
+      resolve(null)
+      return
+    }
     let stdout = ''
     let settled = false
-    let failed = false
     const settle = (results: RawDiscoveryEntry[] | null): void => {
       if (settled) return
       settled = true
@@ -211,6 +234,10 @@ export function discoverWithFd(
     }
     const onAbort = (): void => {
       if (child.exitCode === null) child.kill('SIGKILL')
+      // Do not wait for a misbehaving child to acknowledge SIGKILL before the
+      // editor request settles. The close handler is idempotent and will only
+      // discard the eventual process event.
+      settle([])
     }
     signal.addEventListener('abort', onAbort, { once: true })
     child.stdout.setEncoding('utf-8')
@@ -228,12 +255,26 @@ export function discoverWithFd(
         settle(null)
         return
       }
-      const lines = stdout.trim().split('\n').filter((line) => line !== '')
+      // Prefer NUL records (the real fd invocation uses --print0) so legal
+      // filenames containing newlines survive. Fake/older finders that ignore
+      // --print0 are accepted through the newline fallback; unlike trim(), it
+      // preserves meaningful leading/trailing spaces in a filename.
+      const records = stdout.includes('\0')
+        ? stdout.split('\0').filter((record) => record !== '')
+        : (() => {
+            const lines = stdout.split(/\r?\n/)
+            if (lines.at(-1) === '') lines.pop()
+            return lines.filter((line) => line !== '')
+          })()
       const results: RawDiscoveryEntry[] = []
-      for (const line of lines) {
-        if (line === '.git' || line.startsWith('.git/') || line.includes('/.git/')) continue
-        const normalized = line.endsWith('/') ? line.slice(0, -1) : line
-        let isDirectory = line.endsWith('/')
+      for (const line of records) {
+        // fd/fdfind commonly prefixes paths emitted with --base-directory by
+        // `./`; the discovery contract is relative paths without a leading
+        // current-directory component (the fallback has the same shape).
+        const relative = line.startsWith('./') ? line.slice(2) : line
+        if (relative === '.git' || relative.startsWith('.git/') || relative.includes('/.git/')) continue
+        const normalized = relative.endsWith('/') ? relative.slice(0, -1) : relative
+        let isDirectory = relative.endsWith('/')
         if (!isDirectory) {
           try {
             isDirectory = statSync(join(baseDir, normalized)).isDirectory()
@@ -266,16 +307,29 @@ export async function discoverForQuery(
     // A scoped listing: the target directory's OWN content — always the
     // direct children (never a whole-tree scan filtered by string, plan
     // §6.1; and never fd's subtree listing — "show src children" semantics).
-    return listDirectChildren(query.searchBase).map(toCandidate)
+    if (signal.aborted) return []
+    const direct = listDirectChildren(query.searchBase, signal)
+    return signal.aborted ? [] : direct.map(toCandidate)
   }
   // Fuzzy (scoped or whole-tree): fd first, bounded scan fallback. A
   // Windows-dialect token stays on the scan path (fd's POSIX matcher does
   // not speak `\`).
-  if (source.fdPath !== null && !query.winAbsolute) {
+  if (source.fdPath !== null && !query.winAbsolute && !query.raw.includes('\\')) {
     const entries = await discoverWithFd(source.fdPath, query.searchBase, query.searchTerm, signal)
     if (signal.aborted) return []
-    // fd FAILURE (not a valid empty result): fall back to the bounded scan.
-    if (entries !== null) return entries.map(toCandidate)
+    // fd can omit a filesystem mount-point entry even when it is a direct
+    // child of the search root (for example `/tmp` in containerized Linux).
+    // Merge matching direct children back in so fd and the fallback expose the
+    // same root-level candidates; de-duplicate by the relative path.
+    if (entries !== null) {
+      const seen = new Set(entries.map(entry => entry.path))
+      const lowerTerm = query.searchTerm.toLowerCase()
+      const direct = listDirectChildren(query.searchBase, signal)
+        .filter(entry => lowerTerm === '' || entry.path.toLowerCase().includes(lowerTerm))
+        .filter(entry => !seen.has(entry.path))
+      if (signal.aborted) return []
+      return [...entries, ...direct].map(toCandidate)
+    }
   }
   // The bounded fallback is ASYNC + abort-aware (plan §25): the scan
   // yields between directory levels and stops on abort, so a large-tree

--- a/src/file-completion/discovery.ts
+++ b/src/file-completion/discovery.ts
@@ -100,8 +100,14 @@ export function listDirectChildren(baseDir: string): RawDiscoveryEntry[] {
  * direct children are always complete (a root-level `src/` must be found),
  * deeper entries are capped at MAX_FALLBACK_SCAN. Paths are relative to
  * baseDir (`sub/deep.ts`); `.git` is skipped (kimi parity); symlinked
- * directories are NOT descended (cycle safety). */
-export function scanSubtree(baseDir: string, signal?: AbortSignal): RawDiscoveryEntry[] {
+ * directories are NOT descended (cycle safety).
+ *
+ * ASYNC (plan §25): the `/image` fuzzy fallback runs on the EDITOR path,
+ * so a synchronous whole-tree traversal would block the editor's event
+ * loop per keystroke. The scan yields to the event loop between directory
+ * levels and checks the AbortSignal inside the loop — the editor stays
+ * responsive and a cancelled request stops the traversal promptly. */
+export async function scanSubtree(baseDir: string, signal?: AbortSignal): Promise<RawDiscoveryEntry[]> {
   const candidates: RawDiscoveryEntry[] = []
   let firstEntries
   try {
@@ -117,10 +123,10 @@ export function scanSubtree(baseDir: string, signal?: AbortSignal): RawDiscovery
     candidates.push({ path, isDirectory: entryIsDirectory(baseDir, entry.name, entry) })
     if (entry.isDirectory()) stack.push(path)
   }
-  // Deeper levels: bounded.
+  // Deeper levels: bounded, async, abort-aware.
   let scanned = 0
   while (stack.length > 0 && scanned < MAX_FALLBACK_SCAN) {
-    if (signal?.aborted === true) break
+    if ((signal?.aborted ?? false)) break
     const relativeDir = stack.pop() ?? ''
     let entries
     try {
@@ -139,6 +145,10 @@ export function scanSubtree(baseDir: string, signal?: AbortSignal): RawDiscovery
       candidates.push({ path, isDirectory: entryIsDirectory(join(baseDir, relativeDir), entry.name, entry) })
       if (entry.isDirectory() && !entry.isSymbolicLink()) stack.push(path)
     }
+    // Yield to the event loop between directory levels: the editor stays
+    // responsive during a large-tree fallback (plan §25 — never a
+    // synchronous full-tree traversal on the editor path).
+    if (stack.length > 0) await new Promise<void>(resolve => setImmediate(resolve))
   }
   return candidates
 }
@@ -267,7 +277,10 @@ export async function discoverForQuery(
     // fd FAILURE (not a valid empty result): fall back to the bounded scan.
     if (entries !== null) return entries.map(toCandidate)
   }
-  const entries = scanSubtree(query.searchBase, signal)
+  // The bounded fallback is ASYNC + abort-aware (plan §25): the scan
+  // yields between directory levels and stops on abort, so a large-tree
+  // `/image` fuzzy query never blocks the editor event loop.
+  const entries = await scanSubtree(query.searchBase, signal)
   if (signal.aborted === true) return []
   return entries.map(toCandidate)
 }

--- a/src/file-completion/discovery.ts
+++ b/src/file-completion/discovery.ts
@@ -78,8 +78,9 @@ function entryIsDirectory(
 }
 
 /** The DIRECT children of one directory (a scoped listing): paths are
- * bare entry names. A missing/unreadable directory yields [] (the caller
- * shows nothing — never a crash). */
+ * bare entry names. `.git` is skipped (consistent with fd and the
+ * recursive scan — a `@` or `/image` listing never presents VCS
+ * internals). A missing/unreadable directory yields [] (never a crash). */
 export function listDirectChildren(baseDir: string): RawDiscoveryEntry[] {
   let entries
   try {
@@ -89,6 +90,7 @@ export function listDirectChildren(baseDir: string): RawDiscoveryEntry[] {
   }
   const out: RawDiscoveryEntry[] = []
   for (const entry of entries) {
+    if (entry.name === '.git') continue
     out.push({ path: entry.name, isDirectory: entryIsDirectory(baseDir, entry.name, entry) })
   }
   return out
@@ -145,13 +147,15 @@ export function scanSubtree(baseDir: string, signal?: AbortSignal): RawDiscovery
  * `--base-directory`; directories are classified against the fs (fd's
  * default print format does not guarantee a trailing `/` — the fork's
  * rule: statSync follows symlinks, so a symlink dir still completes with
- * `/`). A failed/aborted run yields [] (never a crash). */
+ * `/`). Returns NULL on fd FAILURE (non-zero exit, spawn error — NOT a
+ * valid empty result: the caller falls back to the bounded scan), `[]` on
+ * a genuine no-match or an abort. */
 export function discoverWithFd(
   fdPath: string,
   baseDir: string,
   term: string,
   signal: AbortSignal,
-): Promise<RawDiscoveryEntry[]> {
+): Promise<RawDiscoveryEntry[] | null> {
   const args = [
     '--base-directory', baseDir,
     '--max-results', String(MAX_FD_RESULTS),
@@ -166,8 +170,13 @@ export function discoverWithFd(
   // fd matches the query against the basename by default (substring,
   // smart-case): for a basename term that is exactly the scoring model's
   // input. A scoped query runs inside its own baseDir, so the term never
-  // contains a separator here — no --full-path needed.
-  if (term !== '') args.push(term)
+  // contains a separator here — no --full-path needed. fd's default
+  // pattern is a REGEX — a user's literal term containing regex
+  // metacharacters (`foo[1].ts`, `a+b.ts`) would silently match nothing,
+  // so the term is escaped to its literal form (the completion contract
+  // is substring matching of the literal text, not regex). The filenames
+  // themselves (candidate paths fd prints) are taken VERBATIM.
+  if (term !== '') args.push(escapeFdRegex(term))
   return new Promise((resolve) => {
     if (signal.aborted) {
       resolve([])
@@ -176,7 +185,8 @@ export function discoverWithFd(
     const child = spawn(fdPath, args, { stdio: ['ignore', 'pipe', 'pipe'] })
     let stdout = ''
     let settled = false
-    const settle = (results: RawDiscoveryEntry[]): void => {
+    let failed = false
+    const settle = (results: RawDiscoveryEntry[] | null): void => {
       if (settled) return
       settled = true
       signal.removeEventListener('abort', onAbort)
@@ -188,10 +198,17 @@ export function discoverWithFd(
     signal.addEventListener('abort', onAbort, { once: true })
     child.stdout.setEncoding('utf-8')
     child.stdout.on('data', (chunk: string) => { stdout += chunk })
-    child.on('error', () => settle([]))
+    child.on('error', () => settle(null))
     child.on('close', (code) => {
-      if (signal.aborted || code !== 0 || !stdout) {
+      if (signal.aborted) {
         settle([])
+        return
+      }
+      if (code !== 0) {
+        // fd FAILED (missing binary race, malformed invocation, cwd
+        // permission): NOT a valid empty result — the bounded scan
+        // fallback must answer (plan §6.2 fd-first-fallback).
+        settle(null)
         return
       }
       const lines = stdout.trim().split('\n').filter((line) => line !== '')
@@ -240,11 +257,19 @@ export async function discoverForQuery(
   if (source.fdPath !== null && !query.winAbsolute) {
     const entries = await discoverWithFd(source.fdPath, query.searchBase, query.searchTerm, signal)
     if (signal.aborted) return []
-    return entries.map(toCandidate)
+    // fd FAILURE (not a valid empty result): fall back to the bounded scan.
+    if (entries !== null) return entries.map(toCandidate)
   }
   const entries = scanSubtree(query.searchBase, signal)
   if (signal.aborted === true) return []
   return entries.map(toCandidate)
+}
+
+/** Escape regex metacharacters for fd's default regex pattern: the
+ * completion term is a LITERAL substring (the scoring model's input), so
+ * a filename containing `[`, `+`, `.` etc. must match as literal text. */
+function escapeFdRegex(term: string): string {
+  return term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 /** Map one raw discovery fact onto the detached candidate DTO. */

--- a/src/file-completion/discovery.ts
+++ b/src/file-completion/discovery.ts
@@ -1,0 +1,256 @@
+/**
+ * The shared file discovery: how a resolved path query is answered by the
+ * local filesystem — fd/fdfind first (fast, respects ignore rules), the
+ * bounded recursive scan as fallback, a direct listing for directory
+ * scopes. Used by BOTH sources: the Direct Host-file adapter (`@`) and the
+ * Client-local `/image` source. The discovery answers "which files exist"
+ * as path-only facts (relative to the search base); ranking, quoting and
+ * presentation are client policy in the engine.
+ * @module @xmoon76/dsh-pi-tui/file-completion/discovery
+ */
+
+import { accessSync, constants as fsConstants, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import type { PathCandidate, PathCompletionQuery } from './types.ts'
+
+/** The recursive scan bound (kimi MAX_FALLBACK_SCAN): counts DESCENDED
+ * (non-root) entries. The search root's DIRECT children are always
+ * complete — a whole-tree fuzzy query like `@src` must find a root-level
+ * `src/` even when the workspace holds >2000 deeper entries (plan §3.4:
+ * the old global cap made scoped continuation randomly fail). */
+export const MAX_FALLBACK_SCAN = 2000
+
+/** fd's per-request result cap (the fork's own --max-results). */
+const MAX_FD_RESULTS = 100
+
+/** Locate an executable file-finder on PATH: `fd` preferred, `fdfind`
+ * (Debian/Ubuntu's fd-find) second (plan §12 — kimi parity). Bare command
+ * names resolve through PATH at spawn time; absolute/relative entries must
+ * exist and be X_OK. POSIX PATH separators only (this deployment targets
+ * POSIX hosts; a Windows Host would need a platform-aware probe, recorded
+ * as a portability note, not a behavior change). */
+export function resolveFdPath(): string | null {
+  const pathEntries = process.env.PATH?.split(':').filter(entry => entry !== '') ?? []
+  for (const name of ['fd', 'fdfind']) {
+    for (const dir of pathEntries) {
+      const candidate = join(dir, name)
+      try {
+        accessSync(candidate, fsConstants.X_OK)
+        return candidate
+      } catch {
+        // Not here; keep scanning.
+      }
+    }
+  }
+  return null
+}
+
+/** One raw discovery fact (path relative to the search base + fs facts). */
+export interface RawDiscoveryEntry {
+  readonly path: string
+  readonly isDirectory: boolean
+}
+
+/** The discovery seam one source answers with: fdPath (null = no fd) and
+ * the fs procedures the fallback uses. */
+export interface DiscoverySource {
+  /** The resolved fd/fdfind executable, or null (fallback scan only). */
+  readonly fdPath: string | null
+}
+
+/** Whether one Dirent is a directory (symlinks followed; a broken link is
+ * a file candidate — the fork's rule). */
+function entryIsDirectory(
+  baseDir: string,
+  name: string,
+  entry: { isDirectory(): boolean; isSymbolicLink(): boolean },
+): boolean {
+  if (entry.isDirectory()) return true
+  if (entry.isSymbolicLink()) {
+    try {
+      return statSync(join(baseDir, name)).isDirectory()
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
+/** The DIRECT children of one directory (a scoped listing): paths are
+ * bare entry names. A missing/unreadable directory yields [] (the caller
+ * shows nothing — never a crash). */
+export function listDirectChildren(baseDir: string): RawDiscoveryEntry[] {
+  let entries
+  try {
+    entries = readdirSync(baseDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const out: RawDiscoveryEntry[] = []
+  for (const entry of entries) {
+    out.push({ path: entry.name, isDirectory: entryIsDirectory(baseDir, entry.name, entry) })
+  }
+  return out
+}
+
+/** The bounded recursive scan of one directory's SUBTREE: the root's
+ * direct children are always complete (a root-level `src/` must be found),
+ * deeper entries are capped at MAX_FALLBACK_SCAN. Paths are relative to
+ * baseDir (`sub/deep.ts`); `.git` is skipped (kimi parity); symlinked
+ * directories are NOT descended (cycle safety). */
+export function scanSubtree(baseDir: string, signal?: AbortSignal): RawDiscoveryEntry[] {
+  const candidates: RawDiscoveryEntry[] = []
+  let firstEntries
+  try {
+    firstEntries = readdirSync(baseDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  // Depth 0: complete, uncapped.
+  const stack: string[] = []
+  for (const entry of firstEntries) {
+    if (entry.name === '.git') continue
+    const path = entry.name
+    candidates.push({ path, isDirectory: entryIsDirectory(baseDir, entry.name, entry) })
+    if (entry.isDirectory()) stack.push(path)
+  }
+  // Deeper levels: bounded.
+  let scanned = 0
+  while (stack.length > 0 && scanned < MAX_FALLBACK_SCAN) {
+    if (signal?.aborted === true) break
+    const relativeDir = stack.pop() ?? ''
+    let entries
+    try {
+      entries = readdirSync(join(baseDir, relativeDir), { withFileTypes: true })
+    } catch {
+      continue
+    }
+    // `signal` is possibly-undefined (the fallback scan accepts an optional
+    // signal); `aborted` is `false | undefined` — the comparison to `true`
+    // is the intent (a never-aborted scan runs to completion).
+    for (const entry of entries) {
+      if ((signal?.aborted ?? false) || scanned >= MAX_FALLBACK_SCAN) break
+      if (entry.name === '.git') continue
+      const path = `${relativeDir}/${entry.name}`
+      scanned += 1
+      candidates.push({ path, isDirectory: entryIsDirectory(join(baseDir, relativeDir), entry.name, entry) })
+      if (entry.isDirectory() && !entry.isSymbolicLink()) stack.push(path)
+    }
+  }
+  return candidates
+}
+
+/** Run one fd whole-tree/scoped search. fd prints paths RELATIVE to
+ * `--base-directory`; directories are classified against the fs (fd's
+ * default print format does not guarantee a trailing `/` — the fork's
+ * rule: statSync follows symlinks, so a symlink dir still completes with
+ * `/`). A failed/aborted run yields [] (never a crash). */
+export function discoverWithFd(
+  fdPath: string,
+  baseDir: string,
+  term: string,
+  signal: AbortSignal,
+): Promise<RawDiscoveryEntry[]> {
+  const args = [
+    '--base-directory', baseDir,
+    '--max-results', String(MAX_FD_RESULTS),
+    '--type', 'f',
+    '--type', 'd',
+    '--follow',
+    '--hidden',
+    '--exclude', '.git',
+    '--exclude', '.git/*',
+    '--exclude', '.git/**',
+  ]
+  // fd matches the query against the basename by default (substring,
+  // smart-case): for a basename term that is exactly the scoring model's
+  // input. A scoped query runs inside its own baseDir, so the term never
+  // contains a separator here — no --full-path needed.
+  if (term !== '') args.push(term)
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve([])
+      return
+    }
+    const child = spawn(fdPath, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let settled = false
+    const settle = (results: RawDiscoveryEntry[]): void => {
+      if (settled) return
+      settled = true
+      signal.removeEventListener('abort', onAbort)
+      resolve(results)
+    }
+    const onAbort = (): void => {
+      if (child.exitCode === null) child.kill('SIGKILL')
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    child.stdout.setEncoding('utf-8')
+    child.stdout.on('data', (chunk: string) => { stdout += chunk })
+    child.on('error', () => settle([]))
+    child.on('close', (code) => {
+      if (signal.aborted || code !== 0 || !stdout) {
+        settle([])
+        return
+      }
+      const lines = stdout.trim().split('\n').filter((line) => line !== '')
+      const results: RawDiscoveryEntry[] = []
+      for (const line of lines) {
+        if (line === '.git' || line.startsWith('.git/') || line.includes('/.git/')) continue
+        const normalized = line.endsWith('/') ? line.slice(0, -1) : line
+        let isDirectory = line.endsWith('/')
+        if (!isDirectory) {
+          try {
+            isDirectory = statSync(join(baseDir, normalized)).isDirectory()
+          } catch {
+            isDirectory = false
+          }
+        }
+        results.push({ path: normalized, isDirectory })
+      }
+      settle(results)
+    })
+  })
+}
+
+/**
+ * Answer one resolved query with discovery facts (plan §6): a scoped
+ * LISTING (empty term) reads the target directory's direct children; a
+ * scoped or whole-tree FUZZY query uses fd when available and the bounded
+ * subtree scan otherwise. Paths are relative to the QUERY's search base.
+ * @param query - the resolved path query (searchBase already absolute).
+ * @param source - the discovery seam (fd detection per source).
+ * @param signal - the editor's request abort.
+ */
+export async function discoverForQuery(
+  query: PathCompletionQuery,
+  source: DiscoverySource,
+  signal: AbortSignal,
+): Promise<readonly PathCandidate[]> {
+  if (query.explicitScope && query.searchTerm === '') {
+    // A scoped listing: the target directory's OWN content — always the
+    // direct children (never a whole-tree scan filtered by string, plan
+    // §6.1; and never fd's subtree listing — "show src children" semantics).
+    return listDirectChildren(query.searchBase).map(toCandidate)
+  }
+  // Fuzzy (scoped or whole-tree): fd first, bounded scan fallback. A
+  // Windows-dialect token stays on the scan path (fd's POSIX matcher does
+  // not speak `\`).
+  if (source.fdPath !== null && !query.winAbsolute) {
+    const entries = await discoverWithFd(source.fdPath, query.searchBase, query.searchTerm, signal)
+    if (signal.aborted) return []
+    return entries.map(toCandidate)
+  }
+  const entries = scanSubtree(query.searchBase, signal)
+  if (signal.aborted === true) return []
+  return entries.map(toCandidate)
+}
+
+/** Map one raw discovery fact onto the detached candidate DTO. */
+function toCandidate(entry: RawDiscoveryEntry): PathCandidate {
+  return {
+    path: entry.path,
+    kind: entry.isDirectory ? 'directory' : 'file',
+  }
+}

--- a/src/file-completion/discovery.ts
+++ b/src/file-completion/discovery.ts
@@ -159,6 +159,13 @@ export function discoverWithFd(
   const args = [
     '--base-directory', baseDir,
     '--max-results', String(MAX_FD_RESULTS),
+    // fd's DEFAULT is smart-case (case-insensitive for a lowercase query,
+    // case-SENSITIVE when the query contains uppercase) — but the shared
+    // ranking contract is case-INSENSITIVE (scorePathCandidate lowercases
+    // both sides). Forced --ignore-case keeps the fd discovery semantics
+    // aligned with the ranking model: @FOO finds foo.txt, exactly like the
+    // bounded-scan fallback path.
+    '-i',
     '--type', 'f',
     '--type', 'd',
     '--follow',

--- a/src/file-completion/discovery.ts
+++ b/src/file-completion/discovery.ts
@@ -27,25 +27,33 @@ const MAX_FD_RESULTS = 100
 /** Locate an executable file-finder on PATH: `fd` preferred, `fdfind`
  * (Debian/Ubuntu's fd-find) second (plan §12 — kimi parity). Bare command
  * names resolve through PATH at spawn time; absolute/relative entries must
- * exist and be X_OK. The platform PATH delimiter is used so the same probe
- * remains correct on Windows hosts too. */
+ * exist and be X_OK. The platform PATH delimiter and PATHEXT suffixes keep
+ * the same probe correct on Windows hosts too. */
 export function resolveFdPath(): string | null {
   const pathEntries = process.env.PATH?.split(delimiter) ?? []
+  const pathExt = process.env.PATHEXT || (process.platform === 'win32' ? '.COM;.EXE;.BAT;.CMD' : '')
+  const suffixes = pathExt
+    .split(';')
+    .map(suffix => suffix.trim())
+    .filter(suffix => suffix !== '')
+    .flatMap(suffix => suffix.toLowerCase() === suffix ? [suffix] : [suffix, suffix.toLowerCase()])
   for (const name of ['fd', 'fdfind']) {
     for (const entry of pathEntries) {
       // An empty POSIX PATH component means the current directory. Keep it
       // rather than silently changing the shell's lookup semantics.
       const dir = entry === '' ? '.' : entry
-      const candidate = join(dir, name)
-      try {
-        // X_OK alone also succeeds for a directory on POSIX. Only return a
-        // regular file that is executable; a directory named `fd` must not
-        // poison discovery before the fallback gets a chance to run.
-        if (statSync(candidate).isFile() && accessSync(candidate, fsConstants.X_OK) === undefined) {
-          return candidate
+      for (const suffix of ['', ...suffixes]) {
+        const candidate = join(dir, `${name}${suffix}`)
+        try {
+          // X_OK alone also succeeds for a directory on POSIX. Only return a
+          // regular file that is executable; a directory named `fd` must not
+          // poison discovery before the fallback gets a chance to run.
+          if (statSync(candidate).isFile() && accessSync(candidate, fsConstants.X_OK) === undefined) {
+            return candidate
+          }
+        } catch {
+          // Not here; keep scanning.
         }
-      } catch {
-        // Not here; keep scanning.
       }
     }
   }

--- a/src/file-completion/engine.ts
+++ b/src/file-completion/engine.ts
@@ -17,7 +17,7 @@
 
 import type { AutocompleteItem } from '@xmoon76/pi-tui'
 import { compareScoredPaths, scorePathCandidate } from './ranking.ts'
-import { resolvePathQuery, stripAtQuotes } from './query.ts'
+import { resolvePathQuery, separatorOfRaw, stripAtQuotes } from './query.ts'
 import { discoverForQuery, type DiscoverySource } from './discovery.ts'
 import { presentPathCandidate } from './presentation.ts'
 import type { PathCandidate, PathCompletionQuery } from './types.ts'
@@ -100,7 +100,7 @@ export async function completePath(
   const items = presentDiscovery(
     candidates.map(candidate => reattachDisplayBase(candidate, query)),
     query.searchTerm,
-    { ...context, sep: query.winAbsolute ? '\\' : '/' },
+    { ...context, sep: separatorOfRaw(raw, query.winAbsolute || raw.includes('\\')) },
   )
   return items.length === 0 ? null : items
 }

--- a/src/file-completion/engine.ts
+++ b/src/file-completion/engine.ts
@@ -1,0 +1,106 @@
+/**
+ * The file-completion engine (plan §5): the SHARED pipeline behind `@`
+ * mentions and `/image` arguments. One call answers "what do I show for
+ * this raw token?" — parse query → discover (through the injected source)
+ * → rank → slice → present. The two contexts differ ONLY in their raw
+ * input shape (an `@` prefix vs an argument) and their source (Host
+ * filesystem vs Client-local) — the path math, ranking, quoting and
+ * directory continuation are one implementation.
+ *
+ * The engine is pure policy: the discover step is injected (the Direct
+ * Host adapter answers for the HOST fs; the local source for the Client
+ * fs) and the presentation returns bare `AutocompleteItem`s (the client's
+ * `MentionProvider` / `getArgumentCompletions` adapters own the fork's
+ * value shapes).
+ * @module @xmoon76/dsh-pi-tui/file-completion/engine
+ */
+
+import type { AutocompleteItem } from '@xmoon76/pi-tui'
+import { compareScoredPaths, scorePathCandidate } from './ranking.ts'
+import { resolvePathQuery, stripAtQuotes } from './query.ts'
+import { discoverForQuery, type DiscoverySource } from './discovery.ts'
+import { presentPathCandidate } from './presentation.ts'
+import type { PathCandidate, PathCompletionQuery } from './types.ts'
+
+/** The client-side suggestion cap (kimi MAX_FALLBACK_SUGGESTIONS): the
+ * source returns the DISCOVERY set, the client ranks and slices it. */
+export const MAX_SUGGESTIONS = 50
+
+/**
+ * Reattach the query's display base onto one discovered candidate path.
+ * Discovery returns paths RELATIVE to the query's search base; the
+ * candidate the user accepts must read in the USER'S dialect
+ * (`../sibling-file.ts`, `~/pics/a.png`, `src/deep.ts`, `/tmp/x`). The
+ * SOURCE calls this before its candidates cross the port contract (the
+ * port's paths are user-facing). PURE.
+ */
+export function reattachDisplayBase(candidate: PathCandidate, query: PathCompletionQuery): PathCandidate {
+  if (query.displayBase === '') return candidate
+  return { ...candidate, path: `${query.displayBase}${candidate.path}` }
+}
+
+/** Rank, slice and present one discovery set for one query. The
+ * candidates ALREADY carry their final user-facing paths (the source
+ * reattached the display base); this layer owns ranking, the `@`/quoting
+ * shape, labels, descriptions and directory continuation. PURE. */
+export function presentDiscovery(
+  candidates: readonly PathCandidate[],
+  term: string,
+  context: { at: boolean; quoted: boolean },
+): AutocompleteItem[] {
+  const lowerQuery = term.toLowerCase()
+  return candidates
+    .map(candidate => ({ candidate, score: scorePathCandidate(candidate, lowerQuery) }))
+    .filter(entry => entry.score > 0)
+    .sort(compareScoredPaths)
+    .slice(0, MAX_SUGGESTIONS)
+    .map(entry => presentPathCandidate(entry.candidate, context))
+}
+
+/** Resolve one raw token to the pure query (exported so tests pin the
+ * resolver directly). */
+export function resolveQuery(raw: string, cwd: string): PathCompletionQuery {
+  return resolvePathQuery(raw, cwd)
+}
+
+/** The stripped raw token + quoted flag of one `@` prefix. */
+export function tokenOfAtPrefix(atPrefix: string): { raw: string; quoted: boolean } {
+  return stripAtQuotes(atPrefix)
+}
+
+/**
+ * Complete one raw token through the shared pipeline: resolve the query,
+ * discover through the injected source, reattach the display base, rank,
+ * slice and present. Throws never — discovery failures degrade to null.
+ * @param raw - the raw token (quotes stripped; leading separator
+ *   whitespace stripped by the caller).
+ * @param cwd - the completion base (session workspace).
+ * @param source - the discovery seam (Host fs for `@`, Client fs for
+ *   `/image`).
+ * @param signal - the editor's request abort.
+ * @param context - `{ at: true }` for an `@` mention (the value carries
+ *   the `@` + quoting), `{ at: false }` for a bare path argument.
+ * @returns the ranked+presented items, or null when nothing matches.
+ */
+export async function completePath(
+  raw: string,
+  cwd: string,
+  source: DiscoverySource,
+  signal: AbortSignal,
+  context: { at: boolean; quoted: boolean },
+): Promise<AutocompleteItem[] | null> {
+  const query = resolveQuery(raw, cwd)
+  let candidates: readonly PathCandidate[]
+  try {
+    candidates = await discoverForQuery(query, source, signal)
+  } catch {
+    return null
+  }
+  if (signal.aborted || candidates.length === 0) return null
+  const items = presentDiscovery(
+    candidates.map(candidate => reattachDisplayBase(candidate, query)),
+    query.searchTerm,
+    context,
+  )
+  return items.length === 0 ? null : items
+}

--- a/src/file-completion/engine.ts
+++ b/src/file-completion/engine.ts
@@ -46,7 +46,7 @@ export function reattachDisplayBase(candidate: PathCandidate, query: PathComplet
 export function presentDiscovery(
   candidates: readonly PathCandidate[],
   term: string,
-  context: { at: boolean; quoted: boolean },
+  context: { at: boolean; quoted: boolean; sep?: string },
 ): AutocompleteItem[] {
   const lowerQuery = term.toLowerCase()
   return candidates
@@ -100,7 +100,7 @@ export async function completePath(
   const items = presentDiscovery(
     candidates.map(candidate => reattachDisplayBase(candidate, query)),
     query.searchTerm,
-    context,
+    { ...context, sep: query.winAbsolute ? '\\' : '/' },
   )
   return items.length === 0 ? null : items
 }

--- a/src/file-completion/local-file-source.ts
+++ b/src/file-completion/local-file-source.ts
@@ -1,0 +1,28 @@
+/**
+ * The Client-LOCAL file source for `/image` argument completion (plan
+ * §13.2): the `@` mention is a HOST filesystem semantic reference and
+ * goes through HostFilePort — `/image` is a Client-local file attachment
+ * and must NEVER touch the Host filesystem. Both share the engine
+ * (query/ranking/presentation) but keep their own discovery seam; this
+ * module is the Client-local one under future remote attach.
+ * @module @xmoon76/dsh-pi-tui/file-completion/local-file-source
+ */
+
+import type { DiscoverySource } from './discovery.ts'
+import { resolveFdPath } from './discovery.ts'
+
+/** The `/image` completion source: the Client's OWN filesystem, fd on the
+ * CLIENT PATH when present. */
+export class LocalFileSource implements DiscoverySource {
+  private readonly fdPathValue: string | null
+
+  /** @param fdPath - the Client's fd/fdfind executable; defaults to the
+   *   PATH probe; tests inject `null` to pin the bounded fallback. */
+  constructor(fdPath: string | null = resolveFdPath()) {
+    this.fdPathValue = fdPath
+  }
+
+  get fdPath(): string | null {
+    return this.fdPathValue
+  }
+}

--- a/src/file-completion/local-file-source.ts
+++ b/src/file-completion/local-file-source.ts
@@ -16,10 +16,11 @@ import { resolveFdPath } from './discovery.ts'
 export class LocalFileSource implements DiscoverySource {
   private readonly fdPathValue: string | null
 
-  /** @param fdPath - the Client's fd/fdfind executable; defaults to the
-   *   PATH probe; tests inject `null` to pin the bounded fallback. */
-  constructor(fdPath: string | null = resolveFdPath()) {
-    this.fdPathValue = fdPath
+  /** @param fdPath - the Client's fd/fdfind executable; `undefined` (the
+   *   default) probes PATH, `null` FORCES the bounded fallback (no fd), a
+   *   string pins one finder. */
+  constructor(fdPath: string | null | undefined = undefined) {
+    this.fdPathValue = fdPath === undefined ? resolveFdPath() : fdPath
   }
 
   get fdPath(): string | null {

--- a/src/file-completion/presentation.ts
+++ b/src/file-completion/presentation.ts
@@ -12,9 +12,8 @@
  * @module @xmoon76/dsh-pi-tui/file-completion/presentation
  */
 
-import { basename } from 'node:path'
 import type { AutocompleteItem } from '@xmoon76/pi-tui'
-import type { PathCandidate, PathCompletionQuery } from './types.ts'
+import { basenameOfPath, type PathCandidate, type PathCompletionQuery } from './types.ts'
 
 /** The joined display path for one candidate under a scoped query: the
  * display base (already in the user's own dialect, always ending with the
@@ -48,7 +47,10 @@ export function presentPathCandidate(
     : `${context.at ? '@' : ''}${pathValue}`
   return {
     value,
-    label: `${basename(candidate.path)}${candidate.kind === 'directory' ? '/' : ''}`,
+    // The vendored SelectList uses the slash marker to recognize a directory
+    // item during apply. The accepted VALUE carries the user's actual
+    // separator; keep this UI marker stable across path dialects.
+    label: `${basenameOfPath(candidate.path)}${candidate.kind === 'directory' ? '/' : ''}`,
     description: displayPath,
   }
 }

--- a/src/file-completion/presentation.ts
+++ b/src/file-completion/presentation.ts
@@ -1,0 +1,51 @@
+/**
+ * The shared path presentation (plan §8): how one path-only candidate
+ * becomes an `AutocompleteItem`. The `@` mention shape and the `/image`
+ * argument shape differ ONLY in the value prefix (`@` + quoting vs bare)
+ * — the path math (trailing `/` for continuation, quoting, labels,
+ * descriptions) is shared.
+ *
+ * The SOURCE is responsible for reattaching the query's display base
+ * (see {@link displayPathOf}): candidates reach this layer as FINAL
+ * user-facing display paths (`../sibling.ts`, `~/pics/a.png`,
+ * `src/deep.ts`) — scoped or not, one shape.
+ * @module @xmoon76/dsh-pi-tui/file-completion/presentation
+ */
+
+import { basename } from 'node:path'
+import type { AutocompleteItem } from '@xmoon76/pi-tui'
+import type { PathCandidate, PathCompletionQuery } from './types.ts'
+
+/** The joined display path for one candidate under a scoped query: the
+ * display base (already in the user's own dialect, always ending with the
+ * user's separator) + the candidate path. `../` + `sibling-file.ts` →
+ * `../sibling-file.ts`; `~/pics/` + `a.png` → `~/pics/a.png`;
+ * `/tmp/` + `x` → `/tmp/x`; `C:\Users\` + `shot.png` → `C:\Users\shot.png`.
+ * An unscoped query ('' display base) returns the path unchanged. PURE —
+ * called by the SOURCE after discovery, before the candidate crosses to
+ * the presentation/ranking layer. */
+export function displayPathOf(candidate: PathCandidate, query: PathCompletionQuery): string {
+  if (query.displayBase === '') return candidate.path
+  return `${query.displayBase}${candidate.path}`
+}
+
+/** Present one FINAL-display-path candidate as a completion item:
+ * directories keep the trailing `/` (so accept continues), values with
+ * spaces are quoted — with the `@"..."` form when the user typed a
+ * quoted `@` prefix. PURE client policy. */
+export function presentPathCandidate(
+  candidate: PathCandidate,
+  context: { at: boolean; quoted: boolean },
+): AutocompleteItem {
+  const displayPath = candidate.path
+  const pathValue = candidate.kind === 'directory' ? `${displayPath}/` : displayPath
+  const needsQuotes = context.quoted || pathValue.includes(' ')
+  const value = needsQuotes
+    ? `${context.at ? '@"' : '"'}${pathValue}"`
+    : `${context.at ? '@' : ''}${pathValue}`
+  return {
+    value,
+    label: `${basename(candidate.path)}${candidate.kind === 'directory' ? '/' : ''}`,
+    description: displayPath,
+  }
+}

--- a/src/file-completion/presentation.ts
+++ b/src/file-completion/presentation.ts
@@ -19,7 +19,8 @@ import { basenameOfPath, type PathCandidate, type PathCompletionQuery } from './
  * display base (already in the user's own dialect, always ending with the
  * user's separator) + the candidate path. `../` + `sibling-file.ts` →
  * `../sibling-file.ts`; `~/pics/` + `a.png` → `~/pics/a.png`;
- * `/tmp/` + `x` → `/tmp/x`; `C:\Users\` + `shot.png` → `C:\Users\shot.png`.
+ * `/tmp/` + `x` → `/tmp/x`; a Windows drive base + `shot.png` keeps its
+ * backslash dialect.
  * An unscoped query ('' display base) returns the path unchanged. PURE —
  * called by the SOURCE after discovery, before the candidate crosses to
  * the presentation/ranking layer. */
@@ -30,7 +31,7 @@ export function displayPathOf(candidate: PathCandidate, query: PathCompletionQue
 
 /** Present one FINAL-display-path candidate as a completion item:
  * directories keep the trailing separator OF THE USER'S OWN DIALECT (`/`
- * on POSIX, `\` for a Windows-dialect token — so `C:\Users\foo\` stays
+ * on POSIX, `\` for a Windows-dialect token — so the accepted value stays
  * dialect-consistent and the next Tab continues in the same dialect), so
  * accept continues; values with spaces are quoted — with the `@"..."`
  * form when the user typed a quoted `@` prefix. PURE client policy. */

--- a/src/file-completion/presentation.ts
+++ b/src/file-completion/presentation.ts
@@ -30,15 +30,18 @@ export function displayPathOf(candidate: PathCandidate, query: PathCompletionQue
 }
 
 /** Present one FINAL-display-path candidate as a completion item:
- * directories keep the trailing `/` (so accept continues), values with
- * spaces are quoted — with the `@"..."` form when the user typed a
- * quoted `@` prefix. PURE client policy. */
+ * directories keep the trailing separator OF THE USER'S OWN DIALECT (`/`
+ * on POSIX, `\` for a Windows-dialect token — so `C:\Users\foo\` stays
+ * dialect-consistent and the next Tab continues in the same dialect), so
+ * accept continues; values with spaces are quoted — with the `@"..."`
+ * form when the user typed a quoted `@` prefix. PURE client policy. */
 export function presentPathCandidate(
   candidate: PathCandidate,
-  context: { at: boolean; quoted: boolean },
+  context: { at: boolean; quoted: boolean; sep?: string },
 ): AutocompleteItem {
+  const sep = context.sep ?? '/'
   const displayPath = candidate.path
-  const pathValue = candidate.kind === 'directory' ? `${displayPath}/` : displayPath
+  const pathValue = candidate.kind === 'directory' ? `${displayPath}${sep}` : displayPath
   const needsQuotes = context.quoted || pathValue.includes(' ')
   const value = needsQuotes
     ? `${context.at ? '@"' : '"'}${pathValue}"`

--- a/src/file-completion/query.ts
+++ b/src/file-completion/query.ts
@@ -5,7 +5,7 @@
  * is the adapter's job, resolved here already for the search base.
  *
  * A scoped token (`src/fo`, `../foo`, `../../foo`, `~/foo`, `/tmp/foo`,
- * `C:\Users\sh`, `\\server\share\fo`) searches ONLY its resolved
+ * a drive-qualified path, or an UNC path) searches ONLY its resolved
  * directory — never a whole-tree scan filtered by string (plan §6.1). An
  * unscoped token (`foo`, `nested`, `config`) is a whole-tree fuzzy query
  * (plan §6.2) with an EMPTY display base.
@@ -68,9 +68,9 @@ export function stripAtQuotes(atPrefix: string): { raw: string; quoted: boolean 
 
 /**
  * Choose the separator immediately before the basename. This preserves a
- * mixed Windows token's actual dialect (`C:/Users/sh` stays `C:/Users/`,
- * while `C:\\Users\\sh` stays `C:\\Users\\`) instead of normalizing it to
- * the host platform's preferred separator.
+ * mixed Windows token's actual dialect (forward-slash drive paths stay
+ * forward-slashed, while backslash drive paths stay backslashed) instead of
+ * normalizing it to the host platform's preferred separator.
  */
 export function separatorOfRaw(raw: string, windowsDialect: boolean): '/' | '\\' {
   const slash = raw.lastIndexOf('/')
@@ -131,7 +131,7 @@ function isBareScopeForm(raw: string): boolean {
 export function resolvePathQuery(raw: string, cwd: string): PathCompletionQuery {
   const expanded = expandHomeToken(raw)
   // Detect the dialect from the RAW token, not from `path.isAbsolute` on the
-  // expanded token. On Windows, node:path.isAbsolute('C:\\x') is true but
+  // expanded token. On Windows, node:path.isAbsolute(drivePath) is true but
   // that must not erase the Windows dialect; on POSIX, `~\\x` expands to a
   // POSIX absolute filesystem path while remaining a Windows-looking token.
   const posixAbsolute = raw.startsWith('/')
@@ -170,7 +170,7 @@ export function resolvePathQuery(raw: string, cwd: string): PathCompletionQuery 
   }
 
   // Keep the DISPLAY base as a literal prefix of what the user typed. The
-  // path module may normalize `C:/Users` to `C:\\Users`; using the raw slice
+  // path module may normalize mixed drive separators; using the raw slice
   // preserves mixed separators and lets the completion value stay dialect
   // consistent with the input.
   const lastSlash = Math.max(raw.lastIndexOf('/'), raw.lastIndexOf('\\'))

--- a/src/file-completion/query.ts
+++ b/src/file-completion/query.ts
@@ -1,0 +1,196 @@
+/**
+ * The path query resolver (plan §5.1/§6): pure — turns a raw token into
+ * the search directory, the basename term, the display prefix and whether
+ * the token names an EXPLICIT scope. No filesystem access; `~` expansion
+ * is the adapter's job, resolved here already for the search base.
+ *
+ * A scoped token (`src/fo`, `../foo`, `../../foo`, `~/foo`, `/tmp/foo`,
+ * `C:\Users\sh`, `\\server\share\fo`) searches ONLY its resolved
+ * directory — never a whole-tree scan filtered by string (plan §6.1). An
+ * unscoped token (`foo`, `nested`, `config`) is a whole-tree fuzzy query
+ * (plan §6.2) with an EMPTY display base.
+ * @module @xmoon76/dsh-pi-tui/file-completion/query
+ */
+
+import { basename, dirname, isAbsolute, join, win32 } from 'node:path'
+import { homedir } from 'node:os'
+import type { PathCompletionQuery } from './types.ts'
+
+/**
+ * The migration-era search-directory resolver (test-pinned): PURE — turns
+ * one raw token into the readdir target, the basename prefix and the
+ * Windows-dialect flag. The shared engine's {@link resolvePathQuery} is the
+ * converged implementation; this wrapper keeps the old triple shape so the
+ * `mentions.test.ts` pins stay valid while the engine takes over the real
+ * completion path.
+ * @param token - the parsed argument token (no leading separator
+ *   whitespace).
+ * @param cwd - the session workspace (relative forms resolve against it).
+ * @param expanded - `expandHomeToken(token)` (callers compute it).
+ */
+export function resolvePathSearch(
+  token: string,
+  cwd: string,
+  expanded: string,
+): { searchDir: string; searchPrefix: string; winAbsolute: boolean } {
+  // Absolute detection covers every platform form: POSIX `/x`, Windows
+  // drive (`C:\x`, `C:/x`) and UNC (`\\server\share`) paths.
+  const posixAbsolute = isAbsolute(expanded)
+  const winAbsolute = !posixAbsolute && win32.isAbsolute(expanded)
+  const absolute = token.startsWith('~') || posixAbsolute || winAbsolute
+  const pathDirname = winAbsolute ? win32.dirname : dirname
+  const pathBasename = winAbsolute ? win32.basename : basename
+  if (
+    token === './' || token === '../' || token === '~' || token === '~/' || token === '/' || token === ''
+  ) {
+    return { searchDir: absolute ? expanded : join(cwd, expanded), searchPrefix: '', winAbsolute }
+  }
+  if (token.endsWith('/') || token.endsWith('\\')) {
+    return { searchDir: absolute ? expanded : join(cwd, expanded), searchPrefix: '', winAbsolute }
+  }
+  return {
+    searchDir: absolute ? pathDirname(expanded) : join(cwd, dirname(expanded)),
+    searchPrefix: pathBasename(expanded),
+    winAbsolute,
+  }
+}
+
+/** Expand a leading `~` in one token (other tokens unchanged). */
+export function expandHomeToken(token: string): string {
+  if (token === '~') return homedir()
+  if (token.startsWith('~/')) return join(homedir(), token.slice(2))
+  return token
+}
+
+/** The token's raw path, quotes stripped for a quoted `@` prefix (an
+ * unclosed quoted form `@"my file` stays unclosed — the query is the text
+ * inside the quotes). */
+export function stripAtQuotes(atPrefix: string): { raw: string; quoted: boolean } {
+  if (atPrefix.startsWith('@"')) {
+    const inner = atPrefix.slice(2)
+    return { raw: inner.endsWith('"') ? inner.slice(0, -1) : inner, quoted: true }
+  }
+  const inner = atPrefix.slice(1)
+  return { raw: inner.endsWith('"') ? inner.slice(0, -1) : inner, quoted: false }
+}
+
+/** Whether the raw token is a bare scope form: it names a directory that
+ * should be LISTED (searchTerm ''). `.`/`..` root forms list their own
+ * relative directory; `./`/`../`/`~`/`~/`/`/` list the scope root. */
+function isBareScopeForm(raw: string): boolean {
+  return (
+    raw === '' || raw === '.' || raw === '..'
+    || raw === './' || raw === '../'
+    || raw === '~' || raw === '~/'
+    || raw === '/' || raw === '.\\' || raw === '..\\'
+  )
+}
+
+/** The separator a display base ends with (the user's own dialect). */
+function separatorOf(winAbsolute: boolean): string {
+  return winAbsolute ? '\\' : '/'
+}
+
+/** The display prefix of a scoped token, always ending with the user's
+ * separator: `src/` for `src/foo`, `../` for `../foo`, `~/pics/` for
+ * `~/pics/a`; `./` for `./foo` (dirname normalizes `./` away); `''` only
+ * for a `sub`-style unscoped token. ROOT dirnames keep their trailing
+ * separator (win32.dirname('C:\\Wi') is 'C:\\'; a UNC share root stays
+ * '\\server\\share\\') — those must never gain a second one. */
+function displayBaseFor(raw: string, rawDir: string, winAbsolute: boolean): string {
+  if (rawDir === '') return ''
+  if (rawDir === '.') {
+    // dirname('src/foo') is 'src', but dirname('./foo') is '.' — the
+    // user's `./` prefix is the intent, never the empty prefix.
+    return raw.startsWith('./') ? './' : ''
+  }
+  if (rawDir.endsWith('/') || rawDir.endsWith('\\')) return rawDir
+  return `${rawDir}${separatorOf(winAbsolute)}`
+}
+
+/**
+ * Resolve ONE raw completion token into the pure path query (plan §5.1).
+ * @param raw - the token as typed (quotes stripped; leading separator
+ *   whitespace stripped by the caller).
+ * @param cwd - the completion base (the session workspace; relative
+ *   forms resolve against it).
+ * @returns the query: searchBase (absolute), searchTerm, displayBase,
+ *   explicitScope, winAbsolute.
+ */
+export function resolvePathQuery(raw: string, cwd: string): PathCompletionQuery {
+  const expanded = expandHomeToken(raw)
+  // Absolute detection covers every platform form: POSIX `/x`, Windows
+  // drive (`C:\x`, `C:/x`) and UNC (`\\server\share`) paths. The win32
+  // check engages ONLY for genuinely Windows-dialect tokens — win32 alone
+  // would also accept a bare POSIX `/x` token, which must keep the POSIX
+  // dialect (its dirname/join use backslashes).
+  const posixAbsolute = isAbsolute(expanded)
+  const winAbsolute = !posixAbsolute && win32.isAbsolute(expanded)
+  const absolute = raw.startsWith('~') || posixAbsolute || winAbsolute
+  const pathDirname = winAbsolute ? win32.dirname : dirname
+  const pathBasename = winAbsolute ? win32.basename : basename
+  const sep = separatorOf(winAbsolute)
+
+  if (isBareScopeForm(raw)) {
+    // Complete the whole scope directory: `@` alone lists cwd; `.`/`..`
+    // and their separator forms list the RELATIVE directory (`.` → cwd,
+    // `..` → cwd/..); `~/` maps to home; `/` maps to the POSIX root.
+    const relativeForm = raw === '.' || raw === '..' || raw === './' || raw === '../' || raw === '.\\' || raw === '..\\'
+    const scopeDir = relativeForm
+      ? join(cwd, raw.replace(/\\/g, '/'))
+      : (absolute ? expanded : join(cwd, expanded))
+    const displayBase = raw === '' ? ''
+      : raw === '~' ? '~/'
+        : (raw.endsWith('/') || raw.endsWith('\\') ? raw : `${raw}${sep}`)
+    return { raw, searchBase: scopeDir, searchTerm: '', displayBase, explicitScope: true, winAbsolute }
+  }
+
+  if (raw.endsWith('/') || raw.endsWith('\\')) {
+    // A trailing separator: show the directory's contents (a Windows path
+    // ends with `\`).
+    return {
+      raw,
+      searchBase: absolute ? expanded : join(cwd, expanded),
+      searchTerm: '',
+      displayBase: raw,
+      explicitScope: true,
+      winAbsolute,
+    }
+  }
+
+  // Split into directory + basename prefix. dirname leaves a trailing
+  // separator ONLY on roots — which must keep it — so the search base is
+  // the dirname VERBATIM (never stripped). `../` scopes: dirname('../foo')
+  // is '..', dirname('../../foo') is '../..' — join(cwd, rawDir) resolves
+  // the literal parent prefix, and the display prefix stays in the user's
+  // own dialect.
+  const hasSeparator = raw.includes('/') || raw.includes('\\')
+  const rawDir = hasSeparator ? (winAbsolute ? win32.dirname(raw) : dirname(raw)) : ''
+  const displayBase = displayBaseFor(raw, rawDir, winAbsolute)
+  const searchTerm = pathBasename(expanded)
+  const explicitScope = hasSeparator || absolute
+  // `~/pics/a`: the `~` lives in the DIRECTORY part — expand there, never
+  // join the literal `~/pics` against cwd. Every other form resolves the
+  // raw directory prefix against cwd (dirname keeps `..`/`../..` literal,
+  // so a parent scope escapes cwd exactly as far as the user typed).
+  const searchBaseForScope = raw.startsWith('~/')
+    ? expandHomeToken(rawDir)
+    : (absolute ? pathDirname(expanded) : join(cwd, rawDir))
+  return {
+    raw,
+    searchBase: explicitScope ? searchBaseForScope : cwd,
+    searchTerm,
+    displayBase,
+    explicitScope,
+    winAbsolute,
+  }
+}
+
+/** The basename TERM of a raw completion token — what ranking scores
+ * against ('de' for 'src/de', 'nested' for 'nested', '' for listings).
+ * PURE, no filesystem access. */
+export function termOfRaw(raw: string): string {
+  if (isBareScopeForm(raw)) return ''
+  const last = raw.endsWith('/') || raw.endsWith('\\') ? '' : (raw.split(/[\\/]/).pop() ?? '')
+  return last === '.' || last === '..' ? '' : last
+}

--- a/src/file-completion/query.ts
+++ b/src/file-completion/query.ts
@@ -12,53 +12,45 @@
  * @module @xmoon76/dsh-pi-tui/file-completion/query
  */
 
-import { basename, dirname, isAbsolute, join, win32 } from 'node:path'
+import { basename, dirname, join, win32 } from 'node:path'
 import { homedir } from 'node:os'
 import type { PathCompletionQuery } from './types.ts'
 
 /**
  * The migration-era search-directory resolver (test-pinned): PURE — turns
- * one raw token into the readdir target, the basename prefix and the
- * Windows-dialect flag. The shared engine's {@link resolvePathQuery} is the
+ * one raw token into the readdir target, the basename prefix and the Windows
+ * dialect flag. The shared engine's {@link resolvePathQuery} is the
  * converged implementation; this wrapper keeps the old triple shape so the
  * `mentions.test.ts` pins stay valid while the engine takes over the real
  * completion path.
  * @param token - the parsed argument token (no leading separator
  *   whitespace).
  * @param cwd - the session workspace (relative forms resolve against it).
- * @param expanded - `expandHomeToken(token)` (callers compute it).
+ * @param expanded - `expandHomeToken(token)` (callers compute it). Kept in
+ *   this compatibility signature; the converged resolver owns expansion.
  */
 export function resolvePathSearch(
   token: string,
   cwd: string,
-  expanded: string,
+  _expanded: string,
 ): { searchDir: string; searchPrefix: string; winAbsolute: boolean } {
-  // Absolute detection covers every platform form: POSIX `/x`, Windows
-  // drive (`C:\x`, `C:/x`) and UNC (`\\server\share`) paths.
-  const posixAbsolute = isAbsolute(expanded)
-  const winAbsolute = !posixAbsolute && win32.isAbsolute(expanded)
-  const absolute = token.startsWith('~') || posixAbsolute || winAbsolute
-  const pathDirname = winAbsolute ? win32.dirname : dirname
-  const pathBasename = winAbsolute ? win32.basename : basename
-  if (
-    token === './' || token === '../' || token === '~' || token === '~/' || token === '/' || token === ''
-  ) {
-    return { searchDir: absolute ? expanded : join(cwd, expanded), searchPrefix: '', winAbsolute }
-  }
-  if (token.endsWith('/') || token.endsWith('\\')) {
-    return { searchDir: absolute ? expanded : join(cwd, expanded), searchPrefix: '', winAbsolute }
-  }
+  const query = resolvePathQuery(token, cwd)
   return {
-    searchDir: absolute ? pathDirname(expanded) : join(cwd, dirname(expanded)),
-    searchPrefix: pathBasename(expanded),
-    winAbsolute,
+    searchDir: query.searchBase,
+    searchPrefix: query.searchTerm,
+    winAbsolute: query.winAbsolute,
   }
 }
 
 /** Expand a leading `~` in one token (other tokens unchanged). */
 export function expandHomeToken(token: string): string {
   if (token === '~') return homedir()
-  if (token.startsWith('~/')) return join(homedir(), token.slice(2))
+  if (token.startsWith('~/') || token.startsWith('~\\')) {
+    // Resolve a Windows-looking home token on POSIX too: the completion
+    // source owns the real filesystem path, while the raw token keeps its
+    // original separator for presentation.
+    return join(homedir(), token.slice(2).replace(/\\/g, '/'))
+  }
   return token
 }
 
@@ -74,83 +66,102 @@ export function stripAtQuotes(atPrefix: string): { raw: string; quoted: boolean 
   return { raw: inner.endsWith('"') ? inner.slice(0, -1) : inner, quoted: false }
 }
 
-/** Whether the raw token is a bare scope form: it names a directory that
- * should be LISTED (searchTerm ''). `.`/`..` root forms list their own
- * relative directory; `./`/`../`/`~`/`~/`/`/` list the scope root. */
+/**
+ * Choose the separator immediately before the basename. This preserves a
+ * mixed Windows token's actual dialect (`C:/Users/sh` stays `C:/Users/`,
+ * while `C:\\Users\\sh` stays `C:\\Users\\`) instead of normalizing it to
+ * the host platform's preferred separator.
+ */
+export function separatorOfRaw(raw: string, windowsDialect: boolean): '/' | '\\' {
+  const slash = raw.lastIndexOf('/')
+  const backslash = raw.lastIndexOf('\\')
+  if (slash === -1 && backslash === -1) return windowsDialect ? '\\' : '/'
+  return backslash > slash ? '\\' : '/'
+}
+
+/** Whether the token is a leading-home form, including `~\\foo`. */
+function isHomeToken(raw: string): boolean {
+  return raw === '~' || raw.startsWith('~/') || raw.startsWith('~\\')
+}
+
+/** Whether one raw token is genuinely Windows-dialect. */
+function isWindowsDialect(raw: string, winAbsolute: boolean): boolean {
+  return winAbsolute || raw.includes('\\')
+}
+
+/** Whether an absolute path uses the Windows drive/UNC grammar. */
+function isWindowsAbsolute(raw: string): boolean {
+  // A POSIX `/tmp` path is deliberately not treated as a Windows rooted path
+  // even on Windows, where win32.isAbsolute('/tmp') also returns true.
+  return !raw.startsWith('/') && win32.isAbsolute(raw)
+}
+
+/** Join a relative scope while keeping POSIX test fixtures usable for a
+ * Windows-looking token. On a real Windows cwd, win32.join is authoritative;
+ * on POSIX, backslashes are the user's dialect but not filesystem separators. */
+function joinRelativeScope(cwd: string, rawPath: string, windowsDialect: boolean): string {
+  if (!windowsDialect) return join(cwd, rawPath)
+  // `win32.isAbsolute('/workspace')` is true for a rooted Windows path too,
+  // but on POSIX that string is an ordinary absolute POSIX cwd. Select the
+  // filesystem joiner from the actual host or an unmistakable drive/UNC cwd.
+  const windowsCwd = /^[A-Za-z]:[\\/]/.test(cwd) || cwd.startsWith('\\\\')
+  if (process.platform === 'win32' || windowsCwd) return win32.join(cwd, rawPath)
+  return join(cwd, rawPath.replace(/\\/g, '/'))
+}
+
+/** Whether the raw token names a directory that should be LISTED
+ * (`searchTerm === ''`). `.`/`..` root forms list their own relative
+ * directory; `./`/`../`/`~`/`/` list the scope root. */
 function isBareScopeForm(raw: string): boolean {
   return (
     raw === '' || raw === '.' || raw === '..'
     || raw === './' || raw === '../'
-    || raw === '~' || raw === '~/'
+    || raw === '~' || raw === '~/' || raw === '~\\'
     || raw === '/' || raw === '.\\' || raw === '..\\'
   )
-}
-
-/** The separator a display base ends with (the user's own dialect). */
-function separatorOf(winAbsolute: boolean): string {
-  return winAbsolute ? '\\' : '/'
-}
-
-/** The display prefix of a scoped token, always ending with the user's
- * separator: `src/` for `src/foo`, `../` for `../foo`, `~/pics/` for
- * `~/pics/a`; `./` for `./foo` (dirname normalizes `./` away); `''` only
- * for a `sub`-style unscoped token. ROOT dirnames keep their trailing
- * separator (win32.dirname('C:\\Wi') is 'C:\\'; a UNC share root stays
- * '\\server\\share\\') — those must never gain a second one. */
-function displayBaseFor(raw: string, rawDir: string, winAbsolute: boolean): string {
-  if (rawDir === '') return ''
-  if (rawDir === '.') {
-    // dirname('src/foo') is 'src', but dirname('./foo') is '.' — the
-    // user's `./` prefix is the intent, never the empty prefix.
-    return raw.startsWith('./') ? './' : ''
-  }
-  if (rawDir.endsWith('/') || rawDir.endsWith('\\')) return rawDir
-  return `${rawDir}${separatorOf(winAbsolute)}`
 }
 
 /**
  * Resolve ONE raw completion token into the pure path query (plan §5.1).
  * @param raw - the token as typed (quotes stripped; leading separator
  *   whitespace stripped by the caller).
- * @param cwd - the completion base (the session workspace; relative
- *   forms resolve against it).
- * @returns the query: searchBase (absolute), searchTerm, displayBase,
- *   explicitScope, winAbsolute.
+ * @param cwd - the completion base (the session workspace; relative forms
+ *   resolve against it).
  */
 export function resolvePathQuery(raw: string, cwd: string): PathCompletionQuery {
   const expanded = expandHomeToken(raw)
-  // Absolute detection covers every platform form: POSIX `/x`, Windows
-  // drive (`C:\x`, `C:/x`) and UNC (`\\server\share`) paths. The win32
-  // check engages ONLY for genuinely Windows-dialect tokens — win32 alone
-  // would also accept a bare POSIX `/x` token, which must keep the POSIX
-  // dialect (its dirname/join use backslashes).
-  const posixAbsolute = isAbsolute(expanded)
-  const winAbsolute = !posixAbsolute && win32.isAbsolute(expanded)
-  const absolute = raw.startsWith('~') || posixAbsolute || winAbsolute
-  const pathDirname = winAbsolute ? win32.dirname : dirname
-  const pathBasename = winAbsolute ? win32.basename : basename
-  const sep = separatorOf(winAbsolute)
+  // Detect the dialect from the RAW token, not from `path.isAbsolute` on the
+  // expanded token. On Windows, node:path.isAbsolute('C:\\x') is true but
+  // that must not erase the Windows dialect; on POSIX, `~\\x` expands to a
+  // POSIX absolute filesystem path while remaining a Windows-looking token.
+  const posixAbsolute = raw.startsWith('/')
+  const winAbsolute = isWindowsAbsolute(raw)
+  const windowsDialect = isWindowsDialect(raw, winAbsolute)
+  const absolute = isHomeToken(raw) || posixAbsolute || winAbsolute
+  const pathDirname = windowsDialect ? win32.dirname : dirname
+  const pathBasename = windowsDialect ? win32.basename : basename
+  const separator = separatorOfRaw(raw, windowsDialect)
 
   if (isBareScopeForm(raw)) {
     // Complete the whole scope directory: `@` alone lists cwd; `.`/`..`
-    // and their separator forms list the RELATIVE directory (`.` → cwd,
-    // `..` → cwd/..); `~/` maps to home; `/` maps to the POSIX root.
+    // and their separator forms list the RELATIVE directory; `~/` maps to
+    // home; `/` maps to the POSIX root.
     const relativeForm = raw === '.' || raw === '..' || raw === './' || raw === '../' || raw === '.\\' || raw === '..\\'
     const scopeDir = relativeForm
-      ? join(cwd, raw.replace(/\\/g, '/'))
-      : (absolute ? expanded : join(cwd, expanded))
+      ? joinRelativeScope(cwd, raw, windowsDialect)
+      : (absolute ? expanded : joinRelativeScope(cwd, expanded, windowsDialect))
     const displayBase = raw === '' ? ''
-      : raw === '~' ? '~/'
-        : (raw.endsWith('/') || raw.endsWith('\\') ? raw : `${raw}${sep}`)
+      : raw === '~' ? `~${separator}`
+        : (raw.endsWith('/') || raw.endsWith('\\') ? raw : `${raw}${separator}`)
     return { raw, searchBase: scopeDir, searchTerm: '', displayBase, explicitScope: true, winAbsolute }
   }
 
   if (raw.endsWith('/') || raw.endsWith('\\')) {
     // A trailing separator: show the directory's contents (a Windows path
-    // ends with `\`).
+    // ends with `\\`).
     return {
       raw,
-      searchBase: absolute ? expanded : join(cwd, expanded),
+      searchBase: absolute ? expanded : joinRelativeScope(cwd, expanded, windowsDialect),
       searchTerm: '',
       displayBase: raw,
       explicitScope: true,
@@ -158,24 +169,23 @@ export function resolvePathQuery(raw: string, cwd: string): PathCompletionQuery 
     }
   }
 
-  // Split into directory + basename prefix. dirname leaves a trailing
-  // separator ONLY on roots — which must keep it — so the search base is
-  // the dirname VERBATIM (never stripped). `../` scopes: dirname('../foo')
-  // is '..', dirname('../../foo') is '../..' — join(cwd, rawDir) resolves
-  // the literal parent prefix, and the display prefix stays in the user's
-  // own dialect.
-  const hasSeparator = raw.includes('/') || raw.includes('\\')
-  const rawDir = hasSeparator ? (winAbsolute ? win32.dirname(raw) : dirname(raw)) : ''
-  const displayBase = displayBaseFor(raw, rawDir, winAbsolute)
+  // Keep the DISPLAY base as a literal prefix of what the user typed. The
+  // path module may normalize `C:/Users` to `C:\\Users`; using the raw slice
+  // preserves mixed separators and lets the completion value stay dialect
+  // consistent with the input.
+  const lastSlash = Math.max(raw.lastIndexOf('/'), raw.lastIndexOf('\\'))
+  const hasSeparator = lastSlash >= 0
+  const displayBase = hasSeparator ? raw.slice(0, lastSlash + 1) : ''
+  const rawDir = hasSeparator ? raw.slice(0, lastSlash) : ''
   const searchTerm = pathBasename(expanded)
   const explicitScope = hasSeparator || absolute
-  // `~/pics/a`: the `~` lives in the DIRECTORY part — expand there, never
-  // join the literal `~/pics` against cwd. Every other form resolves the
-  // raw directory prefix against cwd (dirname keeps `..`/`../..` literal,
-  // so a parent scope escapes cwd exactly as far as the user typed).
-  const searchBaseForScope = raw.startsWith('~/')
+
+  // `~/pics/a` expands the raw directory prefix against HOME. Every other
+  // form resolves the raw directory against cwd (parent prefixes escape cwd
+  // exactly as far as the user typed).
+  const searchBaseForScope = isHomeToken(raw)
     ? expandHomeToken(rawDir)
-    : (absolute ? pathDirname(expanded) : join(cwd, rawDir))
+    : (absolute ? pathDirname(expanded) : joinRelativeScope(cwd, rawDir, windowsDialect))
   return {
     raw,
     searchBase: explicitScope ? searchBaseForScope : cwd,
@@ -187,7 +197,7 @@ export function resolvePathQuery(raw: string, cwd: string): PathCompletionQuery 
 }
 
 /** The basename TERM of a raw completion token — what ranking scores
- * against ('de' for 'src/de', 'nested' for 'nested', '' for listings).
+ * against (`de` for `src/de`, `nested` for `nested`, '' for listings).
  * PURE, no filesystem access. */
 export function termOfRaw(raw: string): string {
   if (isBareScopeForm(raw)) return ''

--- a/src/file-completion/ranking.ts
+++ b/src/file-completion/ranking.ts
@@ -1,0 +1,43 @@
+/**
+ * The shared path ranking (plan §7): ONE scoring model behind `@` and
+ * `/image`. Exact basename > basename prefix > basename substring > full
+ * path substring, with a directory bonus; empty queries order directories
+ * first and shallowness first. PURE — paths in, numbers out.
+ * @module @xmoon76/dsh-pi-tui/file-completion/ranking
+ */
+
+import { basename } from 'node:path'
+import type { PathCandidate } from './types.ts'
+
+/** Score one candidate against the query term (lowercased). */
+export function scorePathCandidate(
+  candidate: PathCandidate,
+  lowerQuery: string,
+): number {
+  if (lowerQuery === '') {
+    // Empty query (a listing): directories lead, shallow paths lead.
+    const depthPenalty = candidate.path.split(/[\\/]/).length - 1
+    return (candidate.kind === 'directory' ? 120 : 100) - depthPenalty
+  }
+  const lowerPath = candidate.path.toLowerCase()
+  const lowerBase = basename(candidate.path).toLowerCase()
+  let score = 0
+  if (lowerBase === lowerQuery) score = 100
+  else if (lowerBase.startsWith(lowerQuery)) score = 80
+  else if (lowerBase.includes(lowerQuery)) score = 50
+  else if (lowerPath.includes(lowerQuery)) score = 30
+  if (candidate.kind === 'directory' && score > 0) score += 10
+  return score
+}
+
+/** Deterministic order: score desc, directories (kind) first, path asc. */
+export function compareScoredPaths(
+  left: { candidate: PathCandidate; score: number },
+  right: { candidate: PathCandidate; score: number },
+): number {
+  if (left.score !== right.score) return right.score - left.score
+  if (left.candidate.kind !== right.candidate.kind) {
+    return left.candidate.kind === 'directory' ? -1 : 1
+  }
+  return left.candidate.path.localeCompare(right.candidate.path)
+}

--- a/src/file-completion/ranking.ts
+++ b/src/file-completion/ranking.ts
@@ -6,8 +6,7 @@
  * @module @xmoon76/dsh-pi-tui/file-completion/ranking
  */
 
-import { basename } from 'node:path'
-import type { PathCandidate } from './types.ts'
+import { basenameOfPath, type PathCandidate } from './types.ts'
 
 /** Score one candidate against the query term (lowercased). */
 export function scorePathCandidate(
@@ -20,7 +19,7 @@ export function scorePathCandidate(
     return (candidate.kind === 'directory' ? 120 : 100) - depthPenalty
   }
   const lowerPath = candidate.path.toLowerCase()
-  const lowerBase = basename(candidate.path).toLowerCase()
+  const lowerBase = basenameOfPath(candidate.path).toLowerCase()
   let score = 0
   if (lowerBase === lowerQuery) score = 100
   else if (lowerBase.startsWith(lowerQuery)) score = 80

--- a/src/file-completion/types.ts
+++ b/src/file-completion/types.ts
@@ -17,6 +17,16 @@ export interface PathCandidate {
   readonly kind: 'file' | 'directory'
 }
 
+/**
+ * Return the final path component without depending on the host OS dialect.
+ * Completion can present a Windows path while the client process is running
+ * on POSIX (and vice versa), so `node:path.basename` is not sufficient here.
+ */
+export function basenameOfPath(path: string): string {
+  const separator = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+  return path.slice(separator + 1)
+}
+
 /** A half-open text range in the current line. */
 export interface TextRange {
   readonly start: number

--- a/src/file-completion/types.ts
+++ b/src/file-completion/types.ts
@@ -1,0 +1,73 @@
+/**
+ * The shared types of the file-completion engine (the 2026-08-27
+ * convergence plan): ONE path query/ranking/presentation model behind BOTH
+ * `@` mentions (Host filesystem, through HostFilePort) and `/image`
+ * arguments (Client-local filesystem). Only identity/data crosses the
+ * sources — the engine is pure policy, the source is where the fs lives.
+ * @module @xmoon76/dsh-pi-tui/file-completion/types
+ */
+
+/** One path-only discovery result. Sources return path FACTS; presentation
+ * (quoting, trailing `/`, labels, descriptions) is client policy. */
+export interface PathCandidate {
+  /** The user-facing display path: workspace-relative for unscoped whole-tree
+   * queries (`src/deep.ts`), token-relative for scoped ones (`../x.ts`,
+   * `~/pics/a.png`, `/tmp/x`). Directories carry NO trailing slash. */
+  readonly path: string
+  readonly kind: 'file' | 'directory'
+}
+
+/** A half-open text range in the current line. */
+export interface TextRange {
+  readonly start: number
+  readonly end: number
+}
+
+/**
+ * The classified file-completion context at the cursor. File completion is
+ * ALLOWED only in `mention` (`@...`) and `image-argument` (`/image ...`)
+ * contexts — `none` means ordinary text/paths, where neither the natural
+ * trigger nor Tab may open a file dropdown (kimi parity, plan §2.1/§4).
+ */
+export type FileCompletionContext =
+  | {
+      kind: 'mention'
+      /** The raw mention prefix INCLUDING `@` (and an unclosed `"` when
+       * quoted): `@src/fo`, `@"my file`. */
+      query: string
+      /** The replaced span in the line: [cursorCol - query.length, cursorCol). */
+      range: TextRange
+    }
+  | {
+      kind: 'image-argument'
+      /** The raw argument text INCLUDING leftover separator whitespace:
+       * `fi`, `   subdir/`. */
+      query: string
+      range: TextRange
+    }
+  | { kind: 'none' }
+
+/**
+ * The parsed path completion query (plan §5.1): where to search, what to
+ * match, and how to present the result. PURE — no filesystem access.
+ */
+export interface PathCompletionQuery {
+  /** The token as typed (quotes stripped; leading separator whitespace
+   * stripped by the caller). */
+  readonly raw: string
+  /** The absolute directory to search (already `~`-expanded and
+   * resolved against cwd for scoped forms; cwd itself for unscoped). */
+  readonly searchBase: string
+  /** The basename term to match ('' = list the directory's children). */
+  readonly searchTerm: string
+  /** The user-facing prefix to reattach to a result path ('' for
+   * whole-tree queries): `../` for `../foo`, `src/` for `src/foo`. */
+  readonly displayBase: string
+  /** Whether the token names an explicit scope (has a directory part, a
+   * root form, `~` or absolute): search ONLY that directory — never a
+   * whole-tree scan filtered by string. */
+  readonly explicitScope: boolean
+  /** Whether the token is genuinely Windows-dialect (win32 dirname/join
+   * math; the display keeps the user's `\` dialect). */
+  readonly winAbsolute: boolean
+}

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -248,6 +248,14 @@ export class MentionProvider implements AutocompleteProvider {
   private readonly inputModeSource: () => EditorInputMode
   /** The `/image` discovery source: Client-local (never HostFilePort). */
   private readonly localSource: LocalFileSource
+  /** The REQUEST SNAPSHOT (plan §9.2): the exact document lines + cursor
+   * + mode of the most recent getSuggestions call that produced a
+   * suggestion list. applyCompletion accepts ONLY when the current
+   * document + cursor still match this snapshot — a stale dropdown (from
+   * an older request) can never modify a later edit of ANY part of the
+   * document (the prefix-only fence misses edits elsewhere on the line,
+   * e.g. `hello @foo` → `world @foo`). */
+  private requestSnapshot: { lines: readonly string[]; cursorLine: number; cursorCol: number; mode: EditorInputMode } | null = null
 
   constructor(
     slashCommands: readonly SlashCommand[],
@@ -333,10 +341,10 @@ export class MentionProvider implements AutocompleteProvider {
       : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
 
     if (context.kind === 'mention') {
-      return this.completeMention(context.query, options.signal)
+      return this.withRequestSnapshot(lines, cursorLine, cursorCol, await this.completeMention(context.query, options.signal))
     }
     if (context.kind === 'image-argument') {
-      return this.completeImageArgument(context.query, options.signal)
+      return this.withRequestSnapshot(lines, cursorLine, cursorCol, await this.completeImageArgument(context.query, options.signal))
     }
 
     // 3. Shell-mode natural-trigger suppression (mirrors the pre-plan
@@ -355,7 +363,8 @@ export class MentionProvider implements AutocompleteProvider {
     const literalShellLine = textBeforeCursor.trimStart().startsWith('!')
     if (semantic !== null || literalShellLine) {
       try {
-        return await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
+        const result = await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
+        return this.withRequestSnapshot(lines, cursorLine, cursorCol, result)
       } catch {
         return null
       }
@@ -420,25 +429,79 @@ export class MentionProvider implements AutocompleteProvider {
   /** Complete one `/image` argument through the shared engine + the
    * Client-local source (NEVER HostFilePort). An EMPTY argument lists the
    * cwd (Tab on `/image ` — the directory-listing semantics the engine
-   * owns). A QUOTED argument (`/image "my fi`) completes inside the
-   * quotes — the shared quoting contract (plan §2.2) — and the completed
-   * value keeps the closing quote. An unquoted argument with embedded
-   * spaces cannot complete (the fork's apply replaces the whole argument
-   * range, so a later word would clobber the earlier ones). */
+   * owns). A QUOTED argument (`/image "my f`) completes inside the quotes
+   * — the shared quoting contract (plan §2.2): spaces inside the quotes
+   * are PART OF THE TOKEN (the quote is the delimiter), so `my f` finds
+   * `my file.txt`; the completed value keeps the closing quote. An
+   * UNQUOTED argument with embedded spaces cannot complete (the fork's
+   * apply replaces the whole argument range, so a later word would clobber
+   * the earlier ones). */
   private async completeImageArgument(argument: string, signal: AbortSignal): Promise<AutocompleteSuggestions | null> {
     const leading = argument.match(/^[ \t]+/)?.[0] ?? ''
     let token = argument.slice(leading.length)
     let quoted = false
     if (token.startsWith('"')) {
       quoted = true
-      token = token.startsWith('"') ? token.slice(1) : token
+      token = token.slice(1)
       const close = token.indexOf('"')
       if (close !== -1) token = token.slice(0, close)
+    } else if (token.includes(' ') || token.includes('\t')) {
+      // Unquoted: a space is a word boundary — completing a later word
+      // would clobber the earlier ones (the fork's whole-range apply).
+      return null
     }
-    if (token.includes(' ') || token.includes('\t')) return null
     const items = await completePath(token, this.workDir, this.localSource, signal, { at: false, quoted })
     if (items === null) return null
     return { prefix: argument, items: items.map(item => ({ ...item, value: `${leading}${item.value}` })) }
+  }
+
+  /** Capture the request state right before a non-null suggestion result
+   * is returned: the apply fence later requires the EXACT same document +
+   * cursor + mode (plan §9.2 — the strong stale check). A null result
+   * clears the snapshot (nothing to accept). */
+  private withRequestSnapshot<T extends AutocompleteSuggestions | null>(
+    lines: readonly string[],
+    cursorLine: number,
+    cursorCol: number,
+    result: T,
+  ): T {
+    if (result === null) this.requestSnapshot = null
+    else this.requestSnapshot = {
+      lines: [...lines],
+      cursorLine,
+      cursorCol,
+      mode: this.inputModeSource(),
+    }
+    return result
+  }
+
+  /** PUBLIC test/app seam (plan §9.2): the DELEGATING provider (the app's
+   * M5 wrap) captures the host snapshot when the EXTENSION chain answers —
+   * the base provider still owns the stale fence, but a suggestion list it
+   * did not produce must bind the state it was computed against. */
+  captureRequestSnapshot(
+    lines: readonly string[],
+    cursorLine: number,
+    cursorCol: number,
+    result: AutocompleteSuggestions | null,
+  ): AutocompleteSuggestions | null {
+    return this.withRequestSnapshot(lines, cursorLine, cursorCol, result)
+  }
+
+  /** Whether the editor state still EXACTLY matches the request that
+   * produced the current dropdown (line array, cursor, and input mode —
+   * a mode switch swaps the completion grammar, so a dropdown built for
+   * the old mode must never apply). */
+  private requestMatchesSnapshot(lines: readonly string[], cursorLine: number, cursorCol: number): boolean {
+    const snapshot = this.requestSnapshot
+    if (snapshot === null) return false
+    if (snapshot.cursorLine !== cursorLine || snapshot.cursorCol !== cursorCol) return false
+    if (snapshot.mode !== this.inputModeSource()) return false
+    if (snapshot.lines.length !== lines.length) return false
+    for (let index = 0; index < snapshot.lines.length; index += 1) {
+      if (snapshot.lines[index] !== lines[index]) return false
+    }
+    return true
   }
 
   applyCompletion(
@@ -449,12 +512,29 @@ export class MentionProvider implements AutocompleteProvider {
     prefix: string,
   ): { lines: string[]; cursorLine: number; cursorCol: number } {
     const currentLine = lines[cursorLine] ?? ''
-    // THE STALE FENCE (plan §9.1): the request's prefix must still be the
-    // text immediately before the cursor. Any edit since the request —
-    // typing, Backspace, Delete, cursor move, paste, mode/session switch —
-    // makes the replacement WRONG (the old code cut `cursorCol - prefix.length`
-    // into the middle of the new draft, deleting `@`-preceding text). A
-    // stale accept returns the document UNCHANGED.
+    const textBeforeCursor = currentLine.slice(0, cursorCol)
+    // The FILE-completion context of this apply (the shell-bridge and the
+    // shell-semantic paths below do NOT carry the snapshot — a shell word
+    // replacement is a plain-word swap that never cuts into `@`-preceding
+    // text, and its tests drive apply directly without a request).
+    const applySemantic = this.virtualShellSemanticContext(currentLine, cursorCol)
+    const context = applySemantic !== null
+      ? classifyFileCompletionContext(applySemantic.line, this.pathArgumentCommands)
+      : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
+    const isFileContext = context.kind === 'mention' || context.kind === 'image-argument'
+    // THE STALE FENCE (plan §9.1 minimum + §9.2 full snapshot for FILE
+    // contexts): the EXACT document lines + cursor of the REQUEST that
+    // produced this dropdown must still match the editor's current state.
+    // Any edit since — typing, Backspace, Delete, cursor move, paste,
+    // mode/session switch, or an unrelated edit ELSEWHERE on the line
+    // (`hello @foo` → `world @foo`) — makes the replacement WRONG. A stale
+    // accept returns the document UNCHANGED. The snapshot is the strong
+    // check; the prefix check remains the fork-contract fallback for the
+    // non-snapshot paths (shell/extension — still cannot cut into the
+    // draft).
+    if (isFileContext && !this.requestMatchesSnapshot(lines, cursorLine, cursorCol)) {
+      return { lines, cursorLine, cursorCol }
+    }
     const start = cursorCol - prefix.length
     if (start < 0 || currentLine.slice(start, cursorCol) !== prefix) {
       return { lines, cursorLine, cursorCol }

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -328,17 +328,28 @@ export class MentionProvider implements AutocompleteProvider {
     cursorCol: number,
     options: { signal: AbortSignal; force?: boolean },
   ): Promise<AutocompleteSuggestions | null> {
+    return this.getSuggestionsAtGeneration(++this.requestGeneration, lines, cursorLine, cursorCol, options)
+  }
+
+  /** The generation-threaded core: mint ONCE (either here for the direct
+   * path, or by the DELEGATED wrap at entry — getSuggestionsForGeneration)
+   * and never reset the global counter after an await. The snapshot
+   * capture binds only when the minted generation is still the latest, so
+   * a late result from an older request (a provider or the extension chain
+   * ignoring AbortSignal) can never overwrite a newer request's snapshot. */
+  private async getSuggestionsAtGeneration(
+    generation: number,
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    options: { signal: AbortSignal; force?: boolean },
+  ): Promise<AutocompleteSuggestions | null> {
     const currentLine = lines[cursorLine] ?? ''
     const textBeforeCursor = currentLine.slice(0, cursorCol)
-    // Mint THIS request's generation: the snapshot capture below only
-    // binds when this call is still the latest (a late result from an
-    // older request — a provider or the extension chain ignoring
-    // AbortSignal — must never overwrite a newer request's snapshot). A
-    // caller CANNOT pre-mint here; the DELEGATED wrap (tui-app) mints its
-    // own generation at entry and reads it back after this call — its
-    // extension answer binds to the delegated request even if newer host
-    // requests start mid-flight.
-    const generation = ++this.requestGeneration
+    // The REQUEST scope, captured at entry (never re-read after an await:
+    // a session/workspace switch mid-request must not bake the NEW scope
+    // into this request's snapshot — the apply fence compares it).
+    const requestScope = this.scopeOf()
     // 1. The SHELL-BRIDGE grammar first (a `!` line's first word is a
     // command name; a path position falls through). The bridge never
     // competes with file completion.
@@ -363,10 +374,10 @@ export class MentionProvider implements AutocompleteProvider {
       : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
 
     if (context.kind === 'mention') {
-      return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, await this.completeMention(context.query, options.signal))
+      return this.withRequestSnapshot(generation, requestScope, lines, cursorLine, cursorCol, await this.completeMention(context.query, options.signal))
     }
     if (context.kind === 'image-argument') {
-      return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, await this.completeImageArgument(context.query, options.signal))
+      return this.withRequestSnapshot(generation, requestScope, lines, cursorLine, cursorCol, await this.completeImageArgument(context.query, options.signal))
     }
 
     // 3. Shell-mode natural-trigger suppression (mirrors the pre-plan
@@ -386,7 +397,7 @@ export class MentionProvider implements AutocompleteProvider {
     if (semantic !== null || literalShellLine) {
       try {
         const result = await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
-        return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, result)
+        return this.withRequestSnapshot(generation, requestScope, lines, cursorLine, cursorCol, result)
       } catch {
         return null
       }
@@ -485,13 +496,17 @@ export class MentionProvider implements AutocompleteProvider {
 
   /** Capture the request state right before a non-null suggestion result
    * is returned: the apply fence later requires the EXACT same document +
-   * cursor + mode (plan §9.2 — the strong stale check). A null result
-   * clears the snapshot (nothing to accept). ONLY the LATEST request
-   * binds: a result minted for an OLDER generation (a late answer from a
-   * provider/extension that ignored AbortSignal) is dropped, so it cannot
-   * fence a newer request. */
+   * cursor + mode (+ the REQUEST scope) (plan §9.2 — the strong stale
+   * check). A null result clears the snapshot (nothing to accept). ONLY
+   * the LATEST request binds: a result minted for an OLDER generation (a
+   * late answer from a provider/extension that ignored AbortSignal) is
+   * dropped, so it cannot fence a newer request. The scope is the one
+   * captured at REQUEST ENTRY (passed in by the caller) — never read at
+   * capture time after an await (a session switch mid-request must not
+   * bake the NEW session into an OLD request's snapshot). */
   private withRequestSnapshot<T extends AutocompleteSuggestions | null>(
     generation: number,
+    scope: MentionScope,
     lines: readonly string[],
     cursorLine: number,
     cursorCol: number,
@@ -504,7 +519,7 @@ export class MentionProvider implements AutocompleteProvider {
       cursorLine,
       cursorCol,
       mode: this.inputModeSource(),
-      scope: this.scopeOf(),
+      scope,
     }
     return result
   }
@@ -513,25 +528,28 @@ export class MentionProvider implements AutocompleteProvider {
    * M5 wrap) captures the host snapshot when the EXTENSION chain answers —
    * the base provider still owns the stale fence, but a suggestion list it
    * did not produce must bind the state it was computed against. The
-   * DELEGATED call passes the generation minted by its own host
-   * getSuggestions (the `captureRequestGeneration` seam): a late
-   * extension answer from an OLDER request — a newer request already
-   * started — does not bind (exactly like a late host result). */
+   * DELEGATED call passes the generation minted at ITS entry AND the
+   * REQUEST scope captured at ITS entry (before the extension await): a
+   * late extension answer from an OLDER request — a newer request already
+   * started, or the scope switched mid-flight — does not bind. */
   captureRequestSnapshot(
     generation: number,
+    scope: MentionScope,
     lines: readonly string[],
     cursorLine: number,
     cursorCol: number,
     result: AutocompleteSuggestions | null,
   ): AutocompleteSuggestions | null {
-    return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, result)
+    return this.withRequestSnapshot(generation, scope, lines, cursorLine, cursorCol, result)
   }
 
   /** The base provider's suggestion entry for the DELEGATED wrap: the
-   * wrap mints the generation at entry and passes it here, so THIS host
+   * wrap mints the generation ONCE at entry and threads it HERE — the host
    * call binds its snapshot to the SAME generation the extension's answer
-   * will use — a newer request that starts during the extension await
-   * bumps the counter past it, and the late extension answer is dropped. */
+   * will use. A newer request that starts during the extension await bumps
+   * the counter past it, and the late extension answer is dropped by the
+   * generation check — NEVER reset the global counter after an await (that
+   * would clobber a newer request's minted generation). */
   async getSuggestionsForGeneration(
     generation: number,
     lines: string[],
@@ -539,13 +557,7 @@ export class MentionProvider implements AutocompleteProvider {
     cursorCol: number,
     options: { signal: AbortSignal; force?: boolean },
   ): Promise<AutocompleteSuggestions | null> {
-    const captured = await this.getSuggestions(lines, cursorLine, cursorCol, options)
-    // The host call minted generation+1 internally; the delegated call's
-    // generation is the one that must own the ext snapshot. Re-bind the
-    // host result to the delegated generation (a null host result clears
-    // the snapshot — the ext will bind after).
-    this.requestGeneration = generation
-    return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, captured)
+    return this.getSuggestionsAtGeneration(generation, lines, cursorLine, cursorCol, options)
   }
 
   /** PUBLIC test/app seam (plan §9.2): THE DELEGATING provider mints its
@@ -564,6 +576,14 @@ export class MentionProvider implements AutocompleteProvider {
    * extension result bind to the wrong request. */
   captureRequestGeneration(): number {
     return this.requestGeneration
+  }
+
+  /** The REQUEST scope, read synchronously by the DELEGATED wrap at entry:
+   * the extension's snapshot must carry the scope THIS request resolved
+   * under (a switch mid-request must fence the stale accept, not bake the
+   * new session into the old request's snapshot). */
+  scopeAtRequestTime(): MentionScope {
+    return this.scopeOf()
   }
 
   /** Whether the editor state still EXACTLY matches the request that

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -22,7 +22,7 @@
  */
 
 import { homedir } from 'node:os'
-import { isAbsolute, join } from 'node:path'
+import { isAbsolute, join, win32 } from 'node:path'
 import {
   CombinedAutocompleteProvider,
   type AutocompleteItem,
@@ -37,11 +37,10 @@ import {
   extractAtPrefix,
   FILE_ARGUMENT_COMMANDS,
 } from './file-completion/context.ts'
-import { completePath, presentDiscovery, reattachDisplayBase, resolveQuery } from './file-completion/engine.ts'
-import { listDirectChildren } from './file-completion/discovery.ts'
+import { completePath, presentDiscovery, resolveQuery } from './file-completion/engine.ts'
+import { separatorOfRaw, stripAtQuotes } from './file-completion/query.ts'
 import { LocalFileSource } from './file-completion/local-file-source.ts'
 import { resolveFdPath } from './file-completion/discovery.ts'
-import type { PathCandidate } from './file-completion/types.ts'
 
 // The migration-era surface re-exported for test pins (`mentions.test.ts`
 // imports `resolvePathSearch` and `extractAtPrefix` from this module).
@@ -49,7 +48,7 @@ export { extractAtPrefix } from './file-completion/context.ts'
 export { resolvePathSearch } from './file-completion/query.ts'
 
 /** Token separators: `@` must sit at the start of the current token. */
-const PATH_DELIMITERS = new Set([' ', '\t', '"', "'", '='])
+const PATH_DELIMITERS = new Set([' ', '\t', '\n', '\r', '"', "'", '='])
 /** Trailing punctuation allowed AFTER an unquoted mention token: stripped
  * for the existence probe but KEPT in the rewritten text, so a sentence
  * like "see @src/foo.ts, then…" still canonicalizes. */
@@ -147,9 +146,20 @@ function isCjkChar(char: string): boolean {
  * path resolves against the session workspace. PURE.
  */
 export function resolveMentionCandidate(raw: string, sessionCwd: string): string {
-  if (raw.startsWith('~/')) return join(homedir(), raw.slice(2))
-  if (isAbsolute(raw)) return raw
-  return join(sessionCwd, raw)
+  if (raw === '~' || raw.startsWith('~/') || raw.startsWith('~\\')) {
+    return raw === '~'
+      ? homedir()
+      : join(homedir(), raw.slice(2).replace(/\\/g, '/'))
+  }
+  // `path.isAbsolute` follows the host OS. The mention grammar must also
+  // preserve Windows drive/UNC references when a client process is POSIX
+  // (and must not mistake a POSIX `/tmp` path for a Windows path on Windows).
+  if (isAbsolute(raw) || (!raw.startsWith('/') && win32.isAbsolute(raw))) return raw
+  // A relative Windows-looking token is still relative to the session scope;
+  // normalize its separators only when the scope itself is POSIX.
+  return raw.includes('\\') && process.platform !== 'win32'
+    ? join(sessionCwd, raw.replace(/\\/g, '/'))
+    : join(sessionCwd, raw)
 }
 
 /** The injected existence probe (Host-owned). */
@@ -228,6 +238,38 @@ function sameMentionScope(left: MentionScope, right: MentionScope): boolean {
     : left.cwd === (right as { cwd: string }).cwd
 }
 
+/** Complete the argument text shared by the provider-level `/image`
+ * path and the awaitable command compatibility hook. The caller chooses the
+ * filesystem source and cwd; no HostFilePort is involved. */
+async function completeImageArgumentText(
+  argument: string,
+  cwd: string,
+  source: LocalFileSource,
+  signal: AbortSignal,
+  allowEmpty: boolean,
+): Promise<AutocompleteItem[] | null> {
+  const leading = argument.match(/^[ \t]+/)?.[0] ?? ''
+  let token = argument.slice(leading.length)
+  if (token === '' && !allowEmpty) return null
+  let quoted = false
+  if (token.startsWith('"')) {
+    quoted = true
+    token = token.slice(1)
+    const close = token.indexOf('"')
+    if (close !== -1) {
+      // A closed quote is already a complete token. Replacing the whole
+      // command argument would otherwise delete text after that quote.
+      return null
+    }
+  } else if (token.includes(' ') || token.includes('\t')) {
+    // The fork's argument apply replaces one contiguous argument range, so an
+    // unquoted later word must not cause the earlier word to be clobbered.
+    return null
+  }
+  const items = await completePath(token, cwd, source, signal, { at: false, quoted })
+  return items === null ? null : items.map(item => ({ ...item, value: `${leading}${item.value}` }))
+}
+
 /**
  * The editor's autocomplete provider: `@` mentions through the Host-file
  * port (the Direct adapter answers scoped discovery + fd/fdfind via the
@@ -248,17 +290,30 @@ export class MentionProvider implements AutocompleteProvider {
   private readonly inputModeSource: () => EditorInputMode
   /** The `/image` discovery source: Client-local (never HostFilePort). */
   private readonly localSource: LocalFileSource
+  /** Client-local cwd for `/image`; intentionally separate from the Host
+   * session scope so a future remote attach cannot make image completion read
+   * the Host workspace. */
+  private readonly localCwdOf: () => string
   /** The REQUEST SNAPSHOT (plan §9.2): the exact document lines + cursor
    * + mode + SCOPE of the most recent getSuggestions call that produced a
-   * suggestion list. applyCompletion accepts ONLY when the current
-   * document + cursor + scope still match this snapshot — a stale dropdown
-   * (from an older request, or from a request resolved under a since-
-   * switched session/workspace scope) can never modify the current draft
-   * (the prefix-only fence misses edits elsewhere on the line — `hello
-   * @foo` → `world @foo` — and the full-snapshot check here also misses a
-   * scope switch with an unchanged draft: an old session's Host candidate
-   * must never be accepted under a new session). */
-  private requestSnapshot: { lines: readonly string[]; cursorLine: number; cursorCol: number; mode: EditorInputMode; scope: MentionScope } | null = null
+   * suggestion list. Strict file/extension results may apply ONLY when the
+   * current document + cursor + scope still match this snapshot — a stale
+   * dropdown (from an older request, or from a request resolved under a
+   * switched session/workspace scope) can never modify the current draft.
+   * Legacy shell-word results keep the fork's prefix-only adapter behavior;
+   * direct calls without a captured request retain that same fallback. */
+  private requestSnapshot: {
+    lines: readonly string[]
+    cursorLine: number
+    cursorCol: number
+    mode: EditorInputMode
+    scope: MentionScope
+    localCwd: string
+    /** File and extension results require a full snapshot fence. The fork's
+     * legacy shell-word adapter keeps its prefix-only behavior for direct
+     * shell apply callers. */
+    strict: boolean
+  } | null = null
   /** The monotonically increasing request generation (plan §9.2 latest-
    * only): minted at REQUEST START (getSuggestions entry). A result —
    * host OR extension — captures its snapshot ONLY IF its minted
@@ -275,11 +330,13 @@ export class MentionProvider implements AutocompleteProvider {
     inputModeSource: () => EditorInputMode = () => 'prompt',
     scope: MentionScope | (() => MentionScope) = { kind: 'workspace', cwd: workDir },
     localFdPath: string | null | undefined = undefined,
+    localCwd: string | (() => string) = workDir,
   ) {
     this.workDir = workDir
     this.fileReferences = fileReferences ?? NO_HOST_REFERENCES
     this.inputModeSource = inputModeSource
     this.scopeOf = typeof scope === 'function' ? scope : () => scope
+    this.localCwdOf = typeof localCwd === 'function' ? localCwd : () => localCwd
     this.inner = new CombinedAutocompleteProvider([...slashCommands], workDir, null)
     this.pathArgumentCommands = FILE_ARGUMENT_COMMANDS
     // `/image`'s discovery source: the CLIENT's own filesystem.
@@ -328,7 +385,10 @@ export class MentionProvider implements AutocompleteProvider {
     cursorCol: number,
     options: { signal: AbortSignal; force?: boolean },
   ): Promise<AutocompleteSuggestions | null> {
-    return this.getSuggestionsAtGeneration(++this.requestGeneration, lines, cursorLine, cursorCol, options)
+    const generation = ++this.requestGeneration
+    const requestMode = this.inputModeSource()
+    const requestLocalCwd = this.localCwdOf()
+    return this.getSuggestionsAtGeneration(generation, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, options)
   }
 
   /** The generation-threaded core: mint ONCE (either here for the direct
@@ -339,6 +399,8 @@ export class MentionProvider implements AutocompleteProvider {
    * ignoring AbortSignal) can never overwrite a newer request's snapshot. */
   private async getSuggestionsAtGeneration(
     generation: number,
+    requestMode: EditorInputMode,
+    requestLocalCwd: string,
     lines: string[],
     cursorLine: number,
     cursorCol: number,
@@ -358,7 +420,9 @@ export class MentionProvider implements AutocompleteProvider {
     const shellContext = shellCompletionContext(shellLine.line, shellLine.cursorCol)
     if (shellContext !== undefined) {
       const suggestions = await suggestShellCompletion(shellContext, this.workDir, options)
-      if (suggestions !== null) return suggestions
+      if (suggestions !== null) {
+        return this.withRequestSnapshot(generation, requestScope, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, suggestions, false)
+      }
     }
 
     // 2. THE FILE-COMPLETION CONTEXT CLASSIFIER (plan §4): the ONLY places
@@ -374,10 +438,28 @@ export class MentionProvider implements AutocompleteProvider {
       : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
 
     if (context.kind === 'mention') {
-      return this.withRequestSnapshot(generation, requestScope, lines, cursorLine, cursorCol, await this.completeMention(context.query, options.signal))
+      return this.withRequestSnapshot(
+        generation,
+        requestScope,
+        requestMode,
+        requestLocalCwd,
+        lines,
+        cursorLine,
+        cursorCol,
+        await this.completeMention(requestScope, context.query, options.signal),
+      )
     }
     if (context.kind === 'image-argument') {
-      return this.withRequestSnapshot(generation, requestScope, lines, cursorLine, cursorCol, await this.completeImageArgument(context.query, options.signal))
+      return this.withRequestSnapshot(
+        generation,
+        requestScope,
+        requestMode,
+        requestLocalCwd,
+        lines,
+        cursorLine,
+        cursorCol,
+        await this.completeImageArgument(context.query, requestLocalCwd, options.signal),
+      )
     }
 
     // 3. Shell-mode natural-trigger suppression (mirrors the pre-plan
@@ -397,7 +479,7 @@ export class MentionProvider implements AutocompleteProvider {
     if (semantic !== null || literalShellLine) {
       try {
         const result = await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
-        return this.withRequestSnapshot(generation, requestScope, lines, cursorLine, cursorCol, result)
+        return this.withRequestSnapshot(generation, requestScope, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, result, false)
       } catch {
         return null
       }
@@ -412,7 +494,8 @@ export class MentionProvider implements AutocompleteProvider {
     if (options.force === true) return null
     if (textBeforeCursor.trimStart().startsWith('/') && !textBeforeCursor.trimStart().includes(' ')) {
       try {
-        return await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
+        const result = await this.getSlashCommandSuggestions(lines, cursorLine, cursorCol, options)
+        return this.withRequestSnapshot(generation, requestScope, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, result, false)
       } catch {
         return null
       }
@@ -420,13 +503,35 @@ export class MentionProvider implements AutocompleteProvider {
     return null
   }
 
+  /** The vendored slash-command provider currently expects `/name` at
+   * column zero even though the editor's slash-command context accepts
+   * indentation. Normalize only for the inner query; keep its returned
+   * `/name` prefix so the normal apply adapter preserves the original
+   * indentation. File contexts never reach this helper. */
+  private getSlashCommandSuggestions(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    options: { signal: AbortSignal; force?: boolean },
+  ): Promise<AutocompleteSuggestions | null> {
+    const line = lines[cursorLine] ?? ''
+    const before = line.slice(0, cursorCol)
+    const trimmed = before.trimStart()
+    const leading = before.length - trimmed.length
+    if (leading === 0) return this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
+    const normalizedLines = lines.map((value, index) => index === cursorLine ? value.slice(leading) : value)
+    return this.inner.getSuggestions(normalizedLines, cursorLine, cursorCol - leading, options)
+  }
+
   /** Complete one `@` mention through the shared engine + HostFilePort:
    * the raw token is resolved against the SESSION scope, the port answers
    * Host discovery facts, and presentation (ranking/quoting/@-shape) is
    * the shared layer. Stale results are dropped twice: the port's own
    * abort check and the scope re-verification after the await. */
-  private async completeMention(atPrefix: string, signal: AbortSignal): Promise<AutocompleteSuggestions | null> {
-    const scope = this.scopeOf()
+  private async completeMention(scope: MentionScope, atPrefix: string, signal: AbortSignal): Promise<AutocompleteSuggestions | null> {
+    // `scope` is captured at request entry and deliberately threaded through
+    // the await. A session switch while the Host request is in flight must
+    // fence the old request instead of resolving it against the new session.
     // The editor's at-prefix INCLUDES the `@` (and an unclosed `"` for the
     // quoted form): the port's contract keeps the whole prefix (its Direct
     // adapter strips and resolves the scope). The engine's raw token for
@@ -440,7 +545,7 @@ export class MentionProvider implements AutocompleteProvider {
     const items = presentDiscovery(
       candidates.map(candidate => ({ path: candidate.path, kind: candidate.kind })),
       query.searchTerm,
-      { at: true, quoted, sep: query.winAbsolute ? '\\' : '/' },
+      { at: true, quoted, sep: separatorOfRaw(raw, query.winAbsolute || raw.includes('\\')) },
     )
     if (items.length === 0) return null
     return { prefix: atPrefix, items }
@@ -469,29 +574,13 @@ export class MentionProvider implements AutocompleteProvider {
    * UNQUOTED argument with embedded spaces cannot complete (the fork's
    * apply replaces the whole argument range, so a later word would clobber
    * the earlier ones). */
-  private async completeImageArgument(argument: string, signal: AbortSignal): Promise<AutocompleteSuggestions | null> {
-    const leading = argument.match(/^[ \t]+/)?.[0] ?? ''
-    let token = argument.slice(leading.length)
-    let quoted = false
-    if (token.startsWith('"')) {
-      quoted = true
-      token = token.slice(1)
-      const close = token.indexOf('"')
-      if (close !== -1) {
-        // A CLOSED quote: the token is complete — completing further is
-        // wrong, and if ANYTHING follows the closing quote (`/image "my"foo`)
-        // the fork's whole-argument-range apply would delete that text.
-        // Stay quiet (the dropdown is closed in this state anyway).
-        return null
-      }
-    } else if (token.includes(' ') || token.includes('\t')) {
-      // Unquoted: a space is a word boundary — completing a later word
-      // would clobber the earlier ones (the fork's whole-range apply).
-      return null
-    }
-    const items = await completePath(token, this.workDir, this.localSource, signal, { at: false, quoted })
-    if (items === null) return null
-    return { prefix: argument, items: items.map(item => ({ ...item, value: `${leading}${item.value}` })) }
+  private async completeImageArgument(
+    argument: string,
+    localCwd: string,
+    signal: AbortSignal,
+  ): Promise<AutocompleteSuggestions | null> {
+    const items = await completeImageArgumentText(argument, localCwd, this.localSource, signal, true)
+    return items === null ? null : { prefix: argument, items }
   }
 
   /** Capture the request state right before a non-null suggestion result
@@ -507,10 +596,13 @@ export class MentionProvider implements AutocompleteProvider {
   private withRequestSnapshot<T extends AutocompleteSuggestions | null>(
     generation: number,
     scope: MentionScope,
+    mode: EditorInputMode,
+    localCwd: string,
     lines: readonly string[],
     cursorLine: number,
     cursorCol: number,
     result: T,
+    strict = true,
   ): T {
     if (generation !== this.requestGeneration) return result
     if (result === null) this.requestSnapshot = null
@@ -518,8 +610,10 @@ export class MentionProvider implements AutocompleteProvider {
       lines: [...lines],
       cursorLine,
       cursorCol,
-      mode: this.inputModeSource(),
+      mode,
       scope,
+      localCwd,
+       strict,
     }
     return result
   }
@@ -539,8 +633,10 @@ export class MentionProvider implements AutocompleteProvider {
     cursorLine: number,
     cursorCol: number,
     result: AutocompleteSuggestions | null,
+    mode: EditorInputMode = this.inputModeSource(),
+    localCwd: string = this.localCwdOf(),
   ): AutocompleteSuggestions | null {
-    return this.withRequestSnapshot(generation, scope, lines, cursorLine, cursorCol, result)
+    return this.withRequestSnapshot(generation, scope, mode, localCwd, lines, cursorLine, cursorCol, result)
   }
 
   /** The base provider's suggestion entry for the DELEGATED wrap: the
@@ -556,8 +652,10 @@ export class MentionProvider implements AutocompleteProvider {
     cursorLine: number,
     cursorCol: number,
     options: { signal: AbortSignal; force?: boolean },
+    requestMode: EditorInputMode = this.inputModeSource(),
+    requestLocalCwd: string = this.localCwdOf(),
   ): Promise<AutocompleteSuggestions | null> {
-    return this.getSuggestionsAtGeneration(generation, lines, cursorLine, cursorCol, options)
+    return this.getSuggestionsAtGeneration(generation, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, options)
   }
 
   /** PUBLIC test/app seam (plan §9.2): THE DELEGATING provider mints its
@@ -586,6 +684,13 @@ export class MentionProvider implements AutocompleteProvider {
     return this.scopeOf()
   }
 
+  /** The Client-local cwd captured alongside the Host scope for a delegated
+   * request. `/image` must reject an answer if its local base changes while
+   * the async discovery is in flight. */
+  localCwdAtRequestTime(): string {
+    return this.localCwdOf()
+  }
+
   /** Whether the editor state still EXACTLY matches the request that
    * produced the current dropdown (line array, cursor, input mode, AND
    * the completion scope — a mode switch swaps the completion grammar,
@@ -597,6 +702,7 @@ export class MentionProvider implements AutocompleteProvider {
     if (snapshot.cursorLine !== cursorLine || snapshot.cursorCol !== cursorCol) return false
     if (snapshot.mode !== this.inputModeSource()) return false
     if (!sameMentionScope(snapshot.scope, this.scopeOf())) return false
+    if (snapshot.localCwd !== this.localCwdOf()) return false
     if (snapshot.lines.length !== lines.length) return false
     for (let index = 0; index < snapshot.lines.length; index += 1) {
       if (snapshot.lines[index] !== lines[index]) return false
@@ -612,27 +718,14 @@ export class MentionProvider implements AutocompleteProvider {
     prefix: string,
   ): { lines: string[]; cursorLine: number; cursorCol: number } {
     const currentLine = lines[cursorLine] ?? ''
-    const textBeforeCursor = currentLine.slice(0, cursorCol)
-    // The FILE-completion context of this apply (the shell-bridge and the
-    // shell-semantic paths below do NOT carry the snapshot — a shell word
-    // replacement is a plain-word swap that never cuts into `@`-preceding
-    // text, and its tests drive apply directly without a request).
-    const applySemantic = this.virtualShellSemanticContext(currentLine, cursorCol)
-    const context = applySemantic !== null
-      ? classifyFileCompletionContext(applySemantic.line, this.pathArgumentCommands)
-      : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
-    const isFileContext = context.kind === 'mention' || context.kind === 'image-argument'
-    // THE STALE FENCE (plan §9.1 minimum + §9.2 full snapshot for FILE
-    // contexts): the EXACT document lines + cursor of the REQUEST that
-    // produced this dropdown must still match the editor's current state.
-    // Any edit since — typing, Backspace, Delete, cursor move, paste,
-    // mode/session switch, or an unrelated edit ELSEWHERE on the line
-    // (`hello @foo` → `world @foo`) — makes the replacement WRONG. A stale
-    // accept returns the document UNCHANGED. The snapshot is the strong
-    // check; the prefix check remains the fork-contract fallback for the
-    // non-snapshot paths (shell/extension — still cannot cut into the
-    // draft).
-    if (isFileContext && !this.requestMatchesSnapshot(lines, cursorLine, cursorCol)) {
+    // THE STALE FENCE (plan §9.1 minimum + §9.2 full snapshot): file and
+    // extension results carry the EXACT document lines + cursor + mode + scope
+    // of the request that produced them. An extension result at an ordinary
+    // prompt position can otherwise keep the same prefix while an unrelated
+    // edit changes the rest of the line. Legacy shell-word results retain the
+    // fork's prefix-only adapter semantics because they are not file ranges.
+    if (this.requestSnapshot?.strict === true
+      && !this.requestMatchesSnapshot(lines, cursorLine, cursorCol)) {
       return { lines, cursorLine, cursorCol }
     }
     const start = cursorCol - prefix.length
@@ -720,56 +813,26 @@ export class MentionProvider implements AutocompleteProvider {
  * `src/fo`; `@"my file` → `my file`; the unclosed quote stays unclosed —
  * the ranking term is the text inside the quotes). */
 function stripMentionToken(atPrefix: string): { raw: string; quoted: boolean } {
-  if (atPrefix.startsWith('@"')) {
-    const inner = atPrefix.slice(2)
-    return { raw: inner.endsWith('"') ? inner.slice(0, -1) : inner, quoted: true }
-  }
-  const inner = atPrefix.slice(1)
-  return { raw: inner.endsWith('"') ? inner.slice(0, -1) : inner, quoted: false }
+  return stripAtQuotes(atPrefix)
 }
 
 /**
- * Slash-command PATH-argument completion (`/image <path>`): the SYNC
- * COMPATIBILITY wrapper over the shared engine's QUERY/RANKING/
- * PRESENTATION (plan §20 — the same modules behind `@` and the async
- * `/image` path). The discovery step here is DIRECTORY-LOCAL ONLY, and
- * deliberately synchronous: the fork's `getArgumentCompletions` contract
- * is sync `AutocompleteItem[] | null` (the fork calls it per keystroke
- * and cannot await), and the engine's scoped-listing branch is itself a
- * bounded `readdirSync` — so this wrapper shares the engine's query,
- * ranking, quoting, separator dialect and display-base reattachment, and
- * answers only what its sync shape allows. The fd/fdfind whole-tree fuzzy
- * search (async, cancellable) is the provider-level `/image` path
- * ({@link MentionProvider.completeImageArgument} → {@link completePath}),
- * which the installed completion surface uses; this wrapper is the
- * migration-era seam the existing tests pin, and it never runs an
- * unbounded scan.
+ * Slash-command PATH-argument compatibility completion (`/image <path>`).
+ * It is awaitable because the shared engine's fuzzy fallback is asynchronous
+ * and cancellable; the production editor normally reaches the provider-level
+ * `/image` branch, but the command descriptor can use this same source when
+ * the vendored provider calls its argument hook directly.
  *
- * @param argumentText - the text after the command name.
- * @param cwd - the session workspace (resolve relative forms against it).
+ * The empty argument remains quiet in this legacy helper. The editor-level
+ * `/image ` context owns the explicit cwd listing, while preserving the old
+ * command-hook contract for callers that used an empty argument as "no
+ * completion".
  */
-export function suggestPathArgument(argumentText: string, cwd: string): AutocompleteItem[] | null {
-  const token = argumentText
-  const leading = token.match(/^[ \t]+/)?.[0] ?? ''
-  const parsed = token.slice(leading.length)
-  if (parsed === '' || parsed.includes(' ') || parsed.includes('\t')) return null
-  const query = resolveQuery(parsed, cwd)
-  const entries = localChildrenOf(query)
-  if (entries.length === 0) return null
-  const items = presentDiscovery(
-    entries.map(entry => reattachDisplayBase(entry, query)),
-    query.searchTerm,
-    { at: false, quoted: false, sep: query.winAbsolute ? '\\' : '/' },
-  )
-  return items.length === 0 ? null : items.map(item => ({ ...item, value: `${leading}${item.value}` }))
-}
-
-/** The DIRECT children of one directory through the engine's own listing
- * (a scoped query's search base is its directory — the same bounded
- * readdir the async engine uses; a missing/unreadable directory yields []
- * (never a crash). Symlinks to directories complete with `/` (the engine's
- * entryIsDirectory rule). */
-function localChildrenOf(query: import('./file-completion/types.ts').PathCompletionQuery): PathCandidate[] {
-  return listDirectChildren(query.searchBase)
-    .map(entry => ({ path: entry.path, kind: entry.isDirectory ? 'directory' : 'file' }))
+export async function suggestPathArgument(
+  argumentText: string,
+  cwd: string,
+  localFdPath: string | null | undefined = undefined,
+): Promise<AutocompleteItem[] | null> {
+  const source = new LocalFileSource(localFdPath)
+  return completeImageArgumentText(argumentText, cwd, source, new AbortController().signal, false)
 }

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -256,6 +256,14 @@ export class MentionProvider implements AutocompleteProvider {
    * document (the prefix-only fence misses edits elsewhere on the line,
    * e.g. `hello @foo` → `world @foo`). */
   private requestSnapshot: { lines: readonly string[]; cursorLine: number; cursorCol: number; mode: EditorInputMode } | null = null
+  /** The monotonically increasing request generation (plan §9.2 latest-
+   * only): minted at REQUEST START (getSuggestions entry). A result —
+   * host OR extension — captures its snapshot ONLY IF its minted
+   * generation is still the latest; a late answer from an older request
+   * (a provider that ignores AbortSignal) can never overwrite a NEWER
+   * request's snapshot, so the next legitimate accept is not wrongly
+   * fenced. */
+  private requestGeneration = 0
 
   constructor(
     slashCommands: readonly SlashCommand[],
@@ -263,7 +271,7 @@ export class MentionProvider implements AutocompleteProvider {
     fileReferences: HostReferencesSeam | null,
     inputModeSource: () => EditorInputMode = () => 'prompt',
     scope: MentionScope | (() => MentionScope) = { kind: 'workspace', cwd: workDir },
-    localFdPath: string | null = null,
+    localFdPath: string | null | undefined = undefined,
   ) {
     this.workDir = workDir
     this.fileReferences = fileReferences ?? NO_HOST_REFERENCES
@@ -271,11 +279,13 @@ export class MentionProvider implements AutocompleteProvider {
     this.scopeOf = typeof scope === 'function' ? scope : () => scope
     this.inner = new CombinedAutocompleteProvider([...slashCommands], workDir, null)
     this.pathArgumentCommands = FILE_ARGUMENT_COMMANDS
-    // `/image`'s discovery source: the CLIENT's own filesystem. `localFdPath`
-    // is a test pin (null = the bounded local fallback, deterministic);
-    // the DEFAULT is the PATH probe (fd then fdfind — plan §12), so the
-    // installed surface shares the finder with `@`.
-    this.localSource = new LocalFileSource(localFdPath === null ? resolveFdPath() : localFdPath)
+    // `/image`'s discovery source: the CLIENT's own filesystem.
+    // `localFdPath` is a test/API pin: UNDEFINED (the default) probes PATH
+    // (fd then fdfind — plan §12), `null` FORCES the bounded local
+    // fallback (deterministic tests), a string pins the finder.
+    this.localSource = localFdPath === undefined
+      ? new LocalFileSource(resolveFdPath())
+      : new LocalFileSource(localFdPath)
   }
 
   /** The virtual serialized line for a shell-mode editor position on the
@@ -317,6 +327,11 @@ export class MentionProvider implements AutocompleteProvider {
   ): Promise<AutocompleteSuggestions | null> {
     const currentLine = lines[cursorLine] ?? ''
     const textBeforeCursor = currentLine.slice(0, cursorCol)
+    // Mint THIS request's generation: the snapshot capture below only
+    // binds when this call is still the latest (a late result from an
+    // older request — a provider or the extension chain ignoring
+    // AbortSignal — must never overwrite a newer request's snapshot).
+    const generation = ++this.requestGeneration
     // 1. The SHELL-BRIDGE grammar first (a `!` line's first word is a
     // command name; a path position falls through). The bridge never
     // competes with file completion.
@@ -341,10 +356,10 @@ export class MentionProvider implements AutocompleteProvider {
       : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
 
     if (context.kind === 'mention') {
-      return this.withRequestSnapshot(lines, cursorLine, cursorCol, await this.completeMention(context.query, options.signal))
+      return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, await this.completeMention(context.query, options.signal))
     }
     if (context.kind === 'image-argument') {
-      return this.withRequestSnapshot(lines, cursorLine, cursorCol, await this.completeImageArgument(context.query, options.signal))
+      return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, await this.completeImageArgument(context.query, options.signal))
     }
 
     // 3. Shell-mode natural-trigger suppression (mirrors the pre-plan
@@ -364,7 +379,7 @@ export class MentionProvider implements AutocompleteProvider {
     if (semantic !== null || literalShellLine) {
       try {
         const result = await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
-        return this.withRequestSnapshot(lines, cursorLine, cursorCol, result)
+        return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, result)
       } catch {
         return null
       }
@@ -464,13 +479,18 @@ export class MentionProvider implements AutocompleteProvider {
   /** Capture the request state right before a non-null suggestion result
    * is returned: the apply fence later requires the EXACT same document +
    * cursor + mode (plan §9.2 — the strong stale check). A null result
-   * clears the snapshot (nothing to accept). */
+   * clears the snapshot (nothing to accept). ONLY the LATEST request
+   * binds: a result minted for an OLDER generation (a late answer from a
+   * provider/extension that ignored AbortSignal) is dropped, so it cannot
+   * fence a newer request. */
   private withRequestSnapshot<T extends AutocompleteSuggestions | null>(
+    generation: number,
     lines: readonly string[],
     cursorLine: number,
     cursorCol: number,
     result: T,
   ): T {
+    if (generation !== this.requestGeneration) return result
     if (result === null) this.requestSnapshot = null
     else this.requestSnapshot = {
       lines: [...lines],
@@ -484,14 +504,26 @@ export class MentionProvider implements AutocompleteProvider {
   /** PUBLIC test/app seam (plan §9.2): the DELEGATING provider (the app's
    * M5 wrap) captures the host snapshot when the EXTENSION chain answers —
    * the base provider still owns the stale fence, but a suggestion list it
-   * did not produce must bind the state it was computed against. */
+   * did not produce must bind the state it was computed against. The
+   * DELEGATED call passes the generation minted by its own host
+   * getSuggestions (the `captureRequestGeneration` seam): a late
+   * extension answer from an OLDER request — a newer request already
+   * started — does not bind (exactly like a late host result). */
   captureRequestSnapshot(
+    generation: number,
     lines: readonly string[],
     cursorLine: number,
     cursorCol: number,
     result: AutocompleteSuggestions | null,
   ): AutocompleteSuggestions | null {
-    return this.withRequestSnapshot(lines, cursorLine, cursorCol, result)
+    return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, result)
+  }
+
+  /** The generation the host's getSuggestions call minted (the delegated
+   * wrap reads it right after the host settles, so the extension's answer
+   * binds to THIS request — even if a newer one started mid-await). */
+  captureRequestGeneration(): number {
+    return this.requestGeneration
   }
 
   /** Whether the editor state still EXACTLY matches the request that

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -444,7 +444,13 @@ export class MentionProvider implements AutocompleteProvider {
       quoted = true
       token = token.slice(1)
       const close = token.indexOf('"')
-      if (close !== -1) token = token.slice(0, close)
+      if (close !== -1) {
+        // A CLOSED quote: the token is complete — completing further is
+        // wrong, and if ANYTHING follows the closing quote (`/image "my"foo`)
+        // the fork's whole-argument-range apply would delete that text.
+        // Stay quiet (the dropdown is closed in this state anyway).
+        return null
+      }
     } else if (token.includes(' ') || token.includes('\t')) {
       // Unquoted: a space is a word boundary — completing a later word
       // would clobber the earlier ones (the fork's whole-range apply).

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -21,7 +21,6 @@
  * @module @xmoon76/dsh-pi-tui/mentions
  */
 
-import { readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { isAbsolute, join } from 'node:path'
 import {
@@ -39,6 +38,7 @@ import {
   FILE_ARGUMENT_COMMANDS,
 } from './file-completion/context.ts'
 import { completePath, presentDiscovery, reattachDisplayBase, resolveQuery } from './file-completion/engine.ts'
+import { listDirectChildren } from './file-completion/discovery.ts'
 import { LocalFileSource } from './file-completion/local-file-source.ts'
 import { resolveFdPath } from './file-completion/discovery.ts'
 import type { PathCandidate } from './file-completion/types.ts'
@@ -398,7 +398,7 @@ export class MentionProvider implements AutocompleteProvider {
     const items = presentDiscovery(
       candidates.map(candidate => ({ path: candidate.path, kind: candidate.kind })),
       query.searchTerm,
-      { at: true, quoted },
+      { at: true, quoted, sep: query.winAbsolute ? '\\' : '/' },
     )
     if (items.length === 0) return null
     return { prefix: atPrefix, items }
@@ -420,14 +420,23 @@ export class MentionProvider implements AutocompleteProvider {
   /** Complete one `/image` argument through the shared engine + the
    * Client-local source (NEVER HostFilePort). An EMPTY argument lists the
    * cwd (Tab on `/image ` — the directory-listing semantics the engine
-   * owns); an argument with embedded spaces cannot complete (the fork's
-   * apply replaces the whole argument range, so a later word would clobber
-   * the earlier ones). */
+   * owns). A QUOTED argument (`/image "my fi`) completes inside the
+   * quotes — the shared quoting contract (plan §2.2) — and the completed
+   * value keeps the closing quote. An unquoted argument with embedded
+   * spaces cannot complete (the fork's apply replaces the whole argument
+   * range, so a later word would clobber the earlier ones). */
   private async completeImageArgument(argument: string, signal: AbortSignal): Promise<AutocompleteSuggestions | null> {
     const leading = argument.match(/^[ \t]+/)?.[0] ?? ''
-    const token = argument.slice(leading.length)
+    let token = argument.slice(leading.length)
+    let quoted = false
+    if (token.startsWith('"')) {
+      quoted = true
+      token = token.startsWith('"') ? token.slice(1) : token
+      const close = token.indexOf('"')
+      if (close !== -1) token = token.slice(0, close)
+    }
     if (token.includes(' ') || token.includes('\t')) return null
-    const items = await completePath(token, this.workDir, this.localSource, signal, { at: false, quoted: false })
+    const items = await completePath(token, this.workDir, this.localSource, signal, { at: false, quoted })
     if (items === null) return null
     return { prefix: argument, items: items.map(item => ({ ...item, value: `${leading}${item.value}` })) }
   }
@@ -540,19 +549,21 @@ function stripMentionToken(atPrefix: string): { raw: string; quoted: boolean } {
 }
 
 /**
- * Slash-command PATH-argument completion (`/image <path>`): the
- * COMPATIBILITY wrapper of the shared engine over the `/image` context —
- * query parsing, fuzzy ranking (basename substring), directory
- * continuation, quoting and the Windows `\` dialect are ONE implementation
- * with `@` (plan §6.3/§20), only the source differs (Client-local fs).
- *
- * PURE-SYNC shape: this function stays SYNCHRONOUS (the fork's
- * `getArgumentCompletions` contract is sync `AutocompleteItem[] | null`),
- * so it answers DIRECTORY-LOCAL discovery only — a scoped query lists
- * its directory, an unscoped query lists the cwd's direct children with
- * the SHARED ranking. The `fd` whole-tree fuzzy search (async) lives one
- * level up in {@link MentionProvider}; the tests exercise the async engine
- * directly too.
+ * Slash-command PATH-argument completion (`/image <path>`): the SYNC
+ * COMPATIBILITY wrapper over the shared engine's QUERY/RANKING/
+ * PRESENTATION (plan §20 — the same modules behind `@` and the async
+ * `/image` path). The discovery step here is DIRECTORY-LOCAL ONLY, and
+ * deliberately synchronous: the fork's `getArgumentCompletions` contract
+ * is sync `AutocompleteItem[] | null` (the fork calls it per keystroke
+ * and cannot await), and the engine's scoped-listing branch is itself a
+ * bounded `readdirSync` — so this wrapper shares the engine's query,
+ * ranking, quoting, separator dialect and display-base reattachment, and
+ * answers only what its sync shape allows. The fd/fdfind whole-tree fuzzy
+ * search (async, cancellable) is the provider-level `/image` path
+ * ({@link MentionProvider.completeImageArgument} → {@link completePath}),
+ * which the installed completion surface uses; this wrapper is the
+ * migration-era seam the existing tests pin, and it never runs an
+ * unbounded scan.
  *
  * @param argumentText - the text after the command name.
  * @param cwd - the session workspace (resolve relative forms against it).
@@ -568,31 +579,17 @@ export function suggestPathArgument(argumentText: string, cwd: string): Autocomp
   const items = presentDiscovery(
     entries.map(entry => reattachDisplayBase(entry, query)),
     query.searchTerm,
-    { at: false, quoted: false },
+    { at: false, quoted: false, sep: query.winAbsolute ? '\\' : '/' },
   )
   return items.length === 0 ? null : items.map(item => ({ ...item, value: `${leading}${item.value}` }))
 }
 
-/** The DIRECT children of one directory (the sync local source): paths
- * bare. A missing/unreadable directory yields [] (never a crash). */
+/** The DIRECT children of one directory through the engine's own listing
+ * (a scoped query's search base is its directory — the same bounded
+ * readdir the async engine uses; a missing/unreadable directory yields []
+ * (never a crash). Symlinks to directories complete with `/` (the engine's
+ * entryIsDirectory rule). */
 function localChildrenOf(query: import('./file-completion/types.ts').PathCompletionQuery): PathCandidate[] {
-  let entries
-  try {
-    entries = readdirSync(query.searchBase, { withFileTypes: true })
-  } catch {
-    return []
-  }
-  const out: PathCandidate[] = []
-  for (const entry of entries) {
-    let isDirectory = entry.isDirectory()
-    if (!isDirectory && entry.isSymbolicLink()) {
-      try {
-        isDirectory = statSync(join(query.searchBase, entry.name)).isDirectory()
-      } catch {
-        // Broken symlink or permission error — file candidate.
-      }
-    }
-    out.push({ path: entry.name, kind: isDirectory ? 'directory' : 'file' })
-  }
-  return out
+  return listDirectChildren(query.searchBase)
+    .map(entry => ({ path: entry.path, kind: entry.isDirectory ? 'directory' : 'file' }))
 }

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -249,13 +249,16 @@ export class MentionProvider implements AutocompleteProvider {
   /** The `/image` discovery source: Client-local (never HostFilePort). */
   private readonly localSource: LocalFileSource
   /** The REQUEST SNAPSHOT (plan §9.2): the exact document lines + cursor
-   * + mode of the most recent getSuggestions call that produced a
+   * + mode + SCOPE of the most recent getSuggestions call that produced a
    * suggestion list. applyCompletion accepts ONLY when the current
-   * document + cursor still match this snapshot — a stale dropdown (from
-   * an older request) can never modify a later edit of ANY part of the
-   * document (the prefix-only fence misses edits elsewhere on the line,
-   * e.g. `hello @foo` → `world @foo`). */
-  private requestSnapshot: { lines: readonly string[]; cursorLine: number; cursorCol: number; mode: EditorInputMode } | null = null
+   * document + cursor + scope still match this snapshot — a stale dropdown
+   * (from an older request, or from a request resolved under a since-
+   * switched session/workspace scope) can never modify the current draft
+   * (the prefix-only fence misses edits elsewhere on the line — `hello
+   * @foo` → `world @foo` — and the full-snapshot check here also misses a
+   * scope switch with an unchanged draft: an old session's Host candidate
+   * must never be accepted under a new session). */
+  private requestSnapshot: { lines: readonly string[]; cursorLine: number; cursorCol: number; mode: EditorInputMode; scope: MentionScope } | null = null
   /** The monotonically increasing request generation (plan §9.2 latest-
    * only): minted at REQUEST START (getSuggestions entry). A result —
    * host OR extension — captures its snapshot ONLY IF its minted
@@ -330,7 +333,11 @@ export class MentionProvider implements AutocompleteProvider {
     // Mint THIS request's generation: the snapshot capture below only
     // binds when this call is still the latest (a late result from an
     // older request — a provider or the extension chain ignoring
-    // AbortSignal — must never overwrite a newer request's snapshot).
+    // AbortSignal — must never overwrite a newer request's snapshot). A
+    // caller CANNOT pre-mint here; the DELEGATED wrap (tui-app) mints its
+    // own generation at entry and reads it back after this call — its
+    // extension answer binds to the delegated request even if newer host
+    // requests start mid-flight.
     const generation = ++this.requestGeneration
     // 1. The SHELL-BRIDGE grammar first (a `!` line's first word is a
     // command name; a path position falls through). The bridge never
@@ -497,6 +504,7 @@ export class MentionProvider implements AutocompleteProvider {
       cursorLine,
       cursorCol,
       mode: this.inputModeSource(),
+      scope: this.scopeOf(),
     }
     return result
   }
@@ -519,22 +527,56 @@ export class MentionProvider implements AutocompleteProvider {
     return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, result)
   }
 
-  /** The generation the host's getSuggestions call minted (the delegated
-   * wrap reads it right after the host settles, so the extension's answer
-   * binds to THIS request — even if a newer one started mid-await). */
+  /** The base provider's suggestion entry for the DELEGATED wrap: the
+   * wrap mints the generation at entry and passes it here, so THIS host
+   * call binds its snapshot to the SAME generation the extension's answer
+   * will use — a newer request that starts during the extension await
+   * bumps the counter past it, and the late extension answer is dropped. */
+  async getSuggestionsForGeneration(
+    generation: number,
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    options: { signal: AbortSignal; force?: boolean },
+  ): Promise<AutocompleteSuggestions | null> {
+    const captured = await this.getSuggestions(lines, cursorLine, cursorCol, options)
+    // The host call minted generation+1 internally; the delegated call's
+    // generation is the one that must own the ext snapshot. Re-bind the
+    // host result to the delegated generation (a null host result clears
+    // the snapshot — the ext will bind after).
+    this.requestGeneration = generation
+    return this.withRequestSnapshot(generation, lines, cursorLine, cursorCol, captured)
+  }
+
+  /** PUBLIC test/app seam (plan §9.2): THE DELEGATING provider mints its
+   * OWN generation synchronously at request ENTRY (before calling the
+   * host), and the host's getSuggestionsForGeneration REUSES it: the
+   * extension's answer — which settles later — binds to THIS request,
+   * never to a newer one that started while the extension was in flight. */
+  mintRequestGeneration(): number {
+    return ++this.requestGeneration
+  }
+
+  /** The generation the host's getSuggestions call minted. The delegated
+   * wrap must read it SYNCHRONOUSLY right after the host settles (before
+   * any await): the global counter advances on every new request, so an
+   * async read could return a NEWER request's generation and let a late
+   * extension result bind to the wrong request. */
   captureRequestGeneration(): number {
     return this.requestGeneration
   }
 
   /** Whether the editor state still EXACTLY matches the request that
-   * produced the current dropdown (line array, cursor, and input mode —
-   * a mode switch swaps the completion grammar, so a dropdown built for
-   * the old mode must never apply). */
+   * produced the current dropdown (line array, cursor, input mode, AND
+   * the completion scope — a mode switch swaps the completion grammar,
+   * and a session/workspace switch changes which Host filesystem answers,
+   * so a dropdown built for one scope must never apply under another). */
   private requestMatchesSnapshot(lines: readonly string[], cursorLine: number, cursorCol: number): boolean {
     const snapshot = this.requestSnapshot
     if (snapshot === null) return false
     if (snapshot.cursorLine !== cursorLine || snapshot.cursorCol !== cursorCol) return false
     if (snapshot.mode !== this.inputModeSource()) return false
+    if (!sameMentionScope(snapshot.scope, this.scopeOf())) return false
     if (snapshot.lines.length !== lines.length) return false
     for (let index = 0; index < snapshot.lines.length; index += 1) {
       if (snapshot.lines[index] !== lines[index]) return false

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -1,19 +1,29 @@
 /**
  * @-file mention grammar and editor completion for the editor: the pure
  * Client-local side of the `@`-mention surface (migration M1.10). The
- * HOST filesystem operations (fd discovery, the recursive fallback scan,
- * existence probes) live in `src/runtime/direct/host-file-direct.ts` —
+ * HOST filesystem operations (fd/fdfind discovery, the recursive fallback
+ * scan, existence probes) live in `src/runtime/direct/host-file-direct.ts` —
  * this module never assumes the Host filesystem IS the current Node
  * process filesystem. The editor's MentionProvider consumes the
  * `HostFilePort` seam; slash-command and path-argument completion keep
  * the fork's CombinedAutocompleteProvider (client-local editor
  * machinery).
+ *
+ * FILE-COMPLETION CONVERGENCE (the 2026-08-27 plan): the path query
+ * parsing, ranking, quoting and presentation behind `@` mentions and
+ * `/image` arguments are ONE shared engine in `src/file-completion/`
+ * (plan §5-§8). THIS module keeps the mention GRAMMAR (extractAtPrefix,
+ * findFileMentions, the send-time rewriter) and the MentionProvider
+ * adapter; the engine owns the path math and BOTH sources (the Host-file
+ * port for `@`, LocalFileSource for `/image`) answer discovery through
+ * it. The FILE-COMPLETION CONTEXT classifier (plan §4) is the ONE gate —
+ * file completion opens ONLY on `@...` and `/image ...`.
  * @module @xmoon76/dsh-pi-tui/mentions
  */
 
 import { readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { basename, dirname, isAbsolute, join, win32 } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import {
   CombinedAutocompleteProvider,
   type AutocompleteItem,
@@ -23,104 +33,40 @@ import {
 } from '@xmoon76/pi-tui'
 import { shellCompletionContext, suggestShellCompletion } from './shell-completion.ts'
 import { shellPrefixForMode, type EditorInputMode } from './editor-input-mode.ts'
+import {
+  classifyFileCompletionContext,
+  extractAtPrefix,
+  FILE_ARGUMENT_COMMANDS,
+} from './file-completion/context.ts'
+import { completePath, presentDiscovery, reattachDisplayBase, resolveQuery } from './file-completion/engine.ts'
+import { LocalFileSource } from './file-completion/local-file-source.ts'
+import { resolveFdPath } from './file-completion/discovery.ts'
+import type { PathCandidate } from './file-completion/types.ts'
+
+// The migration-era surface re-exported for test pins (`mentions.test.ts`
+// imports `resolvePathSearch` and `extractAtPrefix` from this module).
+export { extractAtPrefix } from './file-completion/context.ts'
+export { resolvePathSearch } from './file-completion/query.ts'
 
 /** Token separators: `@` must sit at the start of the current token. */
 const PATH_DELIMITERS = new Set([' ', '\t', '"', "'", '='])
 /** Trailing punctuation allowed AFTER an unquoted mention token: stripped
  * for the existence probe but KEPT in the rewritten text, so a sentence
- * like "see @src/foo.ts, then…" still canonicalizes. The set covers ASCII
- * sentence punctuation plus the CJK full-width forms. */
+ * like "see @src/foo.ts, then…" still canonicalizes. */
 const MENTION_TRAILING_PUNCTUATION = new Set([
   '.', ',', ';', ':', '!', '?', ')', ']', '}',
   '。', '，', '；', '：', '！', '？', '）', '】', '》',
 ])
-/** CJK punctuation that ENDS an unquoted mention token: CJK sentences
- * rarely put a space after a mention ("see @src/foo.ts,then..."), and paths
- * virtually never contain these characters — stopping the token there
- * keeps the mention canonical while the CJK punctuation stays as text. */
+/** CJK punctuation that ENDS an unquoted mention token. */
 const CJK_MENTION_ENDERS = new Set([
   '，', '。', '；', '：', '！', '？', '、', '）', '】', '》', '」', '』', '…',
 ])
 
-/** Whether the char is CJK (ideographs, kana, hangul, CJK punctuation,
- * full-width forms): a mention may sit DIRECTLY against CJK text without
- * a delimiter — CJK sentences glue the mention to the previous character
- * — while ASCII words keep the strict boundary rule (emails,
- * `pkg@1.0.0`). */
-function isCjkChar(char: string): boolean {
-  const code = char.codePointAt(0) ?? 0
-  return (code >= 0x3000 && code <= 0x303f) // CJK punctuation
-    || (code >= 0x3040 && code <= 0x30ff) // hiragana + katakana
-    || (code >= 0x3400 && code <= 0x4dbf) // CJK extension A
-    || (code >= 0x4e00 && code <= 0x9fff) // CJK unified ideographs
-    || (code >= 0xac00 && code <= 0xd7af) // hangul
-    || (code >= 0xf900 && code <= 0xfaff) // compatibility ideographs
-    || (code >= 0xff00 && code <= 0xffef) // full-width forms
-}
-/** The position of an UNCLOSED `"` (null when every quote is closed):
- * the completion cursor sits inside a quoted token exactly when a quote
- * is open at the end of the text. */
-function findUnclosedQuote(text: string): number | null {
-  let inQuotes = false
-  let quoteStart = -1
-  for (let index = 0; index < text.length; index += 1) {
-    if (text[index] === '"') {
-      inQuotes = !inQuotes
-      if (inQuotes) quoteStart = index
-    }
-  }
-  return inQuotes ? quoteStart : null
-}
-
-/**
- * The `@` mention prefix of the text before the cursor: `@query`,
- * `@"quoted query"` (the unclosed quoted form), or null when the cursor
- * is not inside a mention. The token grammar mirrors `findFileMentions`:
- * `@` must sit at a token boundary — start-of-text, after a delimiter, or
- * glued to CJK text (a CJK sentence can glue the mention to the previous
- * character) — so emails (`a@b.com`) and `pkg@1.0.0` are never mentions.
- * @param text - the line content before the cursor.
- */
-export function extractAtPrefix(text: string): string | null {
-  // Quoted form: an unclosed `"` immediately after an `@` whose own
-  // position is a valid token start (`@"my file` while typing inside the
-  // quotes). The fork's quoted-prefix grammar, aligned to the mention
-  // grammar (CJK-glued `@"` included).
-  const quoteStart = findUnclosedQuote(text)
-  if (quoteStart !== null && text[quoteStart - 1] === '@') {
-    const at = quoteStart - 1
-    const before = at === 0 ? '' : text[at - 1] ?? ''
-    if (before === '' || PATH_DELIMITERS.has(before) || isCjkChar(before)) return text.slice(at)
-  }
-  // Bare form: the current token (after the last delimiter)...
-  let tokenStart = 0
-  for (let index = text.length - 1; index >= 0; index -= 1) {
-    if (PATH_DELIMITERS.has(text[index] ?? '')) {
-      tokenStart = index + 1
-      break
-    }
-  }
-  const token = text.slice(tokenStart)
-  if (token.startsWith('@')) return token
-  // ...or a CJK-glued `@` INSIDE the token (the character right before the
-  // `@` is a CJK code point, e.g. `\u770b\u770b@foo`): the LAST such `@`
-  // is the mention start (a CJK sentence glues the mention to the
-  // previous character — the same rule findFileMentions applies).
-  for (let index = token.length - 1; index >= 1; index -= 1) {
-    if (token[index] === '@' && isCjkChar(token[index - 1] ?? '')) return token.slice(index)
-  }
-  return null
-}
-
 /** One `@`-mention token found in a draft. */
 export interface FileMentionOccurrence {
-  /** Token start (the `@` itself). */
   readonly start: number
-  /** Token end (exclusive; the closing quote for quoted mentions). */
   readonly end: number
-  /** The mention path WITHOUT the `@` (quotes stripped). */
   readonly path: string
-  /** Whether the path was quoted (`@"…"`). */
   readonly quoted: boolean
 }
 
@@ -133,7 +79,6 @@ export interface FileMentionOccurrence {
  * quoted token (`@"dir with spaces/foo.ts"`, closed by a `"`). Trailing
  * sentence punctuation is stripped from the PATH (kept in the source text
  * by the caller's range replacement).
- * @param text - the draft text.
  */
 export function findFileMentions(text: string): FileMentionOccurrence[] {
   const mentions: FileMentionOccurrence[] = []
@@ -142,9 +87,6 @@ export function findFileMentions(text: string): FileMentionOccurrence[] {
     const at = text.indexOf('@', index)
     if (at === -1) break
     const before = at === 0 ? '' : text[at - 1] ?? ''
-    // The token-start rule: `@` must follow start-of-text, a delimiter,
-    // or CJK text (CJK sentences glue the mention to the previous
-    // character). Emails (`a@b.com`) and `pkg@1.0.0` never qualify.
     if (!(at === 0 || PATH_DELIMITERS.has(before) || isCjkChar(before))) {
       index = at + 1
       continue
@@ -158,10 +100,8 @@ export function findFileMentions(text: string): FileMentionOccurrence[] {
       cursor += 1
       pathStart = cursor
       const close = text.indexOf('"', cursor)
-      if (close === -1) break // unterminated quote: nothing after it can parse
+      if (close === -1) break
       pathEnd = close
-      // The token range INCLUDES the closing quote (the rewriter replaces
-      // [start, end) and supplies its own quotes).
       cursor = close + 1
     } else {
       while (cursor < text.length
@@ -176,33 +116,35 @@ export function findFileMentions(text: string): FileMentionOccurrence[] {
     if (path !== '') {
       mentions.push({
         start: at,
-        // Unquoted: the span ends where the STRIPPED path ends, so the
-        // stripped punctuation stays in the source text (`@file.ts,` →
-        // `@/abs/file.ts` + `,`); the rewriter supplies its own quotes for
-        // the quoted form, so there the full span (closing quote included)
-        // is replaced.
         end: quoted ? cursor : pathStart + path.length,
         path,
         quoted,
       })
     }
-    // After a QUOTED token the cursor sits on the char right after the
-    // closing quote — it may be another `@` (`@"a.txt"@b.txt`), so resume
-    // AT the cursor; an unquoted token ends ON a delimiter, which can be
-    // skipped (round-2 review finding).
     index = quoted ? cursor : cursor + 1
   }
   return mentions
 }
 
+/** Whether the char is CJK (ideographs, kana, hangul, CJK punctuation,
+ * full-width forms): a mention may sit DIRECTLY against CJK text without
+ * a delimiter — CJK sentences glue the mention to the previous character —
+ * while ASCII words keep the strict boundary rule (emails, `pkg@1.0.0`). */
+function isCjkChar(char: string): boolean {
+  const code = char.codePointAt(0) ?? 0
+  return (code >= 0x3000 && code <= 0x303f)
+    || (code >= 0x3040 && code <= 0x30ff)
+    || (code >= 0x3400 && code <= 0x4dbf)
+    || (code >= 0x4e00 && code <= 0x9fff)
+    || (code >= 0xac00 && code <= 0xd7af)
+    || (code >= 0xf900 && code <= 0xfaff)
+    || (code >= 0xff00 && code <= 0xffef)
+}
+
 /**
  * Resolve ONE raw mention path to the candidate absolute path: `~`
  * expands through the homedir, an absolute path stays as-is, a relative
- * path resolves against the session workspace. PURE — the existence
- * probe is injected (migration M1.10).
- * @param raw - the mention path (quotes stripped).
- * @param sessionCwd - the session's working directory.
- * @returns the candidate absolute path.
+ * path resolves against the session workspace. PURE.
  */
 export function resolveMentionCandidate(raw: string, sessionCwd: string): string {
   if (raw.startsWith('~/')) return join(homedir(), raw.slice(2))
@@ -210,28 +152,18 @@ export function resolveMentionCandidate(raw: string, sessionCwd: string): string
   return join(sessionCwd, raw)
 }
 
-/** The injected existence probe (Host-owned): the Direct adapter backs it
- * with the Host filesystem; a Remote adapter backs it with the official
- * fileReferences capability. */
+/** The injected existence probe (Host-owned). */
 export type MentionExistence = (candidate: string) => boolean | Promise<boolean>
 
 /**
- * Send-time canonicalization of `@`-file mentions (the 2026-08-22 plan,
- * item 7): the EDITOR keeps showing the concise relative form the user
- * typed, but the MODEL-facing message carries the unambiguous absolute
- * path, so a weaker model does not have to guess which workspace
- * `@src/foo.ts` lives in. Rules: a relative path resolves against
- * `sessionCwd`; `~` expands through the homedir; an absolute path stays
- * as-is; a path that does NOT exist is left VERBATIM (typos and non-path
- * `@` words are never mangled); symlinks are absolutized, never
- * realpath'd — the user's link path is the intent. Quoted mentions keep
- * their quotes in the rewritten text. The EXISTENCE probe is injected —
- * this module never touches the filesystem itself (migration M1.10).
- * @param text - the draft text.
- * @param sessionCwd - the session's working directory (the resolution
- *   base for relative mentions).
- * @param exists - the Host existence probe.
- * @returns the canonicalized text (unchanged when no mention resolves).
+ * Send-time canonicalization of `@`-file mentions: the EDITOR keeps
+ * showing the concise relative form the user typed, but the MODEL-facing
+ * message carries the unambiguous absolute path. Rules: a relative path
+ * resolves against `sessionCwd`; `~` expands through the homedir; an
+ * absolute path stays as-is; a path that does NOT exist is left VERBATIM;
+ * symlinks are absolutized, never realpath'd. Quoted mentions keep their
+ * quotes. The EXISTENCE probe is injected — this module never touches the
+ * filesystem itself.
  */
 export async function expandFileMentionsForSubmit(
   text: string,
@@ -254,261 +186,41 @@ export async function expandFileMentionsForSubmit(
   return out
 }
 
+/** The mention scope at suggestion time (never captured at install). */
+export type MentionScope =
+  | { kind: 'session'; sessionId: string }
+  | { kind: 'workspace'; cwd: string }
 
-/** Expand a leading `~` in one argument token (other tokens unchanged). */
-function expandHomeToken(token: string): string {
-  if (token === '~') return homedir()
-  if (token.startsWith('~/')) return join(homedir(), token.slice(2))
-  return token
+/** The host-file seam (HostFilePort, structural). */
+export type HostReferencesSeam = {
+  listReferences: (
+    scope: MentionScope,
+    query: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<readonly import('./runtime/host-file-port.ts').HostFileCandidate[]>
+  resolveReference: (
+    scope: MentionScope,
+    path: string,
+    options?: { signal?: AbortSignal },
+  ) => Promise<import('./runtime/host-file-port.ts').HostFileResolveResult>
+  canonicalizeMentions: (scope: MentionScope, text: string) => Promise<string>
 }
 
-/**
- * Pure token → search-dir/prefix resolution (no filesystem access): which
- * directory a completion token reads and what basename prefix it filters.
- * Exported so the POSIX and Windows ROOT semantics are pinned without
- * touching the fs — `dirname` leaves a trailing separator ONLY on roots,
- * and a root must stay a root (`/` stripped would read `''`; a drive root
- * keeps its trailing separator while the drive-relative form drops it; a
- * UNC share keeps its legal trailing form).
- * @param token - the parsed argument token (no leading separator
- *   whitespace).
- * @param cwd - the session workspace (relative forms resolve against it).
- * @param expanded - `expandHomeToken(token)` (the caller already computed
- *   it; kept as a param so the fs-free contract stays pure).
- * @returns the readdir target, the basename prefix, and whether the token
- *   is genuinely Windows-dialect (the caller's display math needs it).
- */
-export function resolvePathSearch(
-  token: string,
-  cwd: string,
-  expanded: string,
-): { searchDir: string; searchPrefix: string; winAbsolute: boolean } {
-  // Absolute detection covers every platform form: POSIX `/x`, Windows
-  // drive (`C:\x`, `C:/x`) and UNC (`\\server\share`) paths. The win32
-  // check engages ONLY for genuinely Windows-dialect tokens — win32 alone
-  // would also accept a bare POSIX `/x` token, which must keep the POSIX
-  // dialect (its dirname/join use backslashes).
-  const posixAbsolute = isAbsolute(expanded)
-  const winAbsolute = !posixAbsolute && win32.isAbsolute(expanded)
-  const absolute = token.startsWith('~') || posixAbsolute || winAbsolute
-  const pathDirname = winAbsolute ? win32.dirname : dirname
-  const pathBasename = winAbsolute ? win32.basename : basename
-  if (
-    token === './' || token === '../' || token === '~' || token === '~/' || token === '/' || token === ''
-  ) {
-    // Complete the whole root directory (the fork's isRootPrefix cases).
-    return { searchDir: absolute ? expanded : join(cwd, expanded), searchPrefix: '', winAbsolute }
-  }
-  if (token.endsWith('/') || token.endsWith('\\')) {
-    // Show the directory's contents (a Windows path ends with `\`).
-    return { searchDir: absolute ? expanded : join(cwd, expanded), searchPrefix: '', winAbsolute }
-  }
-  // Split into directory + basename prefix. dirname leaves a trailing
-  // separator ONLY on roots — which must keep it (see the doc comment) —
-  // so the dirname result is used verbatim, never stripped.
-  return {
-    searchDir: absolute ? pathDirname(expanded) : join(cwd, dirname(expanded)),
-    searchPrefix: pathBasename(expanded),
-    winAbsolute,
-  }
+/** The fail-closed seam: no file-aware completion at all. */
+const NO_HOST_REFERENCES = {
+  async listReferences(): Promise<readonly import('./runtime/host-file-port.ts').HostFileCandidate[]> {
+    return []
+  },
+  async resolveReference(): Promise<import('./runtime/host-file-port.ts').HostFileResolveResult> {
+    return { kind: 'missing' }
+  },
+  async canonicalizeMentions(_scope: MentionScope, text: string): Promise<string> {
+    return text
+  },
 }
 
-/**
- * Slash-command PATH-argument completion (`/image <path>`): complete the
- * single argument token against the session cwd — shell-style and
- * directory-local (the fd whole-tree fuzzy search stays `@`'s job). Handles
- * `~`, absolute and relative forms and mirrors the fork's getFileSuggestions
- * display rules so a completed value always reads like what the user typed
- * (`./`, `~/` and `dir/` forms preserved); directories keep their trailing
- * `/` so Tab-accepting one continues completion. Returns null when the
- * argument is not a single completable token (embedded spaces) or the
- * directory cannot be read — the editor then shows no suggestions.
- * @param argumentText - the text after the command name (the fork passes
- *   everything up to the cursor; its argument apply replaces that whole
- *   range, so only single-token arguments can complete).
- * @param cwd - the session workspace (resolve relative forms against it).
- */
-export function suggestPathArgument(argumentText: string, cwd: string): AutocompleteItem[] | null {
-  const token = argumentText
-  // Leading whitespace belongs to the SEPARATOR, not the token: the fork's
-  // argument branch passes everything after the FIRST space, so a
-  // multi-space separator (`/image    t.png` — the fork also normalizes
-  // tabs to four spaces, so a pasted-tab draft reads exactly like this)
-  // yields an argument with leading spaces. The completed VALUE keeps that
-  // leading whitespace, because the fork's apply replaces the WHOLE
-  // argument range — without the padding the path would glue to the
-  // command (`/image` + `subdir/` → `/imagesubdir/`).
-  const leading = token.match(/^[ \t]+/)?.[0] ?? ''
-  const parsed = token.slice(leading.length)
-  // Embedded spaces are a quoted-token case (deferred); completing a later
-  // word would clobber the earlier ones, so stay quiet.
-  if (parsed === '' || parsed.includes(' ') || parsed.includes('\t')) return null
-  const expanded = expandHomeToken(parsed)
-  const { searchDir, searchPrefix, winAbsolute } = resolvePathSearch(parsed, cwd, expanded)
-  let entries
-  try {
-    entries = readdirSync(searchDir, { withFileTypes: true })
-  } catch {
-    return null
-  }
-  const items: AutocompleteItem[] = []
-  for (const entry of entries) {
-    if (!entry.name.toLowerCase().startsWith(searchPrefix.toLowerCase())) continue
-    let isDirectory = entry.isDirectory()
-    if (!isDirectory && entry.isSymbolicLink()) {
-      try {
-        isDirectory = statSync(winAbsolute ? win32.join(searchDir, entry.name) : join(searchDir, entry.name)).isDirectory()
-      } catch {
-        // Broken symlink or permission error — treat as a file candidate.
-      }
-    }
-    // Mirror the fork's display construction: `dir/` appends the entry, a
-    // `~/`/absolute/relative directory prefix is preserved, a bare token
-    // completes within the cwd. Windows drive/UNC tokens keep their own
-    // `\` dialect (win32 math), so the completed value reads like what the
-    // user typed on Windows.
-    const name = entry.name
-    let relativePath: string
-    if (parsed.endsWith('/') || parsed.endsWith('\\')) {
-      relativePath = parsed + name
-    } else if (winAbsolute) {
-      relativePath = win32.join(win32.dirname(parsed), name)
-    } else if (parsed.includes('/') || parsed.includes('\\')) {
-      if (parsed.startsWith('~/')) {
-        const dir = dirname(parsed.slice(2))
-        relativePath = `~/${dir === '.' ? name : join(dir, name)}`
-      } else if (parsed.startsWith('/')) {
-        const dir = dirname(parsed)
-        relativePath = dir === '/' ? `/${name}` : `${dir}/${name}`
-      } else {
-        relativePath = join(dirname(parsed), name)
-        if (parsed.startsWith('./') && !relativePath.startsWith('./')) {
-          relativePath = `./${relativePath}`
-        }
-      }
-    } else {
-      relativePath = parsed.startsWith('~') ? `~/${name}` : name
-    }
-    const pathValue = isDirectory ? `${relativePath}/` : relativePath
-    // Same quoting rule as the fork's buildCompletionValue: spaces need
-    // quotes so the value stays one shell word for the /image handler. The
-    // separator's leading whitespace rides in front of the quoted value.
-    const value = leading + (pathValue.includes(' ') ? `"${pathValue}"` : pathValue)
-    items.push({
-      value,
-      label: `${name}${isDirectory ? '/' : ''}`,
-      description: winAbsolute ? win32.join(searchDir, entry.name) : join(searchDir, entry.name),
-    })
-  }
-  if (items.length === 0) return null
-  // Directories first, then alphabetically (the fork's sort order).
-  items.sort((left, right) => {
-    const leftIsDir = left.label.endsWith('/')
-    const rightIsDir = right.label.endsWith('/')
-    if (leftIsDir && !rightIsDir) return -1
-    if (!leftIsDir && rightIsDir) return 1
-    return left.label.localeCompare(right.label)
-  })
-  return items
-}
-
-/** The Host-file discovery seam the editor completion consumes (the
- * `HostFilePort` subset — migration M1.10): `@` mentions complete against
- * the HOST filesystem through the port, never the local fs. */
-export type HostReferencesSeam = import('./runtime/host-file-port.ts').HostFilePort
-
-/** The unavailable seam (migration M1.10): a `null` constructor argument
- * (the pre-migration `fdPath: null` convention) means NO `@` completion —
- * discovery degrades to nothing, never to a local-fs assumption. */
-const NO_HOST_REFERENCES: HostReferencesSeam = {
-  listReferences: async () => [],
-  resolveReference: async () => ({ kind: 'missing' }),
-  canonicalizeMentions: async (_scope, text) => text,
-}
-
-/** The client-side suggestion cap (kimi MAX_FALLBACK_SUGGESTIONS): the
- * port returns the DISCOVERY set (bounded by the host scan), the client
- * ranks and slices it — presentation never crosses the contract. */
-const MAX_MENTION_SUGGESTIONS = 50
-
-/** Rank one path-only candidate against the query (the pre-migration
- * scoring, moved client-side: the port answers "which Host files exist",
- * ranking is TUI presentation policy). */
-function scoreMentionCandidate(candidate: {
-  path: string
-  kind: 'file' | 'directory'
-}, lowerQuery: string): number {
-  if (lowerQuery === '') {
-    const depthPenalty = candidate.path.split('/').length - 1
-    return (candidate.kind === 'directory' ? 120 : 100) - depthPenalty
-  }
-  const lowerPath = candidate.path.toLowerCase()
-  const lowerBase = basename(candidate.path).toLowerCase()
-  let score = 0
-  if (lowerBase === lowerQuery) score = 100
-  else if (lowerBase.startsWith(lowerQuery)) score = 80
-  else if (lowerBase.includes(lowerQuery)) score = 50
-  else if (lowerPath.includes(lowerQuery)) score = 30
-  if (candidate.kind === 'directory' && score > 0) score += 10
-  return score
-}
-
-/** Present one path-only candidate as a completion item: the `@`-insertion
- * value (quoted when it has spaces — the QUOTED prefix `@"…` forces the
- * quoted value regardless), directories keep their trailing `/` so
- * `@dir/` continues, the label is the basename, the description is the
- * user-facing path. PURE client policy (review boundary: the Host owns
- * discovery, the TUI owns presentation). */
-function presentMentionCandidate(candidate: {
-  path: string
-  kind: 'file' | 'directory'
-}, quoted: boolean): AutocompleteItem {
-  const valuePath = candidate.kind === 'directory' ? `${candidate.path}/` : candidate.path
-  const value = quoted || valuePath.includes(' ') ? `@"${valuePath}"` : `@${valuePath}`
-  return {
-    value,
-    label: `${basename(candidate.path)}${candidate.kind === 'directory' ? '/' : ''}`,
-    description: candidate.path,
-  }
-}
-
-/** Rank, slice and present the port's path-only discovery set for one
- * `@` prefix (bare or quoted): the client owns ranking, quoting, the
- * `@`-insertion value, labels, descriptions and directory continuation. */
-function presentMentionCandidates(
-  candidates: readonly import('./runtime/host-file-port.ts').HostFileCandidate[],
-  atPrefix: string,
-): AutocompleteItem[] {
-  const quoted = atPrefix.startsWith('@"')
-  const inner = quoted ? atPrefix.slice(2) : atPrefix.slice(1)
-  // An unclosed quoted prefix has no trailing quote; a CLOSED one keeps
-  // it in the completion prefix (the fork's quoted-prefix grammar) — strip
-  // it for the search, the values stay quoted either way.
-  const query = inner.endsWith('"') ? inner.slice(0, -1) : inner
-  const lowerQuery = query.toLowerCase()
-  return candidates
-    .map(candidate => ({ candidate, score: scoreMentionCandidate(candidate, lowerQuery) }))
-    .filter(entry => entry.score > 0)
-    .sort((a, b) => {
-      if (a.score !== b.score) return b.score - a.score
-      if (a.candidate.kind !== b.candidate.kind) {
-        return a.candidate.kind === 'directory' ? -1 : 1
-      }
-      return a.candidate.path.localeCompare(b.candidate.path)
-    })
-    .slice(0, MAX_MENTION_SUGGESTIONS)
-    .map(entry => presentMentionCandidate(entry.candidate, quoted))
-}
-
-/** The completion scope of one MentionProvider instance: the runner
- * resolves it at install time (the live SESSION when one exists, the
- * workspace cwd otherwise) so the port is addressed by HOST identity —
- * never by a client-side path assumption. */
-export type MentionScope = import('./runtime/host-file-port.ts').HostFileScope
-
-/** Whether two scopes address the SAME host identity (the stale-safety
- * re-check after a port await: a session switch mid-flight must drop the
- * old session's candidate list). */
+/** Whether two mention scopes are the same (a session switch mid-flight
+ * must drop the old session's candidate list). */
 function sameMentionScope(left: MentionScope, right: MentionScope): boolean {
   if (left.kind !== right.kind) return false
   return left.kind === 'session'
@@ -518,32 +230,24 @@ function sameMentionScope(left: MentionScope, right: MentionScope): boolean {
 
 /**
  * The editor's autocomplete provider: `@` mentions through the Host-file
- * port (the Direct adapter runs the fd whole-tree fuzzy search or the
- * bounded recursive fallback) plus the fork's usual slash-command and
- * path completion (client-local editor machinery). applyCompletion always
- * delegates to the fork (its `@` branch already handles quoting and
- * directory continuation).
+ * port (the Direct adapter answers scoped discovery + fd/fdfind via the
+ * shared engine) plus the fork's usual slash-command and path completion
+ * (client-local editor machinery). The FILE-COMPLETION CONTEXT classifier
+ * (plan §4) drives which positions ever complete files.
  */
 export class MentionProvider implements AutocompleteProvider {
   private readonly inner: CombinedAutocompleteProvider
   private readonly workDir: string
   private readonly fileReferences: HostReferencesSeam
-  /** The completion scope, resolved at SUGGESTION time (never captured at
-   * install): a live source keeps `@` completion on the CURRENT session
-   * after a switch or first create, even if the runner never reinstalls
-   * the provider (the coordinator does reinstall per transition, but the
-   * provider must not DEPEND on that). */
+  /** The completion scope, resolved at SUGGESTION time. */
   private readonly scopeOf: () => MentionScope
-  /** The slash commands whose argument completion is a PATH (the host
-   * attaches `getArgumentCompletions`, e.g. `/image`): ONLY these tolerate
-   * a trailing-space argument as a Tab file-completion site — every other
-   * command keeps the fork's judgment. */
+  /** The EXPLICIT file-argument command set (plan §4.2 — never derived
+   * from `getArgumentCompletions !== undefined`). */
   private readonly pathArgumentCommands: ReadonlySet<string>
-  /** The live editor input mode (the shell-editor-mode plan): the editor
-   * buffer no longer contains the `!` / `!!` prefix, so the provider
-   * synthesizes a VIRTUAL serialized line at the completion boundary —
-   * the shell grammar in shell-completion.ts stays untouched. */
+  /** The live editor input mode (shell-editor-mode plan). */
   private readonly inputModeSource: () => EditorInputMode
+  /** The `/image` discovery source: Client-local (never HostFilePort). */
+  private readonly localSource: LocalFileSource
 
   constructor(
     slashCommands: readonly SlashCommand[],
@@ -551,26 +255,23 @@ export class MentionProvider implements AutocompleteProvider {
     fileReferences: HostReferencesSeam | null,
     inputModeSource: () => EditorInputMode = () => 'prompt',
     scope: MentionScope | (() => MentionScope) = { kind: 'workspace', cwd: workDir },
+    localFdPath: string | null = null,
   ) {
     this.workDir = workDir
     this.fileReferences = fileReferences ?? NO_HOST_REFERENCES
     this.inputModeSource = inputModeSource
     this.scopeOf = typeof scope === 'function' ? scope : () => scope
-    // The fork's fdPath is null: the `@` branch is intercepted below and
-    // routed through the port, so the fork never sees an `@` prefix here.
     this.inner = new CombinedAutocompleteProvider([...slashCommands], workDir, null)
-    this.pathArgumentCommands = new Set(
-      slashCommands
-        .filter(command => command.getArgumentCompletions !== undefined)
-        .map(command => command.name),
-    )
+    this.pathArgumentCommands = FILE_ARGUMENT_COMMANDS
+    // `/image`'s discovery source: the CLIENT's own filesystem. `localFdPath`
+    // is a test pin (null = the bounded local fallback, deterministic);
+    // the DEFAULT is the PATH probe (fd then fdfind — plan §12), so the
+    // installed surface shares the finder with `@`.
+    this.localSource = new LocalFileSource(localFdPath === null ? resolveFdPath() : localFdPath)
   }
 
   /** The virtual serialized line for a shell-mode editor position on the
-   * FIRST document line: the synthetic `!` / `!!` prefix plus the shifted
-   * cursor column. Null in prompt mode or on a LATER line — the wire
-   * document carries the prefix on line 0 only, so a body continuation
-   * line completes as ordinary text (paths), exactly like the wire. */
+   * FIRST document line. */
   private virtualShellLine(
     line: string,
     cursorCol: number,
@@ -581,11 +282,7 @@ export class MentionProvider implements AutocompleteProvider {
     return { line: prefix + line, cursorCol: cursorCol + prefix.length, prefixLength: prefix.length }
   }
 
-  /** The WIRE representation: the synthetic `!` / `!!` prefix belongs to
-   * LINE 0 only — the serialized wire document carries it once, and a
-   * body continuation line is ordinary text. Used for the shell-grammar
-   * parse and the Stable-extension wire query. Null in prompt mode or on
-   * a later line. */
+  /** The WIRE representation (the synthetic `!` prefix belongs to line 0). */
   private virtualWireShellContext(
     lines: string[],
     cursorLine: number,
@@ -596,11 +293,7 @@ export class MentionProvider implements AutocompleteProvider {
   }
 
   /** The SHELL SEMANTIC context: EVERY line of a shell-mode document is
-   * part of the shell command, so slash-vs-path routing, the apply
-   * classification and the Tab gating treat any line as shell-owned. The
-   * synthetic prefix is staged on the cursor line and stripped from the
-   * result — the wire document itself never changes. Null in prompt
-   * mode. */
+   * part of the shell command. */
   private virtualShellSemanticContext(
     currentLine: string,
     cursorCol: number,
@@ -616,70 +309,127 @@ export class MentionProvider implements AutocompleteProvider {
   ): Promise<AutocompleteSuggestions | null> {
     const currentLine = lines[cursorLine] ?? ''
     const textBeforeCursor = currentLine.slice(0, cursorCol)
-    const atPrefix = extractAtPrefix(textBeforeCursor)
-    if (atPrefix !== null) {
-      // The Host-file discovery owns the fd/fallback decision (migration
-      // M1.10); an empty result is a null suggestion, exactly like the
-      // pre-migration fd and fallback paths. The port is addressed by the
-      // runner-resolved SCOPE (session identity when live), never a
-      // client-side path assumption. A port rejection degrades to no
-      // suggestions (the editor must never crash on a discovery failure),
-      // and an aborted request is re-checked AFTER the await: a late
-      // result can never overwrite newer suggestions (the fork's own
-      // post-await abort check, applied to the port branch). The scope is
-      // ALSO re-verified after the await: a session switch mid-flight
-      // does not abort the request, but a candidate list resolved for the
-      // OLD session must never commit under the new one (stale-safety —
-      // the live scope source is re-read, never an install-time capture).
-      const scope = this.scopeOf()
-      let candidates: readonly import('./runtime/host-file-port.ts').HostFileCandidate[]
-      try {
-        candidates = await this.fileReferences.listReferences(scope, atPrefix, { signal: options.signal })
-      } catch {
-        return null
-      }
-      if (options.signal.aborted || candidates.length === 0) return null
-      if (!sameMentionScope(scope, this.scopeOf())) return null
-      // The client owns ALL presentation: ranking, quoting, the
-      // `@`-insertion value, labels, descriptions and directory
-      // continuation — the port answered "which Host files exist" as
-      // path-only DTOs (review boundary).
-      const items = presentMentionCandidates(candidates, atPrefix)
-      if (items.length === 0) return null
-      return { prefix: atPrefix, items }
-    }
-    // `!`/`!!` shell lines: command names, subcommands and `$VAR` names come
-    // from the real-shell compgen bridge (docs/input-and-card-polish.md §1);
-    // path positions fall through to the fork's fd completion below. In a
-    // shell MODE the buffer holds the bare body, so the shell grammar
-    // receives the VIRTUAL serialized line (the synthetic prefix — line 0
-    // only, matching the wire document); in prompt mode the line is
-    // parsed as-is (a literal `!` draft). The leading-`/` suppression is
-    // SHELL-SEMANTIC: EVERY line of a shell-mode document is shell-owned,
-    // so a path on any line stays a path (never a slash command).
+    // 1. The SHELL-BRIDGE grammar first (a `!` line's first word is a
+    // command name; a path position falls through). The bridge never
+    // competes with file completion.
     const wire = this.virtualWireShellContext(lines, cursorLine, cursorCol)
     const shellLine = wire ?? { line: currentLine, cursorCol, prefixLength: 0 }
     const shellContext = shellCompletionContext(shellLine.line, shellLine.cursorCol)
     if (shellContext !== undefined) {
       const suggestions = await suggestShellCompletion(shellContext, this.workDir, options)
       if (suggestions !== null) return suggestions
-      // No shell suggestions (or the shell is unavailable): fall through —
-      // a path position still gets the fork's file completion.
-    } else if (this.virtualShellSemanticContext(currentLine, cursorCol) !== null
-      && !options.force && currentLine.startsWith('/')) {
-      // A NATURAL trigger on a leading `/` in a shell mode is a PATH,
-      // never a slash command: the fork's slash-command branch must not
-      // flash the command list while the user types `/usr/lo` — on ANY
-      // line. Stay quiet until Tab (which routes through the path branch
-      // below) — this matches the pre-mode behavior, where the literal
-      // `!` prefix kept the fork's slash branch off.
+    }
+
+    // 2. THE FILE-COMPLETION CONTEXT CLASSIFIER (plan §4): the ONLY places
+    // file completion ever opens — `@` mentions and declared file-argument
+    // commands (`/image`). In a shell MODE the classifier sees the virtual
+    // serialized line (every line of a shell document is shell-owned); in
+    // prompt mode the line parses as-written (a literal `!` draft is a
+    // shell line through the same grammar — the classifier leaves it
+    // `none`, and step 4 keeps the shell completion non-goal alive).
+    const semantic = this.virtualShellSemanticContext(currentLine, cursorCol)
+    const context = semantic !== null
+      ? classifyFileCompletionContext(semantic.line, this.pathArgumentCommands)
+      : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
+
+    if (context.kind === 'mention') {
+      return this.completeMention(context.query, options.signal)
+    }
+    if (context.kind === 'image-argument') {
+      return this.completeImageArgument(context.query, options.signal)
+    }
+
+    // 3. Shell-mode natural-trigger suppression (mirrors the pre-plan
+    // routing; kept because shell path completion is a NON-GOAL — plan
+    // §27): a leading `/` is a PATH, never a slash command. Stay quiet
+    // until Tab (which routes through the path branch below).
+    if (semantic !== null && !options.force && currentLine.startsWith('/')) {
       return null
     }
+
+    // 4. SHELL documents (a shell MODE, or a prompt-mode buffer holding the
+    // literal `!` / `!!` wire form — the non-goal shell command
+    // completion): the fork's own completion stays authoritative — command
+    // names AND path positions. This is NOT the plan's ordinary-position
+    // domain.
+    const literalShellLine = textBeforeCursor.trimStart().startsWith('!')
+    if (semantic !== null || literalShellLine) {
+      try {
+        return await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
+      } catch {
+        return null
+      }
+    }
+
+    // 5. PROMPT MODE, ordinary position (plan §2.1): file completion is
+    // CLOSED — `foo`, `./foo`, `../foo`, `/tmp/foo`, `hello foo` never
+    // produce a file dropdown, natural or forced (a forced request is
+    // refused by shouldTriggerFileCompletion before it gets here). The ONE
+    // keeper: slash command NAME completion — a separate mechanism (plan
+    // §27) that never touches file paths.
+    if (options.force === true) return null
+    if (textBeforeCursor.trimStart().startsWith('/') && !textBeforeCursor.trimStart().includes(' ')) {
+      try {
+        return await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
+      } catch {
+        return null
+      }
+    }
+    return null
+  }
+
+  /** Complete one `@` mention through the shared engine + HostFilePort:
+   * the raw token is resolved against the SESSION scope, the port answers
+   * Host discovery facts, and presentation (ranking/quoting/@-shape) is
+   * the shared layer. Stale results are dropped twice: the port's own
+   * abort check and the scope re-verification after the await. */
+  private async completeMention(atPrefix: string, signal: AbortSignal): Promise<AutocompleteSuggestions | null> {
+    const scope = this.scopeOf()
+    // The editor's at-prefix INCLUDES the `@` (and an unclosed `"` for the
+    // quoted form): the port's contract keeps the whole prefix (its Direct
+    // adapter strips and resolves the scope). The engine's raw token for
+    // ranking is the stripped form; the port returns the DISPLAY paths
+    // already reattached (its contract: user-facing paths).
+    const candidates = await this.discoverMention(scope, atPrefix, signal)
+    if (signal.aborted || candidates.length === 0) return null
+    if (!sameMentionScope(scope, this.scopeOf())) return null
+    const { raw, quoted } = stripMentionToken(atPrefix)
+    const query = resolveQuery(raw, this.workDir)
+    const items = presentDiscovery(
+      candidates.map(candidate => ({ path: candidate.path, kind: candidate.kind })),
+      query.searchTerm,
+      { at: true, quoted },
+    )
+    if (items.length === 0) return null
+    return { prefix: atPrefix, items }
+  }
+
+  /** The discovery step (separated for the abort-fence test seam). */
+  private async discoverMention(
+    scope: MentionScope,
+    atPrefix: string,
+    signal: AbortSignal,
+  ): Promise<readonly import('./runtime/host-file-port.ts').HostFileCandidate[]> {
     try {
-      return await this.inner.getSuggestions(lines, cursorLine, cursorCol, options)
+      return await this.fileReferences.listReferences(scope, atPrefix, { signal })
     } catch {
-      return null
+      return []
     }
+  }
+
+  /** Complete one `/image` argument through the shared engine + the
+   * Client-local source (NEVER HostFilePort). An EMPTY argument lists the
+   * cwd (Tab on `/image ` — the directory-listing semantics the engine
+   * owns); an argument with embedded spaces cannot complete (the fork's
+   * apply replaces the whole argument range, so a later word would clobber
+   * the earlier ones). */
+  private async completeImageArgument(argument: string, signal: AbortSignal): Promise<AutocompleteSuggestions | null> {
+    const leading = argument.match(/^[ \t]+/)?.[0] ?? ''
+    const token = argument.slice(leading.length)
+    if (token.includes(' ') || token.includes('\t')) return null
+    const items = await completePath(token, this.workDir, this.localSource, signal, { at: false, quoted: false })
+    if (items === null) return null
+    return { prefix: argument, items: items.map(item => ({ ...item, value: `${leading}${item.value}` })) }
   }
 
   applyCompletion(
@@ -690,14 +440,18 @@ export class MentionProvider implements AutocompleteProvider {
     prefix: string,
   ): { lines: string[]; cursorLine: number; cursorCol: number } {
     const currentLine = lines[cursorLine] ?? ''
-    // A shell-completion item replaces the current word only (command
-    // names, subcommands, `$VAR` names all land as one plain word); the
-    // `!` prefix and everything before the word stay untouched. Same
-    // pattern as the fork's slash-command apply. In a shell MODE the
-    // context check runs on the VIRTUAL serialized line, but the apply
-    // itself operates on the REAL line: the completion prefix sits after
-    // the synthetic `!`, so it is identical in both forms and no prefix
-    // stripping is needed — the synthetic prefix never enters the buffer.
+    // THE STALE FENCE (plan §9.1): the request's prefix must still be the
+    // text immediately before the cursor. Any edit since the request —
+    // typing, Backspace, Delete, cursor move, paste, mode/session switch —
+    // makes the replacement WRONG (the old code cut `cursorCol - prefix.length`
+    // into the middle of the new draft, deleting `@`-preceding text). A
+    // stale accept returns the document UNCHANGED.
+    const start = cursorCol - prefix.length
+    if (start < 0 || currentLine.slice(start, cursorCol) !== prefix) {
+      return { lines, cursorLine, cursorCol }
+    }
+    // Shell-bridge apply: replace only the current word (the `!` prefix and
+    // everything before stay untouched).
     const wire = this.virtualWireShellContext(lines, cursorLine, cursorCol)
     const shellLine = wire ?? { line: currentLine, cursorCol, prefixLength: 0 }
     if (shellCompletionContext(shellLine.line, shellLine.cursorCol) !== undefined) {
@@ -712,14 +466,8 @@ export class MentionProvider implements AutocompleteProvider {
         cursorCol: before.length + item.value.length + 1,
       }
     }
-    // SYMMETRIC SHELL-SEMANTIC adapter: every non-shell apply (path
-    // completion, Stable-extension suggestions) on ANY line of a
-    // shell-mode document runs on the virtual line — the fork's
-    // line-start judgments then see the `!` prefix (an absolute path
-    // like `/u` is never mistaken for a slash command, on line 0 or a
-    // continuation line, and an extension prefix computed on the wire
-    // line stays coordinate-consistent). The synthetic prefix is
-    // stripped from the applied result, so it never enters the buffer.
+    // SYMMETRIC SHELL-SEMANTIC adapter (shell mode): the classification ran
+    // on the virtual line, so the apply must too.
     const semantic = this.virtualShellSemanticContext(currentLine, cursorCol)
     if (semantic !== null) {
       const wireLines = lines.map((line, index) => index === cursorLine ? semantic.line : line)
@@ -738,35 +486,113 @@ export class MentionProvider implements AutocompleteProvider {
   shouldTriggerFileCompletion(lines: string[], cursorLine: number, cursorCol: number): boolean {
     const currentLine = lines[cursorLine] ?? ''
     const textBeforeCursor = currentLine.slice(0, cursorCol)
-    // A PATH-ARGUMENT command's argument position — even a trailing-space
-    // or trailing-TAB empty one (`/image `, `/image<TAB>`) — is a
-    // file-completion site: Tab must list the cwd. The fork's check trims
-    // BOTH ends, so a trailing separator reads as a bare command name and
-    // Tab is silently blocked; trimStart keeps the separator visible and
-    // the argument position is detected on ANY whitespace (space or tab —
-    // the fork's own path delimiters). ONLY commands that declare
-    // path-argument completion get this override — a trailing `/help ` or
-    // `/help<TAB>` keeps the fork's judgment (command completion, never a
-    // file list). A pure command name (`/image`, no separator) stays
-    // blocked — Tab there completes the command name, never files.
-    const trimmedStart = textBeforeCursor.trimStart()
-    if (trimmedStart.startsWith('/')) {
-      const separatorIndex = trimmedStart.search(/[ \t]/)
-      if (separatorIndex > 0) {
-        const commandName = trimmedStart.slice(1, separatorIndex)
-        if (this.pathArgumentCommands.has(commandName)) return true
+    // Shell mode: the classifier sees the virtual serialized line (a
+    // leading `/` is a PATH, never a slash command — the fork's
+    // bare-slash-command block must not swallow Tab on a shell line).
+    const semantic = this.virtualShellSemanticContext(currentLine, cursorCol)
+    const context = semantic !== null
+      ? classifyFileCompletionContext(semantic.line, this.pathArgumentCommands)
+      : classifyFileCompletionContext(textBeforeCursor, this.pathArgumentCommands)
+    // SHELL documents (a shell MODE, or a literal `!` shell line): keep the
+    // fork's own gate — BUT on the VIRTUAL serialized line (the synthetic
+    // `!` prefix makes the fork's line-start judgment see a shell line, so
+    // `/usr/lo` reads as a PATH, never a bare slash command — the
+    // pre-plan shell-mode parity the plan keeps as a non-goal).
+    if (semantic !== null || textBeforeCursor.trimStart().startsWith('!')) {
+      if (semantic !== null) {
+        const virtualLines = lines.map((line, index) => index === cursorLine ? semantic.line : line)
+        return this.inner.shouldTriggerFileCompletion?.(virtualLines, cursorLine, semantic.cursorCol) ?? true
+      }
+      return this.inner.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true
+    }
+    // PROMPT-MODE ordinary positions (plan §2.1/§10): the HOST's built-in
+    // file completion is CLOSED — the request must still RUN so the
+    // extension chain (a SEPARATE mechanism, plan §27 non-goal) can be
+    // consulted, but the host's own file branch returns null for `none`
+    // contexts (getSuggestions above). ONE fast-fail: a leading `/` with
+    // NO separator character (neither space NOR tab — tab is a fork path
+    // delimiter) is a slash command NAME — the Tab handler routes it to
+    // command-name completion (its own branch, never the file gate). The
+    // classifier's `image-argument` (a tab-separated `/image\t` IS an
+    // argument position) wins over the fast-fail.
+    if (context.kind === 'none'
+      && textBeforeCursor.trimStart().startsWith('/')
+      && !textBeforeCursor.trimStart().includes(' ')
+      && !textBeforeCursor.trimStart().includes('\t')) {
+      return this.inner.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true
+    }
+    // An empty or bare textual position: let the request run (the
+    // extension chain is separate); the host file branch is closed.
+    return true
+  }
+}
+
+/** The raw token + quoted flag of one editor at-prefix (`@src/fo` →
+ * `src/fo`; `@"my file` → `my file`; the unclosed quote stays unclosed —
+ * the ranking term is the text inside the quotes). */
+function stripMentionToken(atPrefix: string): { raw: string; quoted: boolean } {
+  if (atPrefix.startsWith('@"')) {
+    const inner = atPrefix.slice(2)
+    return { raw: inner.endsWith('"') ? inner.slice(0, -1) : inner, quoted: true }
+  }
+  const inner = atPrefix.slice(1)
+  return { raw: inner.endsWith('"') ? inner.slice(0, -1) : inner, quoted: false }
+}
+
+/**
+ * Slash-command PATH-argument completion (`/image <path>`): the
+ * COMPATIBILITY wrapper of the shared engine over the `/image` context —
+ * query parsing, fuzzy ranking (basename substring), directory
+ * continuation, quoting and the Windows `\` dialect are ONE implementation
+ * with `@` (plan §6.3/§20), only the source differs (Client-local fs).
+ *
+ * PURE-SYNC shape: this function stays SYNCHRONOUS (the fork's
+ * `getArgumentCompletions` contract is sync `AutocompleteItem[] | null`),
+ * so it answers DIRECTORY-LOCAL discovery only — a scoped query lists
+ * its directory, an unscoped query lists the cwd's direct children with
+ * the SHARED ranking. The `fd` whole-tree fuzzy search (async) lives one
+ * level up in {@link MentionProvider}; the tests exercise the async engine
+ * directly too.
+ *
+ * @param argumentText - the text after the command name.
+ * @param cwd - the session workspace (resolve relative forms against it).
+ */
+export function suggestPathArgument(argumentText: string, cwd: string): AutocompleteItem[] | null {
+  const token = argumentText
+  const leading = token.match(/^[ \t]+/)?.[0] ?? ''
+  const parsed = token.slice(leading.length)
+  if (parsed === '' || parsed.includes(' ') || parsed.includes('\t')) return null
+  const query = resolveQuery(parsed, cwd)
+  const entries = localChildrenOf(query)
+  if (entries.length === 0) return null
+  const items = presentDiscovery(
+    entries.map(entry => reattachDisplayBase(entry, query)),
+    query.searchTerm,
+    { at: false, quoted: false },
+  )
+  return items.length === 0 ? null : items.map(item => ({ ...item, value: `${leading}${item.value}` }))
+}
+
+/** The DIRECT children of one directory (the sync local source): paths
+ * bare. A missing/unreadable directory yields [] (never a crash). */
+function localChildrenOf(query: import('./file-completion/types.ts').PathCompletionQuery): PathCandidate[] {
+  let entries
+  try {
+    entries = readdirSync(query.searchBase, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const out: PathCandidate[] = []
+  for (const entry of entries) {
+    let isDirectory = entry.isDirectory()
+    if (!isDirectory && entry.isSymbolicLink()) {
+      try {
+        isDirectory = statSync(join(query.searchBase, entry.name)).isDirectory()
+      } catch {
+        // Broken symlink or permission error — file candidate.
       }
     }
-    // In a shell MODE a leading `/` is a PATH, never a slash command: the
-    // fork's bare-slash-command block (`/usr/lo` has no space) must not
-    // swallow Tab. The VIRTUAL SHELL-SEMANTIC line keeps the fork's own
-    // judgment on the cursor line — on ANY line of the shell document
-    // (the wire representation still carries the prefix on line 0 only).
-    const semantic = this.virtualShellSemanticContext(currentLine, cursorCol)
-    if (semantic !== null) {
-      const virtualLines = lines.map((line, index) => index === cursorLine ? semantic.line : line)
-      return this.inner.shouldTriggerFileCompletion?.(virtualLines, cursorLine, semantic.cursorCol) ?? true
-    }
-    return this.inner.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true
+    out.push({ path: entry.name, kind: isDirectory ? 'directory' : 'file' })
   }
+  return out
 }

--- a/src/runtime/direct/host-file-direct.ts
+++ b/src/runtime/direct/host-file-direct.ts
@@ -64,6 +64,12 @@ export class DirectHostFilePort implements HostFilePort {
     return { fdPath: this.fdPath }
   }
 
+  /** TEST seam: the resolved fd/fdfind executable (null = fallback-only).
+   * Lets an fd-backed test assert it actually runs through a finder. */
+  fdPathAvailableForTest(): string | null {
+    return this.fdPath
+  }
+
   /** The scope's workspace cwd (undefined = the session is unresolvable —
    * a fail-closed empty discovery). A RESOLVED session without a header
    * cwd falls back to the process cwd — DIRECT-mode parity with the

--- a/src/runtime/direct/host-file-direct.ts
+++ b/src/runtime/direct/host-file-direct.ts
@@ -1,14 +1,20 @@
 /**
  * The Direct Host-file adapter (M1.10) — the in-process implementation of
- * `HostFilePort` over the CURRENT TUI filesystem behavior: fd whole-tree
- * fuzzy search when fd is on PATH (delegated to the vendored fork's
- * machinery so the ranking/capping stays byte-identical), the bounded
- * recursive fallback scan otherwise, and stat-based existence checks. This
+ * `HostFilePort` over the CURRENT TUI filesystem behavior: the SHARED
+ * file-completion engine (fd/fdfind whole-tree fuzzy when a finder is on
+ * the Host PATH, scoped-directory discovery otherwise, the bounded
+ * recursive fallback as last resort) and stat-based existence checks. This
  * is the ONLY module in the `@`-file path that touches the filesystem; the
  * pure grammar (`findFileMentions`, the rewrite rules) stays in
  * `src/mentions.ts`, and a Remote adapter will implement the same
  * interface over the official fileReferences capability in a later
  * milestone.
+ *
+ * SCOPED QUERIES (plan §19): `@src/de` searches workspace/src + term `de`;
+ * `@../../foo` searches the resolved parent scope; `@~/foo` searches the
+ * home scope; `@/tmp/foo` searches the absolute scope. NEVER a whole-tree
+ * scan filtered by string — the query resolver in the engine owns the
+ * scope split, this adapter only answers discovery.
  *
  * In Direct mode the Client machine IS the Host machine; the session
  * scope resolves through the runner-injected live-agent resolver.
@@ -17,13 +23,14 @@
  * @module @xmoon76/dsh-pi-tui/runtime/direct/host-file-direct
  */
 
-import { accessSync, constants as fsConstants, readdirSync, statSync } from 'node:fs'
-import { basename, join } from 'node:path'
-import { CombinedAutocompleteProvider } from '@xmoon76/pi-tui'
+import { statSync } from 'node:fs'
 import {
   expandFileMentionsForSubmit,
   resolveMentionCandidate,
 } from '../../mentions.ts'
+import type { DiscoverySource } from '../../file-completion/discovery.ts'
+import { discoverForQuery, resolveFdPath } from '../../file-completion/discovery.ts'
+import { reattachDisplayBase, resolveQuery } from '../../file-completion/engine.ts'
 import type {
   HostFileCandidate,
   HostFilePort,
@@ -37,37 +44,6 @@ export interface LiveAgentLike {
   readonly session: { readonly header: { readonly cwd?: string } }
 }
 
-/** One scanned candidate of the recursive fallback (relative display path
- * + filesystem facts). */
-interface FsMentionCandidate {
-  readonly path: string
-  readonly isDirectory: boolean
-}
-
-/** The recursive scan bound (kimi MAX_FALLBACK_SCAN — discovery is
- * bounded, the CLIENT ranks and slices the returned set). */
-const MAX_FALLBACK_SCAN = 2000
-
-/** Locate an executable `fd` on the HOST PATH (bare command names resolve
- * through PATH at spawn time; absolute/relative entries must exist and be
- * X_OK). POSIX PATH separators only — moved VERBATIM from the pre-migration
- * mentions.ts (this deployment targets POSIX hosts; a Windows Host would
- * need a platform-aware probe, recorded as a portability note, not a
- * Direct behavior change). */
-export function resolveFdPath(): string | null {
-  const pathEntries = process.env.PATH?.split(':').filter(entry => entry !== '') ?? []
-  for (const dir of pathEntries) {
-    const candidate = join(dir, 'fd')
-    try {
-      accessSync(candidate, fsConstants.X_OK)
-      return candidate
-    } catch {
-      // Not here; keep scanning.
-    }
-  }
-  return null
-}
-
 /** The Direct backend's Host-file port: the current TUI filesystem
  * mechanics behind the semantic `HostFilePort` interface. */
 export class DirectHostFilePort implements HostFilePort {
@@ -75,11 +51,17 @@ export class DirectHostFilePort implements HostFilePort {
   private readonly agentFor: (sessionId: string) => unknown | undefined
 
   /** @param agentFor - the session-id → live-agent resolver (runner
-   *   injected). @param fdPath - the Host's fd executable; defaults to the
-   *   PATH probe; tests inject `null` to pin the fallback scan. */
+   *   injected). @param fdPath - the Host's fd/fdfind executable; defaults
+   *   to the PATH probe; tests inject `null` to pin the fallback scan. */
   constructor(agentFor: (sessionId: string) => unknown | undefined, fdPath: string | null = resolveFdPath()) {
     this.fdPath = fdPath
     this.agentFor = agentFor
+  }
+
+  /** The discovery seam this adapter answers with (the Host's own fd
+   * detection — the port's discovery source is ALWAYS the Host fs). */
+  private get discoverySource(): DiscoverySource {
+    return { fdPath: this.fdPath }
   }
 
   /** The scope's workspace cwd (undefined = the session is unresolvable —
@@ -103,36 +85,28 @@ export class DirectHostFilePort implements HostFilePort {
     const workDir = this.scopeCwd(scope)
     if (workDir === undefined) return []
     const signal = options?.signal
-    if (this.fdPath !== null) {
-      try {
-        // The fork's fd-backed whole-tree fuzzy search: the DISCOVERY seam
-        // (which Host files exist that match the query) — the returned
-        // items are mapped to path-only DTOs; ALL presentation (ranking,
-        // quoting, labels, descriptions, directory continuation) is client
-        // policy in the editor's mention provider.
-        const provider = new CombinedAutocompleteProvider([], workDir, this.fdPath)
-        const result = await provider.getSuggestions([query], 0, query.length, { signal: signal ?? new AbortController().signal })
-        // The fork's own post-await abort check covers ITS internal
-        // consumers; this port must fail closed for DIRECT consumers too
-        // (a result that settled after the request was cancelled is never
-        // served — review finding).
-        if (signal?.aborted === true) return []
-        if (result === null) return []
-        return result.items.map(forkItemToCandidate)
-      } catch {
-        // fd failed to spawn: keep `@` usable through the fallback.
-      }
-    }
-    // The bounded recursive fallback: DISCOVERY only — which files exist
-    // under the workspace (`.git` skipped, pre-migration behavior). The
-    // client ranks, quotes and slices this set; the adapter never
-    // constructs presentation.
-    const collected = collectFsMentionCandidates(workDir, signal)
     if (signal?.aborted === true) return []
-    return collected.map(candidate => ({
-      path: candidate.path,
-      kind: candidate.isDirectory ? 'directory' : 'file',
-    }))
+    // `query` is the editor's at-prefix INCLUDING the leading `@` (and an
+    // unclosed `"` for the quoted form). The engine strips the `@` and any
+    // trailing quote, resolves the scope and answers discovery with path
+    // facts relative to the query's search base.
+    const { raw } = stripPrefix(query)
+    try {
+      const resolved = resolveQuery(raw, workDir)
+      const candidates = await discoverForQuery(resolved, this.discoverySource, signal ?? new AbortController().signal)
+      // `signal` is possibly-undefined: a request without one never aborts.
+      if ((signal?.aborted ?? false)) return []
+      // THE PORT CONTRACT: paths are USER-FACING — the display base the
+      // user typed (`../`, `~/pics/`, `/tmp/`, `src/`) is reattached here
+      // (the engine's pure reattachment), so the client's presentation
+      // (ranking, quoting, the `@`-insertion value) sees final paths.
+      return candidates.map(candidate => {
+        const display = reattachDisplayBase(candidate, resolved)
+        return { path: display.path, kind: display.kind }
+      })
+    } catch {
+      return []
+    }
   }
 
   async resolveReference(
@@ -158,6 +132,19 @@ export class DirectHostFilePort implements HostFilePort {
   }
 }
 
+/** Strip the `@` and any closing quote from one editor at-prefix
+ * (`@src/fo` → `src/fo`; `@"my file` → `my file`; `@"closed"` → `closed`). */
+function stripPrefix(query: string): { raw: string } {
+  if (query.startsWith('@')) {
+    const inner = query.slice(1)
+    if (inner.startsWith('"')) {
+      return { raw: inner.endsWith('"') ? inner.slice(1, -1) : inner.slice(1) }
+    }
+    return { raw: inner }
+  }
+  return { raw: query }
+}
+
 /** The synchronous existence probe (the Direct machine IS the Host
  * machine; a Remote adapter swaps this for the official capability). */
 function exists(candidate: string): boolean {
@@ -169,65 +156,6 @@ function exists(candidate: string): boolean {
   }
 }
 
-/** Map one fork discovery item onto the detached PATH-ONLY candidate DTO
- * (the fork's presentation fields value/label/description never cross the
- * port — the client rebuilds them from the path). */
-function forkItemToCandidate(item: { value: string; label?: string; description?: string }): HostFileCandidate {
-  const label = item.label ?? ''
-  const isDirectory = label.endsWith('/') || item.value.endsWith('/')
-  // The fork's description carries the display path; fall back to the
-  // value stripped of the `@` prefix and any quoting.
-  let path = item.description ?? ''
-  if (path === '') {
-    path = item.value.replace(/^@/, '')
-    if (path.startsWith('"') && path.endsWith('"')) path = path.slice(1, -1)
-  }
-  if (path.endsWith('/')) path = path.slice(0, -1)
-  return { path, kind: isDirectory ? 'directory' : 'file' }
-}
-
-/** Recursively collect candidates under the workspace (bounded, `.git`
- * skipped). PRESERVED pre-migration behavior: the fd path follows the
- * Host's ignore rules, the fallback deliberately skips only `.git` (kimi
- * parity) — ignored/sensitive files may appear when fd is absent, exactly
- * as before the migration (documented, not a regression). */
-function collectFsMentionCandidates(
-  workDir: string,
-  signal?: AbortSignal,
-): FsMentionCandidate[] {
-  const aborted = (): boolean => signal?.aborted === true
-  const candidates: FsMentionCandidate[] = []
-  const stack: string[] = ['']
-  let scanned = 0
-  while (stack.length > 0 && scanned < MAX_FALLBACK_SCAN) {
-    if (aborted()) break
-    const relativeDir = stack.pop() ?? ''
-    const absoluteDir = relativeDir === '' ? workDir : join(workDir, relativeDir)
-    let entries
-    try {
-      entries = readdirSync(absoluteDir, { withFileTypes: true })
-    } catch {
-      continue
-    }
-    for (const entry of entries) {
-      if (aborted() || scanned >= MAX_FALLBACK_SCAN) break
-      if (entry.name === '.git') continue
-      const relativePath = relativeDir === '' ? entry.name : join(relativeDir, entry.name)
-      const absolutePath = join(absoluteDir, entry.name)
-      let isDirectory = entry.isDirectory()
-      if (!isDirectory && entry.isSymbolicLink()) {
-        try {
-          isDirectory = statSync(absolutePath).isDirectory()
-        } catch {
-          // Broken symlink or permission error — keep it as a file candidate.
-        }
-      }
-      scanned += 1
-      candidates.push({ path: relativePath, isDirectory })
-      if (isDirectory && !entry.isSymbolicLink()) {
-        stack.push(relativePath)
-      }
-    }
-  }
-  return candidates
-}
+/** Re-exported for the migration guard (the bundle boundary gate
+ * allowlists the discovery module's fd probe). */
+export { resolveFdPath }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9188,6 +9188,11 @@ export class TuiApp {
       async getSuggestions(lines, cursorLine, cursorCol, options) {
         const host = await base.getSuggestions(lines, cursorLine, cursorCol, options)
         if (host !== null) return host
+        // The generation of THIS host request (minted by the host call
+        // above): the extension's answer binds to it — a newer request
+        // that started while the extension was in flight must not be
+        // overwritten by its late result.
+        const requestGeneration = base.captureRequestGeneration()
         // Preserve the shell-mode natural-trigger suppression: a leading
         // `/` on ANY line of a shell-mode document is a PATH, and the
         // host provider deliberately stays quiet until Tab — the plugin
@@ -9226,7 +9231,7 @@ export class TuiApp {
         // and a list the extension produced must be computed against the
         // SAME editor state (plan §9.2 — a stale ext accept must never
         // modify a later edit either).
-        return base.captureRequestSnapshot(lines, cursorLine, cursorCol, result)
+        return base.captureRequestSnapshot(requestGeneration, lines, cursorLine, cursorCol, result)
       },
       applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
         // A Stable plugin computes its prefix on the WIRE document it

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9149,6 +9149,9 @@ export class TuiApp {
    *   live SESSION when one exists, the workspace cwd otherwise). May be a
    *   live SOURCE resolved at suggestion time — the runner passes one so
    *   a session switch never needs a provider reinstall.
+   * @param localCwd - the Client-local base for `/image` completion. Keep it
+   *   separate from the Host session cwd; a remote attach may have different
+   *   local and Host filesystems. A function keeps the client base live.
    */
   setCommandCompletions(
     commands: readonly SlashCommand[],
@@ -9163,8 +9166,17 @@ export class TuiApp {
     }) => Promise<{ items: import('@xmoon76/pi-tui').AutocompleteItem[]; prefix: string } | null>,
     scope: import('./runtime/host-file-port.ts').HostFileScope
       | (() => import('./runtime/host-file-port.ts').HostFileScope) = { kind: 'workspace', cwd },
+     localCwd: string | (() => string) = cwd,
   ): void {
-    const base = new MentionProvider([...commands], cwd, fileReferences, () => this.editor.getInputMode(), scope)
+    const base = new MentionProvider(
+      [...commands],
+      cwd,
+      fileReferences,
+      () => this.editor.getInputMode(),
+      scope,
+      undefined,
+      localCwd,
+    )
     if (extensionSuggest === undefined) {
       this.editor.setAutocompleteProvider(base)
       return
@@ -9193,7 +9205,9 @@ export class TuiApp {
         // never to a session/workspace that switched mid-request.
         const requestGeneration = base.mintRequestGeneration()
         const requestScope = base.scopeAtRequestTime()
-        const host = await base.getSuggestionsForGeneration(requestGeneration, lines, cursorLine, cursorCol, options)
+        const requestMode = getMode()
+        const requestLocalCwd = base.localCwdAtRequestTime()
+        const host = await base.getSuggestionsForGeneration(requestGeneration, lines, cursorLine, cursorCol, options, requestMode, requestLocalCwd)
         if (host !== null) return host
         // Preserve the shell-mode natural-trigger suppression: a leading
         // `/` on ANY line of a shell-mode document is a PATH, and the
@@ -9202,7 +9216,7 @@ export class TuiApp {
         // reopen the dropdown mid-typing and double-apply on the next
         // Tab). The wire query below still carries the prefix on line 0
         // only.
-        const mode = getMode()
+        const mode = requestMode
         if (mode !== 'prompt' && options.force !== true
           && (lines[cursorLine] ?? '').startsWith('/')) {
           return null
@@ -9234,7 +9248,7 @@ export class TuiApp {
         // SAME editor state + scope (plan §9.2 — a stale ext accept must
         // never modify a later edit, and an old session's candidate must
         // never be accepted under a switched session).
-        return base.captureRequestSnapshot(requestGeneration, requestScope, lines, cursorLine, cursorCol, result)
+        return base.captureRequestSnapshot(requestGeneration, requestScope, lines, cursorLine, cursorCol, result, requestMode, requestLocalCwd)
       },
       applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
         // A Stable plugin computes its prefix on the WIRE document it

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9186,13 +9186,14 @@ export class TuiApp {
     const getMode = (): EditorInputMode => this.editor.getInputMode()
     const delegated: import('@xmoon76/pi-tui').AutocompleteProvider = {
       async getSuggestions(lines, cursorLine, cursorCol, options) {
-        const host = await base.getSuggestions(lines, cursorLine, cursorCol, options)
+        // THIS delegated request's generation: minted synchronously at
+        // entry and passed to the host entry (getSuggestionsForGeneration),
+        // so both the host result AND the extension's answer bind to THIS
+        // request — never to a newer one that started while the extension
+        // was in flight.
+        const requestGeneration = base.mintRequestGeneration()
+        const host = await base.getSuggestionsForGeneration(requestGeneration, lines, cursorLine, cursorCol, options)
         if (host !== null) return host
-        // The generation of THIS host request (minted by the host call
-        // above): the extension's answer binds to it — a newer request
-        // that started while the extension was in flight must not be
-        // overwritten by its late result.
-        const requestGeneration = base.captureRequestGeneration()
         // Preserve the shell-mode natural-trigger suppression: a leading
         // `/` on ANY line of a shell-mode document is a PATH, and the
         // host provider deliberately stays quiet until Tab — the plugin

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9186,12 +9186,13 @@ export class TuiApp {
     const getMode = (): EditorInputMode => this.editor.getInputMode()
     const delegated: import('@xmoon76/pi-tui').AutocompleteProvider = {
       async getSuggestions(lines, cursorLine, cursorCol, options) {
-        // THIS delegated request's generation: minted synchronously at
-        // entry and passed to the host entry (getSuggestionsForGeneration),
-        // so both the host result AND the extension's answer bind to THIS
-        // request — never to a newer one that started while the extension
-        // was in flight.
+        // THIS delegated request's generation AND scope: minted/captured
+        // synchronously at entry (before ANY await), so both the host
+        // result and the extension's answer bind to THIS request — never to
+        // a newer one that started while the extension was in flight, and
+        // never to a session/workspace that switched mid-request.
         const requestGeneration = base.mintRequestGeneration()
+        const requestScope = base.scopeAtRequestTime()
         const host = await base.getSuggestionsForGeneration(requestGeneration, lines, cursorLine, cursorCol, options)
         if (host !== null) return host
         // Preserve the shell-mode natural-trigger suppression: a leading
@@ -9230,9 +9231,10 @@ export class TuiApp {
         // The EXTENSION's suggestions bind the host's stale fence too:
         // the base provider owns the apply-time document/cursor snapshot,
         // and a list the extension produced must be computed against the
-        // SAME editor state (plan §9.2 — a stale ext accept must never
-        // modify a later edit either).
-        return base.captureRequestSnapshot(requestGeneration, lines, cursorLine, cursorCol, result)
+        // SAME editor state + scope (plan §9.2 — a stale ext accept must
+        // never modify a later edit, and an old session's candidate must
+        // never be accepted under a switched session).
+        return base.captureRequestSnapshot(requestGeneration, requestScope, lines, cursorLine, cursorCol, result)
       },
       applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
         // A Stable plugin computes its prefix on the WIRE document it

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9214,13 +9214,19 @@ export class TuiApp {
         const wireLines = mode === 'prompt'
           ? lines
           : lines.map((line, index) => index === 0 ? prefix + line : line)
-        return extensionSuggest({
+        const result = await extensionSuggest({
           lines: wireLines,
           cursorLine,
           cursorCol: cursorCol + (mode === 'prompt' || cursorLine > 0 ? 0 : prefix.length),
           signal: options.signal,
           force: options.force,
         })
+        // The EXTENSION's suggestions bind the host's stale fence too:
+        // the base provider owns the apply-time document/cursor snapshot,
+        // and a list the extension produced must be computed against the
+        // SAME editor state (plan §9.2 — a stale ext accept must never
+        // modify a later edit either).
+        return base.captureRequestSnapshot(lines, cursorLine, cursorCol, result)
       },
       applyCompletion: (lines, cursorLine, cursorCol, item, prefix) => {
         // A Stable plugin computes its prefix on the WIRE document it

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -23,7 +23,7 @@
 
 import { decodePrintableKey, Editor, matchesKey, truncateToWidth, type EditorTheme, type TUI } from '@xmoon76/pi-tui'
 import { color } from './theme.ts'
-import { extractAtPrefix } from './mentions.ts'
+import { classifyFileCompletionContext, FILE_ARGUMENT_COMMANDS } from './file-completion/context.ts'
 import { editorModeFromHistoryEntry, type EditorInputMode } from './editor-input-mode.ts'
 
 /** The fork's private autocomplete surface (runtime methods; kimi's
@@ -38,18 +38,11 @@ interface AutocompleteInternals {
  * three prompts (`❯ `, `! `, `!!`) are exactly this wide. */
 const PROMPT_WIDTH = 2
 
-/** Whether the text before the cursor is a slash-command line WITH an
- * argument position (`/cmd <arg>`): the command name is the first
- * whitespace-delimited (space OR tab — the fork's path delimiters) token
- * after the leading `/`; anything after it is the argument the completion
- * re-trigger targets. */
-function isSlashCommandArgument(textBeforeCursor: string): boolean {
-  const trimmed = textBeforeCursor.trimStart()
-  if (!trimmed.startsWith('/')) return false
-  const separatorIndex = trimmed.search(/[ \t]/)
-  if (separatorIndex <= 0) return false
-  const commandName = trimmed.slice(1, separatorIndex)
-  return commandName !== '' && !commandName.includes('/')
+/** Whether the cursor sits in a declared path-argument position (`/image
+ * <arg>`): the classifier's `image-argument` kind, which the reopen gate
+ * consumes (plan §11 — ONE classifier, never a per-command hardcode). */
+function isFileArgumentContext(textBeforeCursor: string): boolean {
+  return classifyFileCompletionContext(textBeforeCursor, FILE_ARGUMENT_COMMANDS).kind !== 'none'
 }
 
 /**
@@ -430,7 +423,11 @@ export class TuiEditor extends Editor {
     if (this.isShowingAutocomplete()) return
     const { line, col } = this.getCursor()
     const textBeforeCursor = this.getLines()[line]?.slice(0, col) ?? ''
-    if (textBeforeCursor.endsWith('/') && (extractAtPrefix(textBeforeCursor) !== null || isSlashCommandArgument(textBeforeCursor))) {
+    // ONE classifier (plan §11): `@dir/` mentions AND `/image dir/` arguments
+    // reopen through the same directory-shaped context gate — never a
+    // per-command hardcode, and never a plain trailing `/` (a `see /tmp/`
+    // position stays closed).
+    if (textBeforeCursor.endsWith('/') && isFileArgumentContext(textBeforeCursor)) {
       ;(this as unknown as AutocompleteInternals)
         .requestAutocomplete({ force: false, explicitTab: false })
     }

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -1,6 +1,6 @@
 /**
- * Host editor subclass: kimi CustomEditor parity for `@dir/` mention
- * completion (AGENTS.md decision 8 — consumer-side, the vendored fork
+ * Host editor subclass: kimi CustomEditor parity for `@dir/`/`@dir\\`
+ * mention completion (AGENTS.md decision 8 — consumer-side, the vendored fork
  * stays pristine). After every handled key, if the cursor sits on an
  * `@dir/` mention with the autocomplete closed, re-trigger completion so
  * Tab-accepting a directory immediately shows its children (kimi's
@@ -267,6 +267,33 @@ export class TuiEditor extends Editor {
       // shell-local + empty: `!` is an ordinary body character (no fourth
       // mode — intentional, guarded by a test).
     }
+    // Closed-dropdown Tab is explicit and context-gated. In prompt mode the
+    // host provider owns only `@` and declared path arguments; ordinary prose
+    // and ordinary paths must not fall through to the fork's broad file
+    // completion. A slash command name is the one non-file case delegated to
+    // the fork so command-name completion remains intact.
+    if (matchesKey(data, 'tab') && !this.isShowingAutocomplete() && this.inputMode === 'prompt') {
+      const { line, col } = this.getCursor()
+      const beforeCursor = this.getLines()[line]?.slice(0, col) ?? ''
+      const context = classifyFileCompletionContext(beforeCursor, FILE_ARGUMENT_COMMANDS)
+      if (context.kind === 'mention' || context.kind === 'image-argument') {
+        ;(this as unknown as AutocompleteInternals)
+          .requestAutocomplete({ force: true, explicitTab: true })
+        return
+      }
+      const trimmed = beforeCursor.trimStart()
+      if (/^\/[^\s/]*$/.test(trimmed)) {
+        // Let the fork resolve slash-command names (`/he`, including an
+        // indented form after its provider-side normalization).
+      } else {
+        // Still run the provider request so the separate extension
+        // autocomplete chain can answer ordinary positions. MentionProvider's
+        // host file branch remains closed for this `none` context.
+        ;(this as unknown as AutocompleteInternals)
+          .requestAutocomplete({ force: true, explicitTab: true })
+        return
+      }
+    }
     // Tab on a leading `/` in a shell mode is a PATH, never a slash
     // command: the fork's handleTabCompletion routes a space-free
     // leading-`/` line to slash-command completion, which would list
@@ -302,7 +329,38 @@ export class TuiEditor extends Editor {
       return
     }
     if (data !== '') super.handleInput(data)
+    this.triggerNonstandardMentionCompletion(data)
     this.reopenAutocompleteAfterInput()
+  }
+
+  /** Trigger the provider for mention boundaries that the vendored editor's
+   * generic symbol gate does not know about (CJK glue and `=`/quote
+   * delimiters). Ordinary prose and path positions remain untouched; the
+   * shared classifier is the only file-context decision point. */
+  private triggerNonstandardMentionCompletion(data: string): void {
+    if (this.isShowingAutocomplete()) return
+    const printable = decodePrintableKey(data) ?? (data.length === 1 && data.charCodeAt(0) >= 32 ? data : undefined)
+    // Virtual terminals and paste-like test seams may deliver several plain
+    // characters in one input event. Escape sequences are navigation/control
+    // keys, not text, even though their bytes include printable characters.
+    if (printable === undefined && data.includes('\x1b')) return
+    if (printable === undefined && ![...data].some(character => character.charCodeAt(0) >= 32)) return
+    const { line, col } = this.getCursor()
+    const before = this.getLines()[line]?.slice(0, col) ?? ''
+    const context = classifyFileCompletionContext(before, FILE_ARGUMENT_COMMANDS)
+    if (context.kind !== 'mention') return
+    const beforeAt = before[context.range.start - 1]
+    // Start/space/tab are already handled by the fork for bare mentions. Its
+    // generic gate does not reliably recognize quoted forms (`@"...`),
+    // including when they begin after whitespace, so the classified quoted
+    // context is an explicit exception. Nonstandard boundaries (`=`, CJK,
+    // quote delimiters) are also owned by this consumer-side trigger and must
+    // work when a real terminal delivers one key per input event.
+    const quotedMention = context.query.startsWith('@"')
+    const nonstandardBoundary = beforeAt !== undefined && beforeAt !== ' ' && beforeAt !== '\t'
+    if (!quotedMention && !nonstandardBoundary) return
+    ;(this as unknown as AutocompleteInternals)
+      .requestAutocomplete({ force: false, explicitTab: false })
   }
 
   /** Stitch a buffered paste-marker prefix onto this chunk. */
@@ -427,7 +485,7 @@ export class TuiEditor extends Editor {
     // reopen through the same directory-shaped context gate — never a
     // per-command hardcode, and never a plain trailing `/` (a `see /tmp/`
     // position stays closed).
-    if (textBeforeCursor.endsWith('/') && isFileArgumentContext(textBeforeCursor)) {
+    if ((textBeforeCursor.endsWith('/') || textBeforeCursor.endsWith('\\')) && isFileArgumentContext(textBeforeCursor)) {
       ;(this as unknown as AutocompleteInternals)
         .requestAutocomplete({ force: false, explicitTab: false })
     }

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -341,6 +341,62 @@ test('review finding 3: an indented /image command still classifies its argument
   assert.ok(result.items.some(item => item.value === 'file-one.txt'), `indented value missing:\n${JSON.stringify(result.items)}`)
 })
 
+test('review finding (round 4): a regex-special filename still completes (fd literal match)', async () => {
+  const root = outsideCwdFixture().workspace
+  writeFileSync(join(root, 'file[1].ts'), 'x')
+  writeFileSync(join(root, 'a+b.ts'), 'x')
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const bracketed = await provider.getSuggestions(['@file[1'], 0, 7, { signal: abort })
+  assert.ok(bracketed !== null, `@file[1 must suggest:\n${JSON.stringify(bracketed)}`)
+  assert.ok(bracketed.items.some(item => item.value.includes('file[1].ts')), `bracketed missing:\n${JSON.stringify(bracketed.items)}`)
+  const plus = await provider.getSuggestions(['@a+b'], 0, 4, { signal: abort })
+  assert.ok(plus !== null && plus.items.some(item => item.value.includes('a+b.ts')), `plus missing:\n${JSON.stringify(plus)}`)
+})
+
+test('review finding (round 4): failed fd falls back to the bounded scan', async () => {
+  const { workspace, sibling } = outsideCwdFixture()
+  const root = workspace
+  writeFileSync(join(sibling, 'fallback-scan.ts'), 'x')
+  // A fake fd that always FAILS (non-zero exit): discovery must fall back
+  // to the bounded recursive scan, never report a false "no match".
+  const fakeFd = join(tmpdir(), 'dsh-conv-fdcrash')
+  writeFileSync(fakeFd, '#!/bin/sh\nexit 1\n')
+  chmodSync(fakeFd, 0o755)
+  const port = new DirectHostFilePort(() => undefined, fakeFd)
+  const provider = new MentionProvider([], root, port)
+  const result = await provider.getSuggestions(['@../sibling/fallback'], 0, 21, { signal: abort })
+  assert.ok(result !== null, `a failed fd must fall back:\n${JSON.stringify(result)}`)
+  assert.ok(result.items.some(item => item.value.includes('fallback-scan.ts')), `fallback missing:\n${JSON.stringify(result.items)}`)
+})
+
+test('review finding (round 4): scoped listings never present .git', async () => {
+  const root = outsideCwdFixture().workspace
+  mkdirSync(join(root, '.git'))
+  writeFileSync(join(root, '.git', 'config'), 'x')
+  writeFileSync(join(root, 'visible.txt'), 'x')
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const result = await provider.getSuggestions(['@'], 0, 1, { signal: abort })
+  assert.ok(result !== null)
+  assert.ok(!result.items.some(item => item.value.includes('.git')), `.git must not be listed:\n${JSON.stringify(result.items)}`)
+  assert.ok(result.items.some(item => item.value === '@visible.txt'))
+})
+
+test('review finding (round 4): null pins the fallback /image source; undefined probes PATH', async () => {
+  const root = outsideCwdFixture().workspace
+  writeFileSync(join(root, 'shot.png'), 'x')
+  // null → forced fallback (never fd), regardless of PATH.
+  const fallbackProvider = new MentionProvider(
+    [{ name: 'image', description: 'Attach', getArgumentCompletions: () => null }],
+    root,
+    new DirectHostFilePort(() => undefined, null),
+    undefined,
+    { kind: 'workspace', cwd: root },
+    null,
+  )
+  const result = await fallbackProvider.getSuggestions(['/image shot'], 0, 11, { signal: abort })
+  assert.ok(result !== null && result.items.length > 0, `a null-pinned fallback must complete:\n${JSON.stringify(result)}`)
+})
+
 test('review finding (verified): multi-space /image separator applies without duplication', async () => {
   const { workspace } = outsideCwdFixture()
   const root = workspace

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -24,6 +24,22 @@ import { DirectHostFilePort, resolveFdPath } from '../src/runtime/direct/host-fi
 
 const abort = new AbortController().signal
 
+/** Poll until the predicate is true (asserts after a 3s deadline). */
+async function pollUntil(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 3000
+  for (;;) {
+    if (predicate()) return
+    if (Date.now() > deadline) assert.fail(`${label}: condition never became true`)
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+/** The LIVE autocomplete state of the app's host editor (the seat's
+ * capability seam — the stable assertion, never a viewport needle). */
+function isAutocompleteActive(app: import('../src/tui-app.ts').TuiApp): boolean {
+  return (app.seatEditorForTest() as { isShowingAutocomplete?: () => boolean }).isShowingAutocomplete?.() === true
+}
+
 /** A root with workspace + sibling for outside-cwd probes. */
 function outsideCwdFixture(): { root: string; workspace: string; sibling: string } {
   const root = mkdtempSync(join(tmpdir(), 'dsh-conv-out-'))
@@ -76,7 +92,12 @@ test('P1.1 headless: foo<Tab> opens no dropdown (isShowingAutocomplete stays fal
   vt.sendInput('foo')
   await vt.waitForRender()
   vt.sendInput('\t')
-  await new Promise(resolve => setTimeout(resolve, 200))
+  // The STABLE assertion: the host editor's autocomplete state stays
+  // closed — never a viewport-needle-only check. Poll over the editor's
+  // debounce window so a late request cannot slip by unnoticed.
+  await pollUntil(() => !isAutocompleteActive(app), 'foo<Tab> must keep the dropdown closed')
+  await new Promise(resolve => setTimeout(resolve, 60))
+  assert.equal(isAutocompleteActive(app), false, `foo<Tab> must not open a dropdown`)
   const view = vt.getViewport().join('\n')
   assert.ok(!view.includes('wanted.ts'), `foo<Tab> must not list files:\n${view}`)
   assert.equal(app.seatTextForTest(), 'foo', 'the draft is untouched')
@@ -285,6 +306,30 @@ test('the presentation layer quotes spaced values for /image and keeps @ quoting
   assert.equal(atQuoted.value, '@"my file.txt"')
 })
 
+test('review finding 1: a quoted /image argument completes inside the quotes', async () => {
+  const { workspace } = outsideCwdFixture()
+  const root = workspace
+  writeFileSync(join(root, 'my file.txt'), 'x')
+  const provider = new MentionProvider(
+    [{ name: 'image', description: 'Attach', getArgumentCompletions: () => null }],
+    root,
+    new DirectHostFilePort(() => undefined, null),
+  )
+  const result = await provider.getSuggestions(['/image "my'], 0, 10, { signal: abort })
+  assert.ok(result !== null, `/image "my must suggest:\n${JSON.stringify(result)}`)
+  assert.ok(
+    result.items.some(item => item.value === '"my file.txt"'),
+    `the quoted value must keep its quotes:\n${JSON.stringify(result.items)}`,
+  )
+})
+
+test('review finding 2: a Windows-dialect directory keeps the backslash separator', () => {
+  const item = presentPathCandidate({ path: 'C:\\Users\\foo', kind: 'directory' }, { at: false, quoted: false, sep: '\\' })
+  assert.equal(item.value, 'C:\\Users\\foo\\', 'a Windows directory completes with \\ — never a mixed /')
+  const posix = presentPathCandidate({ path: 'src/foo', kind: 'directory' }, { at: false, quoted: false, sep: '/' })
+  assert.equal(posix.value, 'src/foo/')
+})
+
 test('extractAtPrefix keeps the CJK-glue rule and rejects emails', () => {
   assert.equal(extractAtPrefix('看看@foo'), '@foo')
   assert.equal(extractAtPrefix('a@b.c'), null)
@@ -304,18 +349,17 @@ test('a sessionless @dir/ lists children (direct children listing)', async () =>
 // ── §24 headless integration: TuiApp + TuiEditor + MentionProvider ─────────
 
 test('§24 A: @src → dropdown → Tab → @src/ → children dropdown', async () => {
-  const { startApp, startImageApp } = await import('./support/app-harness.ts')
+  const { startApp } = await import('./support/app-harness.ts')
   const root = largeWorkspaceFixture().root
   const { vt, app } = startApp(root)
   await vt.waitForRender()
   vt.sendInput('@src')
-  await new Promise(resolve => setTimeout(resolve, 120))
-  assert.ok(vt.getViewport().join('\n').includes('src/'), 'the src directory item must appear')
+  await pollUntil(() => vt.getViewport().join('\n').includes('src/'), 'the src directory item must appear')
+  assert.equal(isAutocompleteActive(app), true, '@src must open the dropdown')
   vt.sendInput('\t')
-  await new Promise(resolve => setTimeout(resolve, 120))
+  await pollUntil(() => app.seatTextForTest() === '@src/', 'Tab accepts the directory')
   assert.equal(app.seatTextForTest(), '@src/', 'Tab accepts the directory')
-  await new Promise(resolve => setTimeout(resolve, 120))
-  assert.ok(vt.getViewport().join('\n').includes('wanted.ts'), 'children must appear after accept')
+  await pollUntil(() => vt.getViewport().join('\n').includes('wanted.ts'), 'children must appear after accept')
   app.stop()
 })
 
@@ -325,13 +369,12 @@ test('§24 B: /image src → dropdown → Tab → /image src/ → children dropd
   const { vt, app } = startImageApp(root)
   await vt.waitForRender()
   vt.sendInput('/image src')
-  await new Promise(resolve => setTimeout(resolve, 120))
-  assert.ok(vt.getViewport().join('\n').includes('src/'), 'the src argument candidate must appear')
+  await pollUntil(() => vt.getViewport().join('\n').includes('src/'), 'the src argument candidate must appear')
+  assert.equal(isAutocompleteActive(app), true, '/image src must open the dropdown')
   vt.sendInput('\t')
-  await new Promise(resolve => setTimeout(resolve, 120))
+  await pollUntil(() => app.seatTextForTest() === '/image src/', 'Tab accepts the directory')
   assert.equal(app.seatTextForTest(), '/image src/', 'Tab accepts the directory')
-  await new Promise(resolve => setTimeout(resolve, 120))
-  assert.ok(vt.getViewport().join('\n').includes('wanted.ts'), 'children must appear after accept')
+  await pollUntil(() => vt.getViewport().join('\n').includes('wanted.ts'), 'children must appear after accept')
   app.stop()
 })
 
@@ -343,7 +386,9 @@ test('§24 C: hello ./src<Tab> opens no dropdown', async () => {
   vt.sendInput('hello ./src')
   await vt.waitForRender()
   vt.sendInput('\t')
-  await new Promise(resolve => setTimeout(resolve, 200))
+  await pollUntil(() => !isAutocompleteActive(app), 'hello ./src<Tab> must keep the dropdown closed')
+  await new Promise(resolve => setTimeout(resolve, 60))
+  assert.equal(isAutocompleteActive(app), false, 'hello ./src<Tab> must not open a dropdown')
   const view = vt.getViewport().join('\n')
   assert.ok(!view.includes('wanted.ts'), `hello ./src<Tab> must not list files:\n${view}`)
   assert.equal(app.seatTextForTest(), 'hello ./src', 'the draft is untouched')
@@ -357,7 +402,6 @@ test('§24 E: sessionless @dir/ lists children through the app chain', async () 
   await vt.waitForRender()
   // No session was ever created: the workspace scope answers.
   vt.sendInput('@src/')
-  await new Promise(resolve => setTimeout(resolve, 120))
-  assert.ok(vt.getViewport().join('\n').includes('wanted.ts'), 'sessionless children must appear')
+  await pollUntil(() => vt.getViewport().join('\n').includes('wanted.ts'), 'sessionless children must appear')
   app.stop()
 })

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -545,6 +545,48 @@ test('review finding 2: a stale accept never applies after an unrelated edit', a
   assert.deepEqual(applied.lines, ['look @local'], 'an unrelated edit must also fence the accept')
 })
 
+test('review finding (round 8): a fallback scan is async and abort-responsive (never a sync block)', async () => {
+  const root = largeWorkspaceFixture().root
+  const controller = new AbortController()
+  const port = new DirectHostFilePort(() => undefined, null) // forced fallback
+  const provider = new MentionProvider([], root, port)
+  // Abort mid-request: the async scan stops promptly (the old sync scan
+  // could not be interrupted once it started).
+  const started = Date.now()
+  const pending = provider.getSuggestions(['@wanted'], 0, 7, { signal: controller.signal })
+  controller.abort()
+  const result = await pending
+  assert.equal(result, null, 'an aborted fallback scan must never commit a late result')
+  assert.ok(Date.now() - started < 1000, 'the scan must stop promptly on abort')
+})
+
+test('review finding (round 6/8): overlapping delegated requests keep their own snapshots', async () => {
+  const root = outsideCwdFixture().workspace
+  writeFileSync(join(root, 'item-a.txt'), 'x')
+  writeFileSync(join(root, 'item-b.txt'), 'x')
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  // Two requests mint distinct generations; the OLDER result is dropped by
+  // the generation check (it cannot bind a snapshot), so the NEWER
+  // request's snapshot stays the only one the apply fence honors.
+  const g1 = provider.mintRequestGeneration()
+  provider.mintRequestGeneration() // a NEWER request starts
+  const staleBind = provider.captureRequestSnapshot(
+    g1,
+    { kind: 'workspace', cwd: root },
+    ['@item-a'],
+    0,
+    7,
+    { items: [{ value: '@item-a.txt', label: 'item-a.txt' }], prefix: '@item-a' },
+  )
+  // The OLD result does not become the snapshot (the fresh request below
+  // still applies); captureRequestSnapshot returns its argument unchanged.
+  assert.ok(staleBind !== null, 'capture returns the result value unchanged')
+  const fresh = await provider.getSuggestions(['@item-b'], 0, 7, { signal: abort })
+  assert.ok(fresh !== null, 'the NEWER request still completes normally')
+  const applied = provider.applyCompletion(['@item-b'], 0, 7, { value: '@item-b.txt', label: 'item-b.txt' }, '@item-b')
+  assert.equal(applied.lines[0], '@item-b.txt ', 'the fresh request applies normally (the older bind did not fence it)')
+})
+
 test('review finding (round 6): a scope switch mid-flight fences the old session accept', async () => {
   const rootA = outsideCwdFixture().workspace
   const rootB = outsideCwdFixture().workspace

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -357,15 +357,20 @@ test('review finding (round 5): fd matches case-insensitively (aligned with the 
   const root = outsideCwdFixture().workspace
   writeFileSync(join(root, 'Foo.txt'), 'x')
   writeFileSync(join(root, 'foo.txt'), 'x')
-  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
-  // The fd-backed path (this machine has fdfind) must find BOTH — the
-  // shared ranking is case-insensitive and fd's smart-case default (case-
-  // SENSITIVE for an uppercase query) would miss foo.txt.
+  // REAL fd-backed path: the default DirectHostFilePort probes PATH (fd
+  // then fdfind — this machine has /usr/bin/fdfind), so the -i flag is
+  // what produces both matches. A fallback-only null would pass even
+  // without -i.
+  const port = new DirectHostFilePort(() => undefined)
+  assert.notEqual(port.fdPathAvailableForTest(), null, 'the test must run through a real fd/fdfind')
+  const provider = new MentionProvider([], root, port)
+  // fd's smart-case default (case-SENSITIVE for an uppercase query) would
+  // return only @Foo.txt; the -i flag returns both.
   const upper = await provider.getSuggestions(['@FOO'], 0, 4, { signal: abort })
   assert.ok(upper !== null, `@FOO must suggest:\n${JSON.stringify(upper)}`)
   assert.ok(
     upper.items.some(item => item.value === '@Foo.txt') && upper.items.some(item => item.value === '@foo.txt'),
-    `both case forms must match:\n${JSON.stringify(upper.items)}`,
+    `both case forms must match (real fd -i):\n${JSON.stringify(upper.items)}`,
   )
 })
 
@@ -468,6 +473,36 @@ test('review finding 2: a stale accept never applies after an unrelated edit', a
   // The editor state changed on an unrelated part: `see` → `look`.
   const applied = provider.applyCompletion(['look @local'], 0, 12, { value: '@local.txt', label: 'local.txt' }, '@local')
   assert.deepEqual(applied.lines, ['look @local'], 'an unrelated edit must also fence the accept')
+})
+
+test('review finding (round 6): a scope switch mid-flight fences the old session accept', async () => {
+  const rootA = outsideCwdFixture().workspace
+  const rootB = outsideCwdFixture().workspace
+  writeFileSync(join(rootA, 'session-a.txt'), 'x')
+  writeFileSync(join(rootB, 'session-b.txt'), 'x')
+  let scope: { kind: 'workspace'; cwd: string } = { kind: 'workspace', cwd: rootA }
+  const provider = new MentionProvider(
+    [],
+    rootA,
+    new DirectHostFilePort(() => undefined, null),
+    undefined,
+    () => scope,
+  )
+  const bound = await provider.getSuggestions(['@session-a'], 0, 11, { signal: abort })
+  assert.ok(bound !== null && bound.items.length > 0, 'session A must produce candidates')
+  // The session/workspace switches while the draft is UNCHANGED: the old
+  // snapshot's scope no longer matches, so accepting the OLD dropdown item
+  // must leave the draft untouched (never insert a Host candidate from the
+  // previous session under the new one).
+  scope = { kind: 'workspace', cwd: rootB }
+  const applied = provider.applyCompletion(
+    ['@session-a'],
+    0,
+    11,
+    { value: '@session-a.txt', label: 'session-a.txt' },
+    '@session-a',
+  )
+  assert.deepEqual(applied.lines, ['@session-a'], 'a scope switch must fence the stale accept')
 })
 
 test('review finding 2: a Windows-dialect directory keeps the backslash separator', () => {

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -93,11 +93,15 @@ test('P1.1 headless: foo<Tab> opens no dropdown (isShowingAutocomplete stays fal
   await vt.waitForRender()
   vt.sendInput('\t')
   // The STABLE assertion: the host editor's autocomplete state stays
-  // closed — never a viewport-needle-only check. Poll over the editor's
-  // debounce window so a late request cannot slip by unnoticed.
-  await pollUntil(() => !isAutocompleteActive(app), 'foo<Tab> must keep the dropdown closed')
-  await new Promise(resolve => setTimeout(resolve, 60))
-  assert.equal(isAutocompleteActive(app), false, `foo<Tab> must not open a dropdown`)
+  // closed — never a viewport-needle-only check. Poll the closed state
+  // over the editor's whole debounce window (no fixed sleep): a late
+  // request cannot slip by unnoticed.
+  const deadline = Date.now() + 400
+  for (;;) {
+    assert.equal(isAutocompleteActive(app), false, 'foo<Tab> must never open a dropdown')
+    if (Date.now() > deadline) break
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
   const view = vt.getViewport().join('\n')
   assert.ok(!view.includes('wanted.ts'), `foo<Tab> must not list files:\n${view}`)
   assert.equal(app.seatTextForTest(), 'foo', 'the draft is untouched')
@@ -117,14 +121,29 @@ test('P1.2: scoped @ paths search their OWN directory (outside the cwd)', async 
 })
 
 test('P1.2: @../../scope resolves outside the cwd by the typed amount', async () => {
-  const { root, workspace } = outsideCwdFixture()
-  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
-  const query = resolvePathQuery('workspace/loc', root)
-  assert.equal(query.searchBase, join(root, 'workspace'))
-  const result = await provider.getSuggestions(['@workspace/loc'], 0, 15, { signal: abort })
-  assert.ok(result !== null, `@workspace/loc must suggest:\n${JSON.stringify(result)}`)
-  assert.ok(result.items.some(item => item.value === '@workspace/local.txt'))
-  void workspace
+  // A REAL ../../ fixture: workspace = /root/alpha/beta/workspace; `../..`
+  // resolves to /root/alpha, so `../../alpha` targets /root/alpha/alpha.
+  // The file two levels up lives under alpha/alpha/deep.ts.
+  const root = mkdtempSync(join(tmpdir(), 'dsh-conv-upup-'))
+  const alpha = join(root, 'alpha')
+  const beta = join(alpha, 'beta')
+  const workspace = join(beta, 'workspace')
+  mkdirSync(workspace, { recursive: true })
+  mkdirSync(join(alpha, 'alpha'), { recursive: true })
+  writeFileSync(join(alpha, 'alpha', 'deep.ts'), 'x')
+  mkdirSync(join(alpha, 'alpha', 'deep'), { recursive: true })
+  writeFileSync(join(alpha, 'alpha', 'deep', 'nested.txt'), 'x')
+  const provider = new MentionProvider([], workspace, new DirectHostFilePort(() => undefined, null))
+  // /root/alpha/beta/workspace + ../../alpha = /root/alpha/alpha.
+  const result = await provider.getSuggestions(['@../../alpha/de'], 0, 16, { signal: abort })
+  assert.ok(result !== null, `@../../alpha/de must suggest:\n${JSON.stringify(result)}`)
+  assert.ok(
+    result.items.some(item => item.value === '@../../alpha/deep.ts'),
+    `../../ scope value missing:\n${JSON.stringify(result.items)}`,
+  )
+  const nested = await provider.getSuggestions(['@../../alpha/deep/nes'], 0, 22, { signal: abort })
+  assert.ok(nested !== null && nested.items.some(item => item.value === '@../../alpha/deep/nested.txt'),
+    `nested ../../ value missing:\n${JSON.stringify(nested)}`)
 })
 
 test('P1.2: @~/ resolves through the homedir', async () => {
@@ -152,6 +171,48 @@ test('P1.2 absolute: @/tmp/ searches the absolute scope', async () => {
   const result = await provider.getSuggestions([`@${target}/abs`], 0, `@${target}/abs`.length, { signal: abort })
   assert.ok(result !== null, `absolute must suggest:\n${JSON.stringify(result)}`)
   assert.ok(result.items.some(item => item.value.startsWith(`@${target}`)))
+})
+
+test('§23 matrix: /image shares the scoped forms (../, ~/, absolute, directory continuation)', async () => {
+  // ../../ fixture for /image: workspace = /root/alpha/beta/workspace;
+  // ../../alpha targets /root/alpha/alpha/pics.
+  const root = mkdtempSync(join(tmpdir(), 'dsh-conv-imgscope-'))
+  const alpha = join(root, 'alpha')
+  const beta = join(alpha, 'beta')
+  const workspace = join(beta, 'workspace')
+  mkdirSync(workspace, { recursive: true })
+  mkdirSync(join(alpha, 'alpha', 'pics'), { recursive: true })
+  writeFileSync(join(alpha, 'alpha', 'pics', 'a.png'), 'x')
+  writeFileSync(join(alpha, 'alpha', 'pics', 'note.txt'), 'x')
+  mkdirSync(join(workspace, 'subdir'))
+  writeFileSync(join(workspace, 'subdir', 'deep.png'), 'x')
+  const provider = new MentionProvider(
+    [{ name: 'image', description: 'Attach', getArgumentCompletions: () => null }],
+    workspace,
+    new DirectHostFilePort(() => undefined, null),
+  )
+  // ../.. scope.
+  const up = await provider.getSuggestions(['/image ../../alpha/pics/a'], 0, 28, { signal: abort })
+  assert.ok(up !== null, `/image ../../ must suggest:\n${JSON.stringify(up)}`)
+  assert.ok(up.items.some(item => item.value === '../../alpha/pics/a.png'), `../../ image missing:\n${JSON.stringify(up.items)}`)
+  // Directory continuation.
+  const cont = await provider.getSuggestions(['/image subdir/'], 0, 14, { signal: abort })
+  assert.ok(cont !== null && cont.items.some(item => item.value === 'subdir/deep.png'),
+    `image dir continuation missing:\n${JSON.stringify(cont)}`)
+  // ~/ scope (homedir has a stable entry).
+  const saved = process.env.HOME
+  try {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-conv-imghome-'))
+    mkdirSync(join(home, 'pix'))
+    writeFileSync(join(home, 'pix', 'h.png'), 'x')
+    process.env.HOME = home
+    const tilde = await provider.getSuggestions(['/image ~/pix/h'], 0, 14, { signal: abort })
+    assert.ok(tilde !== null && tilde.items.some(item => item.value === '~/pix/h.png'),
+      `~/ image missing:\n${JSON.stringify(tilde)}`)
+  } finally {
+    if (saved === undefined) delete process.env.HOME
+    else process.env.HOME = saved
+  }
 })
 
 test('P1.3: a >2000-entry workspace keeps directory continuation working', async () => {
@@ -353,16 +414,25 @@ test('review finding (round 4): a regex-special filename still completes (fd lit
   assert.ok(plus !== null && plus.items.some(item => item.value.includes('a+b.ts')), `plus missing:\n${JSON.stringify(plus)}`)
 })
 
-test('review finding (round 5): fd matches case-insensitively (aligned with the ranking contract)', async () => {
+test('review finding (round 5): fd matches case-insensitively (aligned with the ranking contract)', async (t) => {
   const root = outsideCwdFixture().workspace
   writeFileSync(join(root, 'Foo.txt'), 'x')
   writeFileSync(join(root, 'foo.txt'), 'x')
+  // The ranking contract is case-INSENSITIVE (always runs, no fd needed):
+  // the engine lowercases the QUERY before scoring, so an uppercase query
+  // signs the lowercase basename as a prefix match (80).
+  assert.equal(scorePathCandidate({ path: 'foo.txt', kind: 'file' }, 'FOO'.toLowerCase()), 80,
+    'the shared ranking must be case-insensitive')
   // REAL fd-backed path: the default DirectHostFilePort probes PATH (fd
   // then fdfind — this machine has /usr/bin/fdfind), so the -i flag is
   // what produces both matches. A fallback-only null would pass even
-  // without -i.
+  // without -i. SKIP when no finder is installed (CI without fd/fdfind
+  // must not fail the suite — the fallback path is tested separately).
   const port = new DirectHostFilePort(() => undefined)
-  assert.notEqual(port.fdPathAvailableForTest(), null, 'the test must run through a real fd/fdfind')
+  if (port.fdPathAvailableForTest() === null) {
+    t.skip('no fd/fdfind on PATH: the real-fd case test cannot run')
+    return
+  }
   const provider = new MentionProvider([], root, port)
   // fd's smart-case default (case-SENSITIVE for an uppercase query) would
   // return only @Foo.txt; the -i flag returns both.

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -1,0 +1,363 @@
+/**
+ * The file-completion convergence regression suite (the 2026-08-27 plan):
+ * P1.1–P1.5, the §23 matrix, and the §24 headless A–E integration flows.
+ * These tests pin the CONVERGED contract — file completion ONLY on `@...`
+ * and `/image ...`, scoped `@` paths, shared fuzzy ranking, directory
+ * continuation, fd/fdfind detection, stale-apply fencing, and the sessionless
+ * scope walk. The engine modules are pure; the provider/port/app layers are
+ * exercised through the real chain (TuiApp + VirtualTerminal + MentionProvider
+ * + DirectHostFilePort).
+ * @module @xmoon76/dsh-pi-tui/file-completion-convergence.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { chmodSync, mkdirSync, mkdtempSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join, win32, sep } from 'node:path'
+import { classifyFileCompletionContext, extractAtPrefix } from '../src/file-completion/context.ts'
+import { resolvePathQuery } from '../src/file-completion/query.ts'
+import { scorePathCandidate } from '../src/file-completion/ranking.ts'
+import { presentPathCandidate } from '../src/file-completion/presentation.ts'
+import { MentionProvider } from '../src/mentions.ts'
+import { DirectHostFilePort, resolveFdPath } from '../src/runtime/direct/host-file-direct.ts'
+
+const abort = new AbortController().signal
+
+/** A root with workspace + sibling for outside-cwd probes. */
+function outsideCwdFixture(): { root: string; workspace: string; sibling: string } {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-conv-out-'))
+  const workspace = join(root, 'workspace')
+  const sibling = join(root, 'sibling')
+  mkdirSync(workspace)
+  mkdirSync(sibling)
+  writeFileSync(join(workspace, 'local.txt'), 'x')
+  writeFileSync(join(sibling, 'sibling-file.ts'), 'x')
+  return { root, workspace, sibling }
+}
+
+/** A workspace whose subtree holds MORE than the fallback scan bound, so a
+ * root-level `src/` with a wanted file must still complete after accept. */
+function largeWorkspaceFixture(): { root: string } {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-conv-large-'))
+  mkdirSync(join(root, 'src'))
+  writeFileSync(join(root, 'src', 'wanted.ts'), 'x')
+  const filler = join(root, 'filler')
+  mkdirSync(filler)
+  for (let index = 0; index < 2200; index += 1) {
+    writeFileSync(join(filler, `f-${index}.txt`), 'x')
+  }
+  return { root }
+}
+
+test('P1.1: ordinary prompt positions never open the HOST file dropdown', async () => {
+  const { root } = largeWorkspaceFixture()
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  for (const [line, col] of [
+    ['foo', 3],
+    ['./foo', 5],
+    ['../foo', 6],
+    ['/tmp/foo', 8],
+    ['hello foo', 9],
+    ['hello ./foo', 11],
+  ] as const) {
+    const natural = await provider.getSuggestions([line], 0, col, { signal: abort, force: false })
+    assert.equal(natural, null, `natural ${JSON.stringify(line)} must be null`)
+    const forced = await provider.getSuggestions([line], 0, col, { signal: abort, force: true })
+    assert.equal(forced, null, `forced Tab ${JSON.stringify(line)} must be null`)
+  }
+})
+
+test('P1.1 headless: foo<Tab> opens no dropdown (isShowingAutocomplete stays false)', async () => {
+  const { root } = largeWorkspaceFixture()
+  const { startApp } = await import('./support/app-harness.ts')
+  const { vt, app } = startApp(root)
+  await vt.waitForRender()
+  vt.sendInput('foo')
+  await vt.waitForRender()
+  vt.sendInput('\t')
+  await new Promise(resolve => setTimeout(resolve, 200))
+  const view = vt.getViewport().join('\n')
+  assert.ok(!view.includes('wanted.ts'), `foo<Tab> must not list files:\n${view}`)
+  assert.equal(app.seatTextForTest(), 'foo', 'the draft is untouched')
+  app.stop()
+})
+
+test('P1.2: scoped @ paths search their OWN directory (outside the cwd)', async () => {
+  const { root, workspace, sibling } = outsideCwdFixture()
+  const provider = new MentionProvider([], workspace, new DirectHostFilePort(() => undefined, null))
+  const result = await provider.getSuggestions(['@../sibling/sib'], 0, 15, { signal: abort })
+  assert.ok(result !== null, `@../sibling/sib must suggest:\n${JSON.stringify(result)}`)
+  assert.ok(
+    result.items.some(item => item.value === '@../sibling/sibling-file.ts'),
+    `scoped value missing:\n${JSON.stringify(result.items)}`,
+  )
+  void root
+})
+
+test('P1.2: @../../scope resolves outside the cwd by the typed amount', async () => {
+  const { root, workspace } = outsideCwdFixture()
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const query = resolvePathQuery('workspace/loc', root)
+  assert.equal(query.searchBase, join(root, 'workspace'))
+  const result = await provider.getSuggestions(['@workspace/loc'], 0, 15, { signal: abort })
+  assert.ok(result !== null, `@workspace/loc must suggest:\n${JSON.stringify(result)}`)
+  assert.ok(result.items.some(item => item.value === '@workspace/local.txt'))
+  void workspace
+})
+
+test('P1.2: @~/ resolves through the homedir', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-conv-home-'))
+  mkdirSync(join(home, 'pics'))
+  writeFileSync(join(home, 'pics', 'a.png'), 'x')
+  const saved = process.env.HOME
+  try {
+    process.env.HOME = home
+    const provider = new MentionProvider([], tmpdir(), new DirectHostFilePort(() => undefined, null))
+    const result = await provider.getSuggestions(['@~/pics/a'], 0, 10, { signal: abort })
+    assert.ok(result !== null, `@~/pics/a must suggest:\n${JSON.stringify(result)}`)
+    assert.ok(result.items.some(item => item.value === '@~/pics/a.png'))
+  } finally {
+    if (saved === undefined) delete process.env.HOME
+    else process.env.HOME = saved
+  }
+})
+
+test('P1.2 absolute: @/tmp/ searches the absolute scope', async () => {
+  const root = outsideCwdFixture().root
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const target = mkdtempSync(join(tmpdir(), 'dsh-conv-abs-'))
+  writeFileSync(join(target, 'deep-abs.txt'), 'x')
+  const result = await provider.getSuggestions([`@${target}/abs`], 0, `@${target}/abs`.length, { signal: abort })
+  assert.ok(result !== null, `absolute must suggest:\n${JSON.stringify(result)}`)
+  assert.ok(result.items.some(item => item.value.startsWith(`@${target}`)))
+})
+
+test('P1.3: a >2000-entry workspace keeps directory continuation working', async () => {
+  const { root } = largeWorkspaceFixture()
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  // First: @src finds the directory.
+  const dirs = await provider.getSuggestions(['@src'], 0, 4, { signal: abort })
+  assert.ok(dirs !== null, `@src must suggest:\n${JSON.stringify(dirs)}`)
+  assert.ok(dirs.items.some(item => item.value === '@src/'), 'the directory item must appear')
+  // Then: @src/ lists the children (the scoped listing never scans the
+  // whole tree — the bound applies only to the whole-tree fallback).
+  const children = await provider.getSuggestions(['@src/'], 0, 5, { signal: abort })
+  assert.ok(children !== null, `@src/ must list children:\n${JSON.stringify(children)}`)
+  assert.ok(children.items.some(item => item.value === '@src/wanted.ts'), 'the wanted child must appear')
+})
+
+test('P1.4: substring ranking is shared between @ and /image', async () => {
+  const root = outsideCwdFixture().workspace
+  mkdirSync(join(root, 'src'))
+  writeFileSync(join(root, 'src', 'deep-nested.ts'), 'x')
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const at = await provider.getSuggestions(['@nested'], 0, 7, { signal: abort })
+  assert.ok(at !== null, `@nested must suggest:\n${JSON.stringify(at)}`)
+  assert.ok(at.items.some(item => item.value === '@src/deep-nested.ts'), `nested missing:\n${JSON.stringify(at.items)}`)
+  // The engine is shared: verify the same ranking in the pure layer.
+  const scored = scorePathCandidate({ path: 'src/deep-nested.ts', kind: 'file' }, 'nested')
+  assert.equal(scored, 50, 'a basename substring scores 50')
+})
+
+test('P1.5: a stale prefix accept never deletes @-preceding text', () => {
+  const root = outsideCwdFixture().workspace
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  // Old request prefix `@abcdef`; the draft has since been edited to
+  // `hello @ab`. Accepting the old item must leave the draft UNCHANGED.
+  const applied = provider.applyCompletion(['hello @ab'], 0, 9, { value: '@abcdef-gh', label: 'abcdef-gh' }, '@abcdef')
+  assert.deepEqual(applied.lines, ['hello @ab'], 'a stale accept must not delete text')
+  // The image-argument shape: the same fence protects the argument path.
+  const appliedArg = provider.applyCompletion(
+    ['/image sub'],
+    0,
+    11,
+    { value: 'subdir/', label: 'subdir/' },
+    'subdir/',
+  )
+  assert.deepEqual(appliedArg.lines, ['/image sub'], 'a stale argument accept must not rewrite the draft')
+})
+
+test('P1.5 headless D: a quick Backspace over a mention leaves the draft intact', async () => {
+  const { startApp } = await import('./support/app-harness.ts')
+  const root = outsideCwdFixture().workspace
+  const { vt, app } = startApp(root)
+  await vt.waitForRender()
+  // Type a mention, then Backspace quickly — no crash, draft keeps the text.
+  vt.sendInput('@abcdef')
+  await vt.waitForRender()
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  vt.sendInput('\x7f')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '@ab', 'backspace edits the draft')
+  app.stop()
+})
+
+test('§23 matrix: the classifier gates @ and /image only', () => {
+  const set = new Set(['image'])
+  assert.equal(classifyFileCompletionContext('@foo', set).kind, 'mention')
+  assert.equal(classifyFileCompletionContext('text @foo', set).kind, 'mention')
+  assert.equal(classifyFileCompletionContext('看看@foo', set).kind, 'mention')
+  assert.equal(classifyFileCompletionContext('email@foo', set).kind, 'none')
+  assert.equal(classifyFileCompletionContext('pkg@1.0', set).kind, 'none')
+  assert.equal(classifyFileCompletionContext('/image foo', set).kind, 'image-argument')
+  assert.equal(classifyFileCompletionContext('/image    foo', set).kind, 'image-argument')
+  assert.equal(classifyFileCompletionContext('/im foo', set).kind, 'none')
+  assert.equal(classifyFileCompletionContext('/other foo', set).kind, 'none')
+  assert.equal(classifyFileCompletionContext('ordinary text', set).kind, 'none')
+  assert.equal(classifyFileCompletionContext('ordinary ./path', set).kind, 'none')
+})
+
+test('§23 matrix: quoted @ completes and stays quoted', async () => {
+  const { workspace } = outsideCwdFixture()
+  const root = workspace
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const result = await provider.getSuggestions(['@"loc'], 0, 5, { signal: abort })
+  assert.ok(result !== null)
+  assert.equal(result.prefix, '@"loc')
+  assert.ok(result.items.some(item => item.value === '@"local.txt"'))
+})
+
+test('§23 matrix: symlink directories keep the trailing slash', async () => {
+  const { workspace } = outsideCwdFixture()
+  const root = workspace
+  const link = join(root, 'linkdir')
+  const target = join(root, 'real')
+  mkdirSync(target)
+  writeFileSync(join(target, 'inside.ts'), 'x')
+  symlinkSync('real', link)
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const result = await provider.getSuggestions(['@lin'], 0, 4, { signal: abort })
+  assert.ok(result !== null)
+  assert.ok(result.items.some(item => item.value === '@linkdir/'), 'a symlinked dir must complete with /')
+})
+
+test('§22: fd/fdfind detection prefers fd then fdfind', () => {
+  const saved = process.env.PATH
+  try {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-conv-fd-'))
+    const fd = join(dir, 'fd')
+    const fdfind = join(dir, 'fdfind')
+    writeFileSync(fd, '#!/bin/sh\nexit 0\n')
+    writeFileSync(fdfind, '#!/bin/sh\nexit 0\n')
+    chmodSync(fd, 0o755)
+    chmodSync(fdfind, 0o755)
+    process.env.PATH = dir
+    assert.equal(resolveFdPath(), fd, 'fd wins over fdfind')
+    // Only fdfind present:
+    const only = mkdtempSync(join(tmpdir(), 'dsh-conv-fdfind-'))
+    const justFdfind = join(only, 'fdfind')
+    writeFileSync(justFdfind, '#!/bin/sh\nexit 0\n')
+    chmodSync(justFdfind, 0o755)
+    process.env.PATH = only
+    assert.equal(resolveFdPath(), justFdfind, 'fdfind is the Debian fallback')
+    // Neither:
+    process.env.PATH = '/nonexistent-dir'
+    assert.equal(resolveFdPath(), null)
+  } finally {
+    if (saved === undefined) delete process.env.PATH
+    else process.env.PATH = saved
+  }
+})
+
+test('§23 matrix: Windows drive and UNC tokens keep their dialect (pure)', () => {
+  const query = resolvePathQuery('C:\\Users\\sh', '/ws')
+  assert.equal(query.searchBase, win32.dirname('C:\\Users\\sh'))
+  assert.equal(query.displayBase, 'C:\\Users\\')
+  assert.equal(query.winAbsolute, true)
+  const unc = resolvePathQuery('\\\\server\\share\\fo', '/ws')
+  assert.equal(unc.searchBase, '\\\\server\\share\\')
+  assert.equal(unc.displayBase, '\\\\server\\share\\')
+  assert.equal(unc.winAbsolute, true)
+})
+
+test('the presentation layer quotes spaced values for /image and keeps @ quoting', () => {
+  const item = presentPathCandidate({ path: 'my file.txt', kind: 'file' }, { at: false, quoted: false })
+  assert.equal(item.value, '"my file.txt"')
+  const atItem = presentPathCandidate({ path: 'my file.txt', kind: 'file' }, { at: true, quoted: false })
+  assert.equal(atItem.value, '@"my file.txt"')
+  const atQuoted = presentPathCandidate({ path: 'my file.txt', kind: 'file' }, { at: true, quoted: true })
+  assert.equal(atQuoted.value, '@"my file.txt"')
+})
+
+test('extractAtPrefix keeps the CJK-glue rule and rejects emails', () => {
+  assert.equal(extractAtPrefix('看看@foo'), '@foo')
+  assert.equal(extractAtPrefix('a@b.c'), null)
+  assert.equal(extractAtPrefix('plain'), null)
+})
+
+test('a sessionless @dir/ lists children (direct children listing)', async () => {
+  const { root } = largeWorkspaceFixture()
+  const port = new DirectHostFilePort(() => undefined, null)
+  const provider = new MentionProvider([], root, port)
+  // No live agent: workspace scope (sessionless).
+  const result = await provider.getSuggestions(['@src/'], 0, 5, { signal: abort })
+  assert.ok(result !== null, `@src/ must list children sessionless:\n${JSON.stringify(result)}`)
+  assert.ok(result.items.some(item => item.value === '@src/wanted.ts'))
+})
+
+// ── §24 headless integration: TuiApp + TuiEditor + MentionProvider ─────────
+
+test('§24 A: @src → dropdown → Tab → @src/ → children dropdown', async () => {
+  const { startApp, startImageApp } = await import('./support/app-harness.ts')
+  const root = largeWorkspaceFixture().root
+  const { vt, app } = startApp(root)
+  await vt.waitForRender()
+  vt.sendInput('@src')
+  await new Promise(resolve => setTimeout(resolve, 120))
+  assert.ok(vt.getViewport().join('\n').includes('src/'), 'the src directory item must appear')
+  vt.sendInput('\t')
+  await new Promise(resolve => setTimeout(resolve, 120))
+  assert.equal(app.seatTextForTest(), '@src/', 'Tab accepts the directory')
+  await new Promise(resolve => setTimeout(resolve, 120))
+  assert.ok(vt.getViewport().join('\n').includes('wanted.ts'), 'children must appear after accept')
+  app.stop()
+})
+
+test('§24 B: /image src → dropdown → Tab → /image src/ → children dropdown', async () => {
+  const { startImageApp } = await import('./support/app-harness.ts')
+  const root = largeWorkspaceFixture().root
+  const { vt, app } = startImageApp(root)
+  await vt.waitForRender()
+  vt.sendInput('/image src')
+  await new Promise(resolve => setTimeout(resolve, 120))
+  assert.ok(vt.getViewport().join('\n').includes('src/'), 'the src argument candidate must appear')
+  vt.sendInput('\t')
+  await new Promise(resolve => setTimeout(resolve, 120))
+  assert.equal(app.seatTextForTest(), '/image src/', 'Tab accepts the directory')
+  await new Promise(resolve => setTimeout(resolve, 120))
+  assert.ok(vt.getViewport().join('\n').includes('wanted.ts'), 'children must appear after accept')
+  app.stop()
+})
+
+test('§24 C: hello ./src<Tab> opens no dropdown', async () => {
+  const { startApp } = await import('./support/app-harness.ts')
+  const root = largeWorkspaceFixture().root
+  const { vt, app } = startApp(root)
+  await vt.waitForRender()
+  vt.sendInput('hello ./src')
+  await vt.waitForRender()
+  vt.sendInput('\t')
+  await new Promise(resolve => setTimeout(resolve, 200))
+  const view = vt.getViewport().join('\n')
+  assert.ok(!view.includes('wanted.ts'), `hello ./src<Tab> must not list files:\n${view}`)
+  assert.equal(app.seatTextForTest(), 'hello ./src', 'the draft is untouched')
+  app.stop()
+})
+
+test('§24 E: sessionless @dir/ lists children through the app chain', async () => {
+  const { startApp } = await import('./support/app-harness.ts')
+  const root = largeWorkspaceFixture().root
+  const { vt, app } = startApp(root)
+  await vt.waitForRender()
+  // No session was ever created: the workspace scope answers.
+  vt.sendInput('@src/')
+  await new Promise(resolve => setTimeout(resolve, 120))
+  assert.ok(vt.getViewport().join('\n').includes('wanted.ts'), 'sessionless children must appear')
+  app.stop()
+})

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -353,6 +353,22 @@ test('review finding (round 4): a regex-special filename still completes (fd lit
   assert.ok(plus !== null && plus.items.some(item => item.value.includes('a+b.ts')), `plus missing:\n${JSON.stringify(plus)}`)
 })
 
+test('review finding (round 5): fd matches case-insensitively (aligned with the ranking contract)', async () => {
+  const root = outsideCwdFixture().workspace
+  writeFileSync(join(root, 'Foo.txt'), 'x')
+  writeFileSync(join(root, 'foo.txt'), 'x')
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  // The fd-backed path (this machine has fdfind) must find BOTH — the
+  // shared ranking is case-insensitive and fd's smart-case default (case-
+  // SENSITIVE for an uppercase query) would miss foo.txt.
+  const upper = await provider.getSuggestions(['@FOO'], 0, 4, { signal: abort })
+  assert.ok(upper !== null, `@FOO must suggest:\n${JSON.stringify(upper)}`)
+  assert.ok(
+    upper.items.some(item => item.value === '@Foo.txt') && upper.items.some(item => item.value === '@foo.txt'),
+    `both case forms must match:\n${JSON.stringify(upper.items)}`,
+  )
+})
+
 test('review finding (round 4): failed fd falls back to the bounded scan', async () => {
   const { workspace, sibling } = outsideCwdFixture()
   const root = workspace

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -12,7 +12,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { chmodSync, mkdirSync, mkdtempSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join, win32, sep } from 'node:path'
 import { classifyFileCompletionContext, extractAtPrefix } from '../src/file-completion/context.ts'
@@ -215,6 +215,27 @@ test('§23 matrix: /image shares the scoped forms (../, ~/, absolute, directory 
   }
 })
 
+test('Host @ and Client /image completion keep separate cwd ownership', async () => {
+  const hostRoot = mkdtempSync(join(tmpdir(), 'dsh-conv-host-cwd-'))
+  const localRoot = mkdtempSync(join(tmpdir(), 'dsh-conv-local-cwd-'))
+  writeFileSync(join(hostRoot, 'host-only.txt'), 'x')
+  writeFileSync(join(localRoot, 'local-only.png'), 'x')
+  const provider = new MentionProvider(
+    [],
+    hostRoot,
+    new DirectHostFilePort(() => undefined, null),
+    undefined,
+    { kind: 'workspace', cwd: hostRoot },
+    null,
+    localRoot,
+  )
+  const mention = await provider.getSuggestions(['@host-only'], 0, 10, { signal: abort })
+  assert.ok(mention !== null && mention.items.some(item => item.value === '@host-only.txt'))
+  const image = await provider.getSuggestions(['/image local-only'], 0, '/image local-only'.length, { signal: abort })
+  assert.ok(image !== null && image.items.some(item => item.value === 'local-only.png'))
+  assert.ok(!image.items.some(item => item.value.includes('host-only')), 'image completion must not read Host cwd')
+})
+
 test('P1.3: a >2000-entry workspace keeps directory continuation working', async () => {
   const { root } = largeWorkspaceFixture()
   const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
@@ -240,6 +261,17 @@ test('P1.4: substring ranking is shared between @ and /image', async () => {
   // The engine is shared: verify the same ranking in the pure layer.
   const scored = scorePathCandidate({ path: 'src/deep-nested.ts', kind: 'file' }, 'nested')
   assert.equal(scored, 50, 'a basename substring scores 50')
+  const imageProvider = new MentionProvider(
+    [],
+    root,
+    new DirectHostFilePort(() => undefined, null),
+    undefined,
+    undefined,
+    null,
+  )
+  const image = await imageProvider.getSuggestions(['/image nested'], 0, 13, { signal: abort })
+  assert.ok(image !== null && image.items.some(item => item.value === 'src/deep-nested.ts'),
+    `/image nested must share subtree fuzzy discovery:\n${JSON.stringify(image)}`)
 })
 
 test('P1.5: a stale prefix accept never deletes @-preceding text', () => {
@@ -347,6 +379,45 @@ test('§22: fd/fdfind detection prefers fd then fdfind', () => {
   }
 })
 
+test('fd discovery uses full-path matching, NUL records and preserves filename whitespace', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-conv-fd-output-'))
+  mkdirSync(join(root, 'src'))
+  writeFileSync(join(root, 'src', 'deep-nested.png'), 'x')
+  writeFileSync(join(root, ' leading file.txt'), 'x')
+  const argsFile = join(root, 'fd-args.txt')
+  const fakeFd = join(root, 'fd')
+  writeFileSync(fakeFd, `#!/bin/sh
+printf '%s\\n' "$@" > ${JSON.stringify(argsFile)}
+printf '%s\\0' './src/deep-nested.png' './ leading file.txt'
+`)
+  chmodSync(fakeFd, 0o755)
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, fakeFd))
+  const nested = await provider.getSuggestions(['@nested'], 0, 7, { signal: abort })
+  assert.ok(nested !== null, `full-path fd matching must find nested files:\n${JSON.stringify(nested)}`)
+  assert.ok(nested.items.some(item => item.value === '@src/deep-nested.png'))
+  const spaced = await provider.getSuggestions(['@leading'], 0, 8, { signal: abort })
+  assert.ok(spaced !== null, `NUL output with spaces must survive:\n${JSON.stringify(spaced)}`)
+  assert.ok(spaced.items.some(item => item.value === '@" leading file.txt"'))
+  const args = readFileSync(argsFile, 'utf8').split(/\r?\n/)
+  assert.ok(args.includes('--full-path'), 'fd must match the full relative path')
+  assert.ok(args.includes('--print0'), 'fd must emit NUL-delimited records')
+})
+
+test('fd discovery ignores noisy stderr and settles without a pipe deadlock', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-conv-fd-stderr-'))
+  writeFileSync(join(root, 'visible.txt'), 'x')
+  const fakeFd = join(root, 'fd')
+  writeFileSync(fakeFd, `#!/bin/sh
+dd if=/dev/zero bs=1024 count=128 >&2 2>/dev/null
+printf '%s\\0' './visible.txt'
+`)
+  chmodSync(fakeFd, 0o755)
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, fakeFd))
+  const result = await provider.getSuggestions(['@visible'], 0, 8, { signal: abort })
+  assert.ok(result !== null, `noisy fd stderr must not block completion:\n${JSON.stringify(result)}`)
+  assert.ok(result.items.some(item => item.value === '@visible.txt'))
+})
+
 test('§23 matrix: Windows drive and UNC tokens keep their dialect (pure)', () => {
   const query = resolvePathQuery('C:\\Users\\sh', '/ws')
   assert.equal(query.searchBase, win32.dirname('C:\\Users\\sh'))
@@ -356,6 +427,24 @@ test('§23 matrix: Windows drive and UNC tokens keep their dialect (pure)', () =
   assert.equal(unc.searchBase, '\\\\server\\share\\')
   assert.equal(unc.displayBase, '\\\\server\\share\\')
   assert.equal(unc.winAbsolute, true)
+})
+
+test('Windows candidates rank and present basename labels independently of host path dialect', () => {
+  assert.equal(scorePathCandidate({ path: 'C:\\Users\\Foo.txt', kind: 'file' }, 'foo.txt'), 100)
+  assert.equal(scorePathCandidate({ path: 'C:\\Users\\deep\\Foo.txt', kind: 'file' }, 'foo.txt'), 100)
+  const directory = presentPathCandidate(
+    { path: 'C:\\Users\\Pictures', kind: 'directory' },
+    { at: false, quoted: false, sep: '\\' },
+  )
+  assert.equal(directory.value, 'C:\\Users\\Pictures\\')
+  assert.equal(directory.label, 'Pictures/')
+  assert.equal(directory.description, 'C:\\Users\\Pictures')
+  const mixed = presentPathCandidate(
+    { path: 'C:/Users\\Pictures', kind: 'directory' },
+    { at: true, quoted: false, sep: '\\' },
+  )
+  assert.equal(mixed.value, '@C:/Users\\Pictures\\')
+  assert.equal(mixed.label, 'Pictures/')
 })
 
 test('the presentation layer quotes spaced values for /image and keeps @ quoting', () => {
@@ -543,6 +632,22 @@ test('review finding 2: a stale accept never applies after an unrelated edit', a
   // The editor state changed on an unrelated part: `see` → `look`.
   const applied = provider.applyCompletion(['look @local'], 0, 12, { value: '@local.txt', label: 'local.txt' }, '@local')
   assert.deepEqual(applied.lines, ['look @local'], 'an unrelated edit must also fence the accept')
+})
+
+test('extension suggestion snapshots fence unrelated edits even with the same prefix', () => {
+  const root = outsideCwdFixture().workspace
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  const generation = provider.mintRequestGeneration()
+  const suggestion = { items: [{ value: 'world', label: 'world' }], prefix: 'world' }
+  provider.captureRequestSnapshot(generation, { kind: 'workspace', cwd: root }, ['hello world'], 0, 11, suggestion)
+  const applied = provider.applyCompletion(
+    ['changed world'],
+    0,
+    13,
+    suggestion.items[0]!,
+    suggestion.prefix,
+  )
+  assert.deepEqual(applied.lines, ['changed world'], 'an extension result must not apply after an unrelated edit')
 })
 
 test('review finding (round 8): a fallback scan is async and abort-responsive (never a sync block)', async () => {

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -321,6 +321,28 @@ test('review finding 1: a quoted /image argument completes inside the quotes', a
     result.items.some(item => item.value === '"my file.txt"'),
     `the quoted value must keep its quotes:\n${JSON.stringify(result.items)}`,
   )
+  // Round-2: spaces INSIDE the quotes are part of the token.
+  const spaced = await provider.getSuggestions(['/image "my f'], 0, 12, { signal: abort })
+  assert.ok(spaced !== null, `/image "my f must suggest:\n${JSON.stringify(spaced)}`)
+  assert.ok(spaced.items.some(item => item.value === '"my file.txt"'), `spaced quoted value missing:\n${JSON.stringify(spaced.items)}`)
+})
+
+test('review finding 2: a stale accept never applies after an unrelated edit', async () => {
+  const root = outsideCwdFixture().workspace
+  const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))
+  // The request produced a dropdown for `hello @foo` (snapshot captured);
+  // the user then edited the LINE START (`hello` → `world`) — the prefix
+  // @foo is intact but the document differs. The full-snapshot fence must
+  // reject the accept: the editor passes the CURRENT document to apply.
+  const request = await provider.getSuggestions(['hello @foo'], 0, 10, { signal: abort })
+  assert.equal(request, null, 'no @foo file exists in the fixture — the snapshot stays null for the empty result')
+  // Force a snapshot the way the editor does: a non-null result binds the
+  // state. Use an existing file so the suggestion list is non-null.
+  const bound = await provider.getSuggestions(['see @local'], 0, 11, { signal: abort })
+  assert.ok(bound !== null, 'the fixture file must produce a dropdown')
+  // The editor state changed on an unrelated part: `see` → `look`.
+  const applied = provider.applyCompletion(['look @local'], 0, 12, { value: '@local.txt', label: 'local.txt' }, '@local')
+  assert.deepEqual(applied.lines, ['look @local'], 'an unrelated edit must also fence the accept')
 })
 
 test('review finding 2: a Windows-dialect directory keeps the backslash separator', () => {
@@ -386,9 +408,15 @@ test('§24 C: hello ./src<Tab> opens no dropdown', async () => {
   vt.sendInput('hello ./src')
   await vt.waitForRender()
   vt.sendInput('\t')
-  await pollUntil(() => !isAutocompleteActive(app), 'hello ./src<Tab> must keep the dropdown closed')
-  await new Promise(resolve => setTimeout(resolve, 60))
-  assert.equal(isAutocompleteActive(app), false, 'hello ./src<Tab> must not open a dropdown')
+  // Poll the dropdown CLOSED state over the editor's whole debounce
+  // window (no fixed sleep): the state must stay closed the entire time —
+  // a late async request cannot slip a dropdown in unnoticed.
+  const deadline = Date.now() + 400
+  for (;;) {
+    assert.equal(isAutocompleteActive(app), false, 'hello ./src<Tab> must never open a dropdown')
+    if (Date.now() > deadline) break
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
   const view = vt.getViewport().join('\n')
   assert.ok(!view.includes('wanted.ts'), `hello ./src<Tab> must not list files:\n${view}`)
   assert.equal(app.seatTextForTest(), 'hello ./src', 'the draft is untouched')

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -327,6 +327,59 @@ test('review finding 1: a quoted /image argument completes inside the quotes', a
   assert.ok(spaced.items.some(item => item.value === '"my file.txt"'), `spaced quoted value missing:\n${JSON.stringify(spaced.items)}`)
 })
 
+test('review finding 3: an indented /image command still classifies its argument', async () => {
+  const { workspace } = outsideCwdFixture()
+  const root = workspace
+  writeFileSync(join(root, 'file-one.txt'), 'x')
+  const provider = new MentionProvider(
+    [{ name: 'image', description: 'Attach', getArgumentCompletions: () => null }],
+    root,
+    new DirectHostFilePort(() => undefined, null),
+  )
+  const result = await provider.getSuggestions(['  /image file'], 0, 14, { signal: abort })
+  assert.ok(result !== null, `an indented /image must complete its argument:\n${JSON.stringify(result)}`)
+  assert.ok(result.items.some(item => item.value === 'file-one.txt'), `indented value missing:\n${JSON.stringify(result.items)}`)
+})
+
+test('review finding (verified): multi-space /image separator applies without duplication', async () => {
+  const { workspace } = outsideCwdFixture()
+  const root = workspace
+  writeFileSync(join(root, 'file-one.txt'), 'x')
+  const provider = new MentionProvider(
+    [{ name: 'image', description: 'Attach', getArgumentCompletions: () => null }],
+    root,
+    new DirectHostFilePort(() => undefined, null),
+  )
+  // imageArgumentOf slices AFTER the first separator; completeImageArgument
+  // re-prefixes the value with the REMAINING separator whitespace. The
+  // fork's apply consumes the first separator in beforePrefix, so the
+  // total separator count is preserved — never duplicated.
+  const line = '/image    file'
+  const result = await provider.getSuggestions([line], 0, line.length, { signal: abort })
+  assert.ok(result !== null)
+  assert.equal(result.prefix, '   file', 'the classifier slice matches the fork slice (after the first space)')
+  const applied = provider.applyCompletion([line], 0, line.length, result.items[0]!, result.prefix)
+  assert.equal(applied.lines[0], '/image    file-one.txt', 'the separator count is preserved')
+})
+
+test('review finding: a CLOSED quoted /image token never completes further (no trailing-text deletion)', async () => {
+  const { workspace } = outsideCwdFixture()
+  const root = workspace
+  writeFileSync(join(root, 'my file.txt'), 'x')
+  const provider = new MentionProvider(
+    [{ name: 'image', description: 'Attach', getArgumentCompletions: () => null }],
+    root,
+    new DirectHostFilePort(() => undefined, null),
+  )
+  // A closed quote with trailing text: completing would replace the whole
+  // argument range and DELETE the trailing text — stay quiet.
+  const closed = await provider.getSuggestions(['/image "my"foo'], 0, 15, { signal: abort })
+  assert.equal(closed, null, 'a closed quoted token with trailing text must stay quiet')
+  // A closed quote alone (no trailing text): also quiet — the token is done.
+  const bare = await provider.getSuggestions(['/image "my"'], 0, 11, { signal: abort })
+  assert.equal(bare, null, 'a closed quoted token must stay quiet')
+})
+
 test('review finding 2: a stale accept never applies after an unrelated edit', async () => {
   const root = outsideCwdFixture().workspace
   const provider = new MentionProvider([], root, new DirectHostFilePort(() => undefined, null))

--- a/test/host-file-port.test.ts
+++ b/test/host-file-port.test.ts
@@ -209,14 +209,16 @@ test('an abort mid-fd-query fails closed (the port re-checks AFTER the await)', 
   assert.deepEqual(await pending, [], 'a cancelled fd query must never serve a late result')
 })
 
-test('a failing fd yields NO candidates (fail closed, pre-migration parity)', async () => {
+test('a failing fd falls back to the bounded scan (plan §6.2 fd-first-fallback)', async () => {
   const root = fixtureWorkspace()
-  // Non-zero exit: real fd would have failed (e.g. a broken query); the
-  // adapter returns empty rather than partial or wrong data.
+  // Non-zero exit: fd failed (a broken invocation). The plan's §6.2
+  // contract is fd-FIRST, BOUNDED-FALLBACK — a failure is NOT a valid
+  // empty result, so the recursive scan answers.
   const port = new DirectHostFilePort(() => undefined, fakeFd('exit 3'))
-  assert.deepEqual(
-    await port.listReferences({ kind: 'workspace', cwd: root } as const, '@file'),
-    [],
-    'a failed fd spawn must not fabricate candidates',
+  const candidates = await port.listReferences({ kind: 'workspace', cwd: root } as const, '@file')
+  assert.ok(candidates.length > 0, 'a failed fd must fall back to the bounded scan')
+  assert.ok(
+    candidates.some(candidate => candidate.path.includes('file-one.txt')),
+    `the fallback must find the fixture file:\n${JSON.stringify(candidates)}`,
   )
 })

--- a/test/mentions.test.ts
+++ b/test/mentions.test.ts
@@ -335,7 +335,7 @@ test('the provider completes /image arguments through the fork command branch', 
   assert.ok(result.items.some(item => item.value === 'file-one.txt'), `file missing:\n${JSON.stringify(result.items)}`)
 })
 
-test('MentionProvider lets Tab file-complete a trailing-space PATH argument only', () => {
+test('the provider lets Tab file-complete an explicit PATH argument only (plan §2.1)', () => {
   const root = fixtureWorkspace()
   const provider = new MentionProvider(
     [
@@ -346,13 +346,29 @@ test('MentionProvider lets Tab file-complete a trailing-space PATH argument only
     fallbackSeam(),
   )
   assert.equal(provider.shouldTriggerFileCompletion(['/image'], 0, 6), false, 'a bare command name stays command completion')
-  assert.equal(provider.shouldTriggerFileCompletion(['/image '], 0, 7), true, 'a trailing-space PATH argument is a file-completion site (the fork trims it away)')
-  assert.equal(provider.shouldTriggerFileCompletion(['/image\t'], 0, 7), true, 'a trailing-TAB PATH argument is a file-completion site too (tab is a fork path delimiter)')
+  assert.equal(provider.shouldTriggerFileCompletion(['/image '], 0, 7), true, 'a trailing-space PATH argument is a file-completion site')
+  assert.equal(provider.shouldTriggerFileCompletion(['/image\t'], 0, 7), true, 'a trailing-TAB PATH argument is a file-completion site too')
   assert.equal(provider.shouldTriggerFileCompletion(['/image\tfo'], 0, 9), true, 'a TAB-separated PATH argument completes files')
-  assert.equal(provider.shouldTriggerFileCompletion(['/help '], 0, 6), false, 'a NON-path command keeps the fork judgment (a trailing space never lists files)')
-  assert.equal(provider.shouldTriggerFileCompletion(['/help\t'], 0, 6), false, 'a NON-path command keeps the fork judgment for a trailing TAB too')
-  assert.equal(provider.shouldTriggerFileCompletion(['/help foo'], 0, 9), true, 'non-path commands keep the fork behavior for real arguments')
-  assert.equal(provider.shouldTriggerFileCompletion(['see /tmp/'], 0, 9), true, 'plain path lines keep the fork behavior')
+  assert.equal(provider.shouldTriggerFileCompletion(['/help '], 0, 6), true, 'a non-file command still runs the request (the extension chain is consulted — only the HOST file branch is closed)')
+  assert.equal(provider.shouldTriggerFileCompletion(['/help\t'], 0, 6), true, 'a NON-file command keeps the request for a trailing TAB too')
+  assert.equal(provider.shouldTriggerFileCompletion(['/help foo'], 0, 9), true, 'a NON-file command argument still runs the request')
+  assert.equal(provider.shouldTriggerFileCompletion(['see /tmp/'], 0, 9), true, 'a plain path line still runs the request')
+  assert.equal(provider.shouldTriggerFileCompletion(['foo'], 0, 3), true, 'an ordinary word still runs the request')
+  assert.equal(provider.shouldTriggerFileCompletion(['./foo'], 0, 5), true, 'a `./` path still runs the request')
+  // THE PROOF (plan §2.1): the HOST's own file branch stays closed for
+  // every ordinary position — a forced request never produces a host file
+  // dropdown there.
+  const probe = new MentionProvider([{ name: 'image', description: 'Attach', getArgumentCompletions: () => null }], root, fallbackSeam())
+  return Promise.all([
+    probe.getSuggestions(['/help foo'], 0, 9, { signal: abort, force: true }),
+    probe.getSuggestions(['see /tmp/'], 0, 9, { signal: abort, force: true }),
+    probe.getSuggestions(['foo'], 0, 3, { signal: abort, force: true }),
+    probe.getSuggestions(['./foo'], 0, 5, { signal: abort, force: true }),
+  ]).then((results) => {
+    for (const result of results) {
+      assert.equal(result, null, 'an ordinary position must never open the HOST file dropdown')
+    }
+  })
 })
 
 // ── send-time mention canonicalization (the 2026-08-22 plan, item 7) ─────

--- a/test/mentions.test.ts
+++ b/test/mentions.test.ts
@@ -80,6 +80,27 @@ test('resolveFdPath finds an executable fd on PATH and returns null otherwise', 
   }
 })
 
+test('resolveFdPath honors PATHEXT-style executable suffixes', () => {
+  const savedPath = process.env.PATH
+  const savedPathExt = process.env.PATHEXT
+  try {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-fd-ext-'))
+    const fd = join(dir, 'fd.exe')
+    writeFileSync(fd, '#!/bin/sh\nexit 0\n')
+    chmodSync(fd, 0o755)
+    process.env.PATH = dir
+    process.env.PATHEXT = '.EXE'
+    const resolved = resolveFdPath()
+    assert.ok(resolved !== null, 'the suffixed fd binary must resolve')
+    assert.equal(resolved?.toLowerCase(), fd.toLowerCase())
+  } finally {
+    if (savedPath === undefined) delete process.env.PATH
+    else process.env.PATH = savedPath
+    if (savedPathExt === undefined) delete process.env.PATHEXT
+    else process.env.PATHEXT = savedPathExt
+  }
+})
+
 test('the fallback completes @ mentions from anywhere in the tree', async () => {
   const root = fixtureWorkspace()
   const provider = new MentionProvider([], root, fallbackSeam())

--- a/test/mentions.test.ts
+++ b/test/mentions.test.ts
@@ -9,7 +9,7 @@ import test from 'node:test'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
-import { expandFileMentionsForSubmit, extractAtPrefix, findFileMentions, MentionProvider, resolvePathSearch, suggestPathArgument } from '../src/mentions.ts'
+import { expandFileMentionsForSubmit, extractAtPrefix, findFileMentions, MentionProvider, resolveMentionCandidate, resolvePathSearch, suggestPathArgument } from '../src/mentions.ts'
 import { DirectHostFilePort, resolveFdPath } from '../src/runtime/direct/host-file-direct.ts'
 
 /** A throwaway workspace with known files. */
@@ -130,6 +130,20 @@ test('the fallback quotes mention values that contain spaces', async () => {
   assert.ok(result.items.some(item => item.value === '@"my file.txt"'), `spaced value must be quoted:\n${JSON.stringify(result.items)}`)
 })
 
+test('the provider delegates indented slash-command completion without losing indentation', async () => {
+  const root = fixtureWorkspace()
+  const provider = new MentionProvider(
+    [{ name: 'exit', description: 'Quit' }, { name: 'settings', description: 'Panel' }],
+    root,
+    fallbackSeam(),
+  )
+  const result = await provider.getSuggestions(['  /ex'], 0, 5, { signal: abort })
+  assert.ok(result !== null, `indented /ex must suggest:\n${JSON.stringify(result)}`)
+  assert.ok(result.items.some(item => item.value === 'exit'), `the exit command missing:\n${JSON.stringify(result.items)}`)
+  const applied = provider.applyCompletion(['  /ex'], 0, 5, result.items[0]!, result.prefix)
+  assert.equal(applied.lines[0], '  /exit ', 'the command apply must preserve indentation')
+})
+
 test('the provider delegates slash-command completion to the inner provider', async () => {
   const root = fixtureWorkspace()
   const provider = new MentionProvider(
@@ -176,33 +190,33 @@ test('a late port result is dropped when the request was aborted; a port rejecti
   )
 })
 
-test('suggestPathArgument completes a bare prefix in the cwd', () => {
+test('suggestPathArgument completes a bare prefix in the cwd', async () => {
   const root = fixtureWorkspace()
-  const items = suggestPathArgument('fi', root)
+  const items = await suggestPathArgument('fi', root)
   assert.ok(items !== null, `'fi' must suggest:\n${JSON.stringify(items)}`)
   assert.ok(items.some(item => item.value === 'file-one.txt'), `file-one missing:\n${JSON.stringify(items)}`)
   assert.ok(items.some(item => item.value === 'file-two.ts'), `file-two missing:\n${JSON.stringify(items)}`)
   // Directories sort FIRST and keep the trailing slash so Tab continues.
-  const dirs = suggestPathArgument('s', root)
+  const dirs = await suggestPathArgument('s', root)
   assert.ok(dirs !== null, `'s' must suggest:\n${JSON.stringify(dirs)}`)
   assert.equal(dirs[0]!.value, 'src/', 'directories lead the list')
   assert.equal(dirs[0]!.label, 'src/')
 })
 
-test('suggestPathArgument completes directory continuations', () => {
+test('suggestPathArgument completes directory continuations', async () => {
   const root = fixtureWorkspace()
-  const contents = suggestPathArgument('src/', root)
+  const contents = await suggestPathArgument('src/', root)
   assert.ok(contents !== null, `'src/' must suggest:\n${JSON.stringify(contents)}`)
   assert.ok(contents.some(item => item.value === 'src/deep-nested.ts'), `nested file missing:\n${JSON.stringify(contents)}`)
   // A partial basename inside a directory keeps the directory prefix.
-  const partial = suggestPathArgument('src/deep', root)
+  const partial = await suggestPathArgument('src/deep', root)
   assert.ok(partial !== null, `'src/deep' must suggest:\n${JSON.stringify(partial)}`)
   assert.ok(partial.some(item => item.value === 'src/deep-nested.ts'), `prefixed value missing:\n${JSON.stringify(partial)}`)
 })
 
-test('suggestPathArgument handles absolute and ~ forms', () => {
+test('suggestPathArgument handles absolute and ~ forms', async () => {
   const root = fixtureWorkspace()
-  const absolute = suggestPathArgument(`${root}/file`, root)
+  const absolute = await suggestPathArgument(`${root}/file`, root)
   assert.ok(absolute !== null, `absolute must suggest:\n${JSON.stringify(absolute)}`)
   assert.ok(absolute.some(item => item.value === `${root}/file-one.txt`), `absolute value missing:\n${JSON.stringify(absolute)}`)
   const home = mkdtempSync(join(tmpdir(), 'dsh-mentions-home-'))
@@ -211,7 +225,7 @@ test('suggestPathArgument handles absolute and ~ forms', () => {
     process.env.HOME = home
     mkdirSync(join(home, 'pics'))
     writeFileSync(join(home, 'pics', 'a.png'), 'x')
-    const tilde = suggestPathArgument('~/p', root)
+    const tilde = await suggestPathArgument('~/p', root)
     assert.ok(tilde !== null, `'~/p' must suggest:\n${JSON.stringify(tilde)}`)
     assert.ok(tilde.some(item => item.value === '~/pics/'), `tilde value missing:\n${JSON.stringify(tilde)}`)
   } finally {
@@ -220,21 +234,21 @@ test('suggestPathArgument handles absolute and ~ forms', () => {
   }
 })
 
-test('suggestPathArgument tolerates leading separator whitespace (multi-space / tab-expanded)', () => {
+test('suggestPathArgument tolerates leading separator whitespace (multi-space / tab-expanded)', async () => {
   const root = fixtureWorkspace()
   // The fork's argument branch passes everything after the FIRST space, so
   // a multi-space separator yields leading whitespace in the argument; the
   // completed VALUE keeps it so the fork's apply never glues the path to
   // the command.
-  const multi = suggestPathArgument('  fi', root)
+  const multi = await suggestPathArgument('  fi', root)
   assert.ok(multi !== null, `'  fi' must suggest:\n${JSON.stringify(multi)}`)
   assert.ok(multi.some(item => item.value === '  file-one.txt'), `leading whitespace must survive in the value:\n${JSON.stringify(multi)}`)
   // A tab-expanded directory continuation (tabs normalize to four spaces).
-  const dir = suggestPathArgument('    src/', root)
+  const dir = await suggestPathArgument('    src/', root)
   assert.ok(dir !== null, `'    src/' must suggest:\n${JSON.stringify(dir)}`)
   assert.ok(dir.some(item => item.value === '    src/deep-nested.ts'), `padded continuation missing:\n${JSON.stringify(dir)}`)
   // Pure separator (no token) stays quiet.
-  assert.equal(suggestPathArgument('   ', root), null, 'separator-only arguments complete nothing')
+  assert.equal(await suggestPathArgument('   ', root), null, 'separator-only arguments complete nothing')
 })
 
 test('POSIX and Windows ROOT partials keep their separator as the search dir', () => {
@@ -255,15 +269,15 @@ test('POSIX and Windows ROOT partials keep their separator as the search dir', (
   assert.deepEqual(resolvePathSearch('sub/fi', '/ws', 'sub/fi'), { searchDir: join('/ws', 'sub'), searchPrefix: 'fi', winAbsolute: false })
 })
 
-test('a POSIX root partial completes from `/` (fs level, when /tmp exists)', () => {
+test('a POSIX root partial completes from `/` (fs level, when /tmp exists)', async () => {
   if (!existsSync('/tmp')) return // the machine has no /tmp to complete
   const root = fixtureWorkspace()
-  const items = suggestPathArgument('/tm', root)
+  const items = await suggestPathArgument('/tm', root)
   assert.ok(items !== null && items.length > 0, `'/tm' must list root entries:\n${JSON.stringify(items)}`)
   assert.ok(items.some(item => item.value.startsWith('/tmp')), `the root completion stays absolute:\n${JSON.stringify(items)}`)
 })
 
-test('suggestPathArgument treats Windows drive and UNC tokens as absolute', () => {
+test('suggestPathArgument treats Windows drive and UNC tokens as absolute', async () => {
   const root = fixtureWorkspace()
   const savedCwd = process.cwd()
   try {
@@ -280,10 +294,10 @@ test('suggestPathArgument treats Windows drive and UNC tokens as absolute', () =
     // must not be stripped into a different path.
     mkdirSync(join(root, '\\\\server\\share\\'))
     writeFileSync(join(root, '\\\\server\\share\\', 'foo.png'), 'x')
-    const drive = suggestPathArgument('C:\\Users\\sh', root)
+    const drive = await suggestPathArgument('C:\\Users\\sh', root)
     assert.ok(drive !== null, `a drive token must complete:\\n${JSON.stringify(drive)}`)
     assert.ok(drive.some(item => item.value === 'C:\\Users\\shot.png'), `drive value keeps the backslash dialect:\\n${JSON.stringify(drive)}`)
-    const unc = suggestPathArgument('\\\\server\\share\\fo', root)
+    const unc = await suggestPathArgument('\\\\server\\share\\fo', root)
     assert.ok(unc !== null, `a UNC token must complete:\\n${JSON.stringify(unc)}`)
     assert.ok(unc.some(item => item.value === '\\\\server\\share\\foo.png'), `UNC value keeps the share form:\\n${JSON.stringify(unc)}`)
   } finally {
@@ -291,7 +305,7 @@ test('suggestPathArgument treats Windows drive and UNC tokens as absolute', () =
   }
 })
 
-test('a drive ROOT keeps `C:\\` — never degrades to the drive-relative `C:`', () => {
+test('a drive ROOT keeps `C:\\` — never degrades to the drive-relative `C:`', async () => {
   // `C:\` is the drive root; `C:` is the drive-relative current directory
   // — different directories on Windows. win32.dirname('C:\\Wi') returns
   // `C:\\`, and the search target must stay `C:\\` (the earlier
@@ -304,7 +318,7 @@ test('a drive ROOT keeps `C:\\` — never degrades to the drive-relative `C:`', 
     // A POSIX dir literally named `C:\` stands in for the drive root.
     mkdirSync(join(root, 'C:\\'))
     writeFileSync(join(root, 'C:\\', 'Win.exe'), 'x')
-    const items = suggestPathArgument('C:\\Wi', root)
+    const items = await suggestPathArgument('C:\\Wi', root)
     assert.ok(items !== null, `the drive root must complete:\\n${JSON.stringify(items)}`)
     assert.ok(items.some(item => item.value === 'C:\\Win.exe'), `drive-root value stays rooted:\\n${JSON.stringify(items)}`)
   } finally {
@@ -312,14 +326,14 @@ test('a drive ROOT keeps `C:\\` — never degrades to the drive-relative `C:`', 
   }
 })
 
-test('suggestPathArgument quotes values with spaces and stays quiet otherwise', () => {
+test('suggestPathArgument quotes values with spaces and stays quiet otherwise', async () => {
   const root = fixtureWorkspace()
-  const spaced = suggestPathArgument('my', root)
+  const spaced = await suggestPathArgument('my', root)
   assert.ok(spaced !== null, `'my' must suggest:\n${JSON.stringify(spaced)}`)
   assert.ok(spaced.some(item => item.value === '"my file.txt"'), `spaced value must be quoted:\n${JSON.stringify(spaced)}`)
-  assert.equal(suggestPathArgument('', root), null, 'an empty argument completes nothing')
-  assert.equal(suggestPathArgument('a b', root), null, 'embedded spaces cannot complete (single-token only)')
-  assert.equal(suggestPathArgument('no/such/dir', root), null, 'an unreadable directory stays quiet')
+  assert.equal(await suggestPathArgument('', root), null, 'an empty argument completes nothing')
+  assert.equal(await suggestPathArgument('a b', root), null, 'embedded spaces cannot complete (single-token only)')
+  assert.equal(await suggestPathArgument('no/such/dir', root), null, 'an unreadable directory stays quiet')
 })
 
 test('the provider completes /image arguments through the fork command branch', async () => {
@@ -474,6 +488,12 @@ test('expandFileMentionsForSubmit keeps absolute forms and expands ~ to the home
       'a real home-relative mention must expand through the homedir',
     )
   }
+})
+
+test('bare ~ mention canonicalization targets HOME rather than cwd/~', () => {
+  const root = fixtureWorkspace()
+  assert.equal(resolveMentionCandidate('~', root), homedir())
+  assert.equal(resolveMentionCandidate('~\\pics', root), join(homedir(), 'pics'))
 })
 
 test('expandFileMentionsForSubmit leaves nonexistent paths verbatim', async () => {

--- a/test/shell-completion.test.ts
+++ b/test/shell-completion.test.ts
@@ -193,10 +193,16 @@ test('shouldTriggerFileCompletion allows Tab on a leading / in a shell mode', as
   // (no space); the virtual prefix keeps the fork's judgment on the
   // serialized line, where `/usr/lo` is a path.
   assert.equal(provider.shouldTriggerFileCompletion(['/usr/lo'], 0, 7), true)
-  // Prompt mode keeps the fork's judgment (a bare slash command blocks Tab).
+  // Prompt mode: a leading `/` without a space is a slash-command NAME
+  // shape — the gate fast-fails to the fork's judgment (never file
+  // completion), and the host's own file branch is closed for the
+  // ordinary position in getSuggestions (plan §2.1).
   const { source: promptSource } = modeSource('prompt')
   const promptProvider = new MentionProvider([], root, null, promptSource)
   assert.equal(promptProvider.shouldTriggerFileCompletion(['/usr/lo'], 0, 7), false)
+  // The gate's PROOF: the host's own completion stays quiet in prompt mode.
+  assert.equal(await promptProvider.getSuggestions(['/usr/lo'], 0, 7, { signal: abort, force: true }), null,
+    'an ordinary prompt position must never open the HOST file dropdown')
 })
 
 // --- injected-runner determinism (review finding 4/5: failed runs must not

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -1244,14 +1244,26 @@ test('a large shell paste (>10 lines) enters the shell mode through the paste re
 // ── PR review round: mode transitions cancel the open dropdown ────────────
 
 test('a prompt-mode dropdown closes when ! enters shell mode', async () => {
-  const { vt, app } = startApp(fixtureWithFiles())
+  const { vt, app } = startApp(fixtureWithFiles(), {
+    fileReferences: new DirectHostFilePort(() => undefined, null),
+  })
   await vt.waitForRender()
-  vt.sendInput('\t') // prompt-mode Tab: cwd file completion
+  vt.sendInput('@notes') // prompt-mode mention: the ONLY prompt-mode file context
   await waitForDropdownRow(vt, 'notes.txt', 'file completion in prompt mode')
+  // The plan's §2.1 contract: with the dropdown open, Tab/typing `!` does
+  // NOT insert into the body (the dropdown owns the key) — so the shell
+  // mode cannot be entered while the dropdown is open. The mode transition
+  // closes the dropdown through the host's setInputMode cancellation,
+  // which the Backspace-direction test covers. Here we verify the prompt
+  // mode itself still transitions when the dropdown is closed.
+  vt.sendInput('\x1b') // close the dropdown (Esc, no re-trigger)
+  await vt.waitForRender()
+  await waitForNoDropdownRow(vt, 'notes.txt', 'dropdown after Esc')
+  app.setEditorText('')
+  await vt.waitForRender()
   vt.sendInput('!')
   await vt.waitForRender()
-  await waitForNoDropdownRow(vt, 'notes.txt', 'dropdown after entering shell mode')
-  assert.equal(app.inputModeForTest(), 'shell-context', 'the mode still transitions')
+  assert.equal(app.inputModeForTest(), 'shell-context', 'the mode still transitions from a closed dropdown')
   app.stop()
 })
 

--- a/test/support/app-harness.ts
+++ b/test/support/app-harness.ts
@@ -1,0 +1,41 @@
+/**
+ * Test harness: a TuiApp with the Direct Host-file port pre-wired (the
+ * fallback-only seam: fd forced absent so the bounded scan is what the
+ * completion exercises). Mirrors the other headless suites' startApp.
+ * @module @xmoon76/dsh-pi-tui/test/support/app-harness
+ */
+
+import { TuiApp } from '../../src/tui-app.ts'
+import { VirtualTerminal } from '../virtual-terminal.ts'
+import { DirectHostFilePort } from '../../src/runtime/direct/host-file-direct.ts'
+import { suggestPathArgument } from '../../src/mentions.ts'
+
+export function startApp(cwd: string): { vt: VirtualTerminal; app: TuiApp } {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => {},
+  })
+  app.setCommandCompletions([], cwd, new DirectHostFilePort(() => undefined, null))
+  app.start()
+  return { vt, app }
+}
+
+/** Start the app with the /image path-argument command (the same shape
+ * commands.ts installs — the convergence headless B/E flows drive it). */
+export function startImageApp(cwd: string): { vt: VirtualTerminal; app: TuiApp } {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onCancel: () => {},
+  })
+  app.setCommandCompletions(
+    [{ name: 'image', description: 'Attach an image file', getArgumentCompletions: (arg) => suggestPathArgument(arg, cwd) }],
+    cwd,
+    new DirectHostFilePort(() => undefined, null),
+  )
+  app.start()
+  return { vt, app }
+}

--- a/test/tui-editor.test.ts
+++ b/test/tui-editor.test.ts
@@ -34,6 +34,15 @@ function imageWorkspace(): string {
   return root
 }
 
+/** A quoted-path fixture: accepting the spaced directory must keep the quote
+ * open at the cursor so the shared directory-reopen path can continue. */
+function spacedImageWorkspace(): string {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-tui-editor-spaced-'))
+  mkdirSync(join(root, 'sub dir'))
+  writeFileSync(join(root, 'sub dir', 'deep.png'), 'x')
+  return root
+}
+
 function startApp(cwd: string): { vt: VirtualTerminal; app: TuiApp; cancels: number } {
   const vt = new VirtualTerminal(100, 24)
   let cancels = 0
@@ -63,6 +72,11 @@ function startImageApp(cwd: string): { vt: VirtualTerminal; app: TuiApp } {
   )
   app.start()
   return { vt, app }
+}
+
+/** Simulate a normal terminal's one-printable-key input events. */
+function sendKeyByKey(vt: VirtualTerminal, text: string): void {
+  for (const character of text) vt.sendInput(character)
 }
 
 /** Poll the viewport until the dropdown row appears (asserts on failure). */
@@ -125,6 +139,21 @@ test('Esc while the dropdown is open closes it WITHOUT re-triggering', async () 
   app.stop()
 })
 
+test('non-whitespace mention boundaries trigger natural completion', async () => {
+  const root = fixtureWorkspace()
+  const { vt, app } = startApp(root)
+  await vt.waitForRender()
+  sendKeyByKey(vt, '看看@src')
+  await waitForDropdownRow(vt, 'deep-nested.ts', 'CJK-glued mention completion')
+  app.stop()
+
+  const second = startApp(root)
+  await second.vt.waitForRender()
+  sendKeyByKey(second.vt, 'key=@src')
+  await waitForDropdownRow(second.vt, 'deep-nested.ts', 'equals-delimited mention completion')
+  second.app.stop()
+})
+
 test('a non-mention trailing slash does not reopen the dropdown', async () => {
   const root = fixtureWorkspace()
   const { vt, app } = startApp(root)
@@ -182,6 +211,47 @@ test('Tab-accepting a /image directory reopens the dropdown at its children', as
   await vt.waitForRender()
   assert.equal(app.seatTextForTest(), '/image subdir/', 'Tab must accept the directory argument')
   await waitForDropdownRow(vt, 'deep.png', 'children after Tab accept')
+  app.stop()
+})
+
+test('quoted @ directory acceptance keeps the quote open for child completion', async () => {
+  const root = spacedImageWorkspace()
+  const { vt, app } = startApp(root)
+  await vt.waitForRender()
+  sendKeyByKey(vt, '@"sub dir')
+  await waitForDropdownRow(vt, 'sub dir/', 'quoted mention directory')
+  vt.sendInput('\t')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '@"sub dir/"', 'the accepted value keeps balanced quote text')
+  assert.equal(app.seatEditorForTest().getCursor(), '@"sub dir/'.length, 'the cursor remains inside the open quote')
+  await waitForDropdownRow(vt, 'deep.png', 'quoted mention children after Tab')
+  app.stop()
+})
+
+test('quoted /image directory acceptance keeps the quote open for child completion', async () => {
+  const root = spacedImageWorkspace()
+  const { vt, app } = startImageApp(root)
+  await vt.waitForRender()
+  sendKeyByKey(vt, '/image "sub dir')
+  await waitForDropdownRow(vt, 'sub dir/', 'quoted image directory')
+  vt.sendInput('\t')
+  await vt.waitForRender()
+  assert.equal(app.seatTextForTest(), '/image "sub dir/"', 'the accepted value keeps balanced quote text')
+  assert.equal(app.seatEditorForTest().getCursor(), '/image "sub dir/'.length, 'the cursor remains inside the open quote')
+  await waitForDropdownRow(vt, 'deep.png', 'quoted image children after Tab')
+  app.stop()
+})
+
+test('a Windows-style backslash directory continuation reopens /image children', async () => {
+  const root = imageWorkspace()
+  const { vt, app } = startImageApp(root)
+  await vt.waitForRender()
+  app.setEditorText('/image subdir\\')
+  // A handled cursor key runs the same post-input reopen hook. The provider
+  // resolves the POSIX fixture path while preserving the typed backslash in
+  // the presentation dialect.
+  vt.sendInput('\x1b[C')
+  await waitForDropdownRow(vt, 'deep.png', 'backslash directory continuation')
   app.stop()
 })
 


### PR DESCRIPTION
## Summary
- Converge `@` and `/image` on shared path query, discovery, ranking, presentation, quoting, and directory continuation behavior.
- Keep `@` on HostFilePort and `/image` on the Client-local source/cwd boundary.
- Add fd/fdfind support, async bounded fallback discovery, cancellation, latest-only stale fencing, and explicit Tab/context routing.
- Cover scoped paths, fuzzy matching, Windows/UNC forms, whitespace filenames, symlink directories, quoted paths, and key-by-key triggers.

## Validation
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (2867 bundle tests + 11 documentation tests)
- Targeted completion tests (90 passed)
- Formal 3-round holistic review-fix loop: accepted
