### PR TITLE
perf(transcript): add bulk hydrate and linear read grouping

### DIFF
--- a/docs/perf-baseline.md
+++ b/docs/perf-baseline.md
@@ -66,7 +66,7 @@
 - ✅ heap enters a stable range under sustained streaming (growth ≈ 0);
 - ✅ all transcript golden/headless tests keep identical output.
 
-## Long-session projection baseline (PR A)
+## Long-session projection baseline (PR A foundations)
 
 PR A keeps the full session log and changes only local replay bookkeeping:
 
@@ -77,9 +77,11 @@ PR A keeps the full session log and changes only local replay bookkeeping:
 - resume, create, and session-switch surface setup share
   `hydrateSessionUi(events)` instead of pre-folding a resumed log and then
   hydrating it again;
-- the benchmark includes reasoning-heavy, adjacent-read, one-turn-many-step,
-  and a 700k-character text-heavy fixture, and reports transcript/stats apply,
-  snapshot, and heap/RSS measurements separately from renderer timings;
+- the benchmark fixtures include reasoning-heavy, adjacent-read,
+  one-turn-many-step, and a 700k-character text-heavy session. Current
+  projection measurements use the PR B cold `hydrate` path and report
+  transcript/stats hydration, snapshot, and heap/RSS separately from renderer
+  timings;
 - late replay timing is fenced to the current turn and ignores token deltas
   after a step has already settled, so tool-loop replay remains linear.
 
@@ -93,6 +95,30 @@ The benchmark is intentionally observational rather than a wall-clock test;
 compare runs on the same machine and Node version. Its semantic gates remain
 cold-fold/incremental parity and the existing transcript/stats regression
 suites.
+
+## Long-session bulk hydration (PR B)
+
+PR B separates the cold-session path from live event delivery. `hydrate()` folds
+all events in order but defers adjacent settled-read grouping until one final
+linear pass. Normal live tail suffixes continue to use `apply()` and extend a
+read run from its boundary in constant bookkeeping time; non-tail settlements
+retain the defensive reflow fallback. `StatsFolder.hydrate()` exposes the same
+cold-resume boundary while preserving its existing incremental fold.
+
+The following warmed p50 comparison uses the same synthetic one-turn log on
+Node v24.15.0 in the PR B worktree. `apply()` is the event-by-event baseline;
+`hydrate()` is the cold path:
+
+| adjacent settled reads | `TranscriptFolder.apply()` | `TranscriptFolder.hydrate()` |
+|---:|---:|---:|
+| 100 | 0.42ms | 0.38ms |
+| 500 | 0.64ms | 0.95ms |
+| 1000 | 1.21ms | 1.07ms |
+
+The result is still one grouped card with the same arguments, ordering, and
+full result text. The benchmark script reports the cold path as
+`TranscriptFolder.hydrate` / `StatsFolder.hydrate` in its reasoning-heavy,
+read-heavy, and 700k-like scenarios.
 
 ## M11: extension-plugin overhead (plan §23)
 

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -335,35 +335,43 @@ function warmedP50(n: number, run: () => void): number {
 
 /** Long-session projection timings are intentionally separate from renderer timings. */
 interface LongSessionMetrics {
-  transcriptApply: number
-  statsApply: number
+  transcriptHydrate: number
+  statsHydrate: number
   snapshot: number
   messages: number
 }
 
 function measureLongSession(events: readonly SessionEvent[]): LongSessionMetrics {
   const samples = FAST ? 3 : 5
-  const transcriptApply = warmedP50(samples, () => {
+  const transcriptHydrate = warmedP50(samples, () => {
     const folder = new TranscriptFolder()
-    folder.apply(events)
+    folder.hydrate(events)
   })
-  const statsApply = warmedP50(samples, () => {
+  const statsHydrate = warmedP50(samples, () => {
     const folder = new StatsFolder()
-    folder.apply(events)
+    folder.hydrate(events)
   })
   const transcript = new TranscriptFolder()
-  transcript.apply(events)
+  transcript.hydrate(events)
   const statsFolder = new StatsFolder()
-  statsFolder.apply(events)
+  statsFolder.hydrate(events)
   // Snapshot is deliberately sampled repeatedly: the A2 regression was an
   // allocation-free scalar read, not a fold over every historical sample.
   const snapshot = timeIt(FAST ? 20 : 50, () => { statsFolder.snapshot() })
   return {
-    transcriptApply,
-    statsApply,
+    transcriptHydrate,
+    statsHydrate,
     snapshot: stats(snapshot).p50,
     messages: transcript.messages().length,
   }
+}
+
+/** Measure the event-by-event live path for a fresh transcript. */
+function measureTranscriptApply(events: readonly SessionEvent[]): number {
+  return warmedP50(FAST ? 3 : 5, () => {
+    const folder = new TranscriptFolder()
+    folder.apply(events)
+  })
 }
 
 /** Measure only the one-turn multi-step stats path. */
@@ -409,16 +417,17 @@ async function main(): Promise<void> {
     row(`  messages() ×${PROJ_SAMPLES} (${folder.messages().length} messages)`, fmt(st))
   }
 
-  // 1a. PR A long-session projection fixtures. These are intentionally
-  // separate from the renderer benchmark so replay/fold regressions remain
-  // visible even when the TUI cache masks them.
+  // 1a. Long-session projection fixtures. These are intentionally separate
+  // from the renderer benchmark so replay/fold regressions remain visible
+  // even when the TUI cache masks them. The hydrate path is the cold-resume
+  // contract; live suffixes continue to use apply().
   for (const turns of [100, 500, 1000]) {
     const events = buildReasoningHeavyEvents(turns)
     const metrics = measureLongSession(events)
     const memory = process.memoryUsage()
     row(`reasoning-heavy ${events.length} events (${turns} turns)`, `${metrics.messages} messages`)
-    row('  TranscriptFolder.apply', fmtMs(metrics.transcriptApply))
-    row('  StatsFolder.apply', fmtMs(metrics.statsApply))
+    row('  TranscriptFolder.hydrate', fmtMs(metrics.transcriptHydrate))
+    row('  StatsFolder.hydrate', fmtMs(metrics.statsHydrate))
     row(`  StatsFolder.snapshot ×${FAST ? 20 : 50}`, fmtDuration(metrics.snapshot))
     row('  memory heapUsed/rss', `${fmtBytes(memory.heapUsed)} / ${fmtBytes(memory.rss)}`)
   }
@@ -432,15 +441,15 @@ async function main(): Promise<void> {
     row('  StatsFolder.apply', fmtMs(metrics.statsApply))
     row(`  StatsFolder.snapshot ×${FULL_SAMPLES}`, fmtDuration(metrics.snapshot))
   }
-  {
-    const turns = 1
-    const reads = 1000
-    const events = buildReadHeavyEvents(turns, reads)
+  for (const reads of [100, 500, 1000]) {
+    const events = buildReadHeavyEvents(1, reads)
     const metrics = measureLongSession(events)
+    const liveApply = measureTranscriptApply(events)
     const memory = process.memoryUsage()
     row(`read-heavy ${events.length} events (${reads} adjacent reads)`, `${metrics.messages} messages`)
-    row('  TranscriptFolder.apply', fmtMs(metrics.transcriptApply))
-    row('  StatsFolder.apply', fmtMs(metrics.statsApply))
+    row('  TranscriptFolder.apply (live)', fmtMs(liveApply))
+    row('  TranscriptFolder.hydrate (cold)', fmtMs(metrics.transcriptHydrate))
+    row('  StatsFolder.hydrate', fmtMs(metrics.statsHydrate))
     row(`  StatsFolder.snapshot ×${FAST ? 20 : 50}`, fmtDuration(metrics.snapshot))
     row('  memory heapUsed/rss', `${fmtBytes(memory.heapUsed)} / ${fmtBytes(memory.rss)}`)
   }
@@ -450,8 +459,8 @@ async function main(): Promise<void> {
     const metrics = measureLongSession(events)
     const memory = process.memoryUsage()
     row(`700k-like ${events.length} events (${turns} turns, ${turns * (18_000 + 17_000)} chars)`, `${metrics.messages} messages`)
-    row('  TranscriptFolder.apply', fmtMs(metrics.transcriptApply))
-    row('  StatsFolder.apply', fmtMs(metrics.statsApply))
+    row('  TranscriptFolder.hydrate', fmtMs(metrics.transcriptHydrate))
+    row('  StatsFolder.hydrate', fmtMs(metrics.statsHydrate))
     row(`  StatsFolder.snapshot ×${FAST ? 20 : 50}`, fmtDuration(metrics.snapshot))
     row('  memory heapUsed/rss', `${fmtBytes(memory.heapUsed)} / ${fmtBytes(memory.rss)}`)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3257,8 +3257,8 @@ export function apply(ctx: Context, config: Config): void {
       const child = sessions.get(childId)
       if (child !== undefined) {
         const own = childOwnEvents(child.events)
-        childFolder.apply(own)
-        childStats.apply(own)
+        childFolder.hydrate(own)
+        childStats.hydrate(own)
         // The live child's session header carries its workspace (the child
         // may have been born in another directory).
         childCwd = typeof (child as { header?: { cwd?: unknown } }).header?.cwd === 'string'
@@ -3270,8 +3270,8 @@ export function apply(ctx: Context, config: Config): void {
         if (persistence !== undefined) {
           try {
             const own = childOwnEvents((await persistence.inspect(childId)).events)
-            childFolder.apply(own)
-            childStats.apply(own)
+            childFolder.hydrate(own)
+            childStats.hydrate(own)
           } catch {
             // No persisted log either: the view stays empty.
           }

--- a/src/session-ui-hydrate.ts
+++ b/src/session-ui-hydrate.ts
@@ -33,11 +33,11 @@ export interface HydratedSessionUi {
 export function hydrateSessionUi(events: SessionEvents): HydratedSessionUi {
   const transcriptStarted = performance.now()
   const folder = new TranscriptFolder()
-  folder.apply(events)
+  folder.hydrate(events)
   const transcriptMs = performance.now() - transcriptStarted
   const statsStarted = performance.now()
   const statsFolder = new StatsFolder()
-  statsFolder.apply(events)
+  statsFolder.hydrate(events)
   const statsMs = performance.now() - statsStarted
   return {
     folder,

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -384,6 +384,15 @@ export class StatsFolder {
     for (const event of events) this.applyEvent(event)
   }
 
+  /**
+   * Hydrate a cold session log through the same ordered fold as {@link apply}.
+   * The explicit entry point lets session bootstrap distinguish a full log
+   * from live suffixes; stats already has no secondary projection to defer.
+   */
+  hydrate(events: readonly SessionEvent[]): void {
+    this.apply(events)
+  }
+
   /** The derived stats as of the last applied event. */
   snapshot(): SessionStats {
     const derived: SessionStats = { ...this.stats }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -8,9 +8,9 @@
  * entries carrying their owning turn, so the view can expand only the most
  * recent turns (pi's Ctrl+O semantics).
  *
- * `TranscriptFolder` is the stateful engine: call `apply` with appended
- * events and read the message list; `foldTranscript` is the one-shot
- * wrapper. Both support an optional display window (`maxTurns`): turns older
+ * `TranscriptFolder` is the stateful engine: call `apply` with live appended
+ * events or `hydrate` with a cold log, then read the message list;
+ * `foldTranscript` is the one-shot wrapper. Both support an optional display window (`maxTurns`): turns older
  * than the window collapse into one summary entry, bounding the rendered
  * component tree on long sessions.
  * @module @xmoon76/dsh-pi-tui/transcript
@@ -410,6 +410,13 @@ export function groupConsecutiveReads(messages: readonly TranscriptMessage[]): T
  * the message list. Objects are mutated in place across applies, so a caller
  * that rebuilds its view from `messages()` stays consistent at every step.
  */
+type ReadGroupCard = Extract<TranscriptMessage, { kind: 'tool' }>
+
+interface ReadGroupMeta {
+  firstTurn: number
+  spansTurns: boolean
+}
+
 export class TranscriptFolder {
   private readonly items: TranscriptMessage[] = []
   /** The assistant message object per (turn, step); streaming text lands in place. */
@@ -437,12 +444,20 @@ export class TranscriptFolder {
   /**
    * Incremental consecutive-read grouping (stage J): `groupOf` maps an item
    * index to its merged group card (only the FIRST member emits it in the
-   * output); `groupMembers` maps a group card to its member indices. The
-   * projection is maintained on append and on settle, so `messages()` never
-   * re-walks the history to group — only the output list is built.
+   * output); `groupMembers` maps a group card to its member indices. Live
+   * tail appends extend a run from its boundary, while non-tail settlements
+   * use the defensive reflow path. `messages()` never re-walks the history to
+   * group — only the output list is built.
    */
-  private readonly groupOf = new Map<number, Extract<TranscriptMessage, { kind: 'tool' }>>()
-  private readonly groupMembers = new Map<Extract<TranscriptMessage, { kind: 'tool' }>, number[]>()
+  private readonly groupOf = new Map<number, ReadGroupCard>()
+  private readonly groupMembers = new Map<ReadGroupCard, number[]>()
+  /** Constant-time turn-span facts for the live append path. */
+  private readonly groupMeta = new Map<ReadGroupCard, ReadGroupMeta>()
+  /** During cold replay, read cards settle in log order but must not rebuild
+   * their entire adjacent run after every result. The finalizer installs all
+   * groups in one linear pass once the event fold is complete. */
+  private hydrating = false
+  private groupingDirty = false
 
   /**
    * Turn index for the display window (stage J): the first item index of
@@ -650,6 +665,145 @@ export class TranscriptFolder {
     return message.kind === 'tool' && message.name === 'read' && message.status === 'ok'
   }
 
+  /** Build one merged read card without repeatedly concatenating its result. */
+  private makeReadGroup(start: number, end: number): {
+    group: ReadGroupCard
+    members: number[]
+    firstTurn: number
+    spansTurns: boolean
+  } | undefined {
+    const first = this.items[start]
+    if (first === undefined || !TranscriptFolder.groupable(first)) return undefined
+    const members: number[] = []
+    const results: string[] = []
+    const turns = new Set<number>()
+    let firstResult: string | undefined
+    let maxTurn = first.turn
+    for (let index = start; index <= end; index += 1) {
+      const member = this.items[index]
+      if (member === undefined || !TranscriptFolder.groupable(member)) continue
+      members.push(index)
+      turns.add(member.turn)
+      maxTurn = Math.max(maxTurn, member.turn)
+      // Match the existing projection's empty-result behavior: leading empty
+      // results are omitted, but an empty result after the first non-empty one
+      // remains a real (separator-delimited) member.
+      if (firstResult === undefined) {
+        if (member.result !== '') firstResult = member.result
+      } else {
+        results.push(member.result)
+      }
+    }
+    const group: Extract<TranscriptMessage, { kind: 'tool' }> = {
+      ...first,
+      args: `${members.length} files`,
+      result: firstResult === undefined ? '' : [firstResult, ...results].join('\n\n'),
+      turn: maxTurn,
+    }
+    return { group, members, firstTurn: first.turn, spansTurns: turns.size > 1 }
+  }
+
+  /** Rebuild all read groups once after a cold event-log fold. */
+  private rebuildGrouping(): void {
+    this.groupOf.clear()
+    this.groupMembers.clear()
+    this.groupMeta.clear()
+    this.groupedToolCount = 0
+    this.crossTurnGroups = 0
+    for (let start = 0; start < this.items.length;) {
+      const item = this.items[start]!
+      if (item.kind !== 'tool' || item.name !== 'read' || item.status !== 'ok') {
+        if (item.kind === 'tool') this.groupedToolCount += 1
+        start += 1
+        continue
+      }
+      let end = start + 1
+      while (end < this.items.length && TranscriptFolder.groupable(this.items[end]!)) end += 1
+      if (end - start === 1) {
+        this.groupedToolCount += 1
+        start = end
+        continue
+      }
+      const built = this.makeReadGroup(start, end - 1)
+      if (built === undefined) {
+        // The run was checked above; keep a defensive fallback that preserves
+        // the output count if a future item shape invalidates that invariant.
+        this.groupedToolCount += 1
+        start = end
+        continue
+      }
+      for (const member of built.members) this.groupOf.set(member, built.group)
+      this.groupMembers.set(built.group, built.members)
+      this.groupMeta.set(built.group, { firstTurn: built.firstTurn, spansTurns: built.spansTurns })
+      this.groupedToolCount += 1
+      if (built.spansTurns) this.crossTurnGroups += 1
+      start = end
+    }
+  }
+
+  /**
+   * Extend a groupable card that was just settled at the item-list tail.
+   * Normal live delivery follows this path, so an adjacent read run does not
+   * scan its history on every result. A non-tail settlement still falls back
+   * to the defensive reflow path below because it may bridge two runs.
+   */
+  private appendTailGrouping(index: number): boolean {
+    if (index !== this.items.length - 1) return false
+    const item = this.items[index]
+    if (item === undefined || !TranscriptFolder.groupable(item)) return false
+    const previousIndex = index - 1
+    const previous = this.items[previousIndex]
+    if (previous === undefined || !TranscriptFolder.groupable(previous)) return true
+
+    const previousGroup = this.groupOf.get(previousIndex)
+    if (previousGroup !== undefined) {
+      const members = this.groupMembers.get(previousGroup)
+      if (members === undefined) return false
+      const meta = this.groupMeta.get(previousGroup)
+      const firstMember = this.items[members[0]!]
+      const firstTurn = meta?.firstTurn ?? (firstMember !== undefined && 'turn' in firstMember ? firstMember.turn : previous.turn)
+      const wasCross = meta?.spansTurns ?? this.crossTurn(members)
+      members.push(index)
+      this.groupOf.set(index, previousGroup)
+      previousGroup.args = `${members.length} files`
+      previousGroup.result = previousGroup.result === '' ? item.result : `${previousGroup.result}\n\n${item.result}`
+      previousGroup.turn = Math.max(previousGroup.turn, item.turn)
+      const spansTurns = wasCross || item.turn !== firstTurn
+      this.groupMeta.set(previousGroup, { firstTurn, spansTurns })
+      if (!wasCross && spansTurns) this.crossTurnGroups += 1
+      this.groupedToolCount -= 1
+      return true
+    }
+
+    // The previous item is a singleton read: promote it without scanning the
+    // run (there cannot be an older group across a non-groupable boundary).
+    const group: ReadGroupCard = {
+      ...previous,
+      args: '2 files',
+      result: previous.result === '' ? item.result : `${previous.result}\n\n${item.result}`,
+      turn: Math.max(previous.turn, item.turn),
+    }
+    this.groupOf.set(previousIndex, group)
+    this.groupOf.set(index, group)
+    this.groupMembers.set(group, [previousIndex, index])
+    this.groupMeta.set(group, { firstTurn: previous.turn, spansTurns: previous.turn !== item.turn })
+    if (previous.turn !== item.turn) this.crossTurnGroups += 1
+    this.groupedToolCount -= 1
+    return true
+  }
+
+  /** Schedule grouping now, or mark the cold fold for one final grouping pass. */
+  private scheduleGrouping(index: number): void {
+    const item = this.items[index]
+    if (item === undefined || !TranscriptFolder.groupable(item)) return
+    if (this.hydrating) {
+      this.groupingDirty = true
+      return
+    }
+    if (this.appendTailGrouping(index)) return
+    this.reflowGrouping(index)
+  }
+
   /**
    * Rebuild the grouping of the groupable run containing `index` (bounded
    * by non-groupable items). Called when an item BECOMES groupable (a read
@@ -676,10 +830,16 @@ export class TranscriptFolder {
             // `members.length` independent read cards, then the rebuild
             // merges them into one card again — keep the counters in sync.
             this.groupMembers.delete(group)
+            const spansTurns = this.groupMeta.get(group)?.spansTurns ?? this.crossTurn(members)
+            this.groupMeta.delete(group)
             this.groupedToolCount += members.length - 1
-            if (this.crossTurn(members)) this.crossTurnGroups -= 1
+            if (spansTurns) this.crossTurnGroups -= 1
           } else {
             this.groupMembers.set(group, remaining)
+            const first = this.items[remaining[0]!]
+            if (first !== undefined && TranscriptFolder.groupable(first)) {
+              this.groupMeta.set(group, { firstTurn: first.turn, spansTurns: this.crossTurn(remaining) })
+            }
           }
         }
         this.groupOf.delete(i)
@@ -693,7 +853,10 @@ export class TranscriptFolder {
         const prevGroup = this.groupOf.get(start - 1)
         if (prevGroup !== undefined) {
           const members = this.groupMembers.get(prevGroup)!
-          const wasCross = this.crossTurn(members)
+          const meta = this.groupMeta.get(prevGroup)
+          const firstMember = this.items[members[0]!]
+          const firstTurn = meta?.firstTurn ?? (firstMember !== undefined && 'turn' in firstMember ? firstMember.turn : prev.turn)
+          const wasCross = meta?.spansTurns ?? this.crossTurn(members)
           members.push(start)
           this.groupOf.set(start, prevGroup)
           prevGroup.args = `${members.length} files`
@@ -701,7 +864,9 @@ export class TranscriptFolder {
           prevGroup.turn = Math.max(prevGroup.turn, item.turn)
           // Joining a same-turn group with a different-turn read makes it
           // cross-turn (the emitted card now spans two turns).
-          if (!wasCross && this.crossTurn(members)) this.crossTurnGroups += 1
+          const spansTurns = wasCross || item.turn !== firstTurn
+          this.groupMeta.set(prevGroup, { firstTurn, spansTurns })
+          if (!wasCross && spansTurns) this.crossTurnGroups += 1
           return
         }
         // The previous item is a singleton read: promote it to a group.
@@ -712,34 +877,21 @@ export class TranscriptFolder {
         group.args = '2 files'
         group.result = group.result === '' ? item.result : `${group.result}\n\n${item.result}`
         group.turn = Math.max(group.turn, item.turn)
+        this.groupMeta.set(group, { firstTurn: prev.turn, spansTurns: prev.turn !== item.turn })
         if (prev.turn !== item.turn) this.crossTurnGroups += 1
       }
       return
     }
-    // Rebuild the whole run as one group. (The index variables are mutable,
-    // so the type guard is re-applied to locals rather than the array
-    // accesses, which TS cannot keep narrowed.)
-    const first = this.items[start]!
-    if (!TranscriptFolder.groupable(first)) return
-    const group: Extract<TranscriptMessage, { kind: 'tool' }> = { ...first }
-    const members: number[] = []
-    const memberTurns = new Set<number>()
-    for (let i = start; i <= end; i += 1) {
-      const member = this.items[i]!
-      if (!TranscriptFolder.groupable(member)) continue
-      this.groupOf.set(i, group)
-      members.push(i)
-      memberTurns.add(member.turn)
-      if (i > start) {
-        group.result = group.result === '' ? member.result : `${group.result}\n\n${member.result}`
-        group.turn = Math.max(group.turn, member.turn)
-      }
-    }
-    group.args = `${members.length} files`
-    this.groupMembers.set(group, members)
+    // Rebuild the whole run as one group. The result is assembled with one
+    // final join so a long adjacent-read run stays linear in the cold path.
+    const built = this.makeReadGroup(start, end)
+    if (built === undefined) return
+    for (const member of built.members) this.groupOf.set(member, built.group)
+    this.groupMembers.set(built.group, built.members)
+    this.groupMeta.set(built.group, { firstTurn: built.firstTurn, spansTurns: built.spansTurns })
     // The whole run collapsed into one output card.
-    this.groupedToolCount -= members.length - 1
-    if (memberTurns.size > 1) this.crossTurnGroups += 1
+    this.groupedToolCount -= built.members.length - 1
+    if (built.spansTurns) this.crossTurnGroups += 1
   }
 
   /** Whether the members at these indices span more than one turn. */
@@ -761,6 +913,28 @@ export class TranscriptFolder {
    */
   apply(events: readonly SessionEvent[]): void {
     for (const event of events) this.applyEvent(event)
+  }
+
+  /**
+   * Hydrate a cold session log in one batch. Folding remains event-ordered,
+   * but expensive read-run reflow is deferred until every event has settled;
+   * live suffixes must continue to use {@link apply} for immediate grouping.
+   */
+  hydrate(events: readonly SessionEvent[]): void {
+    if (this.hydrating) {
+      this.apply(events)
+      return
+    }
+    this.hydrating = true
+    try {
+      this.apply(events)
+    } finally {
+      this.hydrating = false
+      if (this.groupingDirty) {
+        this.rebuildGrouping()
+        this.groupingDirty = false
+      }
+    }
   }
 
   /** Build the grouped output list (the full projection). */
@@ -1252,7 +1426,7 @@ export class TranscriptFolder {
           card.error = event.data.error
           // A settled read may now be groupable: reflow the run it belongs
           // to (bounded by the nearest non-read cards).
-          this.reflowGrouping(pending.index)
+          this.scheduleGrouping(pending.index)
         } else {
           // Unknown call (e.g. post-compaction): fall back to the last
           // running card with this name IN THE RESULT'S OWN TURN — an
@@ -1269,11 +1443,11 @@ export class TranscriptFolder {
               running.resultBlocks = block?.content
               running.meta = event.data.meta
               running.error = event.data.error
-              this.reflowGrouping(runningIndex)
+              this.scheduleGrouping(runningIndex)
             }
           } else {
             this.appendItem({ kind: 'tool', turn, name, args: '', result: text, status, resultBlocks: block?.content, meta: event.data.meta, error: event.data.error })
-            this.reflowGrouping(this.items.length - 1)
+            this.scheduleGrouping(this.items.length - 1)
           }
         }
         // Focus aggregation: settle the Tool slot ONLY when the result
@@ -1467,7 +1641,7 @@ export class TranscriptFolder {
  */
 export function foldTranscript(events: readonly SessionEvent[], options?: FoldOptions): TranscriptMessage[] {
   const folder = new TranscriptFolder()
-  folder.apply(events)
+  folder.hydrate(events)
   return folder.messages(options)
 }
 

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -155,6 +155,8 @@ async function disposeContext(ctx: Context): Promise<void> {
 interface RunnerProbe {
   transcriptApplyCount: number
   statsApplyCount: number
+  transcriptHydrateCount: number
+  statsHydrateCount: number
   capturedMessages: readonly { kind: string; text?: string }[] | undefined
   apps: TuiApp[]
   restore: () => void
@@ -165,12 +167,16 @@ function installProbe(): RunnerProbe {
   const probe: RunnerProbe = {
     transcriptApplyCount: 0,
     statsApplyCount: 0,
+    transcriptHydrateCount: 0,
+    statsHydrateCount: 0,
     capturedMessages: undefined,
     apps: [],
     restore: () => {},
   }
   const originalTranscriptApply = TranscriptFolder.prototype.apply
   const originalStatsApply = StatsFolder.prototype.apply
+  const originalTranscriptHydrate = TranscriptFolder.prototype.hydrate
+  const originalStatsHydrate = StatsFolder.prototype.hydrate
   const originalSetTranscript = TuiApp.prototype.setTranscript
   const originalStart = TuiApp.prototype.start
   TranscriptFolder.prototype.apply = function (events) {
@@ -180,6 +186,14 @@ function installProbe(): RunnerProbe {
   StatsFolder.prototype.apply = function (events) {
     probe.statsApplyCount += 1
     return originalStatsApply.call(this, events)
+  }
+  TranscriptFolder.prototype.hydrate = function (events) {
+    probe.transcriptHydrateCount += 1
+    return originalTranscriptHydrate.call(this, events)
+  }
+  StatsFolder.prototype.hydrate = function (events) {
+    probe.statsHydrateCount += 1
+    return originalStatsHydrate.call(this, events)
   }
   TuiApp.prototype.setTranscript = function (messages, activities) {
     probe.capturedMessages = messages
@@ -192,6 +206,8 @@ function installProbe(): RunnerProbe {
   probe.restore = () => {
     TranscriptFolder.prototype.apply = originalTranscriptApply
     StatsFolder.prototype.apply = originalStatsApply
+    TranscriptFolder.prototype.hydrate = originalTranscriptHydrate
+    StatsFolder.prototype.hydrate = originalStatsHydrate
     TuiApp.prototype.setTranscript = originalSetTranscript
     TuiApp.prototype.start = originalStart
   }
@@ -239,6 +255,8 @@ test('the real runner hydrates resume, deferred create, and switch exactly once 
     resumeFiber = await mountRunner(resumeContext, home, resumeHarness, { sessionId: resumed.id }, { sessionId: resumed.id })
     assert.equal(probe.transcriptApplyCount, 1)
     assert.equal(probe.statsApplyCount, 1)
+    assert.equal(probe.transcriptHydrateCount, 1)
+    assert.equal(probe.statsHydrateCount, 1)
     assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'resumed answer'))
 
     const newHandler = (resumeHarness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
@@ -247,6 +265,8 @@ test('the real runner hydrates resume, deferred create, and switch exactly once 
     await settle()
     assert.equal(probe.transcriptApplyCount, 2)
     assert.equal(probe.statsApplyCount, 2)
+    assert.equal(probe.transcriptHydrateCount, 2)
+    assert.equal(probe.statsHydrateCount, 2)
     assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'created answer'))
 
     await resumeFiber.dispose()
@@ -258,6 +278,8 @@ test('the real runner hydrates resume, deferred create, and switch exactly once 
     deferredFiber = await mountRunner(deferredContext, home, deferredHarness, {}, {})
     assert.equal(probe.transcriptApplyCount, 2, 'deferred startup must not hydrate an absent session')
     assert.equal(probe.statsApplyCount, 2, 'deferred startup must not hydrate an absent session')
+    assert.equal(probe.transcriptHydrateCount, 2, 'deferred startup must not hydrate an absent session')
+    assert.equal(probe.statsHydrateCount, 2, 'deferred startup must not hydrate an absent session')
     const app = probe.apps.at(-1)
     assert.ok(app, 'the production runner must create a TuiApp')
     app.setDraft('first deferred prompt')
@@ -265,6 +287,8 @@ test('the real runner hydrates resume, deferred create, and switch exactly once 
     await settle()
     assert.equal(probe.transcriptApplyCount, 3)
     assert.equal(probe.statsApplyCount, 3)
+    assert.equal(probe.transcriptHydrateCount, 3)
+    assert.equal(probe.statsHydrateCount, 3)
     assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'created answer'))
   } finally {
     if (resumeFiber !== undefined) await resumeFiber.dispose()

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -754,6 +754,92 @@ test('a failed read breaks the group; a read settling late re-groups into the ru
   assert.equal(tail[0]?.args, '2 files')
 })
 
+test('cold hydrate defers adjacent-read reflow and preserves apply semantics', () => {
+  const events: SessionEvent[] = [event('turn/start', { turn: 0 }, 0)]
+  for (let index = 0; index < 128; index += 1) {
+    const callId = CallId(`hydrate-read-${index}`)
+    events.push(event('tool/call', {
+      turn: 0,
+      step: 0,
+      callId,
+      name: 'read',
+      arguments: JSON.stringify({ file: `file-${index}.ts` }),
+    }, events.length))
+    events.push(event('tool/result', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId(`hydrate-read-message-${index}`),
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId: callId, content: [{ type: 'text', text: `result-${index}` }] }],
+        source: { kind: 'tool', callId },
+      },
+    }, events.length))
+  }
+
+  const expected = new TranscriptFolder()
+  const liveInternals = expected as unknown as {
+    reflowGrouping: (index: number) => void
+  }
+  const originalLiveReflow = liveInternals.reflowGrouping
+  let liveReflowCount = 0
+  liveInternals.reflowGrouping = (index) => {
+    liveReflowCount += 1
+    originalLiveReflow.call(liveInternals, index)
+  }
+  try {
+    for (const item of events) expected.apply([item])
+  } finally {
+    liveInternals.reflowGrouping = originalLiveReflow
+  }
+  assert.equal(liveReflowCount, 0, 'tail live reads must append without a full-run reflow')
+
+  const hydrated = new TranscriptFolder()
+  const internals = hydrated as unknown as {
+    reflowGrouping: (index: number) => void
+  }
+  const originalReflow = internals.reflowGrouping
+  let reflowCount = 0
+  internals.reflowGrouping = (index) => {
+    reflowCount += 1
+    originalReflow.call(internals, index)
+  }
+  try {
+    hydrated.hydrate(events)
+  } finally {
+    internals.reflowGrouping = originalReflow
+  }
+
+  assert.equal(reflowCount, 0, 'cold hydration must finalize read runs once instead of reflowing each result')
+  assert.deepEqual(hydrated.messages(), expected.messages())
+  const tools = hydrated.messages().filter((message): message is Extract<TranscriptMessage, { kind: 'tool' }> => message.kind === 'tool')
+  assert.equal(tools.length, 1)
+  assert.equal(tools[0]?.args, '128 files')
+  assert.ok(tools[0]?.result.startsWith('result-0'))
+  assert.ok(tools[0]?.result.endsWith('result-127'))
+
+  // Hydration is a cold-only optimization: a later live suffix still uses the
+  // immediate grouping path and retains the same public projection semantics.
+  const nextCall = CallId('hydrate-read-live')
+  hydrated.apply([
+    event('tool/call', { turn: 0, step: 0, callId: nextCall, name: 'read', arguments: '{}' }, events.length),
+    event('tool/result', {
+      turn: 0,
+      step: 0,
+      message: {
+        id: MessageId('hydrate-read-live-message'),
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId: nextCall, content: [{ type: 'text', text: 'live-result' }] }],
+        source: { kind: 'tool', callId: nextCall },
+      },
+    }, events.length + 1),
+  ])
+  const liveTools = hydrated.messages().filter((message): message is Extract<TranscriptMessage, { kind: 'tool' }> => message.kind === 'tool')
+  assert.equal(liveTools.length, 1)
+  assert.equal(liveTools[0]?.args, '129 files')
+  assert.ok(liveTools[0]?.result.endsWith('live-result'))
+})
+
 test('subagent/descriptor folds into a delegation card', () => {
   const messages = foldTranscript([
     event('turn/start', { turn: 0 }, 0),


### PR DESCRIPTION
## Summary

- add an explicit cold-session `hydrate()` path for transcript and stats projections
- defer historical read grouping to one linear finalize pass during hydration
- keep live tail read grouping incremental instead of reflowing the whole run
- wire resume and child-session bootstrap through the cold path
- add parity/regression coverage and long-session benchmark reporting

## Validation

- `pnpm install && pnpm build`
- `pnpm typecheck`
- `pnpm test`
- boundary, keybinding, and naming gates
- `BENCH_FAST=1 node --import tsx/esm scripts/bench.mts`
