### PR TITLE
feat(footer): add explicit save flow and unsaved-exit guard

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1798,10 +1798,11 @@ export function registerTuiCommands(
   // `/footer` — the interactive footer configurator (plan M3): LOCAL +
   // SESSIONLESS (usable before any session exists — the preview shows
   // placeholders/unavailable items and the config stays editable). The
-  // panel is a hierarchical editor; S on its Row Selector page validates
-  // + persists + applies, Enter is a navigation key, and Esc walks back
-  // page by page, closing on the selector without touching the active
-  // layout.
+  // panel is a hierarchical editor; the save paths (S, the "Save changes"
+  // row, "Save & Exit") validate + persist + apply through ONE awaited
+  // onSave — the overlay closes only on success (PR E). Enter is a
+  // navigation key, and Esc walks back page by page: a clean selector
+  // closes without touching the active layout, a dirty one asks first.
   //
   // `/statusline` is a deliberate alias (approved): other agents (and
   // users coming from tools that name this surface "statusline") reach
@@ -1844,29 +1845,32 @@ export function registerTuiCommands(
         model,
         registry,
         composer,
-        onSave: (layout, draftCustomItems) => {
+        onSave: async (layout, draftCustomItems) => {
+          // PR E contract: RESOLVE = persisted + applied (the overlay then
+          // closes); THROW = failed — the configurator stays open with the
+          // draft intact, and THIS layer owns the user-facing notify.
+          //
           // Validate the draft (the model's operations keep it well-formed,
           // but the persisted value is never trusted).
           const parsed = parseFooterLayout(layout)
           if (!isFooterLayout(parsed)) {
             app.notify(`footer layout invalid: ${parsed.message}`, 'error')
-            return
+            throw new Error(`footer layout invalid: ${parsed.message}`)
           }
           const customResult = parseFooterCustomItems(draftCustomItems ?? [])
           if (customResult.invalidCount > 0 || customResult.items.length !== (draftCustomItems ?? []).length) {
             app.notify('custom footer items invalid', 'error')
-            return
+            throw new Error('custom footer items invalid')
           }
           const savedCustomItems = customResult.items.map(item => ({ ...item }))
           if (settings !== undefined) {
             // Persist FIRST; the memory commit happens only after the
             // settings write succeeds (plan §15.7 — a failed write keeps
-            // the old layout and definitions and notifies). footerFallbackMode
-            // rides ALONG: the /settings path records the last native mode,
-            // and saving a custom layout IS a native-mode change — the command
+            // the old layout and definitions). footerFallbackMode rides
+            // ALONG: the /settings path records the last native mode, and
+            // saving a custom layout IS a native-mode change — the command
             // surface's restart fallback must resolve to THIS custom layout.
-            detach('footer configurator write', async () => {
-              if (app.isDisposed()) return
+            try {
               await serializeTuiSettingsMutation(settings, async () => {
                 if (app.isDisposed()) return
                 // `/footer` intentionally edits the custom-definition
@@ -1884,12 +1888,19 @@ export function registerTuiCommands(
                   footerCustomItems: persistedCustomItems,
                 })
               })
-              if (app.isDisposed()) return
-              app.setFooterCustomItems(savedCustomItems)
-              runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems }, savedCustomItems)
-              app.notify('footer layout saved', 'info')
-            }, { notify: true })
+            } catch (error) {
+              if (!app.isDisposed()) {
+                app.notify(`footer layout save failed: ${error instanceof Error ? error.message : String(error)}`, 'error')
+              }
+              throw error
+            }
+            if (app.isDisposed()) return
+            app.setFooterCustomItems(savedCustomItems)
+            runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems }, savedCustomItems)
+            app.notify('footer layout saved', 'info')
           } else {
+            // No settings backend: the memory commit IS the save (PR E
+            // §9.3) — resolve into an immediate close.
             app.setFooterCustomItems(savedCustomItems)
             runner.applyFooterSettings({ footer: 'custom', footerLayout: parsed, footerCustomItems: savedCustomItems }, savedCustomItems)
             app.notify('footer layout saved', 'info')

--- a/src/footer/configurator-model.ts
+++ b/src/footer/configurator-model.ts
@@ -226,7 +226,8 @@ function sameFooterRow(a: FooterRowLayout, b: FooterRowLayout): boolean {
 
 /** Structural layout equality (row count, item order, every editable ref
  * field, separators). Field order in the underlying objects is irrelevant
- * by construction — no JSON stringify round-trip. */
+ * by construction — no JSON stringify round-trip. Context-free BY DESIGN:
+ * dirty detection projects both sides through canonicalLayout first. */
 export function sameFooterLayout(a: FooterLayoutV1, b: FooterLayoutV1): boolean {
   if (a.rows.length !== b.rows.length) return false
   return a.rows.every((row, index) => sameFooterRow(row, b.rows[index]!))
@@ -252,6 +253,46 @@ export function sameFooterCustomItems(
 ): boolean {
   if (a.length !== b.length) return false
   return a.every((item, index) => sameFooterCustomItem(item, b[index]!))
+}
+
+/** Resolves an item id to its definition's default format (undefined for
+ * an unknown id — its formats are unknowable, so an explicit format is
+ * always a real override there). */
+type FooterDefaultFormatOf = (id: string) => string | undefined
+
+/** The canonical REF projection the dirty comparison uses (PR E review):
+ * facts the editor itself canonicalizes on the next interaction compare
+ * EQUAL to their absent form —
+ *   tone 'auto'          → absent
+ *   format = default     → absent (registry-aware)
+ *   prefix ''/suffix ''  → absent
+ * A no-op Style Enter (Enter on the already-selected default) or a no-op
+ * Advanced commit (empty buffer) must therefore never read as dirty. */
+function canonicalRef(ref: FooterItemRef, defaultFormatOf: FooterDefaultFormatOf): FooterItemRef {
+  const tone = normalizeToneForCompare(ref.tone)
+  return {
+    id: ref.id,
+    ...(ref.format !== undefined && ref.format !== defaultFormatOf(ref.id) ? { format: ref.format } : {}),
+    ...(tone === undefined ? {} : { tone: tone as FooterTone }),
+    ...(ref.prefix === undefined || ref.prefix === '' ? {} : { prefix: ref.prefix }),
+    ...(ref.suffix === undefined || ref.suffix === '' ? {} : { suffix: ref.suffix }),
+    ...(ref.importance === undefined ? {} : { importance: ref.importance }),
+  }
+}
+
+/** Canonical LAYOUT projection: row/zone ORDER and separators preserved,
+ * every ref projected through canonicalRef. Both sides of the dirty
+ * comparison are projected with the SAME (current) registry, so a
+ * definition change mid-session shifts both views identically. */
+function canonicalLayout(layout: FooterLayoutV1, defaultFormatOf: FooterDefaultFormatOf): FooterLayoutV1 {
+  return {
+    schemaVersion: 1,
+    rows: layout.rows.map(row => ({
+      left: row.left.map(ref => canonicalRef(ref, defaultFormatOf)),
+      right: row.right.map(ref => canonicalRef(ref, defaultFormatOf)),
+      ...(row.separator === undefined ? {} : { separator: { ...row.separator } }),
+    })),
+  }
 }
 
 /** A zone + index pair: where a flat position lives inside one row. */
@@ -408,9 +449,20 @@ export class FooterConfiguratorModel {
    * DEFINITION CATALOG are each compared against the construction
    * baseline. Reversible by contract — every mutation that returns the
    * draft to the baseline state (reorder + reorder back, tone + tone
-   * back, create + delete) returns to clean. */
+   * back, create + delete) returns to clean.
+   *
+   * Registry-aware canonicalization (review round 3): BOTH sides are
+   * projected through canonicalLayout with the CURRENT registry before
+   * comparison, so facts the editor canonicalizes anyway — an explicit
+   * 'auto' tone, a format equal to the definition's default, empty-string
+   * prefix/suffix — never read as dirty. The exported sameFooterLayout
+   * stays a pure comparator; this layer owns the projection. */
   isDirty(): boolean {
-    const layoutDirty = !sameFooterLayout(this.draft as unknown as FooterLayoutV1, this.baselineLayout as unknown as FooterLayoutV1)
+    const defaultFormatOf: FooterDefaultFormatOf = id => this.registry.get(id)?.defaultFormat
+    const layoutDirty = !sameFooterLayout(
+      canonicalLayout(this.draft as unknown as FooterLayoutV1, defaultFormatOf),
+      canonicalLayout(this.baselineLayout as unknown as FooterLayoutV1, defaultFormatOf),
+    )
     const itemsDirty = !sameFooterCustomItems(this.customItems.snapshot(), this.baselineCustomItems)
     return layoutDirty || itemsDirty
   }

--- a/src/footer/configurator-model.ts
+++ b/src/footer/configurator-model.ts
@@ -11,6 +11,8 @@
  *                                          └─ Rename/Delete definition
  *   row → add (searchable Add picker → Create Custom Text flow)
  *   row ⇄ row-move (Move Mode)
+ *   rows → exit-confirm (dirty-Esc: Save & Exit / Discard & Exit / Keep
+ *          Editing — PR E; plus the trailing "Save changes" home action)
  *
  * The UI component only renders and forwards keys; the whole model is
  * headless-testable. The persisted shape (FooterLayoutV1 / FooterItemRef)
@@ -42,6 +44,20 @@ export type FooterConfiguratorMode =
   | 'custom-tone'
   | 'custom-name'
   | 'custom-delete'
+  /** PR E: the dirty-Esc confirmation page (a MODEL mode, never a second
+   * overlay — input focus, resize and the Esc hierarchy stay trivial). */
+  | 'exit-confirm'
+
+/** The Row Selector's semantic selection (PR E §4.2): the cursor's range is
+ * `0..rows.length` — every row index selects that row, and the trailing
+ * entry is the Save action. `rowIndex` itself NEVER carries the sentinel:
+ * it keeps meaning "the row being edited". */
+export type FooterHomeSelection =
+  | { readonly kind: 'row'; readonly rowIndex: number }
+  | { readonly kind: 'save' }
+
+/** The exit-confirm page's actions (PR E §7.2). */
+export type FooterExitChoice = 'save' | 'discard' | 'keep'
 
 /** The advanced editor's fields (v1: the EXISTING ref fields only — no
  * new schema). `reset` is the trailing "Reset to default" action row. */
@@ -82,6 +98,15 @@ export interface FooterConfiguratorState {
   readonly customTone: FooterTone | 'auto'
   /** A fail-soft validation message for the current custom-item flow. */
   readonly customError: string
+  /** The Row Selector's cursor: `0..rows.length-1` are the rows,
+   * `rows.length` is the Save changes action (PR E §4). */
+  readonly homeCursor: number
+  /** The exit-confirm page's selected action (0 Save & Exit, 1 Discard &
+   * Exit, 2 Keep Editing). */
+  readonly exitConfirmCursor: number
+  /** Whether a save is currently in flight (PR E §10): duplicate saves
+   * are refused and the page shows Saving…. */
+  readonly saving: boolean
 }
 
 /** The tone picker's choices: persisted values use the EXISTING semantic
@@ -170,6 +195,65 @@ function cloneLayout(layout: FooterLayoutV1): MutableLayout {
   return { schemaVersion: 1, rows: layout.rows.map(cloneRow) }
 }
 
+/** Dirty comparison treats the ABSENT override and the explicit 'auto'
+ * token as the same fact (the model itself only ever deletes the field on
+ * 'auto' — PR E §5.4's normalized snapshot, not raw JSON equality). */
+function normalizeToneForCompare(tone: string | undefined): string | undefined {
+  return tone === undefined || tone === 'auto' ? undefined : tone
+}
+
+function sameFooterRef(a: FooterItemRef, b: FooterItemRef): boolean {
+  return a.id === b.id
+    && (a.format ?? undefined) === (b.format ?? undefined)
+    && normalizeToneForCompare(a.tone) === normalizeToneForCompare(b.tone)
+    && (a.prefix ?? undefined) === (b.prefix ?? undefined)
+    && (a.suffix ?? undefined) === (b.suffix ?? undefined)
+    && (a.importance ?? undefined) === (b.importance ?? undefined)
+}
+
+function sameFooterRow(a: FooterRowLayout, b: FooterRowLayout): boolean {
+  if (a.left.length !== b.left.length || a.right.length !== b.right.length) return false
+  for (let index = 0; index < a.left.length; index += 1) {
+    if (!sameFooterRef(a.left[index]!, b.left[index]!)) return false
+  }
+  for (let index = 0; index < a.right.length; index += 1) {
+    if (!sameFooterRef(a.right[index]!, b.right[index]!)) return false
+  }
+  if (a.separator === undefined || b.separator === undefined) return a.separator === b.separator
+  return a.separator.text === b.separator.text
+    && normalizeToneForCompare(a.separator.tone) === normalizeToneForCompare(b.separator.tone)
+}
+
+/** Structural layout equality (row count, item order, every editable ref
+ * field, separators). Field order in the underlying objects is irrelevant
+ * by construction — no JSON stringify round-trip. */
+export function sameFooterLayout(a: FooterLayoutV1, b: FooterLayoutV1): boolean {
+  if (a.rows.length !== b.rows.length) return false
+  return a.rows.every((row, index) => sameFooterRow(row, b.rows[index]!))
+}
+
+function sameFooterCustomItem(
+  a: FooterCustomItemSettings,
+  b: FooterCustomItemSettings,
+): boolean {
+  return a.schemaVersion === b.schemaVersion
+    && a.id === b.id
+    && a.kind === b.kind
+    && a.text === b.text
+    && normalizeToneForCompare(a.tone) === normalizeToneForCompare(b.tone)
+}
+
+/** Structural definition-catalog equality in PERSISTED ORDER (the order is
+ * part of the saved document — PR E §5.3). Covers create / text / tone /
+ * rename / delete: every mutation of the catalog changes this result. */
+export function sameFooterCustomItems(
+  a: readonly FooterCustomItemSettings[],
+  b: readonly FooterCustomItemSettings[],
+): boolean {
+  if (a.length !== b.length) return false
+  return a.every((item, index) => sameFooterCustomItem(item, b[index]!))
+}
+
 /** A zone + index pair: where a flat position lives inside one row. */
 export interface FlatPosition {
   readonly zone: 'left' | 'right'
@@ -242,6 +326,16 @@ export class FooterConfiguratorModel {
   private customText = ''
   private customTone: FooterTone | 'auto' = 'auto'
   private customError = ''
+  /** The Row Selector's cursor (Row N, or the trailing Save action). */
+  private homeCursor = 0
+  /** The exit-confirm page's selected action. */
+  private exitConfirmCursor = 0
+  /** True while a save promise is in flight (PR E §10). */
+  private saving = false
+  /** The detached save baseline (PR E §5.2): captured at construction,
+   * never mutated afterwards — draft mutations cannot reach it. */
+  private readonly baselineLayout: MutableLayout
+  private readonly baselineCustomItems: readonly FooterCustomItemSettings[]
   private readonly registry: FooterItemRegistry
   private readonly customItems: FooterCustomItemCatalog
 
@@ -255,8 +349,14 @@ export class FooterConfiguratorModel {
     this.draft = cloneLayout(initial.rows.length === 0
       ? { schemaVersion: 1, rows: [{ left: [], right: [] }] }
       : initial)
+    // The baseline mirrors the NORMALIZED draft (a zero-row initial must
+    // not read as dirty on open) and is double-detached: the catalog
+    // snapshot already copies, but the baseline must survive even a
+    // future snapshot change (PR E §5.2).
+    this.baselineLayout = cloneLayout(this.draft as unknown as FooterLayoutV1)
     this.registry = registry
     this.customItems = customItems ?? new FooterCustomItemCatalog()
+    this.baselineCustomItems = this.customItems.snapshot().map(item => ({ ...item }))
     // A caller that supplies a draft catalog expects the editor's picker and
     // preview to see it through the same registry. Do not replace an existing
     // app source when no draft catalog was requested (legacy callers use the
@@ -282,6 +382,9 @@ export class FooterConfiguratorModel {
       customText: this.customText,
       customTone: this.customTone,
       customError: this.customError,
+      homeCursor: this.homeCursor,
+      exitConfirmCursor: this.exitConfirmCursor,
+      saving: this.saving,
     }
   }
 
@@ -299,6 +402,49 @@ export class FooterConfiguratorModel {
   /** Detached custom definitions in their persisted order. */
   customItemSettings(): FooterCustomItemSettings[] {
     return this.customItems.snapshot()
+  }
+
+  /** Structured dirty detection (PR E §5): the draft LAYOUT and the draft
+   * DEFINITION CATALOG are each compared against the construction
+   * baseline. Reversible by contract — every mutation that returns the
+   * draft to the baseline state (reorder + reorder back, tone + tone
+   * back, create + delete) returns to clean. */
+  isDirty(): boolean {
+    const layoutDirty = !sameFooterLayout(this.draft as unknown as FooterLayoutV1, this.baselineLayout as unknown as FooterLayoutV1)
+    const itemsDirty = !sameFooterCustomItems(this.customItems.snapshot(), this.baselineCustomItems)
+    return layoutDirty || itemsDirty
+  }
+
+  /** Enter the saving state (PR E §10): the panel refuses duplicate save
+   * requests and Esc-close while a save promise is in flight. */
+  beginSave(): void {
+    this.saving = true
+  }
+
+  /** Clear the saving state after a FAILED save (success closes the whole
+   * configurator — there is nothing left to reset). */
+  endSave(): void {
+    this.saving = false
+  }
+
+  /** The Row Selector's semantic selection (PR E §4.2): rows map to their
+   * index; the trailing entry is the Save action. */
+  homeSelection(): FooterHomeSelection {
+    if (this.homeCursor >= this.draft.rows.length) return { kind: 'save' }
+    return { kind: 'row', rowIndex: this.homeCursor }
+  }
+
+  /** Enter on the exit-confirm page (PR E §7.2). 'keep' re-enters the Row
+   * Selector immediately; 'save' and 'discard' keep the mode — the PANEL
+   * performs them (async save path / close-without-write), and what the
+   * user sees next is decided by the save's outcome, not by this method. */
+  exitConfirmAction(): FooterExitChoice {
+    if (this.mode !== 'exit-confirm') return 'keep'
+    if (this.exitConfirmCursor === 0) return 'save'
+    if (this.exitConfirmCursor === 1) return 'discard'
+    this.mode = 'rows'
+    this.exitConfirmCursor = 0
+    return 'keep'
   }
 
   /** Whether an id is one of this editor's user-owned definitions. */
@@ -361,7 +507,7 @@ export class FooterConfiguratorModel {
   moveUp(): void {
     switch (this.mode) {
       case 'rows':
-        this.rowIndex = Math.max(0, this.rowIndex - 1)
+        this.homeCursor = Math.max(0, this.homeCursor - 1)
         return
       case 'row':
         this.cursor = Math.max(0, this.cursor - 1)
@@ -387,6 +533,9 @@ export class FooterConfiguratorModel {
       case 'add':
         this.pickerIndex = Math.max(0, this.pickerIndex - 1)
         return
+      case 'exit-confirm':
+        this.exitConfirmCursor = Math.max(0, this.exitConfirmCursor - 1)
+        return
     }
   }
 
@@ -394,7 +543,8 @@ export class FooterConfiguratorModel {
   moveDown(): void {
     switch (this.mode) {
       case 'rows':
-        this.rowIndex = Math.min(this.draft.rows.length - 1, this.rowIndex + 1)
+        // One past the last row sits the Save changes action (PR E §4).
+        this.homeCursor = Math.min(this.draft.rows.length, this.homeCursor + 1)
         return
       case 'row':
         this.cursor = Math.min(Math.max(0, this.flatCount() - 1), this.cursor + 1)
@@ -427,6 +577,9 @@ export class FooterConfiguratorModel {
         return
       case 'add':
         this.pickerIndex = Math.min(this.addMatches().length, this.pickerIndex + 1)
+        return
+      case 'exit-confirm':
+        this.exitConfirmCursor = Math.min(2, this.exitConfirmCursor + 1)
         return
     }
   }
@@ -589,12 +742,18 @@ export class FooterConfiguratorModel {
   /** Enter: the page's primary action. */
   activate(): void {
     switch (this.mode) {
-      case 'rows':
-        // Enter the highlighted row.
-        this.rowIndex = Math.min(this.rowIndex, this.draft.rows.length - 1)
+      case 'rows': {
+        // Enter opens the SELECTED ROW. The Save action (the trailing
+        // home entry) is deliberately NOT handled here: persistence is
+        // async and therefore panel business (PR E §14) — the panel
+        // routes that Enter to its single save path before activating.
+        const selection = this.homeSelection()
+        if (selection.kind === 'save') return
+        this.rowIndex = selection.rowIndex
         this.mode = 'row'
         this.cursor = 0
         return
+      }
       case 'row':
         if (this.flatCount() > 0) {
           this.mode = 'item'
@@ -775,11 +934,16 @@ export class FooterConfiguratorModel {
         if (added) this.mode = 'row'
         return
       }
+      case 'exit-confirm':
+        // Handled by the panel (PR E §14): Enter maps to the selected
+        // exitConfirmAction(), which routes save/discard through the
+        // panel's single save path and the close-without-write callback.
+        return
     }
   }
 
   /** Esc: navigate back. Returns false exactly when the configurator
-   * should CLOSE (Esc on the Row Selector). */
+   * should CLOSE (Esc on a clean Row Selector). */
   cancel(): boolean {
     if ((this.mode === 'advanced' || this.mode === 'custom-text' || this.mode === 'custom-name') && this.editing) {
       // First Esc inside an inline edit cancels the edit, not the page.
@@ -791,7 +955,24 @@ export class FooterConfiguratorModel {
     }
     switch (this.mode) {
       case 'rows':
+        // PR E §7: a clean draft closes immediately; a dirty draft opens
+        // the exit-confirm page. A save in flight swallows the Esc — the
+        // close decision belongs to the save's outcome, never to a
+        // second concurrent exit path.
+        if (this.saving) return true
+        if (this.isDirty()) {
+          this.mode = 'exit-confirm'
+          this.exitConfirmCursor = 0
+          return true
+        }
         return false
+      case 'exit-confirm':
+        // Esc on the confirmation page IS "Keep Editing" (PR E §7.2) —
+        // never a second close.
+        if (this.saving) return true
+        this.mode = 'rows'
+        this.exitConfirmCursor = 0
+        return true
       case 'add':
         if (this.addQuery !== '') {
           // A search term swallows the first Esc: clear the search.
@@ -1142,6 +1323,11 @@ export class FooterConfiguratorModel {
     this.customText = ''
     this.customTone = 'auto'
     this.customError = ''
+    // The home selection returns to the first row: the layout identity
+    // just changed, so a stale cursor could point past the Save action's
+    // new index (PR E §4.2 — clamp/reanchor the home cursor).
+    this.homeCursor = 0
+    this.exitConfirmCursor = 0
   }
 
   /** Reset the draft to the builtin default layout. */

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -240,6 +240,15 @@ export class FooterConfiguratorPanel implements Component {
    * here — saving guard, atomic draft capture, close-on-success only. */
   private requestSave(): void {
     if (this.model.state().saving) return
+    // Plan §12: a CLEAN draft has nothing to persist — closing IS the
+    // save outcome. This also keeps an unchanged default/compact footer
+    // from being silently rewritten as footer:'custom' by an idle save.
+    // (The exit-confirm page only exists while dirty, so this branch is
+    // reachable from the selector's S / Save changes row only.)
+    if (!this.model.isDirty()) {
+      this.onCancel()
+      return
+    }
     this.model.beginSave()
     this.requestRender()
     // The draft is captured BEFORE the await: the persistence layer must
@@ -318,9 +327,9 @@ export class FooterConfiguratorPanel implements Component {
       // borders stay visible — the physical minimum).
       return [...head, ...pre].slice(0, budget).map(line => truncateToWidth(line, Math.max(1, width), '…'))
     }
-    const bodyMin = state.mode === 'exit-confirm'
-      ? body.lines.length // PR E §17.9: the guard's question + three actions never scroll away
-      : Math.min(body.lines.length, 2)
+    const bodyMin = state.mode === 'exit-confirm' || state.mode === 'rows'
+      ? body.lines.length // PR E §17.9: the guard's question + three actions, and the whole
+      : Math.min(body.lines.length, 2) // selector (rows + Save changes), never scroll away
     let bodyBudget: number
     let previewBlock: string[]
     if (left <= bodyMin + 1) {

--- a/src/footer/configurator.ts
+++ b/src/footer/configurator.ts
@@ -8,7 +8,10 @@
  * lives in the model (headless-testable).
  *
  * Pages (the plan's hierarchy):
- *   rows  — Row Selector (↑↓ select, Enter edit, S save, Esc cancel)
+ *   rows  — Row Selector (↑↓ select, Enter edit, S save, Esc close; the
+ *           trailing "Save changes" action + Unsaved/No changes status)
+ *   exit-confirm — dirty-Esc guard (Save & Exit / Discard & Exit / Keep
+ *           Editing) — a panel+model mode, never a second overlay
  *   row   — Edit Row (Left/Right as VISUAL grouping; ←→ moves sides)
  *   item  — Item Editor (Style / Text / Default tone / Tone / Advanced…)
  *   style — Style picker (live per-format examples)
@@ -16,6 +19,12 @@
  *   advanced — Prefix / Suffix / Importance inline editors + Reset
  *   add   — searchable Add picker (type to filter; Esc clears first)
  *   row-move — Move Mode (↑↓ reorder within the zone)
+ *
+ * Save transaction (PR E): S, the "Save changes" row and the confirm
+ * page's "Save & Exit" all route through ONE requestSave() — the draft is
+ * captured atomically, onSave is awaited, and the overlay closes only on
+ * RESOLVE. A rejection (already notified by the integration layer) keeps
+ * the configurator open with the draft intact and dirty.
  *
  * All key matches go through the project's matchesKey vocabulary (legacy
  * AND Kitty CSI-u / modifyOtherKeys encodings — no raw sequence compares),
@@ -65,7 +74,12 @@ export interface FooterConfiguratorOptions {
   readonly maxVisible: () => number
   /** Request a render after timer-driven input replay. */
   readonly requestRender?: () => void
-  readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void
+  /** PR E: the save is AWAITED. Resolve = persisted (and the memory
+   * commit applied) — the host then closes the overlay. Reject = failed:
+   * the integration layer has already notified, and the panel stays open
+   * with the draft intact. A sync `void` return is tolerated (instant
+   * success) for callers without a settings backend. */
+  readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void | Promise<void>
   readonly onCancel: () => void
 }
 
@@ -79,7 +93,7 @@ export class FooterConfiguratorPanel implements Component {
   private readonly extensionFooterText: () => string
   private readonly maxVisible: () => number
   private readonly requestRender: () => void
-  private readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void
+  private readonly onSave: (layout: FooterLayoutV1, customItems?: readonly import('./custom-items.ts').FooterCustomItemSettings[]) => void | Promise<void>
   private readonly onCancel: () => void
   /** The body scrollport's top offset (stable across renders — the cursor
    * scrolls the body minimally; the fixed shell never moves). */
@@ -111,6 +125,11 @@ export class FooterConfiguratorPanel implements Component {
     this.onCancel = options.onCancel
     this.handleInput = (data: string): void => {
       const state = this.model.state()
+      // A save in flight freezes INPUT (PR E §10): the draft captured for
+      // the pending write must stay the draft on screen, duplicate
+      // Enter/S are refused by construction, and Esc can never race a
+      // second close path. Rendering stays live (resize works).
+      if (state.saving) return
       // Text-input pages swallow text keys FIRST (space is a query
       // character there, never the remove action). Text arrives in three
       // shapes — a plain printable chunk, a Kitty CSI-u / modifyOtherKeys
@@ -129,12 +148,22 @@ export class FooterConfiguratorPanel implements Component {
       }
       if (textMode && !this.skipPasteOnce && this.feedPaste(data)) return
       if (matchesKey(data, 'escape')) {
-        // The model navigates back page by page; only the Row Selector's
-        // Esc closes the configurator (cancel without saving).
+        // The model navigates back page by page; a clean Row Selector's
+        // Esc closes, a dirty one opens the exit-confirm page (PR E §7).
         if (!this.model.cancel()) this.onCancel()
         return
       }
       if (matchesKey(data, 'enter')) {
+        if (state.mode === 'rows' && this.model.homeSelection().kind === 'save') {
+          // Enter on the "Save changes" action — the discoverable save
+          // path (PR E §4.1).
+          this.requestSave()
+          return
+        }
+        if (state.mode === 'exit-confirm') {
+          this.runExitChoice(this.model.exitConfirmAction())
+          return
+        }
         this.model.activate()
         return
       }
@@ -153,9 +182,10 @@ export class FooterConfiguratorPanel implements Component {
         // the navigation keys below (arrows move the add list).
       }
       if (state.mode === 'rows' && matchesKey(data, 's')) {
-        // The Row Selector is the save point: S persists the layout and the
-        // definition catalog as one draft snapshot.
-        this.onSave(this.model.preview(), this.model.customItemSettings())
+        // The power-user shortcut shares the ONE save path with the
+        // "Save changes" row and "Save & Exit" (PR E §13) — never a
+        // second save implementation.
+        this.requestSave()
         return
       }
       if (state.mode === 'row') {
@@ -205,6 +235,48 @@ export class FooterConfiguratorPanel implements Component {
     }
   }
 
+  /** The ONE save path (PR E §13): the S shortcut, the Row Selector's
+   * "Save changes" action and the exit-confirm's "Save & Exit" all land
+   * here — saving guard, atomic draft capture, close-on-success only. */
+  private requestSave(): void {
+    if (this.model.state().saving) return
+    this.model.beginSave()
+    this.requestRender()
+    // The draft is captured BEFORE the await: the persistence layer must
+    // observe one atomic snapshot of layout + definitions.
+    const layout = this.model.preview()
+    const customItems = this.model.customItemSettings()
+    void Promise.resolve() // allowlist: the panel is the chain's terminal sink — .then closes on success, .catch keeps the editor open (never rejects unhandled)
+      .then(() => this.onSave(layout, customItems))
+      .then(() => {
+        // Success: the host wrapper has already closed the overlay after
+        // the persistence resolved (PR E §9). Reset the flag for the
+        // disposed-panel edge (a close() that did not dispose us).
+        this.model.endSave()
+      })
+      .catch(() => {
+        // Failure: the integration layer already notified (PR E §11).
+        // The overlay stays open, the draft is untouched, dirty stays
+        // true — the user can keep editing, retry, or Discard & Exit.
+        this.model.endSave()
+        this.requestRender()
+      })
+  }
+
+  /** Dispatch the exit-confirm page's Enter (PR E §7.2). */
+  private runExitChoice(choice: 'save' | 'discard' | 'keep'): void {
+    if (choice === 'save') {
+      this.requestSave()
+      return
+    }
+    if (choice === 'discard') {
+      // Explicit close-without-write: no persistence of layout or
+      // definitions (PR E §7.2 Discard & Exit).
+      this.onCancel()
+    }
+    // 'keep': the model already returned to the Row Selector.
+  }
+
   invalidate(): void {
     // The fork re-renders after every handleInput dispatch; a model
     // mutation from outside (reset helpers) calls this.
@@ -246,7 +318,9 @@ export class FooterConfiguratorPanel implements Component {
       // borders stay visible — the physical minimum).
       return [...head, ...pre].slice(0, budget).map(line => truncateToWidth(line, Math.max(1, width), '…'))
     }
-    const bodyMin = Math.min(body.lines.length, 2)
+    const bodyMin = state.mode === 'exit-confirm'
+      ? body.lines.length // PR E §17.9: the guard's question + three actions never scroll away
+      : Math.min(body.lines.length, 2)
     let bodyBudget: number
     let previewBlock: string[]
     if (left <= bodyMin + 1) {
@@ -491,6 +565,8 @@ export class FooterConfiguratorPanel implements Component {
         // zone): showing it spares the user guessing where the item will
         // land.
         return `Add Item → Row ${state.rowIndex + 1} · ${state.addSide === 'left' ? 'Left' : 'Right'}`
+      case 'exit-confirm':
+        return 'Unsaved Changes'
       default:
         return 'Configure Footer'
     }
@@ -500,7 +576,9 @@ export class FooterConfiguratorPanel implements Component {
   private help(state: { mode: string; editing: boolean }): string {
     switch (state.mode) {
       case 'rows':
-        return '↑↓ Select · Enter Edit · S Save · Esc Cancel'
+        return '↑↓ Select · Enter Open · S Save · Esc Close'
+      case 'exit-confirm':
+        return '↑↓ Select · Enter Confirm · Esc Keep Editing'
       case 'row':
         return 'A Add · Enter Edit · M Move · ←→ Side · Space Remove · F Style · Esc Back'
       case 'row-move':
@@ -603,7 +681,9 @@ export class FooterConfiguratorPanel implements Component {
       case 'rows': {
         const lines = [color.textStrong('Select row to edit')]
         state.layout.rows.forEach((row, index) => {
-          const active = index === state.rowIndex
+          // The home cursor — not rowIndex — drives the selector highlight
+          // (PR E §4.2: rowIndex stays the EDITED row).
+          const active = index === state.homeCursor
           const marker = active ? color.primary('›') : ' '
           const count = flatLengthOf(row)
           const noun = count === 1 ? 'item' : 'items'
@@ -613,7 +693,36 @@ export class FooterConfiguratorPanel implements Component {
           const line = `${marker} ${active ? color.textStrong(label) : color.text(label)}${' '.repeat(pad)}${color.textMuted(tail)}`
           lines.push(line)
         })
-        return { lines, cursor: 1 + state.rowIndex }
+        // The trailing "Save changes" action (PR E §4/§6): the discoverable
+        // save entry with its transactional status.
+        const saveActive = state.homeCursor >= state.layout.rows.length
+        const status = state.saving
+          ? 'Saving…'
+          : this.model.isDirty() ? 'Unsaved' : 'No changes'
+        const statusPainted = state.saving || !this.model.isDirty()
+          ? color.textMuted(status)
+          : color.warning(status)
+        const pad = Math.max(1, width - 'Save changes'.length - status.length - 4)
+        lines.push(`${saveActive ? color.primary('›') : ' '} ${saveActive ? color.textStrong('Save changes') : color.text('Save changes')}${' '.repeat(pad)}${statusPainted}`)
+        return { lines, cursor: 1 + Math.min(state.homeCursor, state.layout.rows.length) }
+      }
+      case 'exit-confirm': {
+        // PR E §7.2: three explicit exits, no Y/N pair. The save action
+        // reports the in-flight state (PR E §10).
+        const choices = ['Save & Exit', 'Discard & Exit', 'Keep Editing']
+        const activeIndex = Math.min(state.exitConfirmCursor, choices.length - 1)
+        const lines = [color.warning('Save changes before exiting?')]
+        choices.forEach((label, index) => {
+          const active = index === activeIndex
+          const marker = active ? color.primary('›') : ' '
+          const name = active ? color.textStrong(label) : color.text(label)
+          let line = `${marker} ${name}`
+          if (active && label === 'Save & Exit' && state.saving) {
+            line += `${' '.repeat(Math.max(1, 16 - label.length))}${color.textMuted('Saving…')}`
+          }
+          lines.push(line)
+        })
+        return { lines, cursor: 1 + activeIndex }
       }
       case 'row':
       case 'row-move': {

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -9803,17 +9803,19 @@ export class TuiApp {
   /**
    * M3: open the interactive footer configurator overlay. The panel
    * renders the model's draft layout + a live preview composed by the REAL
-   * composer against the current snapshot; S (on the Row Selector page)
-   * saves through onSave, Enter navigates, and Esc walks back page by
-   * page, closing on the selector without touching the active layout.
-   * Returns a closer.
+   * composer against the current snapshot; the save paths (S, the "Save
+   * changes" row, "Save & Exit") AWAIT onSave, Enter navigates, and Esc
+   * walks back page by page — a clean selector closes, a dirty one opens
+   * the exit-confirm page. PR E transaction: the overlay closes only
+   * after onSave RESOLVES; a rejection keeps it open (the integration
+   * layer notifies). Returns a closer.
    */
   openFooterConfigurator(options: {
     model: FooterConfiguratorModel
     registry: FooterItemRegistry
     /** A layered composer for an unsaved custom-definition draft. */
     composer?: FooterComposer
-    onSave: (layout: FooterLayoutV1, customItems?: readonly import('./footer/custom-items.ts').FooterCustomItemSettings[]) => void
+    onSave: (layout: FooterLayoutV1, customItems?: readonly import('./footer/custom-items.ts').FooterCustomItemSettings[]) => void | Promise<void>
     onCancel: () => void
   }): () => void {
     let handle: OverlayHandle | undefined
@@ -9845,8 +9847,14 @@ export class TuiApp {
       },
       requestRender: () => this.requestRender(),
       onSave: (layout, customItems) => {
-        close()
-        options.onSave(layout, customItems)
+        // PR E §9: persist FIRST, close on RESOLUTION only — the old
+        // close-before-save order destroyed the editor on a failed
+        // settings write, leaving the draft unreachable.
+        return Promise.resolve()
+          .then(() => options.onSave(layout, customItems))
+          .then(() => { close() })
+        // A rejection propagates to the panel, which clears its saving
+        // state and keeps the configurator open.
       },
       onCancel: () => {
         close()

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -651,13 +651,34 @@ test('/footer starts from the EFFECTIVE COMPACT layout (a compact user pressing 
   let view = vt.getViewport().join('\n')
   assert.ok(view.includes('Row 1'), `the compact row must be listed:\n${view}`)
   assert.ok(!view.includes('Row 2'), `the compact layout must not start from the two-row default:\n${view}`)
-  // Save UNCHANGED (S): the saved custom layout must stay ONE row.
+  // PR E §12/§18: S on an UNCHANGED (clean) draft closes WITHOUT writing
+  // — an idle save must not flip the compact mode to custom.
   vt.sendInput('s')
   await vt.waitForRender()
   for (let index = 0; index < 20; index += 1) await Promise.resolve()
-  assert.equal(applied.length, 1, 'S must apply the layout')
+  assert.equal(applied.length, 0, 'a clean S must not persist')
+  assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'), 'the clean save closes')
+  assert.equal(app.getFooterMode(), 'compact', 'the compact mode stays untouched')
+
+  // The seeding guarantee still holds where it matters: a DIRTY compact
+  // draft saves as ONE row (the draft started from the EFFECTIVE compact
+  // layout, never the two-row default).
+  await (def!.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
+  await vt.waitForRender()
+  vt.sendInput('\r') // → Edit Row 1
+  await vt.waitForRender()
+  vt.sendInput('a') // → Add picker
+  await vt.waitForRender()
+  vt.sendInput('\r') // add the first available item (makes the draft dirty)
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // → selector
+  await vt.waitForRender()
+  vt.sendInput('s')
+  await vt.waitForRender()
+  for (let index = 0; index < 20; index += 1) await Promise.resolve()
+  assert.equal(applied.length, 1, 'a dirty compact save persists')
   const saved = applied[0]!.footerLayout as { rows: unknown[] }
-  assert.equal(saved.rows.length, 1, `an unchanged compact save must stay one row:\n${JSON.stringify(saved)}`)
+  assert.equal(saved.rows.length, 1, `a dirty compact save must stay one row:\n${JSON.stringify(saved)}`)
   app.stop()
 })
 
@@ -889,5 +910,119 @@ test('/settings footer change PERSISTS footerFallbackMode (the command-mode rest
   }
   assert.equal(settings.doc.footer, 'compact', 'the mode must persist')
   assert.equal(settings.doc.footerFallbackMode, 'compact', 'the fallback mode must persist alongside')
+  app.stop()
+})
+
+test('/footer save failures notify exactly once (validation and write failures)', async () => {
+  const ctx = new Context()
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const commands = fakeCommands()
+  ctx.provide('commands', commands.service as never)
+  const notifications: Array<string> = []
+  ;(app as unknown as { notify: (message: string, level?: string) => void }).notify = (message) => {
+    notifications.push(message)
+  }
+  const saveCallbacks: Array<Parameters<TuiApp['openFooterConfigurator']>[0]['onSave']> = []
+  app.openFooterConfigurator = ((options: Parameters<TuiApp['openFooterConfigurator']>[0]) => {
+    saveCallbacks.push(options.onSave)
+    return () => {}
+  }) as TuiApp['openFooterConfigurator']
+  const known = { schemaVersion: 1 as const, id: 'user:environment', kind: 'text' as const, text: 'OLD', tone: 'warning' as const }
+  let rejectReplace: ((reason?: unknown) => void) | undefined
+  const settings: TuiSettingsLike = {
+    get: () => ({
+      theme: 'auto', iconStyle: 'emoji', footer: 'default', fullscreen: 'on',
+      busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport',
+      focusMode: 'off', footerCustomItems: [known],
+    }),
+    replace: () => new Promise<void>((_resolve, reject) => { rejectReplace = reject }),
+  }
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: { footerCustomItems: [known] } }] } as never)
+  const applied: Array<{ footerLayout?: unknown }> = []
+  const runner: TuiCommandRunner = {
+    ctx,
+    app,
+    diag: { warn: () => {}, error: () => {}, info: () => {} } as never,
+    get liveAgent() { return undefined },
+    ensureSession: async () => {},
+    get selected() { return { current: undefined, assembled: undefined, saveSelection: async () => {} } },
+    tuiSettings: settings,
+    agents: {} as never,
+    sessionReader: { list: async () => [], search: async () => [], titles: async () => new Map(), measureContext: () => undefined, readExportData: async () => ({ kind: 'none' }) },
+    sessionWriter: { followup: () => {}, steer: () => {}, dequeue: () => {}, cancel: () => {}, rename: () => true, refreshTitle: async () => ({ kind: 'ok' as const, title: undefined }) },
+    interaction: { registerQuestionProvider: () => true, onApprovalRequest: () => {}, setApprovalPolicy: () => true },
+    catalog: new DirectCatalogPort(ctx as never, () => undefined),
+    config: new DirectConfigPort(ctx as never, undefined, () => undefined),
+    hostFile: new DirectHostFilePort(() => undefined),
+    commandRegistry: ctx.get('commands') as never,
+    cwd: '/ws',
+    sessionCwd: () => '/ws',
+    imageStore: {} as never,
+    copyToClipboard: async () => true,
+    imageLimits: () => undefined,
+    insertIntoEditor: () => {},
+    prepareDraftMessage: async (text) => ({ role: 'user', id: `u:${text}`, content: [{ type: 'text', text }], source: { kind: 'user' } }) as never,
+    signal: new AbortController().signal,
+    get sessionGeneration() { return 0 },
+    switchSession: async () => undefined,
+    transitionTo: async <T>(steps: { prepare?: () => Promise<void> | void; create: () => Promise<T> }) => {
+      await steps.prepare?.()
+      return { ok: true, next: await steps.create() }
+    },
+    currentPreset: () => undefined,
+    get pendingPreset() { return undefined },
+    set pendingPreset(_id: string | undefined) {},
+    get effectivePresetId() { return undefined },
+    refreshCatalog: async () => ({ kind: 'failed', error: 'not wired in tests' }),
+    recomposeBlank: async () => ({ kind: 'switched', preset: 'standard' }),
+    refreshStatus: () => {},
+    focusEnabled: () => false,
+    setFocusMode: () => {},
+    updateWelcomeCard: () => {},
+    openJobView: () => {},
+    openTasksBrowser: () => {},
+    openRewindPicker: () => {},
+    sessionTransitionPending: () => false,
+    withSessionTransition: async <T>(task: () => T | Promise<T>) => task(),
+    withSessionWriter: async <T>(_sessionId: string, task: () => T | Promise<T>) => task(),
+    enterView: async () => {},
+    requestExit: () => {},
+    extensions: undefined,
+    exit: () => {},
+    applyFooterSettings: (doc) => {
+      if (doc !== undefined) applied.push({ footerLayout: doc.footerLayout })
+    },
+  }
+  registerTuiCommands(runner)
+  const footer = commands.defs.find(entry => entry.name === 'footer')
+  assert.ok(footer?.handler !== undefined)
+  await (footer.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
+  assert.equal(saveCallbacks.length, 1)
+
+  // Scenario A — an INVALID draft (3 rows exceed the v1 cap) rejects and
+  // notifies EXACTLY once; the write path is never reached.
+  notifications.length = 0
+  const invalid = { schemaVersion: 1, rows: [{ left: [{ id: 'model' }], right: [] }, { left: [], right: [] }, { left: [], right: [] }] }
+  await assert.rejects(Promise.resolve().then(() => saveCallbacks[0]!(invalid as FooterLayoutV1, [])))
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
+  assert.equal(notifications.length, 1, `validation notifies once:\n${notifications.join('\n')}`)
+  assert.match(notifications[0]!, /footer layout invalid/)
+  assert.equal(applied.length, 0, 'an invalid draft never applies')
+
+  // Scenario B — a VALID draft whose settings write REJECTS notifies
+  // exactly once (the catch), never twice, and never a success message.
+  notifications.length = 0
+  const valid: FooterLayoutV1 = { schemaVersion: 1, rows: [{ left: [{ id: 'model' }], right: [] }] }
+  const pending = Promise.resolve().then(() => saveCallbacks[0]!(valid, [{ ...known, text: 'NEW' }]))
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
+  assert.ok(rejectReplace !== undefined, 'the write was reached')
+  rejectReplace!(new Error('disk on fire'))
+  await assert.rejects(() => pending)
+  for (let index = 0; index < 5; index += 1) await Promise.resolve()
+  assert.equal(notifications.length, 1, `a failed write notifies once:\n${notifications.join('\n')}`)
+  assert.match(notifications[0]!, /footer layout save failed/)
+  assert.equal(applied.length, 0, 'a failed write never applies the memory commit')
   app.stop()
 })

--- a/test/footer-configurator-model.test.ts
+++ b/test/footer-configurator-model.test.ts
@@ -66,7 +66,8 @@ test('navigation: Enter a row, Esc back, Esc closes', () => {
 test('the Row Selector moves between rows; Enter enters the highlighted row', () => {
   const m = model()
   m.moveDown()
-  assert.equal(m.state().rowIndex, 1)
+  assert.equal(m.state().homeCursor, 1)
+  assert.equal(m.state().rowIndex, 0, 'the selector cursor never moves rowIndex')
   m.activate()
   assert.equal(m.state().mode, 'row')
   assert.equal(m.state().rowIndex, 1)
@@ -557,4 +558,230 @@ test('preset resets and the 1..2 row bound still work alongside the pages', () =
   assert.equal(m.state().layout.rows.length, 2)
   assert.equal(m.state().rowIndex, 0)
   assert.equal(m.state().cursor, 0)
+})
+
+/* ─── PR E: explicit save flow + unsaved-exit guard ──────────────────── */
+
+import { FooterCustomItemCatalog } from '../src/footer/custom-items.ts'
+
+/** A model over a one-row layout that PLACES one custom definition, with
+ * a fresh registry (the model wires the draft catalog into it). */
+function customModel(): { m: FooterConfiguratorModel; catalog: FooterCustomItemCatalog } {
+  const catalog = new FooterCustomItemCatalog([
+    { schemaVersion: 1, id: 'user:env', kind: 'text', text: 'PROD', tone: 'auto' },
+  ])
+  const layout = { schemaVersion: 1 as const, rows: [{ left: [{ id: 'model' }, { id: 'user:env' }], right: [] }] }
+  return { m: new FooterConfiguratorModel(layout, createBuiltinFooterRegistry(), catalog), catalog }
+}
+
+/** Walk the flat cursor onto the named item of the edited row (clamps at
+ * the row end). */
+function walkToId(m: FooterConfiguratorModel, id: string): void {
+  for (let i = 0; i < 64; i += 1) {
+    const row = m.state().layout.rows[m.state().rowIndex]!
+    const flat = m.state().cursor
+    const ref = flat < row.left.length ? row.left[flat] : row.right[flat - row.left.length]
+    if (ref?.id === id) return
+    if (flat >= row.left.length + row.right.length - 1) {
+      while (m.state().cursor > 0) m.moveUp()
+      return
+    }
+    m.moveDown()
+  }
+  assert.fail(`cursor never reached "${id}"`)
+}
+
+/** Open the item editor on the named item of row 1. */
+function openItemMenu(m: FooterConfiguratorModel, id: string): void {
+  m.activate() // rows → row
+  walkToId(m, id)
+  m.activate() // row → item
+}
+
+test('PR E: isDirty starts clean on open', () => {
+  assert.equal(model().isDirty(), false)
+  assert.equal(customModel().m.isDirty(), false, 'a placed custom definition does not read as dirty')
+})
+
+test('PR E: removing an item is dirty; re-adding it at the same slot is clean', () => {
+  const layout = { schemaVersion: 1 as const, rows: [{ left: [{ id: 'model' }], right: [] }] }
+  const m = new FooterConfiguratorModel(layout, createBuiltinFooterRegistry())
+  m.activate()
+  m.removeActive()
+  assert.equal(m.isDirty(), true, 'removal is dirty')
+  m.startAdd() // empty row → the Left default side
+  assert.ok(m.addMatches().includes('model'), 'the removed item returns to the pool')
+  let guard = 0
+  while (m.addMatches()[Math.min(m.state().pickerIndex, m.addMatches().length - 1)] !== 'model' && guard < 64) {
+    m.moveDown()
+    guard += 1
+  }
+  m.activate() // add it back — appended to the (empty) left zone
+  assert.equal(m.state().mode, 'row')
+  assert.equal(m.isDirty(), false, 'the restored layout matches the baseline')
+})
+
+test('PR E: item order is dirty; the order round-trip is clean (Move Mode)', () => {
+  const m = model()
+  m.activate()
+  m.startMove()
+  m.moveDown()
+  assert.equal(m.isDirty(), true, 'reorder is dirty')
+  m.moveUp()
+  assert.equal(m.isDirty(), false, 'reorder back is clean')
+})
+
+test('PR E: a zone round-trip of the last left item restores clean', () => {
+  const m = model()
+  m.activate()
+  walkToId(m, 'ext:*') // the right zone starts empty; ext:* is the last left ref
+  m.moveZone('right')
+  assert.equal(m.isDirty(), true, 'the zone move is dirty')
+  m.moveZone('left')
+  assert.equal(m.isDirty(), false, 'moving back re-appends at the original slot')
+})
+
+test('PR E: an explicit auto tone normalizes against an absent tone', () => {
+  const layout = { schemaVersion: 1 as const, rows: [{ left: [{ id: 'model', tone: 'auto' as const }], right: [] }] }
+  const m = new FooterConfiguratorModel(layout, createBuiltinFooterRegistry())
+  assert.equal(m.isDirty(), false, 'tone:auto baseline is clean')
+  m.activate() // row
+  m.activate() // item (cursor 0 = model)
+  m.moveDown() // menu: Style → Tone
+  m.activate() // tone picker (opens on the current choice)
+  m.activate() // apply Auto — the draft deletes the field
+  assert.equal(m.isDirty(), false, 'auto → absent is the same fact')
+})
+
+test('PR E: custom definition text and tone edits dirty; restores clean', () => {
+  const { m } = customModel()
+  openItemMenu(m, 'user:env')
+  assert.equal(m.state().mode, 'item')
+
+  // Text (menu entry 0): edit → dirty; restore → clean.
+  m.activate()
+  assert.equal(m.state().mode, 'custom-text')
+  m.text('X')
+  m.activate() // commit
+  assert.equal(m.isDirty(), true, 'text edit is dirty')
+  m.activate() // custom-text again
+  m.backspace()
+  m.activate() // commit
+  assert.equal(m.isDirty(), false, 'text restore is clean')
+
+  // Definition tone (menu entry 1): change → dirty; restore → clean.
+  m.moveDown()
+  m.activate() // custom-tone picker (opens on Auto)
+  assert.equal(m.state().mode, 'custom-tone')
+  m.moveDown()
+  m.activate() // apply Primary
+  assert.equal(m.isDirty(), true, 'definition tone is dirty')
+  m.activate() // picker again
+  m.moveUp()
+  m.activate() // apply Auto
+  assert.equal(m.isDirty(), false, 'definition tone restore is clean')
+})
+
+test('PR E: rename and delete of a custom definition count as dirty', () => {
+  const { m } = customModel()
+  openItemMenu(m, 'user:env')
+  // Menu: 0 Text, 1 Default tone, 2 Tone, 3 Advanced, 4 Rename, 5 Delete.
+  m.moveDown()
+  m.moveDown()
+  m.moveDown()
+  m.moveDown()
+  m.activate() // custom-name (buffer seeded with the current name)
+  assert.equal(m.state().mode, 'custom-name')
+  m.text('2')
+  m.activate() // commit the rename
+  assert.equal(m.isDirty(), true, 'rename is dirty')
+  m.activate() // custom-name again
+  m.backspace()
+  m.activate() // rename back
+  assert.equal(m.isDirty(), false, 'rename back is clean')
+
+  m.moveDown() // menu entry 5 = Delete definition
+  m.activate() // delete page
+  m.activate() // confirm
+  assert.equal(m.state().mode, 'row', 'delete returns to the row page')
+  assert.equal(m.isDirty(), true, 'delete is dirty')
+})
+
+test('PR E: the home selection covers rows plus the Save action', () => {
+  const m = model()
+  assert.deepEqual(m.homeSelection(), { kind: 'row', rowIndex: 0 })
+  m.moveDown()
+  assert.deepEqual(m.homeSelection(), { kind: 'row', rowIndex: 1 })
+  m.moveDown()
+  assert.deepEqual(m.homeSelection(), { kind: 'save' })
+  m.moveDown()
+  assert.deepEqual(m.homeSelection(), { kind: 'save' }, 'the save entry is the clamp')
+  m.activate()
+  assert.equal(m.state().mode, 'rows', 'model-activate on the Save entry is a no-op (the panel owns persistence)')
+  m.moveUp()
+  assert.deepEqual(m.homeSelection(), { kind: 'row', rowIndex: 1 })
+})
+
+test('PR E: addRow shifts the Save entry; removeRow reanchors the home cursor', () => {
+  const layout = { schemaVersion: 1 as const, rows: [{ left: [{ id: 'model' }], right: [] }] }
+  const m = new FooterConfiguratorModel(layout, createBuiltinFooterRegistry())
+  m.moveDown() // → Save (the only entry after row 1)
+  assert.deepEqual(m.homeSelection(), { kind: 'save' })
+  m.addRow()
+  assert.equal(m.state().layout.rows.length, 2)
+  assert.deepEqual(m.homeSelection(), { kind: 'row', rowIndex: 1 }, 'the save entry moved one line down')
+  m.moveDown()
+  assert.deepEqual(m.homeSelection(), { kind: 'save' })
+  m.removeRow() // row identity change → reanchor
+  assert.equal(m.state().homeCursor, 0)
+  assert.deepEqual(m.homeSelection(), { kind: 'row', rowIndex: 0 })
+})
+
+test('PR E: a dirty selector Esc opens exit-confirm; a clean one closes', () => {
+  const m = model()
+  assert.equal(m.cancel(), false, 'clean → close')
+  assert.equal(m.state().mode, 'rows')
+  m.activate()
+  m.removeActive()
+  m.cancel() // → rows
+  assert.equal(m.isDirty(), true)
+  assert.equal(m.cancel(), true, 'dirty → the guard opens')
+  assert.equal(m.state().mode, 'exit-confirm')
+  assert.equal(m.state().exitConfirmCursor, 0)
+  assert.equal(m.cancel(), true, 'Esc inside the guard is Keep Editing')
+  assert.equal(m.state().mode, 'rows')
+  assert.equal(m.isDirty(), true, 'the draft is preserved')
+})
+
+test('PR E: exit-confirm actions route save/discard/keep', () => {
+  const m = model()
+  m.activate()
+  m.removeActive()
+  m.cancel() // row → rows
+  m.cancel() // dirty → exit-confirm
+  assert.equal(m.exitConfirmAction(), 'save')
+  assert.equal(m.state().mode, 'exit-confirm', 'save keeps the page — the save outcome decides what comes next')
+  m.moveDown()
+  assert.equal(m.exitConfirmAction(), 'discard')
+  assert.equal(m.state().mode, 'exit-confirm', 'discard keeps the mode; the panel closes without writing')
+  m.moveDown()
+  assert.equal(m.exitConfirmAction(), 'keep')
+  assert.equal(m.state().mode, 'rows', 'keep returns to the selector')
+  assert.equal(m.exitConfirmAction(), 'keep', 'outside the guard it is a plain keep')
+})
+
+test('PR E: the saving flag gates Esc-close until the save settles', () => {
+  const m = model()
+  m.activate()
+  m.removeActive()
+  m.cancel() // row → rows
+  m.cancel() // dirty → exit-confirm
+  m.beginSave()
+  assert.equal(m.state().saving, true)
+  assert.equal(m.cancel(), true, 'Esc during a save is swallowed')
+  assert.equal(m.state().mode, 'exit-confirm', 'no mode escape mid-save')
+  m.endSave()
+  assert.equal(m.state().saving, false)
+  assert.equal(m.cancel(), true, 'after a failure the guard works again')
+  assert.equal(m.state().mode, 'rows')
 })

--- a/test/footer-configurator-model.test.ts
+++ b/test/footer-configurator-model.test.ts
@@ -782,6 +782,29 @@ test('PR E: the saving flag gates Esc-close until the save settles', () => {
   assert.equal(m.state().mode, 'exit-confirm', 'no mode escape mid-save')
   m.endSave()
   assert.equal(m.state().saving, false)
-  assert.equal(m.cancel(), true, 'after a failure the guard works again')
+  assert.equal(m.cancel(), true, 'after a failure the guard works again (Esc = Keep Editing)')
   assert.equal(m.state().mode, 'rows')
+})
+
+test('PR E: create then delete of a NEW custom item returns to clean', () => {
+  const m = model()
+  m.activate() // → row 1
+  m.startAdd()
+  m.text('zz-no-match')
+  assert.equal(m.addMatches().length, 0, 'the filter isolates the create action')
+  assert.ok(m.isCreateOption())
+  m.activate() // → create-name
+  m.text('Temp')
+  m.activate() // → create-text
+  m.text('TMP')
+  m.activate() // → create-tone
+  m.activate() // create with Auto — the definition is created AND placed
+  assert.equal(m.isDirty(), true, 'the created definition + its placement are dirty')
+  m.activate() // item editor (the cursor landed on the new item)
+  // Menu: 0 Text, 1 Default tone, 2 Tone, 3 Advanced, 4 Rename, 5 Delete.
+  for (let i = 0; i < 5; i += 1) m.moveDown()
+  m.activate() // delete page
+  m.activate() // confirm — removes the definition and every reference
+  assert.equal(m.state().mode, 'row')
+  assert.equal(m.isDirty(), false, 'create + delete of the new item restores the baseline exactly')
 })

--- a/test/footer-configurator-model.test.ts
+++ b/test/footer-configurator-model.test.ts
@@ -653,6 +653,40 @@ test('PR E: an explicit auto tone normalizes against an absent tone', () => {
   assert.equal(m.isDirty(), false, 'auto → absent is the same fact')
 })
 
+test('PR E: an explicit DEFAULT format is the same fact as no format', () => {
+  const reg = createBuiltinFooterRegistry()
+  const def = reg.get('model')
+  assert.ok(def !== undefined && def.formats.includes(def.defaultFormat))
+  const layout = { schemaVersion: 1 as const, rows: [{ left: [{ id: 'model', format: def.defaultFormat }], right: [] }] }
+  const m = new FooterConfiguratorModel(layout, reg)
+  assert.equal(m.isDirty(), false, 'explicit-default-format baseline is clean')
+  // The Style picker's NO-OP round-trip (review round 3): the picker opens
+  // on the current choice; Enter applies the SAME format — applyFormat
+  // canonicalizes the draft by DELETING the field. That must not read as
+  // dirty against the explicit-default baseline.
+  m.activate() // row
+  m.activate() // item (cursor 0 = model)
+  m.activate() // style picker (opens on the current format)
+  m.activate() // apply the same format → the draft drops the field
+  assert.equal(m.isDirty(), false, 'a no-op Style Enter must not read as dirty')
+})
+
+test('PR E: empty-string prefix/suffix are the same fact as absent', () => {
+  const layout = { schemaVersion: 1 as const, rows: [{ left: [{ id: 'model', prefix: '', suffix: '' }], right: [] }] }
+  const m = new FooterConfiguratorModel(layout, createBuiltinFooterRegistry())
+  assert.equal(m.isDirty(), false, 'empty-string baseline is clean')
+  // The Advanced editor's NO-OP commit: an empty buffer DELETES the
+  // field — that canonicalization must not read as dirty either.
+  m.activate() // row
+  m.activate() // item (cursor 0 = model)
+  m.moveDown() // menu: Style → Tone
+  m.moveDown() // Tone → Advanced
+  m.activate() // advanced page (Prefix selected)
+  m.activate() // open the inline editor (seeds '')
+  m.activate() // commit the empty buffer → the field is deleted
+  assert.equal(m.isDirty(), false, 'a no-op Advanced commit must not read as dirty')
+})
+
 test('PR E: custom definition text and tone edits dirty; restores clean', () => {
   const { m } = customModel()
   openItemMenu(m, 'user:env')

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -56,7 +56,7 @@ test('the configurator opens on the Row Selector with a live preview', async () 
   assert.ok(view.includes('Preview'), `preview label missing:\n${view}`)
   assert.ok(view.includes('Row 1'), `the row list missing:\n${view}`)
   assert.ok(view.includes('deepseek/flash'), `preview must compose the real snapshot:\n${view}`)
-  assert.ok(view.includes('↑↓ Select · Enter Edit · S Save · Esc Cancel'), `the selector help missing:\n${view}`)
+  assert.ok(view.includes('↑↓ Select · Enter Open · S Save · Esc Close'), `the selector help missing:\n${view}`)
   app.stop()
 })
 
@@ -1060,5 +1060,233 @@ test('a 4-physical-row preview cannot eat the editable body (10-row terminal)', 
   assert.ok(text.includes('A Add'), `the help must stay visible:\n${text}`)
   assert.ok(text.includes('Preview'), `the preview must stay visible:\n${text}`)
   assert.ok(text.includes('Extension items'), `the ACTIVE item must stay visible (the body must never be eaten):\n${text}`)
+  app.stop()
+})
+
+/* ─── PR E: explicit save flow + unsaved-exit guard ──────────────────── */
+
+/** Flush pending microtasks (save-promise chains) without a fixed delay. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve()
+  await new Promise<void>(resolve => setImmediate(resolve))
+}
+
+function openWith(
+  app: TuiApp,
+  hooks: { onSave?: () => void | Promise<void>; onCancel?: () => void } = {},
+): FooterConfiguratorModel {
+  const model = new FooterConfiguratorModel(DEFAULT_FOOTER_LAYOUT, app.getFooterItemRegistry())
+  app.openFooterConfigurator({
+    model,
+    registry: app.getFooterItemRegistry(),
+    onSave: hooks.onSave ?? (() => {}),
+    onCancel: hooks.onCancel ?? (() => {}),
+  })
+  return model
+}
+
+/** Enter the row, remove the first item, walk back: a reliably dirty draft
+ * sitting on the Row Selector. */
+async function makeDirty(vt: VirtualTerminal): Promise<void> {
+  vt.sendInput('\r') // → Edit Row 1
+  await vt.waitForRender()
+  vt.sendInput(' ') // remove the cursor's item
+  await vt.waitForRender()
+  vt.sendInput('\x1b') // → selector (dirty)
+  await vt.waitForRender()
+}
+
+test('PR E: the selector advertises Save changes with Unsaved / No changes', async () => {
+  const { vt, app } = startApp()
+  openWith(app)
+  await vt.waitForRender()
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Save changes'), `the save action missing:\n${view}`)
+  assert.ok(view.includes('No changes'), `the clean status missing:\n${view}`)
+  await makeDirty(vt)
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Unsaved'), `the dirty status missing:\n${view}`)
+  app.stop()
+})
+
+test('PR E: Enter on Save changes saves and closes the configurator', async () => {
+  const { vt, app } = startApp()
+  let saved = 0
+  let cancelled = 0
+  openWith(app, { onSave: () => { saved += 1 }, onCancel: () => { cancelled += 1 } })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  vt.sendInput('\x1b[B') // ↓ Row 2
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B') // ↓ Save changes
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await settle()
+  await vt.waitForRender()
+  assert.equal(saved, 1, 'Enter on the Save action saves')
+  assert.equal(cancelled, 0)
+  const view = vt.getViewport().join('\n')
+  assert.ok(!view.includes('Configure Footer'), `a successful save closes the configurator:\n${view}`)
+  app.stop()
+})
+
+test('PR E: dirty Esc opens the exit guard; Esc there keeps editing', async () => {
+  const { vt, app } = startApp()
+  let cancelled = 0
+  openWith(app, { onCancel: () => { cancelled += 1 } })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Save changes before exiting?'), `the guard missing:\n${view}`)
+  assert.ok(view.includes('Save & Exit') && view.includes('Discard & Exit') && view.includes('Keep Editing'),
+    `the three actions missing:\n${view}`)
+  assert.equal(cancelled, 0, 'the guard must not close')
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Select row to edit'), 'Esc in the guard keeps editing')
+  assert.ok(view.includes('Unsaved'), 'the draft stays dirty')
+  assert.equal(cancelled, 0)
+  app.stop()
+})
+
+test('PR E: Save & Exit saves; Discard & Exit closes without saving', async () => {
+  // Save & Exit.
+  {
+    const { vt, app } = startApp()
+    let saved = 0
+    let cancelled = 0
+    openWith(app, { onSave: () => { saved += 1 }, onCancel: () => { cancelled += 1 } })
+    await vt.waitForRender()
+    await makeDirty(vt)
+    vt.sendInput('\x1b')
+    await vt.waitForRender()
+    vt.sendInput('\r') // Save & Exit (cursor 0)
+    await settle()
+    await vt.waitForRender()
+    assert.equal(saved, 1)
+    assert.equal(cancelled, 0)
+    assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'), 'the overlay closed after success')
+    app.stop()
+  }
+  // Discard & Exit.
+  {
+    const { vt, app } = startApp()
+    let saved = 0
+    let cancelled = 0
+    openWith(app, { onSave: () => { saved += 1 }, onCancel: () => { cancelled += 1 } })
+    await vt.waitForRender()
+    await makeDirty(vt)
+    vt.sendInput('\x1b')
+    await vt.waitForRender()
+    vt.sendInput('\x1b[B') // → Discard & Exit
+    await vt.waitForRender()
+    vt.sendInput('\r')
+    await settle()
+    await vt.waitForRender()
+    assert.equal(saved, 0, 'discard never persists')
+    assert.equal(cancelled, 1, 'discard closes via onCancel')
+    assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'), 'the overlay closed')
+    app.stop()
+  }
+})
+
+test('PR E: Keep Editing returns to the selector with the draft intact', async () => {
+  const { vt, app } = startApp()
+  let saved = 0
+  let cancelled = 0
+  const model = openWith(app, { onSave: () => { saved += 1 }, onCancel: () => { cancelled += 1 } })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  const draftBefore = JSON.stringify(model.preview())
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B') // → Keep Editing
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Select row to edit'), 'back on the selector')
+  assert.equal(saved, 0)
+  assert.equal(cancelled, 0)
+  assert.equal(JSON.stringify(model.preview()), draftBefore, 'the draft is untouched')
+  app.stop()
+})
+
+test('PR E: a failed save keeps the configurator open with the draft dirty', async () => {
+  const { vt, app } = startApp()
+  let attempts = 0
+  let cancelled = 0
+  let fail = true
+  openWith(app, {
+    onSave: async () => {
+      attempts += 1
+      if (fail) throw new Error('write failed')
+    },
+    onCancel: () => { cancelled += 1 },
+  })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  vt.sendInput('s')
+  await settle()
+  await vt.waitForRender()
+  assert.equal(attempts, 1)
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Configure Footer'), `a failed save keeps the editor open:\n${view}`)
+  assert.ok(view.includes('Unsaved'), 'the draft stays dirty')
+  // The retry succeeds.
+  fail = false
+  vt.sendInput('s')
+  await settle()
+  await vt.waitForRender()
+  assert.equal(attempts, 2)
+  assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'), 'the successful retry closes')
+  assert.equal(cancelled, 0)
+  app.stop()
+})
+
+test('PR E: a save in flight refuses duplicate saves and Esc-close', async () => {
+  const { vt, app } = startApp()
+  let attempts = 0
+  let release: (() => void) | undefined
+  const gate = new Promise<void>(resolve => { release = resolve })
+  openWith(app, { onSave: () => { attempts += 1; return gate } })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  vt.sendInput('s')
+  await settle()
+  vt.sendInput('s') // duplicate — refused by the saving guard
+  await settle()
+  vt.sendInput('\x1b') // must not close mid-save either
+  await settle()
+  assert.equal(attempts, 1, 'only one persistence call')
+  release?.()
+  await settle()
+  await vt.waitForRender()
+  assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'), 'the gated save still closes on success')
+  app.stop()
+})
+
+test('PR E: the exit guard keeps all three actions visible at 40x10', async () => {
+  const vt = new VirtualTerminal(40, 10)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  let cancelled = 0
+  openWith(app, { onCancel: () => { cancelled += 1 } })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Save changes before exiting?'), `the question must be visible:\n${view}`)
+  assert.ok(view.includes('Save & Exit'), `Save & Exit must be visible:\n${view}`)
+  assert.ok(view.includes('Discard & Exit'), `Discard & Exit must be visible:\n${view}`)
+  assert.ok(view.includes('Keep Editing'), `Keep Editing must be visible:\n${view}`)
+  assert.ok(view.includes('╰'), 'the frame must survive')
+  assert.equal(cancelled, 0)
   app.stop()
 })

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -1290,3 +1290,93 @@ test('PR E: the exit guard keeps all three actions visible at 40x10', async () =
   assert.equal(cancelled, 0)
   app.stop()
 })
+
+test('PR E: a clean draft closes WITHOUT persisting (Save changes / S)', async () => {
+  const { vt, app } = startApp()
+  let saved = 0
+  let closed = 0
+  openWith(app, { onSave: () => { saved += 1 }, onCancel: () => { closed += 1 } })
+  await vt.waitForRender()
+  // ↓ ↓ lands on Save changes. Enter with NOTHING edited must close
+  // without a save (plan §12: skip the meaningless settings replace — an
+  // idle save must never flip the active default/compact footer to
+  // custom).
+  vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await settle()
+  await vt.waitForRender()
+  assert.equal(saved, 0, 'a clean save must not persist')
+  assert.equal(closed, 1, 'the configurator closed as the save outcome')
+  assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'))
+  app.stop()
+})
+
+test('PR E: S on a clean draft closes without persisting', async () => {
+  const { vt, app } = startApp()
+  let saved = 0
+  let closed = 0
+  openWith(app, { onSave: () => { saved += 1 }, onCancel: () => { closed += 1 } })
+  await vt.waitForRender()
+  vt.sendInput('s')
+  await settle()
+  await vt.waitForRender()
+  assert.equal(saved, 0, 'the clean S shortcut must not persist')
+  assert.equal(closed, 1)
+  assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'))
+  app.stop()
+})
+
+test('PR E: closing during an in-flight save is safe (no unhandled rejection)', async () => {
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  let attempts = 0
+  let release: (() => void) | undefined
+  const gate = new Promise<void>(resolve => { release = resolve })
+  const close = app.openFooterConfigurator({
+    model: new FooterConfiguratorModel(DEFAULT_FOOTER_LAYOUT, app.getFooterItemRegistry()),
+    registry: app.getFooterItemRegistry(),
+    onSave: () => { attempts += 1; return gate },
+    onCancel: () => {},
+  })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  vt.sendInput('s')
+  await settle()
+  assert.equal(attempts, 1)
+  close() // e.g. a session switch disposes the overlay mid-write
+  release?.()
+  await settle()
+  await settle()
+  await vt.waitForRender()
+  app.stop()
+})
+
+test('PR E: the Save row stays visible at 40x10 and Saving… survives a resize', async () => {
+  const vt = new VirtualTerminal(40, 10)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  let attempts = 0
+  let release: (() => void) | undefined
+  const gate = new Promise<void>(resolve => { release = resolve })
+  openWith(app, { onSave: () => { attempts += 1; return gate } })
+  await vt.waitForRender()
+  await makeDirty(vt)
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Save changes'), `the save action must be visible at 40x10:\n${view}`)
+  assert.ok(view.includes('Unsaved'), `the dirty status must be visible at 40x10:\n${view}`)
+  vt.sendInput('s')
+  await settle()
+  vt.resize(80, 24)
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Saving…'), `Saving… must survive a resize mid-save:\n${view}`)
+  release?.()
+  await settle()
+  await vt.waitForRender()
+  assert.ok(!vt.getViewport().join('\n').includes('Configure Footer'), 'the released save closes on success')
+  app.stop()
+})


### PR DESCRIPTION
## Summary

PR E from the footer roadmap: make `/footer`'s save a **discoverable, transactional flow** instead of a hidden `S` shortcut that closed the editor before persistence settled.

## What changes

### 1. Home "Save changes" action
- The Row Selector gains a selectable **Save changes** row with a live status column: `Unsaved` (warning) / `No changes` / `Saving…` (muted).
- It uses an independent `homeCursor` (`homeSelection()` → `{kind:'row'}` | `{kind:'save'}`); `rowIndex` keeps meaning "the row being edited" — no sentinel.
- `S` remains the power-user shortcut. `S`, the Save row and "Save & Exit" share **one** `requestSave()` path.

### 2. Structured, reversible dirty detection
- A detached baseline (layout **and** custom-definition catalog) is captured at open; `isDirty()` compares via new `sameFooterLayout` / `sameFooterCustomItems` helpers (structural equality; `auto` and absent tones normalize to the same fact — no JSON key-order luck).
- Reversible by contract: reorder/reorder-back, create/delete, rename/rename-back and tone round-trips all return to clean — no sticky boolean. Custom-item create / text / tone / rename / delete **all** count as dirty.

### 3. Exit-confirm on dirty Esc
- Esc on a **clean** selector closes immediately (no dialog, unchanged behavior).
- Esc on a **dirty** selector opens an exit-confirm **page** (a model mode — not a second overlay): **Save & Exit / Discard & Exit / Keep Editing**; Esc there is Keep Editing; Discard never persists.
- The guard page and the whole selector never scroll their actions away (body-minimum rule), even at 40×10.

### 4. Persist-success-before-close
- `onSave` is now awaited (`void | Promise<void>`); the overlay closes only on **resolve**. The old close-before-save order destroyed the editor on a failed settings write.
- Failure → notified by the command layer (exactly once, pinned by test), configurator stays open, draft intact, dirty preserved, retry possible.
- Memory commit still happens only after the settings write succeeds; `footerFallbackMode` / `mergeFooterCustomItemsForSave` ride-along behavior unchanged; no-settings backend still applies memory and closes.
- A `saving` flag freezes input mid-save: duplicate Enter/S refused, Esc cannot race a second close path; closing mid-flight is rejection-safe.

## Compatibility / non-goals

- No persisted-schema change (`FooterLayoutV1`, `FooterItemRef`, `footerCustomItems` untouched), no migration.
- No extension surface change; no vendored `packages/pi-tui` change; command trust untouched.
- Non-goals honored: no auto-save, no Ctrl+S, no undo/history, no generic dialog framework, no new footer schema.

## Tests

- 12 new model tests + 8 new UI tests covering the plan §17 matrix: layout & custom-item dirty round-trips, clean-Esc vs dirty-Esc, all three confirm actions, save failure + retry, double-save guard, in-flight dispose, 40×10 resize matrix, exact-once error notifications (command level).
- Full bundle suite green (3062 tests), typecheck (fork + bundle), naming/boundary/keybinding gates, `git diff --check`.
- Reviewed via a two-round external review loop (round 1: 3 findings → 1 adjudicated false positive + 2 fixed; round 2: accepted, no findings).