### PR TITLE
feat: optimize long-session replay foundations

### DIFF
--- a/docs/perf-baseline.md
+++ b/docs/perf-baseline.md
@@ -4,7 +4,7 @@
 > the optimization (incremental read grouping + per-message render cache) ·
 > Node v26.7.0 · headless xterm at 24 rows · `BENCH_FAST=1` iteration counts.
 >
-> Re-run: `node --expose-gc scripts/bench.mts`
+> Re-run: `node --expose-gc --import tsx/esm scripts/bench.mts`
 > (full sweep without `BENCH_FAST`). The benchmark is NOT part of the test
 > suite — it is a manual, non-default tool by design.
 
@@ -65,6 +65,32 @@
   (0.5ms p50 regardless of the 2220-message transcript);
 - ✅ heap enters a stable range under sustained streaming (growth ≈ 0);
 - ✅ all transcript golden/headless tests keep identical output.
+
+## Long-session projection baseline (PR A)
+
+PR A keeps the full session log and changes only local replay bookkeeping:
+
+- open reasoning entries are indexed by turn, so `turn/end` settles only the
+  still-open entries it owns;
+- decode-window duration is accumulated as a scalar, so
+  `StatsFolder.snapshot()` does not revisit completed samples;
+- resume, create, and session-switch surface setup share
+  `hydrateSessionUi(events)` instead of pre-folding a resumed log and then
+  hydrating it again;
+- the benchmark includes reasoning-heavy, adjacent-read, and a 700k-character
+  text-heavy fixture, and reports transcript/stats apply, snapshot, and
+  heap/RSS measurements separately from renderer timings.
+
+Run the projection and renderer sweep with:
+
+```sh
+BENCH_FAST=1 node --expose-gc --import tsx/esm scripts/bench.mts
+```
+
+The benchmark is intentionally observational rather than a wall-clock test;
+compare runs on the same machine and Node version. Its semantic gates remain
+cold-fold/incremental parity and the existing transcript/stats regression
+suites.
 
 ## M11: extension-plugin overhead (plan §23)
 

--- a/docs/perf-baseline.md
+++ b/docs/perf-baseline.md
@@ -77,9 +77,11 @@ PR A keeps the full session log and changes only local replay bookkeeping:
 - resume, create, and session-switch surface setup share
   `hydrateSessionUi(events)` instead of pre-folding a resumed log and then
   hydrating it again;
-- the benchmark includes reasoning-heavy, adjacent-read, and a 700k-character
-  text-heavy fixture, and reports transcript/stats apply, snapshot, and
-  heap/RSS measurements separately from renderer timings.
+- the benchmark includes reasoning-heavy, adjacent-read, one-turn-many-step,
+  and a 700k-character text-heavy fixture, and reports transcript/stats apply,
+  snapshot, and heap/RSS measurements separately from renderer timings;
+- late replay timing is fenced to the current turn and ignores token deltas
+  after a step has already settled, so tool-loop replay remains linear.
 
 Run the projection and renderer sweep with:
 

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -202,6 +202,34 @@ function repeatedText(length: number): string {
   return TEXT_HEAVY_BLOCK.repeat(Math.ceil(length / TEXT_HEAVY_BLOCK.length)).slice(0, length)
 }
 
+/** Build one long turn with many settled model steps (tool-loop shape). */
+function buildManyStepEvents(steps: number): SessionEvent[] {
+  const events: SessionEvent[] = []
+  pushEvent(events, 'turn/start', { turn: 0 })
+  for (let step = 0; step < steps; step += 1) {
+    pushEvent(events, 'step/start', { turn: 0, step })
+    pushEvent(events, 'assistant/chunk', {
+      turn: 0,
+      step,
+      chunk: { type: 'text-delta', index: 0, text: 'x' },
+    })
+    pushEvent(events, 'assistant/message', {
+      turn: 0,
+      step,
+      message: {
+        id: `many-step-message-${step}`,
+        role: 'assistant',
+        content: [{ type: 'text', text: 'x' }],
+        source: { kind: 'model', provider: 'bench', model: 'bench' },
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    })
+    pushEvent(events, 'step/end', { turn: 0, step })
+  }
+  pushEvent(events, 'turn/end', { turn: 0, reason: { kind: 'completed' } })
+  return events
+}
+
 /** Build a moderate-size text-heavy log without requiring real tokenization. */
 function buildTextHeavyEvents(turns: number, assistantChars: number, resultChars: number): SessionEvent[] {
   const events: SessionEvent[] = []
@@ -338,6 +366,18 @@ function measureLongSession(events: readonly SessionEvent[]): LongSessionMetrics
   }
 }
 
+/** Measure only the one-turn multi-step stats path. */
+function measureManyStepStats(events: readonly SessionEvent[]): { statsApply: number; snapshot: number } {
+  const statsApply = warmedP50(FAST ? 3 : 5, () => {
+    const folder = new StatsFolder()
+    folder.apply(events)
+  })
+  const folder = new StatsFolder()
+  folder.apply(events)
+  const snapshot = stats(timeIt(FULL_SAMPLES, () => { folder.snapshot() })).p50
+  return { statsApply, snapshot }
+}
+
 function fmtBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes.toFixed(0)} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`
@@ -381,6 +421,16 @@ async function main(): Promise<void> {
     row('  StatsFolder.apply', fmtMs(metrics.statsApply))
     row(`  StatsFolder.snapshot ×${FAST ? 20 : 50}`, fmtDuration(metrics.snapshot))
     row('  memory heapUsed/rss', `${fmtBytes(memory.heapUsed)} / ${fmtBytes(memory.rss)}`)
+  }
+
+  // 1b. Keep the single-turn tool-loop shape visible: settledPerStep must
+  // retain current-turn samples without scanning them on every step event.
+  for (const steps of [100, 500, 1000]) {
+    const events = buildManyStepEvents(steps)
+    const metrics = measureManyStepStats(events)
+    row(`one-turn-many-steps ${events.length} events (${steps} steps)`, `${steps} settled steps`)
+    row('  StatsFolder.apply', fmtMs(metrics.statsApply))
+    row(`  StatsFolder.snapshot ×${FULL_SAMPLES}`, fmtDuration(metrics.snapshot))
   }
   {
     const turns = 1

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
  * @xmoon76/dsh-pi-tui/scripts/bench — non-default performance benchmark
- * (run explicitly: `node scripts/bench.mjs`; never part of the test suite).
+ * (run explicitly: `node --import tsx/esm scripts/bench.mts`; never part of the test suite).
  *
  * Builds synthetic session logs (markdown, diffs, consecutive reads, tool
  * calls, CJK/emoji) and measures, across widths and themes:
  *
+ *   - long-session folds: reasoning-heavy, adjacent-read, and 700k-like
+ *     TranscriptFolder/StatsFolder apply and snapshot timings;
  *   - ingest: TranscriptFolder.apply() time per event count;
  *   - projection: messages() p50/p95/p99 (the incremental read-grouping);
  *   - rebuild: TuiApp.setTranscript cold (full markdown parse) vs warm
@@ -23,6 +25,7 @@
 import xterm from '@xterm/headless'
 import { TuiApp } from '../src/tui-app.ts'
 import { TranscriptFolder } from '../src/transcript.ts'
+import { StatsFolder } from '../src/stats.ts'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { TranscriptMessage } from '../src/transcript.ts'
 
@@ -67,7 +70,7 @@ const MARKDOWN_BLOCKS = [
 
 const DIFF_BODY = 'diff --git a/src/a.ts b/src/a.ts\nindex 111..222 100644\n--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1,3 +1,4 @@\n const a = 1\n+const b = 2\n-const old = 3\n // tail'
 
-/** Build `turns` turns of events; each turn ≈ 9 events. */
+/** Build `turns` turns of events; each turn is about 16 events. */
 function buildEvents(turns: number): SessionEvent[] {
   const events: SessionEvent[] = []
   let seq = 0
@@ -126,6 +129,126 @@ function buildEvents(turns: number): SessionEvent[] {
   return events
 }
 
+/** Append a synthetic event while keeping fixture construction readable. */
+function pushEvent(events: SessionEvent[], type: string, data: unknown): void {
+  const seq = events.length
+  events.push({ type, seq, time: seq, data } as SessionEvent)
+}
+
+/** Build reasoning-heavy history: every turn opens a reasoning entry before it settles. */
+function buildReasoningHeavyEvents(turns: number): SessionEvent[] {
+  const events: SessionEvent[] = []
+  for (let turn = 0; turn < turns; turn += 1) {
+    pushEvent(events, 'turn/start', { turn })
+    pushEvent(events, 'step/start', { turn, step: 0 })
+    for (let delta = 0; delta < 4; delta += 1) {
+      pushEvent(events, 'assistant/chunk', {
+        turn,
+        step: 0,
+        chunk: { type: 'reasoning-delta', index: delta, text: `reasoning ${turn}/${delta}` },
+      })
+    }
+    pushEvent(events, 'assistant/message', {
+      turn,
+      step: 0,
+      message: {
+        id: `reasoning-message-${turn}`,
+        role: 'assistant',
+        content: [{ type: 'text', text: `answer ${turn}` }],
+        source: { kind: 'model', provider: 'bench', model: 'bench' },
+      },
+      usage: { inputTokens: 100, outputTokens: 40 },
+    })
+    pushEvent(events, 'step/end', { turn, step: 0 })
+    pushEvent(events, 'turn/end', { turn, reason: { kind: 'completed' } })
+  }
+  return events
+}
+
+/** Build a run of adjacent settled reads to exercise historical grouping. */
+function buildReadHeavyEvents(turns: number, readsPerTurn: number): SessionEvent[] {
+  const events: SessionEvent[] = []
+  let call = 0
+  for (let turn = 0; turn < turns; turn += 1) {
+    pushEvent(events, 'turn/start', { turn })
+    for (let read = 0; read < readsPerTurn; read += 1) {
+      const callId = `read-${call++}`
+      pushEvent(events, 'tool/call', {
+        turn,
+        step: 0,
+        callId,
+        name: 'read',
+        arguments: JSON.stringify({ file: `src/file-${callId}.ts` }),
+      })
+      pushEvent(events, 'tool/result', {
+        turn,
+        step: 0,
+        message: {
+          id: `read-message-${callId}`,
+          role: 'user',
+          content: [{ type: 'tool-result', toolCallId: callId, content: [{ type: 'text', text: `file ${callId}` }] }],
+          source: { kind: 'tool', callId },
+        },
+      })
+    }
+    pushEvent(events, 'turn/end', { turn, reason: { kind: 'completed' } })
+  }
+  return events
+}
+
+const TEXT_HEAVY_BLOCK = 'The long-session fixture keeps a large assistant response and a large tool result in the folded history. '
+
+function repeatedText(length: number): string {
+  return TEXT_HEAVY_BLOCK.repeat(Math.ceil(length / TEXT_HEAVY_BLOCK.length)).slice(0, length)
+}
+
+/** Build a moderate-size text-heavy log without requiring real tokenization. */
+function buildTextHeavyEvents(turns: number, assistantChars: number, resultChars: number): SessionEvent[] {
+  const events: SessionEvent[] = []
+  for (let turn = 0; turn < turns; turn += 1) {
+    pushEvent(events, 'turn/start', { turn })
+    pushEvent(events, 'user/message', {
+      id: `text-heavy-user-${turn}`,
+      role: 'user',
+      content: [{ type: 'text', text: `summarize fixture ${turn}` }],
+      source: { kind: 'user' },
+    })
+    pushEvent(events, 'step/start', { turn, step: 0 })
+    pushEvent(events, 'assistant/message', {
+      turn,
+      step: 0,
+      message: {
+        id: `text-heavy-assistant-${turn}`,
+        role: 'assistant',
+        content: [{ type: 'text', text: repeatedText(assistantChars) }],
+        source: { kind: 'model', provider: 'bench', model: 'bench' },
+      },
+      usage: { inputTokens: assistantChars, outputTokens: assistantChars },
+    })
+    pushEvent(events, 'step/end', { turn, step: 0 })
+    const callId = `text-heavy-tool-${turn}`
+    pushEvent(events, 'tool/call', {
+      turn,
+      step: 0,
+      callId,
+      name: 'bash',
+      arguments: JSON.stringify({ command: 'cat large-output.txt' }),
+    })
+    pushEvent(events, 'tool/result', {
+      turn,
+      step: 0,
+      message: {
+        id: `text-heavy-result-${turn}`,
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId: callId, content: [{ type: 'text', text: repeatedText(resultChars) }] }],
+        source: { kind: 'tool', callId },
+      },
+    })
+    pushEvent(events, 'turn/end', { turn, reason: { kind: 'completed' } })
+  }
+  return events
+}
+
 // --- measurement helpers ----------------------------------------------------
 
 function percentile(sorted: number[], p: number): number {
@@ -152,6 +275,11 @@ function fmtMs(ms: number): string {
   return `${ms.toFixed(2)}ms`
 }
 
+/** Keep sub-millisecond projection timings visible in the report. */
+function fmtDuration(ms: number): string {
+  return ms < 1 ? `${(ms * 1000).toFixed(2)}µs` : fmtMs(ms)
+}
+
 /** Run a callback `n` times and return per-call wall times. */
 function timeIt(n: number, run: () => void): number[] {
   const samples: number[] = []
@@ -171,6 +299,51 @@ const STREAM_SAMPLES = FAST ? 50 : 200
 const FULL_SAMPLES = FAST ? 20 : 50
 const HEAP_REBUILDS = FAST ? 300 : 2000
 
+/** Warm one callback, then report its median measured sample. */
+function warmedP50(n: number, run: () => void): number {
+  run()
+  return stats(timeIt(n, run)).p50
+}
+
+/** Long-session projection timings are intentionally separate from renderer timings. */
+interface LongSessionMetrics {
+  transcriptApply: number
+  statsApply: number
+  snapshot: number
+  messages: number
+}
+
+function measureLongSession(events: readonly SessionEvent[]): LongSessionMetrics {
+  const samples = FAST ? 3 : 5
+  const transcriptApply = warmedP50(samples, () => {
+    const folder = new TranscriptFolder()
+    folder.apply(events)
+  })
+  const statsApply = warmedP50(samples, () => {
+    const folder = new StatsFolder()
+    folder.apply(events)
+  })
+  const transcript = new TranscriptFolder()
+  transcript.apply(events)
+  const statsFolder = new StatsFolder()
+  statsFolder.apply(events)
+  // Snapshot is deliberately sampled repeatedly: the A2 regression was an
+  // allocation-free scalar read, not a fold over every historical sample.
+  const snapshot = timeIt(FAST ? 20 : 50, () => { statsFolder.snapshot() })
+  return {
+    transcriptApply,
+    statsApply,
+    snapshot: stats(snapshot).p50,
+    messages: transcript.messages().length,
+  }
+}
+
+function fmtBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes.toFixed(0)} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`
+}
+
 // --- the benchmark ----------------------------------------------------------
 
 async function main(): Promise<void> {
@@ -182,12 +355,55 @@ async function main(): Promise<void> {
   // 1. ingest + projection
   for (const turns of [111, 1111, 5555]) {
     const events = buildEvents(turns)
+    // Each timing sample gets a fresh folder. Re-applying the same log to a
+    // stateful folder would benchmark duplicated history, not ingestion.
+    const ingest = warmedP50(FAST ? 3 : 5, () => {
+      const candidate = new TranscriptFolder()
+      candidate.apply(events)
+    })
     const folder = new TranscriptFolder()
-    const ingest = timeIt(3, () => folder.apply(events))
+    folder.apply(events)
     const projection = timeIt(PROJ_SAMPLES, () => folder.messages())
     const st = stats(projection)
-    row(`ingest ${events.length} events (${turns} turns)`, fmtMs(ingest[0]!))
-    row(`  messages() ×200 (${folder.messages().length} messages)`, fmt(st))
+    row(`ingest ${events.length} events (${turns} turns)`, fmtMs(ingest))
+    row(`  messages() ×${PROJ_SAMPLES} (${folder.messages().length} messages)`, fmt(st))
+  }
+
+  // 1a. PR A long-session projection fixtures. These are intentionally
+  // separate from the renderer benchmark so replay/fold regressions remain
+  // visible even when the TUI cache masks them.
+  for (const turns of [100, 500, 1000]) {
+    const events = buildReasoningHeavyEvents(turns)
+    const metrics = measureLongSession(events)
+    const memory = process.memoryUsage()
+    row(`reasoning-heavy ${events.length} events (${turns} turns)`, `${metrics.messages} messages`)
+    row('  TranscriptFolder.apply', fmtMs(metrics.transcriptApply))
+    row('  StatsFolder.apply', fmtMs(metrics.statsApply))
+    row(`  StatsFolder.snapshot ×${FAST ? 20 : 50}`, fmtDuration(metrics.snapshot))
+    row('  memory heapUsed/rss', `${fmtBytes(memory.heapUsed)} / ${fmtBytes(memory.rss)}`)
+  }
+  {
+    const turns = 1
+    const reads = 1000
+    const events = buildReadHeavyEvents(turns, reads)
+    const metrics = measureLongSession(events)
+    const memory = process.memoryUsage()
+    row(`read-heavy ${events.length} events (${reads} adjacent reads)`, `${metrics.messages} messages`)
+    row('  TranscriptFolder.apply', fmtMs(metrics.transcriptApply))
+    row('  StatsFolder.apply', fmtMs(metrics.statsApply))
+    row(`  StatsFolder.snapshot ×${FAST ? 20 : 50}`, fmtDuration(metrics.snapshot))
+    row('  memory heapUsed/rss', `${fmtBytes(memory.heapUsed)} / ${fmtBytes(memory.rss)}`)
+  }
+  {
+    const turns = 20
+    const events = buildTextHeavyEvents(turns, 18_000, 17_000)
+    const metrics = measureLongSession(events)
+    const memory = process.memoryUsage()
+    row(`700k-like ${events.length} events (${turns} turns, ${turns * (18_000 + 17_000)} chars)`, `${metrics.messages} messages`)
+    row('  TranscriptFolder.apply', fmtMs(metrics.transcriptApply))
+    row('  StatsFolder.apply', fmtMs(metrics.statsApply))
+    row(`  StatsFolder.snapshot ×${FAST ? 20 : 50}`, fmtDuration(metrics.snapshot))
+    row('  memory heapUsed/rss', `${fmtBytes(memory.heapUsed)} / ${fmtBytes(memory.rss)}`)
   }
 
   // 2. rebuild (cold vs warm) across widths, plus the streaming case
@@ -209,17 +425,31 @@ async function main(): Promise<void> {
     row(`rebuild ${messages.length} messages @${width} cols (cold, fresh app)`, fmtMs(cold[0]!))
     row(`  same content (warm cache)`, fmt(stats(warm)))
     // 20 Hz streaming: one assistant message's text replaced per frame.
-    const streaming = [...messages]
-    const target = streaming.findIndex(message => message.kind === 'assistant')
+    // Clone only the target card so the baseline fixture remains immutable for
+    // the fullscreen and heap scenarios below; each frame keeps a fixed-size
+    // replacement instead of appending an ever-growing suffix.
+    const target = messages.findIndex(message => message.kind === 'assistant')
+    const streaming = messages.map((message, index) => {
+      if (index !== target || message.kind !== 'assistant') return message
+      return { ...message }
+    })
+    const streamEntry = streaming[target]
+    const streamBase = streamEntry?.kind === 'assistant' ? streamEntry.text : ''
+    const streamPrefix = streamBase.slice(0, Math.max(0, streamBase.length - 8))
+    let streamFrame = 0
     const warmStream = timeIt(STREAM_SAMPLES, () => {
-      const entry = streaming[target]
-      if (entry !== undefined && entry.kind === 'assistant') entry.text += ' tail'
+      if (streamEntry !== undefined && streamEntry.kind === 'assistant') {
+        streamEntry.text = `${streamPrefix}frame-${String(streamFrame++ % 100).padStart(2, '0')}`
+      }
       app.setTranscript(streaming)
     })
     row(`  streaming 1 message/frame @${width}`, fmt(stats(warmStream)))
-    // Theme switch cost (once per switch).
-    const theme = timeIt(5, () => app.applyTheme('light'))
-    row(`  theme dark→light @${width}`, fmtMs(theme[0]!))
+    // Theme switch cost: alternate palettes so every sample is a real switch.
+    let themeFrame = 0
+    const theme = timeIt(5, () => {
+      app.applyTheme(themeFrame++ % 2 === 0 ? 'light' : 'dark')
+    })
+    row(`  theme dark↔light @${width}`, fmt(stats(theme)))
     app.stop()
   }
 
@@ -247,7 +477,7 @@ async function main(): Promise<void> {
     for (let i = 0; i < HEAP_REBUILDS; i += 1) app.setTranscript(messages)
     gc()
     const after = process.memoryUsage().heapUsed
-    row(`heap growth per warm rebuild (${HEAP_REBUILDS}×, gc)`, `${((after - before) / 2000).toFixed(1)} B/rebuild`)
+    row(`heap growth per warm rebuild (${HEAP_REBUILDS}×, gc)`, `${((after - before) / Math.max(1, HEAP_REBUILDS)).toFixed(1)} B/rebuild`)
     gc()
     const settled = process.memoryUsage().heapUsed
     row(`settled heap for ${messages.length} messages @120`, `${(settled / 1024 / 1024).toFixed(1)} MiB`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ import { childOwnEvents, textOf, TranscriptFolder } from './transcript.ts'
 import type { TranscriptMessage } from './transcript.ts'
 import { focusModeOf, installFocusPrompt, type FocusState } from './focus.ts'
 import { formatStats, StatsFolder } from './stats.ts'
+import { hydrateSessionUi } from './session-ui-hydrate.ts'
 import { plainSectionEqual } from './status/equal.ts'
 import { deriveRunnerPermission } from './status/derive-permission.ts'
 import { StatusStore } from './status/store.ts'
@@ -1066,6 +1067,18 @@ function foldGoal(events: readonly SessionEvent[]): string | undefined {
   return undefined
 }
 
+/** Time one cold-bootstrap fold without changing its authoritative semantics. */
+function timedBootstrapScan<T>(diag: Diag, name: string, eventCount: number, scan: () => T): T {
+  const started = performance.now()
+  const result = scan()
+  diag.debug('session bootstrap scan', {
+    scan: name,
+    eventCount,
+    elapsedMs: Number((performance.now() - started).toFixed(3)),
+  })
+  return result
+}
+
 /** A balanced completed-turn prefix for forking: the log up to (and including)
  * the last `turn/end`. Undefined when no turn has completed yet.
  * @param events - the session log.
@@ -1993,16 +2006,12 @@ export function apply(ctx: Context, config: Config): void {
       if (liveAgent === undefined) return undefined
       return ctx.get('agentPresets')?.composedPreset(liveAgent.ctx) ?? resolveSessionPreset(liveAgent.session)
     }
-    // Incremental fold state for the live session's log; reset on switch. The
-    // folder/stats/goal stay empty until a session exists (deferred start).
+    // Incremental fold state for the live session's log; reset on switch. A
+    // resumed session is hydrated only by initLiveSession below, so startup
+    // wiring never pre-folds the same event log a second time.
     let folder = new TranscriptFolder()
     let statsFolder = new StatsFolder()
     let goalText: string | undefined
-    if (liveAgent !== undefined) {
-      folder.apply(liveAgent.session.events)
-      statsFolder.apply(liveAgent.session.events)
-      goalText = foldGoal(liveAgent.session.events)
-    }
 
     /** Repaint the welcome card from the live agent's current facts. Re-read
      * on every call so a still-blank session's preset switch shows up. */
@@ -5380,7 +5389,9 @@ export function apply(ctx: Context, config: Config): void {
 
     // The TUI-owned slash commands are registered by registerCommands()
     // inside initLiveSession, exactly once after the first session exists.
-    refreshStatus()
+    // The initial status projection is committed after session hydration (or
+    // in the deferred branch below), so a resumed session never paints a
+    // temporary empty stats projection.
     // The persistent dock's task lines + the footer badge follow the
     // background-job registry: every change refreshes the active-task
     // snapshot (no polling). `refreshTasks` is hoisted so the task browser
@@ -5638,13 +5649,51 @@ export function apply(ctx: Context, config: Config): void {
       // the all-directory search): a legacy-only history file in this cwd
       // becomes recoverable immediately, even if it predates this process.
       rememberHistoryCwd(agent.session.header.cwd ?? '')
-      folder = new TranscriptFolder()
-      folder.apply(agent.session.events)
-      statsFolder = new StatsFolder()
-      statsFolder.apply(agent.session.events)
-      goalText = foldGoal(agent.session.events)
-      app.setWorking(workingFromLog(agent.session.events))
-      app.setSessionTitle(foldSessionTitle(agent.session.events)?.title)
+      const events = agent.session.events
+      // This is the single cold-hydration path for a live session. Do not
+      // pre-apply the same event log during runner wiring: a resumed session
+      // otherwise pays for two full transcript and stats replays before its
+      // first usable frame.
+      const hydrated = hydrateSessionUi(events)
+      folder = hydrated.folder
+      statsFolder = hydrated.statsFolder
+      diag.debug('session bootstrap scan', {
+        scan: 'transcript',
+        eventCount: events.length,
+        elapsedMs: Number(hydrated.scanTimings.transcriptMs.toFixed(3)),
+      })
+      diag.debug('session bootstrap scan', {
+        scan: 'stats',
+        eventCount: events.length,
+        elapsedMs: Number(hydrated.scanTimings.statsMs.toFixed(3)),
+      })
+      goalText = timedBootstrapScan(diag, 'goal', events.length, () => foldGoal(events))
+      const working = timedBootstrapScan(diag, 'working', events.length, () => workingFromLog(events))
+      const planMode = timedBootstrapScan(diag, 'plan', events.length, () => foldPlanMode(events))
+      const title = timedBootstrapScan(diag, 'title', events.length, () => foldSessionTitle(events)?.title)
+      app.setPlanMode(planMode)
+      app.setWorking(working)
+      app.setBusy(working)
+      app.setSessionTitle(title)
+      // Session-local bootstrap state must not leak across a switch. Fold the
+      // latest todo snapshot once from the same log (an empty log clears it).
+      const todos = timedBootstrapScan(diag, 'todo', events.length, () => {
+        for (let index = events.length - 1; index >= 0; index -= 1) {
+          const event = events[index]
+          if (event?.type === 'todo/write') return event.data.todos
+        }
+        return []
+      })
+      app.setTodoSummary(todos)
+      // A resumed session may be mid-compaction. Reset the old phase first;
+      // then re-arm only the newest live bracket, matching the log fold.
+      const resumedCompaction = timedBootstrapScan(diag, 'compaction', events.length, () => compactingFromLog(events))
+      compactingId = resumedCompaction.id
+      app.setCompactionPhase(resumedCompaction.active ? 'summarizing' : 'idle')
+      if (resumedCompaction.active) {
+        app.setBusy(true)
+        app.setWorking(true)
+      }
       app.clearLocalMessages()
       app.clearNotify() // a notice from the previous session is stale here
       // Issue #8: a stale armed exit chord must not exit the NEW session.
@@ -6409,38 +6458,10 @@ export function apply(ctx: Context, config: Config): void {
     // accumulate duplicate Host listeners (review finding).
     const disposeCredentialSubscription = backend.config.credentials.onChanged(refreshCredentialSurface)
     lifecycleController.signal.addEventListener('abort', disposeCredentialSubscription, { once: true })
-    // Initial plan badge, busy indicator, and auto title from the log (a
-    // resumed session may be persisted mid-turn). Without a session the
-    // surfaces stay at their idle defaults.
-    if (liveAgent !== undefined) {
-      app.setPlanMode(foldPlanMode(liveAgent.session.events))
-      app.setWorking(workingFromLog(liveAgent.session.events))
-      app.setBusy(workingFromLog(liveAgent.session.events))
-      app.setSessionTitle(foldSessionTitle(liveAgent.session.events)?.title)
-      // Initial compaction state: a resumed session may be persisted
-      // MID-compaction (compaction/start without a matching end) — the
-      // working row shows the unified label and the busy flag keeps the
-      // single-Esc cancel armed. A session/end-seed boundary makes any
-      // EARLIER unmatched start stale (upstream invariant), so only a
-      // bracket in the LIVE part of the log re-arms the surface. The log
-      // holds no summary/end yet, so the safest phase inference is
-      // 'summarizing' (in progress).
-      const resumedCompaction = compactingFromLog(liveAgent.session.events)
-      if (resumedCompaction.active) {
-        compactingId = resumedCompaction.id
-        app.setCompactionPhase('summarizing')
-        app.setBusy(true)
-        app.setWorking(true)
-      }
-      // Initial todo state: the last todo/write snapshot in the log.
-      for (let index = liveAgent.session.events.length - 1; index >= 0; index -= 1) {
-        const event = liveAgent.session.events[index]
-        if (event.type === 'todo/write') {
-          app.setTodoSummary(event.data.todos)
-          break
-        }
-      }
-    }
+    // Plan, busy, title, compaction, and todo bootstrap state are installed by
+    // initLiveSession together with the two hydrated projections. Keeping all
+    // session-owned bootstrap work there avoids a second full-log scan on
+    // resume and also makes session switches restore the same state.
 
     // The interactive answerer: every approval ask becomes a dialog. An
     // already-aborted request settles cancelled synchronously; otherwise the

--- a/src/session-ui-hydrate.ts
+++ b/src/session-ui-hydrate.ts
@@ -1,0 +1,47 @@
+/**
+ * One cold-session UI hydration path.
+ *
+ * The transcript and stats folders intentionally keep separate folds because
+ * they own different projections, but a session bootstrap must create and
+ * populate both together. Keeping that operation in one small adapter makes
+ * it harder for a resume path to pre-fold the same event log and then hydrate
+ * it again when the live surface is installed.
+ * @module @xmoon76/dsh-pi-tui/session-ui-hydrate
+ */
+
+import { StatsFolder } from './stats.ts'
+import { TranscriptFolder } from './transcript.ts'
+
+type SessionEvents = Parameters<TranscriptFolder['apply']>[0]
+
+/** The two incremental projections owned by one hydrated session surface. */
+export interface HydratedSessionUi {
+  readonly folder: TranscriptFolder
+  readonly statsFolder: StatsFolder
+  /** Wall time spent in each projection fold, for launch diagnostics. */
+  readonly scanTimings: {
+    readonly transcriptMs: number
+    readonly statsMs: number
+  }
+}
+
+/**
+ * Hydrate the session-owned UI projections exactly once from one event log.
+ * Later live events must be applied as one-event suffixes to the returned
+ * folders; callers should not pre-fold the same log before calling this.
+ */
+export function hydrateSessionUi(events: SessionEvents): HydratedSessionUi {
+  const transcriptStarted = performance.now()
+  const folder = new TranscriptFolder()
+  folder.apply(events)
+  const transcriptMs = performance.now() - transcriptStarted
+  const statsStarted = performance.now()
+  const statsFolder = new StatsFolder()
+  statsFolder.apply(events)
+  const statsMs = performance.now() - statsStarted
+  return {
+    folder,
+    statsFolder,
+    scanTimings: { transcriptMs, statsMs },
+  }
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -96,11 +96,23 @@ interface StepTiming {
   sampledOutputTokens?: number
 }
 
-/** Retain late-replay timing only for the current turn. */
-function pruneSettledBefore(map: Map<string, StepTiming>, turn: number): void {
-  for (const key of map.keys()) {
-    if (turnOfStepKey(key) < turn) map.delete(key)
+/** Advance the late-replay fence and clear the previous turn once. */
+function advanceTimingTurn(
+  open: Map<string, StepTiming>,
+  settled: Map<string, StepTiming>,
+  ended: Set<string>,
+  current: number | undefined,
+  turn: number,
+): number | undefined {
+  // Event logs are normally monotonic. Keeping a monotonic fence also makes
+  // an out-of-order older replay unable to mutate the current turn's timing.
+  if (current === undefined || turn > current) {
+    open.clear()
+    settled.clear()
+    ended.clear()
+    return turn
   }
+  return current
 }
 
 /**
@@ -145,10 +157,17 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
   // assistant/message can replace its output-token sample without retaining
   // timing state for the full session.
   const settledPerStep = new Map<string, StepTiming>()
+  // Step boundaries are idempotent within the active turn; older boundaries
+  // are stale once the timing fence advances.
+  const endedSteps = new Set<string>()
   const throughput: Throughput = { outputMsTotal: 0, decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
   const usage = new StepUsageAccumulator()
   const completedTurns = new Set<number>()
   let lastTurn: number | undefined
+  let settledTurn: number | undefined
+  const enterSettledTurn = (turn: number): void => {
+    settledTurn = advanceTimingTurn(perStep, settledPerStep, endedSteps, settledTurn, turn)
+  }
 
   for (const event of events) {
     // The same lifecycle policy as the Focus fold: after turn/end a late
@@ -163,7 +182,7 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
       case 'turn/start': {
         // Advance the shared usage accounting (review finding).
         usage.onTurnStart(event.data.turn)
-        pruneSettledBefore(settledPerStep, event.data.turn)
+        enterSettledTurn(event.data.turn)
         break
       }
       case 'turn/end': {
@@ -171,52 +190,58 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
         // Finalize any still-open steps so the session total agrees with
         // the Focus per-turn total (review finding).
         usage.onTurnEnd(event.data.turn)
-        // Drop the open timing entries of the ended turn (interrupted
-        // steps never see their step/end) — review finding.
-        for (const key of perStep.keys()) {
-          if (turnOfStepKey(key) === event.data.turn) perStep.delete(key)
-        }
-        for (const key of settledPerStep.keys()) {
-          if (turnOfStepKey(key) === event.data.turn) settledPerStep.delete(key)
+        // Drop all timing state of the ended turn (interrupted steps never
+        // see their step/end; late events are replay artifacts).
+        enterSettledTurn(event.data.turn)
+        if (settledTurn === event.data.turn) {
+          perStep.clear()
+          settledPerStep.clear()
+          endedSteps.clear()
         }
         break
       }
       case 'step/start': {
         const key = stepKey(event.data.turn, event.data.step)
-        pruneSettledBefore(settledPerStep, event.data.turn)
+        enterSettledTurn(event.data.turn)
+        usage.onStepStart(event.data.turn, event.data.step)
+        if (settledTurn !== event.data.turn || endedSteps.has(key) || perStep.has(key)) break
         settledPerStep.delete(key)
         perStep.set(key, { start: event.time })
-        usage.onStepStart(event.data.turn, event.data.step)
         break
       }
       case 'step/end': {
-        pruneSettledBefore(settledPerStep, event.data.turn)
-        // The projection counts turns/steps here (unique turns) and discards
-        // steps that never produced an assistant message; usage is still
-        // counted once per step (the projection's tokenUsage is step-keyed).
-        if (lastTurn !== event.data.turn) {
-          stats.turns += 1
-          lastTurn = event.data.turn
+        const key = stepKey(event.data.turn, event.data.step)
+        enterSettledTurn(event.data.turn)
+        const currentTimingTurn = settledTurn === event.data.turn
+        const firstEnd = currentTimingTurn && !endedSteps.has(key)
+        // The projection counts turns/steps at one unique step/end and
+        // discards older-turn boundaries after the timing fence advances.
+        if (firstEnd) {
+          endedSteps.add(key)
+          if (lastTurn !== event.data.turn) {
+            stats.turns += 1
+            lastTurn = event.data.turn
+          }
+          stats.steps += 1
         }
-        stats.steps += 1
         usage.onStepEnd(event.data.turn, event.data.step)
         // The open timing entry is dropped at step/end, but retain its small
         // settled sample until turn/end so a late authoritative message can
         // replace output tokens without losing throughput parity.
-        const key = stepKey(event.data.turn, event.data.step)
-        const timing = perStep.get(key)
+        const timing = currentTimingTurn ? perStep.get(key) : undefined
         if (timing?.settled === true) settledPerStep.set(key, timing)
-        perStep.delete(key)
+        if (currentTimingTurn) perStep.delete(key)
         break
       }
       case 'assistant/chunk': {
+        enterSettledTurn(event.data.turn)
         const { chunk } = event.data
         if (chunk.type === 'usage') {
           // Streaming usage is provisional: assistant/message carries the same
           // value and replaces it at settle, so it is counted exactly once.
           usage.onUsageChunk(event.data.turn, event.data.step, chunk.usage)
           const key = stepKey(event.data.turn, event.data.step)
-          const timing = perStep.get(key)
+          const timing = settledTurn === event.data.turn ? perStep.get(key) : undefined
           if (timing !== undefined) {
             // The LATEST chunk wins (the assembler value is cumulative) —
             // the same replace rule as the shared accumulator.
@@ -225,17 +250,21 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
         } else if (isTokenDelta(chunk)) {
           // The FIRST token delta of the step stamps the decode-window start
           // (Web firstTokenTime). Reasoning and tool-call deltas count too.
-          const timing = perStep.get(stepKey(event.data.turn, event.data.step))
-          if (timing !== undefined && timing.firstDelta === undefined) {
+          const timing = settledTurn === event.data.turn
+            ? perStep.get(stepKey(event.data.turn, event.data.step))
+            : undefined
+          if (timing !== undefined && timing.settled !== true && timing.firstDelta === undefined) {
             timing.firstDelta = event.time
           }
         }
         break
       }
       case 'assistant/message': {
-        pruneSettledBefore(settledPerStep, event.data.turn)
+        enterSettledTurn(event.data.turn)
         const key = stepKey(event.data.turn, event.data.step)
-        const timing = perStep.get(key) ?? settledPerStep.get(key)
+        const timing = settledTurn === event.data.turn
+          ? perStep.get(key) ?? settledPerStep.get(key)
+          : undefined
         if (timing !== undefined) {
           // The message time is the step's decode end and its usage is the
           // authoritative one; the whole step settles HERE (projection
@@ -334,6 +363,10 @@ export class StatsFolder {
   private readonly perStep = new Map<string, StepTiming>()
   // Retain only the current turn's settled samples for late message replay.
   private readonly settledPerStep = new Map<string, StepTiming>()
+  // Step boundaries are idempotent within the active turn; older boundaries
+  // are stale once the timing fence advances.
+  private readonly endedSteps = new Set<string>()
+  private settledTurn: number | undefined
   private readonly throughput: Throughput = { outputMsTotal: 0, decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
   /** The shared per-step usage accounting (same class as the Focus fold). */
   private readonly usage = new StepUsageAccumulator()
@@ -367,6 +400,11 @@ export class StatsFolder {
     return derived
   }
 
+  /** Advance the replay fence; a turn's settled samples are cleared once. */
+  private enterSettledTurn(turn: number): void {
+    this.settledTurn = advanceTimingTurn(this.perStep, this.settledPerStep, this.endedSteps, this.settledTurn, turn)
+  }
+
   private applyEvent(event: SessionEvent): void {
     if (event.type !== 'turn/end' && event.type !== 'request/context'
       && this.completedTurns.has((event.data as { turn?: unknown }).turn as number)) {
@@ -376,9 +414,7 @@ export class StatsFolder {
       case 'turn/start': {
         // Advance the shared usage accounting (review finding).
         this.usage.onTurnStart(event.data.turn)
-        for (const key of this.settledPerStep.keys()) {
-          if (turnOfStepKey(key) < event.data.turn) this.settledPerStep.delete(key)
-        }
+        this.enterSettledTurn(event.data.turn)
         break
       }
       case 'turn/end': {
@@ -386,64 +422,77 @@ export class StatsFolder {
         // Finalize any still-open steps so the session total agrees with
         // the Focus per-turn total (review finding).
         this.usage.onTurnEnd(event.data.turn)
-        // Drop the open timing entries of the ended turn (interrupted
-        // steps never see their step/end) — review finding.
-        for (const key of this.perStep.keys()) {
-          if (turnOfStepKey(key) === event.data.turn) this.perStep.delete(key)
-        }
-        for (const key of this.settledPerStep.keys()) {
-          if (turnOfStepKey(key) === event.data.turn) this.settledPerStep.delete(key)
+        // Drop all timing state of the ended turn (interrupted steps never
+        // see their step/end; late events are replay artifacts).
+        this.enterSettledTurn(event.data.turn)
+        if (this.settledTurn === event.data.turn) {
+          this.perStep.clear()
+          this.settledPerStep.clear()
+          this.endedSteps.clear()
         }
         break
       }
       case 'step/start': {
         const key = stepKey(event.data.turn, event.data.step)
-        pruneSettledBefore(this.settledPerStep, event.data.turn)
+        this.enterSettledTurn(event.data.turn)
+        this.usage.onStepStart(event.data.turn, event.data.step)
+        if (this.settledTurn !== event.data.turn || this.endedSteps.has(key) || this.perStep.has(key)) break
         this.settledPerStep.delete(key)
         this.perStep.set(key, { start: event.time })
-        this.usage.onStepStart(event.data.turn, event.data.step)
         break
       }
       case 'step/end': {
-        pruneSettledBefore(this.settledPerStep, event.data.turn)
-        if (this.lastTurn !== event.data.turn) {
-          this.stats.turns += 1
-          this.lastTurn = event.data.turn
+        const key = stepKey(event.data.turn, event.data.step)
+        this.enterSettledTurn(event.data.turn)
+        const currentTimingTurn = this.settledTurn === event.data.turn
+        const firstEnd = currentTimingTurn && !this.endedSteps.has(key)
+        // The projection counts turns/steps at one unique step/end and
+        // discards older-turn boundaries after the timing fence advances.
+        if (firstEnd) {
+          this.endedSteps.add(key)
+          if (this.lastTurn !== event.data.turn) {
+            this.stats.turns += 1
+            this.lastTurn = event.data.turn
+          }
+          this.stats.steps += 1
         }
-        this.stats.steps += 1
         this.usage.onStepEnd(event.data.turn, event.data.step)
         // Drop the open entry, retaining only its small settled sample until
         // turn/end so a late authoritative message can preserve throughput
         // parity with the replacement token totals.
-        const key = stepKey(event.data.turn, event.data.step)
-        const timing = this.perStep.get(key)
+        const timing = currentTimingTurn ? this.perStep.get(key) : undefined
         if (timing?.settled === true) this.settledPerStep.set(key, timing)
-        this.perStep.delete(key)
+        if (currentTimingTurn) this.perStep.delete(key)
         break
       }
       case 'assistant/chunk': {
+        this.enterSettledTurn(event.data.turn)
         const { chunk } = event.data
         if (chunk.type === 'usage') {
           this.usage.onUsageChunk(event.data.turn, event.data.step, chunk.usage)
           const key = stepKey(event.data.turn, event.data.step)
-          const timing = this.perStep.get(key)
+          const timing = this.settledTurn === event.data.turn ? this.perStep.get(key) : undefined
           if (timing !== undefined) {
             // The LATEST chunk wins (the assembler value is cumulative) —
             // the same replace rule as the shared accumulator.
             timing.usage = chunk.usage
           }
         } else if (isTokenDelta(chunk)) {
-          const timing = this.perStep.get(stepKey(event.data.turn, event.data.step))
-          if (timing !== undefined && timing.firstDelta === undefined) {
+          const timing = this.settledTurn === event.data.turn
+            ? this.perStep.get(stepKey(event.data.turn, event.data.step))
+            : undefined
+          if (timing !== undefined && timing.settled !== true && timing.firstDelta === undefined) {
             timing.firstDelta = event.time
           }
         }
         break
       }
       case 'assistant/message': {
-        pruneSettledBefore(this.settledPerStep, event.data.turn)
+        this.enterSettledTurn(event.data.turn)
         const key = stepKey(event.data.turn, event.data.step)
-        const timing = this.perStep.get(key) ?? this.settledPerStep.get(key)
+        const timing = this.settledTurn === event.data.turn
+          ? this.perStep.get(key) ?? this.settledPerStep.get(key)
+          : undefined
         if (timing !== undefined) {
           // Keep timing and throughput idempotent if a malformed/replayed log
           // carries the same authoritative message more than once. The shared

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -89,6 +89,18 @@ interface StepTiming {
   firstDelta?: number
   completed?: number
   usage?: UsageLike
+  /** One step may have at most one timing settlement. */
+  settled?: boolean
+  /** The already-accounted decode sample, when usage was available. */
+  sampledDuration?: number
+  sampledOutputTokens?: number
+}
+
+/** Retain late-replay timing only for the current turn. */
+function pruneSettledBefore(map: Map<string, StepTiming>, turn: number): void {
+  for (const key of map.keys()) {
+    if (turnOfStepKey(key) < turn) map.delete(key)
+  }
 }
 
 /**
@@ -111,8 +123,8 @@ function isTokenDelta(chunk: { type: string; text?: string; argumentsDelta?: str
 
 /** Timing/throughput accumulators shared by the fold and the folder. */
 interface Throughput {
-  /** Decode windows (ms) of steps sampled for tok/s. */
-  outputMs: number[]
+  /** Total decode-window duration (ms) of sampled steps. */
+  outputMsTotal: number
   /** Output tokens over the same sampled steps. */
   decodeTokens: number
   /** Summed TTFT over first-token steps. */
@@ -129,7 +141,11 @@ interface Throughput {
 export function computeStats(events: readonly SessionEvent[]): SessionStats {
   const stats: SessionStats = { ...EMPTY }
   const perStep = new Map<string, StepTiming>()
-  const throughput: Throughput = { outputMs: [], decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
+  // Keep settled samples only until their turn closes, so a late duplicate
+  // assistant/message can replace its output-token sample without retaining
+  // timing state for the full session.
+  const settledPerStep = new Map<string, StepTiming>()
+  const throughput: Throughput = { outputMsTotal: 0, decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
   const usage = new StepUsageAccumulator()
   const completedTurns = new Set<number>()
   let lastTurn: number | undefined
@@ -147,6 +163,7 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
       case 'turn/start': {
         // Advance the shared usage accounting (review finding).
         usage.onTurnStart(event.data.turn)
+        pruneSettledBefore(settledPerStep, event.data.turn)
         break
       }
       case 'turn/end': {
@@ -159,13 +176,21 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
         for (const key of perStep.keys()) {
           if (turnOfStepKey(key) === event.data.turn) perStep.delete(key)
         }
+        for (const key of settledPerStep.keys()) {
+          if (turnOfStepKey(key) === event.data.turn) settledPerStep.delete(key)
+        }
         break
       }
-      case 'step/start':
-        perStep.set(stepKey(event.data.turn, event.data.step), { start: event.time })
+      case 'step/start': {
+        const key = stepKey(event.data.turn, event.data.step)
+        pruneSettledBefore(settledPerStep, event.data.turn)
+        settledPerStep.delete(key)
+        perStep.set(key, { start: event.time })
         usage.onStepStart(event.data.turn, event.data.step)
         break
+      }
       case 'step/end': {
+        pruneSettledBefore(settledPerStep, event.data.turn)
         // The projection counts turns/steps here (unique turns) and discards
         // steps that never produced an assistant message; usage is still
         // counted once per step (the projection's tokenUsage is step-keyed).
@@ -175,9 +200,13 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
         }
         stats.steps += 1
         usage.onStepEnd(event.data.turn, event.data.step)
-        // The step's timing is settled at assistant/message; drop the
-        // entry so a long session's map stays bounded (review finding).
-        perStep.delete(stepKey(event.data.turn, event.data.step))
+        // The open timing entry is dropped at step/end, but retain its small
+        // settled sample until turn/end so a late authoritative message can
+        // replace output tokens without losing throughput parity.
+        const key = stepKey(event.data.turn, event.data.step)
+        const timing = perStep.get(key)
+        if (timing?.settled === true) settledPerStep.set(key, timing)
+        perStep.delete(key)
         break
       }
       case 'assistant/chunk': {
@@ -204,15 +233,24 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
         break
       }
       case 'assistant/message': {
+        pruneSettledBefore(settledPerStep, event.data.turn)
         const key = stepKey(event.data.turn, event.data.step)
-        const timing = perStep.get(key)
+        const timing = perStep.get(key) ?? settledPerStep.get(key)
         if (timing !== undefined) {
           // The message time is the step's decode end and its usage is the
           // authoritative one; the whole step settles HERE (projection
           // semantics) — step/end only counts turns/steps and the usage.
-          timing.completed = event.time
-          if (event.data.usage !== undefined) timing.usage = event.data.usage
-          settleStep(stats, timing, throughput)
+          // A duplicate authoritative message may replace token usage, but it
+          // must never add a second wall-time or throughput sample.
+          if (timing.settled !== true) {
+            timing.completed = event.time
+            if (event.data.usage !== undefined) timing.usage = event.data.usage
+            settleStep(stats, timing, throughput)
+            timing.settled = true
+          } else if (event.data.usage !== undefined) {
+            timing.usage = event.data.usage
+            replaceSampledUsage(timing, event.data.usage, throughput)
+          }
         }
         usage.onAssistantMessage(event.data.turn, event.data.step, event.data.usage)
         break
@@ -227,7 +265,7 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
   }
 
   if (throughput.firstTokenCount > 0) stats.firstTokenMsAvg = throughput.firstTokenTotal / throughput.firstTokenCount
-  const streamMs = throughput.outputMs.reduce((sum, ms) => sum + ms, 0)
+  const streamMs = throughput.outputMsTotal
   if (streamMs > 0) stats.tokensPerSec = Math.round((throughput.decodeTokens * 1000) / streamMs)
   const totals = usage.sessionTotals()
   stats.inputTokens = totals.inputTokens
@@ -237,6 +275,23 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
   const billedInput = stats.inputTokens + stats.cacheReadTokens + stats.cacheWriteTokens
   if (billedInput > 0) stats.cacheHitPct = (stats.cacheReadTokens * 100) / billedInput
   return stats
+}
+
+/** Replace the output-token side of an already-accounted decode sample.
+ * Assistant/message usage is authoritative and can replace an earlier value;
+ * the decode window itself still belongs to the first settled message. */
+function replaceSampledUsage(timing: StepTiming, usage: UsageLike, throughput: Throughput): void {
+  const first = timing.firstDelta
+  const completed = timing.completed
+  if (timing.sampledDuration === undefined) {
+    if (first === undefined || completed === undefined) return
+    timing.sampledDuration = Math.max(0, completed - first)
+    throughput.outputMsTotal += timing.sampledDuration
+  } else {
+    throughput.decodeTokens -= timing.sampledOutputTokens ?? 0
+  }
+  throughput.decodeTokens += usage.outputTokens
+  timing.sampledOutputTokens = usage.outputTokens
 }
 
 /** Settle one step's TIMING at its assistant/message boundary. A step with
@@ -256,10 +311,7 @@ function settleStep(stats: SessionStats, timing: StepTiming, throughput: Through
     // the step also reported usage, and vice versa (projection sampled
     // semantics) — a reasoning-only or usage-less step skews neither side.
     const usage = timing.usage
-    if (usage !== undefined) {
-      throughput.outputMs.push(Math.max(0, completed - first))
-      throughput.decodeTokens += usage.outputTokens
-    }
+    if (usage !== undefined) replaceSampledUsage(timing, usage, throughput)
   }
 }
 
@@ -280,7 +332,9 @@ function addUsage(stats: SessionStats, usage: UsageLike): void {
 export class StatsFolder {
   private readonly stats: SessionStats = { ...EMPTY }
   private readonly perStep = new Map<string, StepTiming>()
-  private readonly throughput: Throughput = { outputMs: [], decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
+  // Retain only the current turn's settled samples for late message replay.
+  private readonly settledPerStep = new Map<string, StepTiming>()
+  private readonly throughput: Throughput = { outputMsTotal: 0, decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
   /** The shared per-step usage accounting (same class as the Focus fold). */
   private readonly usage = new StepUsageAccumulator()
   /** Turns finalized by turn/end: late events of theirs are replay
@@ -301,7 +355,7 @@ export class StatsFolder {
   snapshot(): SessionStats {
     const derived: SessionStats = { ...this.stats }
     if (this.throughput.firstTokenCount > 0) derived.firstTokenMsAvg = this.throughput.firstTokenTotal / this.throughput.firstTokenCount
-    const streamMs = this.throughput.outputMs.reduce((sum, ms) => sum + ms, 0)
+    const streamMs = this.throughput.outputMsTotal
     if (streamMs > 0) derived.tokensPerSec = Math.round((this.throughput.decodeTokens * 1000) / streamMs)
     const totals = this.usage.sessionTotals()
     derived.inputTokens = totals.inputTokens
@@ -322,6 +376,9 @@ export class StatsFolder {
       case 'turn/start': {
         // Advance the shared usage accounting (review finding).
         this.usage.onTurnStart(event.data.turn)
+        for (const key of this.settledPerStep.keys()) {
+          if (turnOfStepKey(key) < event.data.turn) this.settledPerStep.delete(key)
+        }
         break
       }
       case 'turn/end': {
@@ -334,23 +391,34 @@ export class StatsFolder {
         for (const key of this.perStep.keys()) {
           if (turnOfStepKey(key) === event.data.turn) this.perStep.delete(key)
         }
+        for (const key of this.settledPerStep.keys()) {
+          if (turnOfStepKey(key) === event.data.turn) this.settledPerStep.delete(key)
+        }
         break
       }
-      case 'step/start':
-        this.perStep.set(stepKey(event.data.turn, event.data.step), { start: event.time })
+      case 'step/start': {
+        const key = stepKey(event.data.turn, event.data.step)
+        pruneSettledBefore(this.settledPerStep, event.data.turn)
+        this.settledPerStep.delete(key)
+        this.perStep.set(key, { start: event.time })
         this.usage.onStepStart(event.data.turn, event.data.step)
         break
+      }
       case 'step/end': {
+        pruneSettledBefore(this.settledPerStep, event.data.turn)
         if (this.lastTurn !== event.data.turn) {
           this.stats.turns += 1
           this.lastTurn = event.data.turn
         }
         this.stats.steps += 1
         this.usage.onStepEnd(event.data.turn, event.data.step)
-        // The step's timing is settled at assistant/message; drop the
-        // entry so the long-lived folder's map stays bounded (review
-        // finding — the old fold deleted it here too).
-        this.perStep.delete(stepKey(event.data.turn, event.data.step))
+        // Drop the open entry, retaining only its small settled sample until
+        // turn/end so a late authoritative message can preserve throughput
+        // parity with the replacement token totals.
+        const key = stepKey(event.data.turn, event.data.step)
+        const timing = this.perStep.get(key)
+        if (timing?.settled === true) this.settledPerStep.set(key, timing)
+        this.perStep.delete(key)
         break
       }
       case 'assistant/chunk': {
@@ -373,12 +441,22 @@ export class StatsFolder {
         break
       }
       case 'assistant/message': {
+        pruneSettledBefore(this.settledPerStep, event.data.turn)
         const key = stepKey(event.data.turn, event.data.step)
-        const timing = this.perStep.get(key)
+        const timing = this.perStep.get(key) ?? this.settledPerStep.get(key)
         if (timing !== undefined) {
-          timing.completed = event.time
-          if (event.data.usage !== undefined) timing.usage = event.data.usage
-          settleStep(this.stats, timing, this.throughput)
+          // Keep timing and throughput idempotent if a malformed/replayed log
+          // carries the same authoritative message more than once. The shared
+          // usage accumulator still applies replacement semantics below.
+          if (timing.settled !== true) {
+            timing.completed = event.time
+            if (event.data.usage !== undefined) timing.usage = event.data.usage
+            settleStep(this.stats, timing, this.throughput)
+            timing.settled = true
+          } else if (event.data.usage !== undefined) {
+            timing.usage = event.data.usage
+            replaceSampledUsage(timing, event.data.usage, this.throughput)
+          }
         }
         this.usage.onAssistantMessage(event.data.turn, event.data.step, event.data.usage)
         break

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -416,6 +416,10 @@ export class TranscriptFolder {
   private readonly assistantEntries = new Map<string, Extract<TranscriptMessage, { kind: 'assistant' }>>()
   /** The thinking entry object per (turn, step), for in-place text updates. */
   private readonly thinkingEntries = new Map<string, Extract<TranscriptMessage, { kind: 'thinking' }>>()
+  /** Thinking entries that still need a lifecycle boundary to settle. The
+   * complete entry map above is retained for replay updates; this index keeps
+   * turn/end from revisiting settled history. */
+  private readonly openThinkingByTurn = new Map<number, Set<Extract<TranscriptMessage, { kind: 'thinking' }>>>()
   /** Tool calls awaiting their result, keyed by callId with their running card. */
   private readonly pendingCalls = new Map<string, { name: string; args: string; turn: number; card: Extract<TranscriptMessage, { kind: 'tool' }>; index: number }>()
   /** Tool names by callId, for result pairing. */
@@ -831,6 +835,23 @@ export class TranscriptFolder {
     return this.windowedMessages(maxTurns)
   }
 
+  /** Remove one thinking entry from the open-lifecycle index. */
+  private closeThinking(entry: Extract<TranscriptMessage, { kind: 'thinking' }>): void {
+    entry.running = false
+    const open = this.openThinkingByTurn.get(entry.turn)
+    if (open === undefined) return
+    open.delete(entry)
+    if (open.size === 0) this.openThinkingByTurn.delete(entry.turn)
+  }
+
+  /** Settle only the thinking entries owned by one ended turn. */
+  private closeThinkingForTurn(turn: number): void {
+    const open = this.openThinkingByTurn.get(turn)
+    if (open === undefined) return
+    for (const entry of open) entry.running = false
+    this.openThinkingByTurn.delete(turn)
+  }
+
   /** The thinking entry object for one (turn, step), created on first reasoning. */
   private thinkingEntry(turn: number, step: number): Extract<TranscriptMessage, { kind: 'thinking' }> {
     const key = stepKey(turn, step)
@@ -838,6 +859,12 @@ export class TranscriptFolder {
     if (entry === undefined) {
       entry = { kind: 'thinking', turn, text: '', running: true }
       this.thinkingEntries.set(key, entry)
+      let open = this.openThinkingByTurn.get(turn)
+      if (open === undefined) {
+        open = new Set()
+        this.openThinkingByTurn.set(turn, open)
+      }
+      open.add(entry)
       this.appendItem(entry)
     }
     return entry
@@ -1058,6 +1085,7 @@ export class TranscriptFolder {
         const activity = this.activityFor(event.data.turn)
         if (activity.completed) break
         const key = stepKey(event.data.turn, event.data.step)
+        const alreadySettled = activity.settledSteps.has(event.data.step)
         const messageBlocks = event.data.message.content
         const text = textOf(messageBlocks)
         const entry = this.assistantEntries.get(key)
@@ -1075,15 +1103,18 @@ export class TranscriptFolder {
           this.assistantEntries.set(key, created)
           this.appendItem(created)
         }
-        // The step is complete: its thinking entry stops streaming.
+        // The step is complete: its thinking entry stops streaming and leaves
+        // the open-lifecycle index, so a later turn/end never revisits it.
         const thinking = this.thinkingEntries.get(key)
-        if (thinking !== undefined) thinking.running = false
+        if (thinking !== undefined) this.closeThinking(thinking)
         // Focus aggregation: the settled assistant text OVERWRITES the
         // candidate's text (authoritative — plan §5.4) but does NOT decide
         // whether it is the final answer; the candidate keeps its step
         // identity and the turn/end resolution decides. The final answer
         // never enters the Message slot (plan §22).
-        activity.assistantMessages += 1
+        // Count one settled output per step; a late duplicate may replace the
+        // transcript text but must not inflate Focus activity.
+        if (!alreadySettled) activity.assistantMessages += 1
         // Every accepted authoritative message settles its step's output —
         // EMPTY and image-only messages included: a later text-delta for
         // it is a replay artifact and must never resurrect a preview
@@ -1263,13 +1294,16 @@ export class TranscriptFolder {
         // synthetic cards or re-settle the activity (review finding).
         const endActivity = this.activityFor(event.data.turn)
         if (endActivity.completed) break
-        // Every thinking entry stops streaming when the turn closes
-        // (interrupted steps never see their assistant/message).
-        for (const entry of this.thinkingEntries.values()) entry.running = false
+        // Every still-open thinking entry of THIS turn stops streaming when
+        // the turn closes (interrupted steps never see their
+        // assistant/message). Settled entries were removed when their
+        // assistant/message arrived, so this is proportional to the open
+        // work rather than to the full history.
         // The synthetic cards carry the EVENT's own turn — never
         // this.currentTurn: a turn-start-less fragment's end must land in
         // its own turn (review finding).
         const endTurn = event.data.turn
+        this.closeThinkingForTurn(endTurn)
         if (event.data.reason.kind === 'error') {
           // Defensive: a malformed/legacy reason without the error detail
           // degrades to the bare marker instead of crashing the fold

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -1,0 +1,279 @@
+/** Runner-level regression coverage for the single cold-session hydration path. */
+
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { Context } from '@deepseek-ai/cordis'
+import { MessageId } from '@deepseek-ai/dsh-llm'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { apply as applyRunner, type Config } from '../src/index.ts'
+import { StatsFolder } from '../src/stats.ts'
+import { TUI_STARTUP_SERVICE } from '../src/startup.ts'
+import { TranscriptFolder } from '../src/transcript.ts'
+import { TuiApp } from '../src/tui-app.ts'
+
+process.env.NO_COLOR = ''
+process.env.FORCE_COLOR = ''
+process.env.CI = ''
+
+function event<K extends SessionEvent['type']>(
+  type: K,
+  data: SessionEvent<K>['data'],
+  seq: number,
+): SessionEvent {
+  return { type, seq, time: 1_700_000_000_000 + seq * 1000, data } as SessionEvent
+}
+
+function sessionEvents(text: string): SessionEvent[] {
+  return [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text },
+    }, 2),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('runner-bootstrap-message'),
+        role: 'assistant',
+        content: [{ type: 'text', text }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 10, outputTokens: 2 },
+    }, 3),
+    event('step/end', { turn: 0, step: 0 }, 4),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5),
+  ]
+}
+
+interface FakeSession {
+  id: string
+  header: { id: string; cwd: string; createdAt: number; version: number }
+  events: SessionEvent[]
+}
+
+interface RunnerHarness {
+  readonly persistence: unknown
+  readonly agents: unknown
+  readonly sessions: unknown
+  readonly defaultModel: unknown
+  readonly commands: unknown
+}
+
+function fakeAgent(session: FakeSession): Agent {
+  const agentContext = new Context()
+  return {
+    session,
+    ctx: agentContext,
+    options: { provider: 'p', model: 'm' },
+    inbox: { nextTurn: [], nextStep: [] },
+    whenIdle: async () => {},
+  } as unknown as Agent
+}
+
+/** Build Direct services whose in-memory registry behaves like the real Host. */
+function makeHarness(home: string, initial?: FakeSession): RunnerHarness {
+  const persisted = new Map<string, FakeSession>()
+  const live = new Map<string, Agent>()
+  if (initial !== undefined) persisted.set(initial.id, initial)
+
+  const makeHandle = (session: FakeSession): { agent: Agent; dispose: () => Promise<void> } => {
+    const agent = fakeAgent(session)
+    live.set(session.id, agent)
+    return {
+      agent,
+      dispose: async () => {
+        live.delete(session.id)
+      },
+    }
+  }
+
+  const persistence = {
+    list: async () => [...persisted.values()].map(session => session.header),
+    inspect: async (id: unknown) => ({ events: persisted.get(String(id))?.events ?? [] }),
+    readRaw: async () => undefined,
+    locate: ({ id }: { id: string }) => ({ kind: 'session', path: join(home, 'sessions', `${id}.jsonl`) }),
+  }
+  const agents = {
+    resume: async ({ resumeSessionId }: { resumeSessionId: unknown }) => {
+      const session = persisted.get(String(resumeSessionId))
+      if (session === undefined) throw new Error(`unknown test session ${String(resumeSessionId)}`)
+      return makeHandle(session)
+    },
+    create: async ({ sessionId }: { sessionId: unknown }) => {
+      const id = String(sessionId)
+      const session: FakeSession = {
+        id,
+        header: { id, cwd: home, createdAt: Date.now(), version: 1 },
+        events: sessionEvents('created answer'),
+      }
+      persisted.set(id, session)
+      return makeHandle(session)
+    },
+    get: (id: string) => live.get(id),
+  }
+  const sessions = {
+    flush: async () => {},
+    get: (id: string) => live.get(id)?.session,
+  }
+  const defaultModel = {
+    currentSelection: () => ({ provider: 'p', model: 'm' }),
+    saveSelection: async () => {},
+  }
+  const definitions = new Map<string, { name: string; description: string; handler: (...args: never[]) => unknown }>()
+  const commands = {
+    register: (definition: { name: string; description: string; handler: (...args: never[]) => unknown }) => {
+      definitions.set(definition.name, definition)
+      return () => {
+        if (definitions.get(definition.name) === definition) definitions.delete(definition.name)
+      }
+    },
+    list: () => [...definitions.values()].map(({ name, description }) => ({ name, description })),
+    execute: async () => ({ result: { kind: 'success' } }),
+    handler: (name: string) => definitions.get(name)?.handler,
+  }
+  return { persistence, agents, sessions, defaultModel, commands }
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 40; index += 1) await Promise.resolve()
+}
+
+/** Dispose every fiber created by the real Cordis context. */
+async function disposeContext(ctx: Context): Promise<void> {
+  for (const runtime of [...ctx.registry.values()]) {
+    for (const fiber of runtime.fibers) await Promise.resolve(fiber.dispose())
+  }
+}
+
+interface RunnerProbe {
+  transcriptApplyCount: number
+  statsApplyCount: number
+  capturedMessages: readonly { kind: string; text?: string }[] | undefined
+  apps: TuiApp[]
+  restore: () => void
+}
+
+/** Observe the production runner without replacing its TUI or projection code. */
+function installProbe(): RunnerProbe {
+  const probe: RunnerProbe = {
+    transcriptApplyCount: 0,
+    statsApplyCount: 0,
+    capturedMessages: undefined,
+    apps: [],
+    restore: () => {},
+  }
+  const originalTranscriptApply = TranscriptFolder.prototype.apply
+  const originalStatsApply = StatsFolder.prototype.apply
+  const originalSetTranscript = TuiApp.prototype.setTranscript
+  const originalStart = TuiApp.prototype.start
+  TranscriptFolder.prototype.apply = function (events) {
+    probe.transcriptApplyCount += 1
+    return originalTranscriptApply.call(this, events)
+  }
+  StatsFolder.prototype.apply = function (events) {
+    probe.statsApplyCount += 1
+    return originalStatsApply.call(this, events)
+  }
+  TuiApp.prototype.setTranscript = function (messages, activities) {
+    probe.capturedMessages = messages
+    return originalSetTranscript.call(this, messages, activities)
+  }
+  TuiApp.prototype.start = function () {
+    probe.apps.push(this)
+    return originalStart.call(this)
+  }
+  probe.restore = () => {
+    TranscriptFolder.prototype.apply = originalTranscriptApply
+    StatsFolder.prototype.apply = originalStatsApply
+    TuiApp.prototype.setTranscript = originalSetTranscript
+    TuiApp.prototype.start = originalStart
+  }
+  return probe
+}
+
+async function mountRunner(
+  ctx: Context,
+  home: string,
+  harness: RunnerHarness,
+  startup: { sessionId?: string },
+  config: Config,
+) {
+  ctx.provide('appExit', () => {})
+  ctx.provide(TUI_STARTUP_SERVICE, { ...startup, shippedPresetRoot: home })
+  ctx.provide('sessionPersistence', harness.persistence as never)
+  ctx.provide('agents', harness.agents as never)
+  ctx.provide('sessions', harness.sessions as never)
+  ctx.provide('agentDefaultModel', harness.defaultModel as never)
+  ctx.provide('commands', harness.commands as never)
+  ctx.provide('loader', { await: async () => {} } as never)
+  const fiber = ctx.plugin((pluginCtx) => applyRunner(pluginCtx, config))
+  await fiber
+  await settle()
+  return fiber
+}
+
+test('the real runner hydrates resume, deferred create, and switch exactly once each', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-runner-bootstrap-'))
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  const probe = installProbe()
+  let resumeContext: Context | undefined
+  let deferredContext: Context | undefined
+  let resumeFiber: { dispose: () => Promise<unknown> } | undefined
+  let deferredFiber: { dispose: () => Promise<unknown> } | undefined
+  try {
+    const resumed: FakeSession = {
+      id: 'runner-session-a',
+      header: { id: 'runner-session-a', cwd: home, createdAt: 1_700_000_000_000, version: 1 },
+      events: sessionEvents('resumed answer'),
+    }
+    const resumeHarness = makeHarness(home, resumed)
+    resumeContext = new Context()
+    resumeFiber = await mountRunner(resumeContext, home, resumeHarness, { sessionId: resumed.id }, { sessionId: resumed.id })
+    assert.equal(probe.transcriptApplyCount, 1)
+    assert.equal(probe.statsApplyCount, 1)
+    assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'resumed answer'))
+
+    const newHandler = (resumeHarness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+    assert.ok(newHandler, 'the real runner must register the /new transition command')
+    await newHandler()
+    await settle()
+    assert.equal(probe.transcriptApplyCount, 2)
+    assert.equal(probe.statsApplyCount, 2)
+    assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'created answer'))
+
+    await resumeFiber.dispose()
+    await disposeContext(resumeContext)
+    resumeFiber = undefined
+
+    const deferredHarness = makeHarness(home)
+    deferredContext = new Context()
+    deferredFiber = await mountRunner(deferredContext, home, deferredHarness, {}, {})
+    assert.equal(probe.transcriptApplyCount, 2, 'deferred startup must not hydrate an absent session')
+    assert.equal(probe.statsApplyCount, 2, 'deferred startup must not hydrate an absent session')
+    const app = probe.apps.at(-1)
+    assert.ok(app, 'the production runner must create a TuiApp')
+    app.setDraft('first deferred prompt')
+    ;(app as unknown as { submitDraft(): void }).submitDraft()
+    await settle()
+    assert.equal(probe.transcriptApplyCount, 3)
+    assert.equal(probe.statsApplyCount, 3)
+    assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'created answer'))
+  } finally {
+    if (resumeFiber !== undefined) await resumeFiber.dispose()
+    if (deferredFiber !== undefined) await deferredFiber.dispose()
+    if (resumeContext !== undefined) await disposeContext(resumeContext)
+    if (deferredContext !== undefined) await disposeContext(deferredContext)
+    probe.restore()
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/test/session-ui-hydrate.test.ts
+++ b/test/session-ui-hydrate.test.ts
@@ -1,0 +1,66 @@
+/** Regression tests for the single cold-session UI hydration adapter. */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MessageId } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { computeStats } from '../src/stats.ts'
+import { hydrateSessionUi } from '../src/session-ui-hydrate.ts'
+import { foldTranscript } from '../src/transcript.ts'
+
+function event<K extends SessionEvent['type']>(
+  type: K,
+  data: SessionEvent<K>['data'],
+  seq: number,
+): SessionEvent {
+  return { type, seq, time: 1_700_000_000_000 + seq * 1000, data } as SessionEvent
+}
+
+test('hydrates transcript and stats projections from the same event log', () => {
+  const events = [
+    event('turn/start', { turn: 0 }, 0),
+    event('user/message', {
+      id: MessageId('hydrate-user'),
+      role: 'user',
+      content: [{ type: 'text', text: 'hello' }],
+      source: { kind: 'user' },
+    }, 1),
+    event('step/start', { turn: 0, step: 0 }, 2),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('hydrate-assistant'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'world' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 10, outputTokens: 2 },
+    }, 3),
+    event('step/end', { turn: 0, step: 0 }, 4),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5),
+  ]
+  const hydrated = hydrateSessionUi(events)
+  assert.deepEqual(hydrated.folder.messages(), foldTranscript(events))
+  assert.deepEqual(hydrated.statsFolder.snapshot(), computeStats(events))
+
+  const transcript = hydrated.folder.messages()
+  const stats = hydrated.statsFolder.snapshot()
+  hydrated.folder.apply([event('user/message', {
+    id: MessageId('hydrate-user-2'),
+    role: 'user',
+    content: [{ type: 'text', text: 'again' }],
+    source: { kind: 'user' },
+  }, 6)])
+  hydrated.statsFolder.apply([event('request/context', {
+    provider: 'p',
+    model: 'm',
+    contextWindow: 1000,
+  }, 7)])
+  const nextTranscript = hydrated.folder.messages()
+  assert.equal(nextTranscript.some(message => message.kind === 'user' && message.text === 'again'), true)
+  assert.notDeepEqual(nextTranscript, transcript)
+  const nextStats = hydrated.statsFolder.snapshot()
+  assert.equal(nextStats.contextWindow, 1000)
+  assert.notDeepEqual(nextStats, stats)
+})

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -168,6 +168,127 @@ test('StatsFolder matches computeStats and folds incrementally', () => {
   )
 })
 
+test('StatsFolder stores sampled decode duration as a scalar', () => {
+  const t = 1_700_000_000_000
+  const folder = new StatsFolder()
+  folder.apply([
+    event('step/start', { turn: 0, step: 0 }, 0, t),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'answer' },
+    }, 1, t + 100),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('m-scalar'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'answer' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 10, outputTokens: 100 },
+    }, 2, t + 1_100),
+    event('step/end', { turn: 0, step: 0 }, 3, t + 1_200),
+    event('step/start', { turn: 0, step: 1 }, 4, t + 2_000),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 1,
+      chunk: { type: 'text-delta', index: 0, text: 'more' },
+    }, 5, t + 2_100),
+    event('assistant/message', {
+      turn: 0,
+      step: 1,
+      message: {
+        id: MessageId('m-scalar-2'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'more' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 5, outputTokens: 50 },
+    }, 6, t + 2_600),
+    event('step/end', { turn: 0, step: 1 }, 7, t + 2_700),
+  ])
+  const throughput = (folder as unknown as { throughput: { outputMsTotal: number; outputMs?: unknown } }).throughput
+  assert.equal(throughput.outputMsTotal, 1_500)
+  assert.equal(throughput.outputMs, undefined, 'a long session must not retain every decode sample')
+  assert.equal(folder.snapshot().tokensPerSec, 100)
+  assert.equal(folder.snapshot().outputTokens, 150)
+})
+
+test('duplicate assistant messages settle timing only once', () => {
+  const t = 1_700_000_000_000
+  const message = (seq: number, time: number, outputTokens = 100): SessionEvent => event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`m-duplicate-${seq}`),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens },
+  }, seq, time)
+  const log = [
+    event('step/start', { turn: 0, step: 0 }, 0, t),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'answer' },
+    }, 1, t + 100),
+    message(2, t + 1_000),
+    // A duplicate authoritative event is anomalous, but must not turn one
+    // model step into two timing/throughput samples.
+    message(3, t + 2_000, 200),
+    event('step/end', { turn: 0, step: 0 }, 4, t + 2_100),
+  ]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(oneShot.llmMs, 1_000)
+  assert.equal(oneShot.firstTokenMsAvg, 100)
+  assert.equal(oneShot.tokensPerSec, 222)
+  assert.equal(oneShot.outputTokens, 200)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('late assistant usage after step/end replaces the sampled throughput token count', () => {
+  const t = 1_700_000_000_000
+  const assistantMessage = (seq: number, time: number, outputTokens: number): SessionEvent => event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`m-late-${seq}`),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens },
+  }, seq, time)
+  const prefix = [
+    event('step/start', { turn: 0, step: 0 }, 0, t),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'answer' },
+    }, 1, t + 100),
+    assistantMessage(2, t + 1_000, 100),
+    event('step/end', { turn: 0, step: 0 }, 3, t + 1_100),
+  ]
+  const late = assistantMessage(4, t + 2_000, 200)
+  const suffix = [late, event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5, t + 2_100)]
+  const oneShot = computeStats([...prefix, ...suffix])
+  const folder = new StatsFolder()
+  folder.apply(prefix)
+  assert.equal(folder.snapshot().tokensPerSec, 111)
+  assert.equal((folder as unknown as { perStep: Map<unknown, unknown> }).perStep.size, 0)
+  folder.apply(suffix)
+  assert.equal(folder.snapshot().outputTokens, 200)
+  assert.equal(folder.snapshot().tokensPerSec, 222)
+  assert.deepEqual(folder.snapshot(), oneShot)
+  assert.equal((folder as unknown as { settledPerStep: Map<unknown, unknown> }).settledPerStep.size, 0)
+})
+
 test('formats the stats line in pi abbreviation vocabulary', () => {
   const line = formatStats({
     turns: 2,

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -252,6 +252,215 @@ test('duplicate assistant messages settle timing only once', () => {
   assert.deepEqual(folder.snapshot(), oneShot)
 })
 
+test('one turn with many steps keeps late-message retention on a cheap turn fence', () => {
+  const t = 1_700_000_000_000
+  const events: SessionEvent[] = [event('turn/start', { turn: 0 }, 0, t)]
+  let seq = 1
+  for (let step = 0; step < 1_000; step += 1) {
+    events.push(event('step/start', { turn: 0, step }, seq++, t + seq))
+    events.push(event('assistant/chunk', {
+      turn: 0,
+      step,
+      chunk: { type: 'text-delta', index: 0, text: 'x' },
+    }, seq++, t + seq))
+    events.push(event('assistant/message', {
+      turn: 0,
+      step,
+      message: {
+        id: MessageId(`m-many-step-${step}`),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'x' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    }, seq++, t + seq))
+    events.push(event('step/end', { turn: 0, step }, seq++, t + seq))
+  }
+  events.push(event('turn/end', { turn: 0, reason: { kind: 'completed' } }, seq, t + seq))
+
+  const oneShot = computeStats(events)
+  const folder = new StatsFolder()
+  folder.apply(events)
+  assert.deepEqual(folder.snapshot(), oneShot)
+  assert.equal(oneShot.steps, 1_000)
+  assert.equal(oneShot.outputTokens, 1_000)
+  assert.equal((folder as unknown as { settledTurn: number | undefined }).settledTurn, 0)
+  assert.equal((folder as unknown as { settledPerStep: Map<unknown, unknown> }).settledPerStep.size, 0)
+})
+
+test('settled timing ignores a late token delta before a duplicate message', () => {
+  const t = 1_700_000_000_000
+  const message = (seq: number, time: number, outputTokens: number): SessionEvent => event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`m-late-delta-${seq}`),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens },
+  }, seq, time)
+  const log = [
+    event('step/start', { turn: 0, step: 0 }, 0, t),
+    // This message settles the step before any token delta was observed.
+    message(1, t + 100, 100),
+    // Replay artifact: a settled step must not acquire a decode start now.
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'late' },
+    }, 2, t + 200),
+    message(3, t + 300, 200),
+    event('step/end', { turn: 0, step: 0 }, 4, t + 400),
+  ]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(oneShot.llmMs, 100)
+  assert.equal(oneShot.firstTokenMsAvg, 0)
+  assert.equal(oneShot.tokensPerSec, 0)
+  assert.equal(oneShot.outputTokens, 200)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('older duplicate messages cannot mutate timing after a higher turn starts', () => {
+  const t = 1_700_000_000_000
+  const message = (seq: number, time: number, outputTokens: number): SessionEvent => event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`m-stale-turn-${seq}`),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens },
+  }, seq, time)
+  const log = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'answer' },
+    }, 2, t + 100),
+    message(3, t + 200, 100),
+    // No step/end yet: this settled timing is still in perStep when the
+    // next turn opens, which is the stale-entry replay shape.
+    event('turn/start', { turn: 1 }, 4, t + 300),
+    message(5, t + 400, 200),
+  ]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  // The late duplicate is stale for both folds: the original sample and
+  // output-token total remain authoritative.
+  assert.equal(oneShot.llmMs, 200)
+  assert.equal(oneShot.tokensPerSec, 1_000)
+  assert.equal(oneShot.outputTokens, 100)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('older token deltas cannot reopen timing after a higher turn starts', () => {
+  const t = 1_700_000_000_000
+  const log = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t),
+    event('turn/start', { turn: 1 }, 2, t + 100),
+    // Both facts belong to the old open timing entry. They must not create a
+    // decode window or settle a footer sample after the turn fence advanced.
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'late' },
+    }, 3, t + 200),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('m-stale-open-turn'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'late' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 10, outputTokens: 100 },
+    }, 4, t + 300),
+  ]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(oneShot.llmMs, 0)
+  assert.equal(oneShot.firstTokenMsAvg, 0)
+  assert.equal(oneShot.tokensPerSec, 0)
+  assert.equal(oneShot.outputTokens, 0)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('duplicate step/start preserves settled timing and a duplicate end is idempotent', () => {
+  const t = 1_700_000_000_000
+  const message = (seq: number, time: number, outputTokens: number): SessionEvent => event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`m-duplicate-boundary-${seq}`),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens },
+  }, seq, time)
+  const log = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'answer' },
+    }, 2, t + 10),
+    message(3, t + 100, 100),
+    // A duplicate start before the first end must preserve the settled timing
+    // object rather than resetting its start/settled state.
+    event('step/start', { turn: 0, step: 0 }, 4, t + 150),
+    message(5, t + 200, 200),
+    event('step/end', { turn: 0, step: 0 }, 6, t + 210),
+    // The same replay can repeat both boundaries after the first end.
+    event('step/start', { turn: 0, step: 0 }, 7, t + 220),
+    message(8, t + 300, 300),
+    event('step/end', { turn: 0, step: 0 }, 9, t + 310),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 10, t + 320),
+  ]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(oneShot.turns, 1)
+  assert.equal(oneShot.steps, 1)
+  assert.equal(oneShot.llmMs, 100)
+  assert.equal(oneShot.firstTokenMsAvg, 10)
+  assert.equal(oneShot.tokensPerSec, Math.round((300 * 1000) / 90))
+  assert.equal(oneShot.outputTokens, 300)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('an older step/end cannot increment stats after a higher turn starts', () => {
+  const t = 1_700_000_000_000
+  const log = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t + 1),
+    event('turn/start', { turn: 1 }, 2, t + 2),
+    event('step/start', { turn: 1, step: 0 }, 3, t + 3),
+    event('step/end', { turn: 1, step: 0 }, 4, t + 4),
+    // The turn-0 boundary is stale and must not create a second step/turn.
+    event('step/end', { turn: 0, step: 0 }, 5, t + 5),
+  ]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(oneShot.turns, 1)
+  assert.equal(oneShot.steps, 1)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
 test('late assistant usage after step/end replaces the sampled throughput token count', () => {
   const t = 1_700_000_000_000
   const assistantMessage = (seq: number, time: number, outputTokens: number): SessionEvent => event('assistant/message', {

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -304,6 +304,82 @@ test('interleaved steps keep separate assistant and thinking entries', () => {
   assert.equal(thinking1.text, 't1-')
 })
 
+test('thinking lifecycle index retains only unsettled entries by turn', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'reasoning-delta', index: 0, text: 'settled' },
+    }, 1),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('msg-settled'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'answer' }],
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+      },
+    }, 2),
+    event('turn/start', { turn: 1 }, 3),
+    event('assistant/chunk', {
+      turn: 1,
+      step: 0,
+      chunk: { type: 'reasoning-delta', index: 0, text: 'still thinking' },
+    }, 4),
+    event('turn/end', { turn: 0, reason: { kind: 'interrupted' } }, 5),
+  ])
+
+  const thinking = folder.messages().filter((message): message is Extract<TranscriptMessage, { kind: 'thinking' }> => message.kind === 'thinking')
+  assert.equal(thinking.find(message => message.turn === 0)?.running, false)
+  assert.equal(thinking.find(message => message.turn === 1)?.running, true,
+    'ending one turn must not settle another turn\'s open reasoning')
+  const open = (folder as unknown as { openThinkingByTurn: Map<number, Set<unknown>> }).openThinkingByTurn
+  assert.equal(open.has(0), false, 'settled entries must leave the open index')
+  assert.equal(open.get(1)?.size, 1)
+
+  folder.apply([event('turn/end', { turn: 1, reason: { kind: 'max-tokens' } }, 6)])
+  const endedThinking = folder.messages().find((message): message is Extract<TranscriptMessage, { kind: 'thinking' }> => message.kind === 'thinking' && message.turn === 1)
+  assert.equal(endedThinking?.running, false)
+  assert.equal(open.size, 0, 'turn/end should discard the ended turn bucket')
+})
+
+test('late reasoning keeps an assistant-settled thinking entry closed', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'reasoning-delta', index: 0, text: 'before' },
+    }, 0),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('msg-late-thinking'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'answer' }],
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+      },
+    }, 1),
+    // The transcript preserves the late replay fragment, but it must not
+    // re-enter the open lifecycle set or become running again.
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'reasoning-delta', index: 0, text: ' after' },
+    }, 2),
+  ])
+  const thinking = folder.messages().find((message): message is Extract<TranscriptMessage, { kind: 'thinking' }> => message.kind === 'thinking')
+  assert.ok(thinking)
+  assert.equal(thinking.running, false)
+  assert.equal(thinking.text, 'before after')
+  const open = (folder as unknown as { openThinkingByTurn: Map<number, Set<unknown>> }).openThinkingByTurn
+  assert.equal(open.size, 0)
+})
+
 test('windows older turns into one summary entry', () => {
   const events: SessionEvent[] = [
     // Turn 0: user prompt + tool call + result.
@@ -1238,6 +1314,48 @@ test('window summaries stay identical across a prune replacement', () => {
     pruneReplacement(11, 'r1', 'aaa-pruned', 2),
   ], { maxTurns: 2 })
   assert.deepEqual(after, before, 'the windowed projection must be byte-identical after a replacement')
+})
+
+test('a late duplicate assistant/message updates text once per step', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('late-message-1'),
+        role: 'assistant',
+        content: [{ type: 'text', text: 'first' }],
+        source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+      },
+    }, 2),
+    event('step/end', { turn: 0, step: 0 }, 3),
+  ])
+  const before = folder.turnActivity(0)
+  assert.ok(before !== undefined)
+  assert.equal(before.assistantMessages, 1)
+
+  // The late authoritative replay arrives after step/end but before turn/end.
+  folder.apply([event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId('late-message-2'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'replacement' }],
+      source: { kind: 'model', provider: 'deepseek', model: 'deepseek-chat' },
+    },
+  }, 4)])
+
+  const after = folder.turnActivity(0)
+  assert.ok(after !== undefined)
+  assert.equal(after.assistantMessages, 1, 'late replay must not inflate per-step activity')
+  const messages = folder.messages()
+  assert.equal(messages.length, 1)
+  assert.ok(messages[0] !== undefined && messages[0].kind === 'assistant')
+  assert.equal(messages[0]?.kind === 'assistant' ? messages[0].text : '', 'replacement')
 })
 
 test('a replacement assistant/message does not mutate Focus activity', () => {


### PR DESCRIPTION
## Summary

- make TranscriptFolder thinking settlement proportional to open entries per turn
- make StatsFolder throughput snapshots O(1) with scalar decode duration accounting
- remove duplicate cold transcript/stats hydration during resume and consolidate bootstrap scans
- add long-session benchmark fixtures and runner/lifecycle regression coverage
- guard duplicate and late assistant messages so token and throughput projections stay consistent

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm gate:boundary`
- `pnpm gate:keybindings`
- `node scripts/naming-gate.mjs`
- `BENCH_FAST=1 node --expose-gc --import tsx/esm scripts/bench.mts`

No virtual-window UX changes are included.
