### PR TITLE
fix(footer): make builtin compact density effective on next

### DIFF
--- a/src/footer/builtin-items.ts
+++ b/src/footer/builtin-items.ts
@@ -21,12 +21,16 @@ import {
   formatContextPercent,
   formatGitBranch,
   formatModel,
+  formatPerformanceCompact,
   formatPerformanceFull,
   formatPerformanceLatency,
   formatPerformanceSpeed,
   formatPermissionPreset,
   formatPlanState,
+  formatRunPhaseCompact,
+  formatSandboxModeCompact,
   formatStatsLine,
+  formatStatsLineCompact,
   formatTokenUsageCompact,
   formatTokenUsageIo,
   formatTokenUsageTotal,
@@ -47,11 +51,14 @@ const permissionPresetItem: FooterItemDefinition = {
   defaultImportance: 110,
   formats: ['badge', 'plain', 'compact'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const preset = snapshot.access.permissionPreset
     if (preset === undefined) return null
-    const text = formatPermissionPreset(preset.id, ref.format ?? 'badge')
+    // Density compact reuses the persisted 'compact' style (ww/ro/yolo);
+    // the user's own format choice is never written back.
+    const format = density === 'compact' ? 'compact' : ref.format ?? 'badge'
+    const text = formatPermissionPreset(preset.id, format)
     if (text === undefined) return null
     const tone = preset.id === 'danger-full-access' || preset.id === 'custom'
       ? 'warning'
@@ -70,12 +77,15 @@ const planStateItem: FooterItemDefinition = {
   defaultImportance: 115,
   formats: ['badge', 'plain'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
+    // Density compact drops the badge brackets (the plan's A-class
+    // mapping); the user's own format choice is never written back.
+    const format = density === 'compact' ? 'plain' : ref.format ?? 'badge'
     const text = formatPlanState(
       snapshot.collaboration.plan.effective,
       snapshot.collaboration.plan.pending,
-      ref.format ?? 'badge',
+      format,
     )
     return text === undefined ? null : { spans: [{ text, tone: 'warning' }] }
   },
@@ -90,11 +100,14 @@ const modelItem: FooterItemDefinition = {
   defaultImportance: 100,
   formats: ['badge', 'plain', 'compact'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const model = snapshot.composition.model
     if (model === undefined) return null
-    return { spans: [{ text: formatModel(model.provider, model.id, model.reasoningEffort, ref.format ?? 'badge') }] }
+    // Density compact reuses the persisted 'compact' style (model id
+    // only); the user's own format choice is never written back.
+    const format = density === 'compact' ? 'compact' : ref.format ?? 'badge'
+    return { spans: [{ text: formatModel(model.provider, model.id, model.reasoningEffort, format) }] }
   },
 }
 
@@ -109,20 +122,29 @@ const tasksItem: FooterItemDefinition = {
   defaultImportance: 85,
   formats: ['badge'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot, _ref, _density, context) {
+  render(snapshot: StatusSnapshot, _ref, density, context) {
     if (snapshot.view.subject.kind !== 'main') return null
-    const parts: string[] = []
     const tasks = snapshot.activity.taskCount
     const agents = snapshot.activity.childAgentCount
-    if (tasks > 0) parts.push(`${tasks} task${tasks === 1 ? '' : 's'} running`)
-    if (agents > 0) parts.push(`${agents} agent${agents === 1 ? '' : 's'}`)
-    if (parts.length === 0) return null
+    if (tasks <= 0 && agents <= 0) return null
     // The ↓ hint mirrors the ROUTING GATE exactly (a P2 regression once
     // shrunk it to "host editor empty" — a shell-mode empty body and a
     // plugin replacement editor with a draft then advertised a ↓ that
     // the gate refuses): the visible prompt-mode seat editor with no
     // overlays can actually open the browser.
     const hint = context.taskBrowserAvailable ? ' · ↓ view' : ''
+    if (density === 'compact') {
+      // The compact badge: `[1t·2a·↓]` — one-letter count codes, the ↓
+      // hint kept as a bare marker.
+      const parts: string[] = []
+      if (tasks > 0) parts.push(`${tasks}t`)
+      if (agents > 0) parts.push(`${agents}a`)
+      if (context.taskBrowserAvailable) parts.push('↓')
+      return { spans: [{ text: `[${parts.join('·')}]`, tone: 'primary' }] }
+    }
+    const parts: string[] = []
+    if (tasks > 0) parts.push(`${tasks} task${tasks === 1 ? '' : 's'} running`)
+    if (agents > 0) parts.push(`${agents} agent${agents === 1 ? '' : 's'}`)
     return { spans: [{ text: `[${parts.join(' · ')}${hint}]`, tone: 'primary' }] }
   },
 }
@@ -136,10 +158,13 @@ const cwdItem: FooterItemDefinition = {
   defaultImportance: 80,
   formats: ['short', 'basename', 'full'],
   defaultFormat: 'short',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     const cwd = snapshot.workspace.cwd
     if (cwd === '') return null
-    return { spans: [{ text: formatWorkingDirectory(cwd, ref.format ?? 'short') }] }
+    // Density compact reuses the persisted 'basename' style; the user's
+    // own format choice is never written back.
+    const format = density === 'compact' ? 'basename' : ref.format ?? 'short'
+    return { spans: [{ text: formatWorkingDirectory(cwd, format) }] }
   },
 }
 
@@ -152,11 +177,15 @@ const gitBranchItem: FooterItemDefinition = {
   defaultImportance: 70,
   formats: ['plain', 'label'],
   defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const branch = snapshot.workspace.branch
     if (branch === undefined || branch === '') return null
-    return { spans: [{ text: formatGitBranch(branch, ref.format ?? 'plain') }] }
+    // Density compact reuses the persisted 'plain' style (a 'label' ref
+    // loses its prefix under pressure); the user's own format choice is
+    // never written back.
+    const format = density === 'compact' ? 'plain' : ref.format ?? 'plain'
+    return { spans: [{ text: formatGitBranch(branch, format) }] }
   },
 }
 
@@ -170,14 +199,19 @@ const contextItem: FooterItemDefinition = {
   defaultImportance: 100,
   formats: ['bar', 'percent', 'full'],
   defaultFormat: 'bar',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const context = snapshot.usage.context
     if (context === undefined || context.windowTokens === undefined || context.windowTokens <= 0) return null
     const used = context.usedTokens ?? 0
     const window = context.windowTokens
-    const format = ref.format ?? 'bar'
     const percent = context.percent ?? Math.min(100, Math.max(0, Math.ceil((used * 100) / window)))
+    // Density compact always prefers the percent form (`ctx 72%`) — the
+    // shortest context presentation — whatever the user's persisted style.
+    if (density === 'compact') {
+      return { spans: [{ text: formatContextPercent(percent), tone: 'primary' }] }
+    }
+    const format = ref.format ?? 'bar'
     if (format === 'full') {
       return { spans: [{ text: formatContextFull(used, window, percent), tone: 'primary' }] }
     }
@@ -224,8 +258,14 @@ const statsLineItem: FooterItemDefinition = {
   defaultImportance: 10,
   formats: ['pi'],
   defaultFormat: 'pi',
-  render(snapshot: StatusSnapshot) {
-    return { spans: [{ text: formatStatsLine(snapshot.usage) }] }
+  render(snapshot: StatusSnapshot, _ref, density) {
+    // Density compact renders the pressure form (input/output + one time
+    // indicator + throughput); the legacy full line stays the preferred
+    // form (its source-consistency contract is untouched).
+    const text = density === 'compact'
+      ? formatStatsLineCompact(snapshot.usage)
+      : formatStatsLine(snapshot.usage)
+    return { spans: [{ text }] }
   },
 }
 
@@ -312,11 +352,15 @@ const agentPresetItem: FooterItemDefinition = {
   defaultImportance: 90,
   formats: ['badge', 'compact'],
   defaultFormat: 'badge',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const preset = snapshot.composition.agentPreset
     if (preset === undefined) return null
-    const text = ref.format === 'compact' && preset.shortLabel !== undefined
+    // Density compact reuses the persisted 'compact' style (the short
+    // label when the state layer provides one); the user's own format
+    // choice is never written back.
+    const compact = density === 'compact' || ref.format === 'compact'
+    const text = compact && preset.shortLabel !== undefined
       ? preset.shortLabel
       : preset.label
     return { spans: [{ text: `[${text}]`, tone: 'accent' }] }
@@ -349,12 +393,15 @@ const sandboxModeItem: FooterItemDefinition = {
   defaultImportance: 80,
   formats: ['plain'],
   defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, _ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const mode = snapshot.access.sandbox?.mode
     if (mode === undefined) return null
     const tone = mode === 'danger-full-access' ? 'warning' : mode === 'read-only' ? 'textMuted' : 'text'
-    return { spans: [{ text: mode, tone }] }
+    // Density compact uses the known codes (ro/ww/yolo); an unknown
+    // future mode keeps its original value (fail-soft).
+    const text = density === 'compact' ? formatSandboxModeCompact(mode) : mode
+    return { spans: [{ text, tone }] }
   },
 }
 
@@ -430,12 +477,15 @@ const runStateItem: FooterItemDefinition = {
   defaultImportance: 95,
   formats: ['plain'],
   defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, _ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const phase = snapshot.activity.phase
     if (phase === 'idle') return null
     const tone = phase === 'working' ? 'primary' : 'warning'
-    return { spans: [{ text: phase, tone }] }
+    // Density compact uses the phase codes (work/w-approval/…); an
+    // unknown future phase keeps its original value (fail-soft).
+    const text = density === 'compact' ? formatRunPhaseCompact(phase) : phase
+    return { spans: [{ text, tone }] }
   },
 }
 
@@ -448,11 +498,12 @@ const queueItem: FooterItemDefinition = {
   defaultImportance: 85,
   formats: ['plain'],
   defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, _ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const count = snapshot.activity.queuedCount
     if (count <= 0) return null
-    return { spans: [{ text: `${count} queued`, tone: 'textDim' }] }
+    const text = density === 'compact' ? `q${count}` : `${count} queued`
+    return { spans: [{ text, tone: 'textDim' }] }
   },
 }
 
@@ -465,11 +516,12 @@ const agentsItem: FooterItemDefinition = {
   defaultImportance: 85,
   formats: ['plain'],
   defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, _ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const count = snapshot.activity.childAgentCount
     if (count <= 0) return null
-    return { spans: [{ text: `${count} agents`, tone: 'textDim' }] }
+    const text = density === 'compact' ? `a${count}` : `${count} agents`
+    return { spans: [{ text, tone: 'textDim' }] }
   },
 }
 
@@ -482,11 +534,14 @@ const todoItem: FooterItemDefinition = {
   defaultImportance: 60,
   formats: ['plain'],
   defaultFormat: 'plain',
-  render(snapshot: StatusSnapshot) {
+  render(snapshot: StatusSnapshot, _ref, density) {
     if (snapshot.view.subject.kind !== 'main') return null
     const count = snapshot.activity.todoCount
     if (count <= 0) return null
-    return { spans: [{ text: `${count} todo`, tone: 'textDim' }] }
+    // `tdN` — deliberately NOT `tN`, which would collide with the
+    // turns-steps counters.
+    const text = density === 'compact' ? `td${count}` : `${count} todo`
+    return { spans: [{ text, tone: 'textDim' }] }
   },
 }
 
@@ -499,10 +554,13 @@ const cacheHitItem: FooterItemDefinition = {
   defaultImportance: 55,
   formats: ['full', 'compact'],
   defaultFormat: 'full',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     const pct = snapshot.usage.cacheHitPct
     if (pct === undefined) return null
-    const text = ref.format === 'compact' ? formatCacheHitCompact(pct) : formatCacheHit(pct)
+    // Density compact reuses the persisted 'compact' style (`91.9%`);
+    // the user's own format choice is never written back.
+    const compact = density === 'compact' || ref.format === 'compact'
+    const text = compact ? formatCacheHitCompact(pct) : formatCacheHit(pct)
     return { spans: [{ text, tone: 'success' }] }
   },
 }
@@ -516,9 +574,11 @@ const tokenUsageItem: FooterItemDefinition = {
   defaultImportance: 50,
   formats: ['io', 'total', 'compact'],
   defaultFormat: 'io',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     const tokens = snapshot.usage.tokens
-    const format = ref.format ?? 'io'
+    // Density compact reuses the persisted 'compact' style (`6.7k`); the
+    // user's own format choice is never written back.
+    const format = density === 'compact' ? 'compact' : ref.format ?? 'io'
     const text = format === 'total'
       ? formatTokenUsageTotal(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
       : format === 'compact'
@@ -538,13 +598,18 @@ const performanceItem: FooterItemDefinition = {
   defaultImportance: 40,
   formats: ['full', 'speed', 'latency'],
   defaultFormat: 'full',
-  render(snapshot: StatusSnapshot, ref) {
+  render(snapshot: StatusSnapshot, ref, density) {
     const performance = snapshot.usage.performance
-    const text = ref.format === 'speed'
-      ? formatPerformanceSpeed(performance.tokensPerSec)
-      : ref.format === 'latency'
-        ? formatPerformanceLatency(performance.firstTokenMs)
-        : formatPerformanceFull(performance.llmMs, performance.tokensPerSec)
+    // Density compact keeps BOTH facts with the shortened unit
+    // (`8.1s 40t/s`) — it never degrades to a speed-only or latency-only
+    // style (that would shift the composite item's semantic center).
+    const text = density === 'compact'
+      ? formatPerformanceCompact(performance.llmMs, performance.tokensPerSec)
+      : ref.format === 'speed'
+        ? formatPerformanceSpeed(performance.tokensPerSec)
+        : ref.format === 'latency'
+          ? formatPerformanceLatency(performance.firstTokenMs)
+          : formatPerformanceFull(performance.llmMs, performance.tokensPerSec)
     return { spans: [{ text, tone: 'textMuted' }] }
   },
 }
@@ -571,3 +636,44 @@ export function createBuiltinFooterRegistry(): FooterItemRegistry {
   registerBuiltinFooterItems(registry)
   return registry
 }
+
+/** The builtin items with a REAL responsive compact density (the plan's
+ * A + B classes): under width pressure the composer's compact pass
+ * renders a strictly shorter form BEFORE any importance drop. A future
+ * builtin must either join this list or the intentional no-op list —
+ * there is no third "not handled" state. */
+export const RESPONSIVE_COMPACT_ITEMS: readonly string[] = [
+  'permission-preset',
+  'plan-state',
+  'model',
+  'tasks',
+  'cwd',
+  'git-branch',
+  'context',
+  'stats-line',
+  'agent-preset',
+  'sandbox-mode',
+  'run-state',
+  'queue',
+  'agents',
+  'todo',
+  'cache-hit',
+  'token-usage',
+  'performance',
+]
+
+/** The builtin items whose compact density INTENTIONALLY equals their
+ * preferred form (the plan's C class): already short, identity-bearing,
+ * or opaque extension text — an explicit decision, never a silent
+ * "forgot to implement". */
+export const INTENTIONALLY_STABLE_DENSITY_ITEMS: readonly string[] = [
+  'turns-steps',
+  'view-scope',
+  'ext:*',
+  'reasoning',
+  'approval-policy',
+  'focus-mode',
+  'focused-seat',
+  'project',
+  'version',
+]

--- a/src/footer/builtin-items.ts
+++ b/src/footer/builtin-items.ts
@@ -14,6 +14,7 @@
  */
 
 import type { StatusSnapshot } from '../status/types.ts'
+import { visibleWidth } from '@xmoon76/pi-tui'
 import {
   formatCacheHit,
   formatCacheHitCompact,
@@ -576,14 +577,18 @@ const tokenUsageItem: FooterItemDefinition = {
   defaultFormat: 'io',
   render(snapshot: StatusSnapshot, ref, density) {
     const tokens = snapshot.usage.tokens
-    // Density compact reuses the persisted 'compact' style (`6.7k`); the
-    // user's own format choice is never written back.
-    const format = density === 'compact' ? 'compact' : ref.format ?? 'io'
-    const text = format === 'total'
+    const preferred = ref.format === 'total'
       ? formatTokenUsageTotal(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
-      : format === 'compact'
+      : ref.format === 'compact'
         ? formatTokenUsageCompact(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
         : formatTokenUsageIo(tokens.input, tokens.output)
+    if (density !== 'compact') return { spans: [{ text: preferred, tone: 'success' }] }
+    // Density compact reuses the persisted 'compact' style (`6.7k`).
+    // When the user's persisted style is ALREADY shorter (a tiny io pair
+    // beside a huge cache total), the compact form is the preferred form
+    // itself — a legitimate no-op, never a wider compact.
+    const compact = formatTokenUsageCompact(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
+    const text = visibleWidth(compact) < visibleWidth(preferred) ? compact : preferred
     return { spans: [{ text, tone: 'success' }] }
   },
 }
@@ -600,16 +605,20 @@ const performanceItem: FooterItemDefinition = {
   defaultFormat: 'full',
   render(snapshot: StatusSnapshot, ref, density) {
     const performance = snapshot.usage.performance
+    const preferred = ref.format === 'speed'
+      ? formatPerformanceSpeed(performance.tokensPerSec)
+      : ref.format === 'latency'
+        ? formatPerformanceLatency(performance.firstTokenMs)
+        : formatPerformanceFull(performance.llmMs, performance.tokensPerSec)
+    if (density !== 'compact') return { spans: [{ text: preferred, tone: 'textMuted' }] }
     // Density compact keeps BOTH facts with the shortened unit
     // (`8.1s 40t/s`) — it never degrades to a speed-only or latency-only
     // style (that would shift the composite item's semantic center).
-    const text = density === 'compact'
-      ? formatPerformanceCompact(performance.llmMs, performance.tokensPerSec)
-      : ref.format === 'speed'
-        ? formatPerformanceSpeed(performance.tokensPerSec)
-        : ref.format === 'latency'
-          ? formatPerformanceLatency(performance.firstTokenMs)
-          : formatPerformanceFull(performance.llmMs, performance.tokensPerSec)
+    // When the user's persisted style is ALREADY shorter (speed/latency),
+    // the compact form is the preferred form itself — a legitimate no-op,
+    // never a wider compact.
+    const compact = formatPerformanceCompact(performance.llmMs, performance.tokensPerSec)
+    const text = visibleWidth(compact) < visibleWidth(preferred) ? compact : preferred
     return { spans: [{ text, tone: 'textMuted' }] }
   },
 }

--- a/src/footer/formatters.ts
+++ b/src/footer/formatters.ts
@@ -156,6 +156,13 @@ export function formatPerformanceFull(llmMs: number, tokensPerSec: number): stri
   return `${formatSeconds(llmMs)} ${tokensPerSec} tok/s`
 }
 
+/** Performance, compact pressure form: `2.0s 40t/s` — the full form's
+ * `tok/s` unit shortened under width pressure (the composite item keeps
+ * BOTH facts; it never degrades to a speed-only or latency-only style). */
+export function formatPerformanceCompact(llmMs: number, tokensPerSec: number): string {
+  return `${formatSeconds(llmMs)} ${tokensPerSec}t/s`
+}
+
 /** Performance, speed-only form: `40 tok/s`. */
 export function formatPerformanceSpeed(tokensPerSec: number): string {
   return `${tokensPerSec} tok/s`
@@ -197,6 +204,49 @@ export function formatStatsLine(usage: UsageStatus): string {
     `${usage.performance.tokensPerSec} tok/s`,
   ]
   return `${piParts.join(' ')} | ${ownParts.join(' · ')}`
+}
+
+/** The pi-vocabulary stats line, compact pressure form:
+ * `↑34k ↓8.1k · LLM 138.8s · 659t/s` — input/output, ONE time indicator
+ * and the throughput survive; the cache (R/W/CH) and TTFB facts are
+ * omitted under width pressure. The structured UsageStatus is untouched
+ * and the legacy formatStatsLine contract is unchanged. */
+export function formatStatsLineCompact(usage: UsageStatus): string {
+  const piParts = [
+    `↑${formatTokens(usage.tokens.input)}`,
+    `↓${formatTokens(usage.tokens.output)}`,
+  ]
+  const ownParts = [
+    `LLM ${formatSeconds(usage.performance.llmMs)}`,
+    `${usage.performance.tokensPerSec}t/s`,
+  ]
+  return `${piParts.join(' ')} · ${ownParts.join(' · ')}`
+}
+
+/** The sandbox mode compact codes: `ro`, `ww`, `yolo`. An unknown future
+ * mode keeps its original value (fail-soft — never an invented
+ * abbreviation). */
+export function formatSandboxModeCompact(mode: string): string {
+  switch (mode) {
+    case 'read-only': return 'ro'
+    case 'workspace-write': return 'ww'
+    case 'danger-full-access': return 'yolo'
+    default: return mode
+  }
+}
+
+/** The run-phase compact codes for the CURRENT RunPhase union (idle is
+ * never rendered by the item). An unknown future phase keeps its original
+ * value (fail-soft — never an invented abbreviation). */
+export function formatRunPhaseCompact(phase: string): string {
+  switch (phase) {
+    case 'working': return 'work'
+    case 'waiting-approval': return 'w-approval'
+    case 'waiting-question': return 'w-question'
+    case 'compacting': return 'compact'
+    case 'applying-compaction': return 'apply-compact'
+    default: return phase
+  }
 }
 
 /** Version formatters: `tui` → `v0.4.0-alpha.1`, `dsh` → `dsh-0.1.2-alpha.2`,

--- a/test/footer-composer-compat.test.ts
+++ b/test/footer-composer-compat.test.ts
@@ -337,11 +337,11 @@ test('independent golden vectors lock the composed output (wide/narrow/compact)'
     composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 20, context: CONTEXT })
       .replace(/\x1b\[[0-9;]*m/g, ''),
     // 20 columns: the status row's preferred form (75 cells) exceeds the
-    // 2×20-cell row budget — importance fitting drops cwd(80)/branch(70)/
-    // context(100) BEFORE model(100)/permission(110) and truncates the
-    // rest; never a slice of the wrapped lines (plan §6.2). The stats row
-    // keeps its own allowance, cut at the full width.
-    '[workspace-write]\n[deepseek/flash]\n↑1.2k ↓3.4k | LLM\n8.1s · TTFB 0s · 0 …',
+    // 2×20-cell row budget — the responsive compact pass shortens the
+    // items FIRST (ww/flash/proj/ctx 25%), and only what still does not
+    // fit drops by importance; never a slice of the wrapped lines (plan
+    // §6.2). The stats row compacts to its pressure form too.
+    'ww  flash  proj\nmain  ctx 25%  t2/s5\n↑1.2k ↓3.4k · LLM\n8.1s · 0t/s',
   )
   assert.equal(
     composer.render({ snapshot: snap, layout: COMPACT_FOOTER_LAYOUT, width: 100, context: CONTEXT })

--- a/test/footer-density.test.ts
+++ b/test/footer-density.test.ts
@@ -184,6 +184,26 @@ test('token-usage compact never exceeds a shorter persisted io style (cache-heav
   assert.equal(renderDensity('token-usage', snap, { id: 'token-usage', format: 'total' }, 'compact'), '1.5M')
 })
 
+test('B-class compact presentations match the agreed golden strings', () => {
+  // The structural invariants prove compact is SHORTER; these goldens
+  // prove it is the AGREED string (a drift like `q3 → x3` or `td3 → t3`
+  // would still satisfy "shorter" but must fail here).
+  const snap = richSnapshot()
+  const cases: Array<[string, string]> = [
+    ['tasks', '[1t·2a·↓]'],
+    ['sandbox-mode', 'ww'],
+    ['run-state', 'w-approval'],
+    ['queue', 'q3'],
+    ['agents', 'a2'],
+    ['todo', 'td3'],
+    ['performance', '138.8s 659t/s'],
+    ['stats-line', '↑34k ↓8.1k · LLM 138.8s · 659t/s'],
+  ]
+  for (const [id, expected] of cases) {
+    assert.equal(renderDensity(id, snap, { id }, 'compact'), expected, `${id} compact golden`)
+  }
+})
+
 test('responsive items: compact is STRICTLY shorter under the canonical fixture', () => {
   const snap = richSnapshot()
   for (const id of RESPONSIVE_COMPACT_ITEMS) {

--- a/test/footer-density.test.ts
+++ b/test/footer-density.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Footer density contract tests (plan 2026-08-31): every builtin item
+ * either has a REAL responsive compact density (a strictly shorter form
+ * under width pressure) or is an explicitly documented intentional no-op —
+ * never a silent "forgot to implement". Style (the persisted format) and
+ * Density (the runtime pressure choice) stay orthogonal: a compact pass
+ * never writes back into the persisted format.
+ *
+ * The headline regression: Row 2 = stats-line + turns-steps. Before the
+ * fix, stats-line's compact render was a no-op, so moderate narrow widths
+ * jumped straight from the full stats line to dropping stats-line
+ * (importance 10) — leaving only `t4/s191`. After the fix the row first
+ * compacts the stats line and only drops it at extreme narrow widths.
+ * @module @xmoon76/dsh-pi-tui/footer-density.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { visibleWidth } from '@xmoon76/pi-tui'
+import {
+  createBuiltinFooterRegistry,
+  INTENTIONALLY_STABLE_DENSITY_ITEMS,
+  RESPONSIVE_COMPACT_ITEMS,
+} from '../src/footer/builtin-items.ts'
+import { FooterComposer, renderSpans } from '../src/footer/composer.ts'
+import type { FooterDensity, FooterItemRef } from '../src/footer/types.ts'
+import { emptyStatusSnapshot, type StatusSnapshot } from '../src/status/types.ts'
+
+const registry = createBuiltinFooterRegistry()
+const composer = new FooterComposer(registry)
+const CONTEXT = { taskBrowserAvailable: true, extensionFooterText: '' }
+
+/** Strip ANSI SGR sequences for text-level assertions. */
+function plain(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, '')
+}
+
+/** Render one item at an explicit density (the preferred/compact helper). */
+function renderDensity(id: string, snapshot: StatusSnapshot, ref: FooterItemRef, density: FooterDensity): string {
+  const def = registry.get(id)
+  assert.ok(def !== undefined, `item ${id} must be registered`)
+  const segment = def.render(snapshot, ref, density, CONTEXT)
+  return segment === null ? '' : plain(renderSpans(segment.spans))
+}
+
+/** Deep-mutable build shape (the snapshot is deeply readonly). */
+type DeepMutable<T> = { -readonly [K in keyof T]: DeepMutable<T[K]> }
+
+/** A rich main-subject snapshot: every responsive item renders a
+ * meaningful preferred form (the canonical density fixture). */
+function richSnapshot(): StatusSnapshot {
+  const snap = emptyStatusSnapshot() as DeepMutable<StatusSnapshot>
+  snap.composition.agentPreset = { id: 'code', label: 'Code preset', shortLabel: 'CP' }
+  snap.composition.model = {
+    provider: 'ollama',
+    id: 'deepseek-v4-flash:0731-cloud',
+    displayName: 'deepseek-v4-flash:0731-cloud',
+    reasoningEffort: 'max',
+  }
+  snap.access.permissionPreset = { id: 'workspace-write', label: 'workspace-write', matched: true }
+  snap.access.sandbox = { mode: 'workspace-write' }
+  snap.access.approval = { policy: 'never' }
+  snap.collaboration.plan = { effective: true }
+  snap.activity = {
+    phase: 'waiting-approval',
+    busy: true,
+    queuedCount: 3,
+    taskCount: 1,
+    childAgentCount: 2,
+    todoCount: 3,
+  }
+  snap.workspace = { cwd: '/home/x/project/foo', branch: 'feat/next', project: 'foo' }
+  snap.usage = {
+    tokens: { input: 34_000, output: 8_100, cacheRead: 520_000, cacheWrite: 0 },
+    cacheHitPct: 93.9,
+    performance: { llmMs: 138_800, firstTokenMs: 2_600, tokensPerSec: 659 },
+    turns: 4,
+    steps: 191,
+  }
+  snap.usage.context = { usedTokens: 195_000, windowTokens: 272_000, percent: 72 }
+  snap.interaction.focusMode = true
+  snap.host.dshVersion = '0.1.2-alpha.2'
+  return snap as StatusSnapshot
+}
+
+/** The plan's Row-2 regression layout: stats-line + turns-steps on the
+ * second logical row. */
+const ROW2_LAYOUT = {
+  schemaVersion: 1 as const,
+  rows: [
+    { left: [{ id: 'permission-preset' }, { id: 'model' }, { id: 'context' }, { id: 'focus-mode' }], right: [] },
+    { left: [{ id: 'stats-line' }, { id: 'turns-steps' }], right: [] },
+  ],
+}
+
+test('Row2 = stats-line + turns-steps compacts BEFORE dropping at moderate narrow widths', () => {
+  const snap = richSnapshot()
+  // Moderate narrow (30): the full stats line cannot fit the 2-line row
+  // budget, but the COMPACT stats line + the counters can. The pre-fix
+  // behavior dropped stats-line here because its compact render was a
+  // no-op — the row collapsed to `t4/s191`.
+  const text = composer.render({ snapshot: snap, layout: ROW2_LAYOUT, width: 30, context: CONTEXT })
+  const lines = plain(text).split('\n')
+  assert.ok(lines.some(line => line.includes('↑34k')), `compact stats must survive:\n${plain(text)}`)
+  assert.ok(lines.some(line => line.includes('t4/s191')), `the counters must survive:\n${plain(text)}`)
+  assert.ok(!plain(text).includes('TTFB'), `the full stats form must not survive at this width:\n${plain(text)}`)
+  assert.ok(lines.length <= 4, `the whole footer stays inside the hard capacity:\n${plain(text)}`)
+  for (const line of lines) assert.ok(visibleWidth(line) <= 30, `overflow:\n${plain(text)}`)
+  // Extreme narrow (15): importance drop still wins (stats-line 10 <
+  // turns-steps 45) — compact is a space-saving step, never a priority
+  // redefinition.
+  const extreme = plain(composer.render({ snapshot: snap, layout: ROW2_LAYOUT, width: 15, context: CONTEXT }))
+  assert.ok(extreme.includes('t4/s191'), `the counters survive extreme narrow:\n${extreme}`)
+  assert.ok(!extreme.includes('↑'), `stats-line drops at extreme narrow:\n${extreme}`)
+})
+
+test('every builtin item has an explicit density decision (responsive or intentional no-op)', () => {
+  const responsive = new Set(RESPONSIVE_COMPACT_ITEMS)
+  const stable = new Set(INTENTIONALLY_STABLE_DENSITY_ITEMS)
+  // No duplicates inside either list.
+  assert.equal(responsive.size, RESPONSIVE_COMPACT_ITEMS.length, 'RESPONSIVE_COMPACT_ITEMS must not repeat ids')
+  assert.equal(stable.size, INTENTIONALLY_STABLE_DENSITY_ITEMS.length, 'INTENTIONALLY_STABLE_DENSITY_ITEMS must not repeat ids')
+  // The two sets partition the whole builtin registry: every registered
+  // item is classified exactly once — a future builtin must choose
+  // responsive compact or an explicit no-op, never "not handled".
+  const union = [...new Set([...RESPONSIVE_COMPACT_ITEMS, ...INTENTIONALLY_STABLE_DENSITY_ITEMS])].sort()
+  assert.deepEqual(union, [...registry.ids()].sort(), 'the density audit must cover every builtin id')
+  for (const id of responsive) {
+    assert.ok(!stable.has(id), `${id} must not be in both density classes`)
+  }
+})
+
+test('responsive items: compact is never wider than preferred (default refs)', () => {
+  const snap = richSnapshot()
+  for (const id of RESPONSIVE_COMPACT_ITEMS) {
+    const preferred = renderDensity(id, snap, { id }, 'preferred')
+    const compact = renderDensity(id, snap, { id }, 'compact')
+    assert.ok(preferred !== '', `${id} must render in the fixture`)
+    assert.ok(compact !== '', `${id} compact must render in the fixture`)
+    assert.ok(
+      visibleWidth(compact) <= visibleWidth(preferred),
+      `${id}: compact (${compact}) must never be wider than preferred (${preferred})`,
+    )
+  }
+})
+
+test('responsive items: compact is STRICTLY shorter under the canonical fixture', () => {
+  const snap = richSnapshot()
+  for (const id of RESPONSIVE_COMPACT_ITEMS) {
+    // git-branch's default format is already the plain form, so its
+    // compact is a no-op there; the fixture uses the label style to prove
+    // the responsive compact is real (the plan's A-class mapping).
+    const ref: FooterItemRef = id === 'git-branch' ? { id, format: 'label' } : { id }
+    const preferred = renderDensity(id, snap, ref, 'preferred')
+    const compact = renderDensity(id, snap, ref, 'compact')
+    assert.ok(preferred !== '', `${id} must render in the fixture`)
+    assert.ok(compact !== '', `${id} compact must render in the fixture`)
+    assert.ok(
+      visibleWidth(compact) < visibleWidth(preferred),
+      `${id}: compact (${compact}) must be strictly shorter than preferred (${preferred})`,
+    )
+  }
+})
+
+test('intentional no-op items keep compact == preferred (explicitly documented)', () => {
+  const snap = richSnapshot()
+  for (const id of INTENTIONALLY_STABLE_DENSITY_ITEMS) {
+    const preferred = renderDensity(id, snap, { id }, 'preferred')
+    const compact = renderDensity(id, snap, { id }, 'compact')
+    assert.equal(compact, preferred, `${id} must be an explicit density no-op`)
+  }
+  // The identity-bearing / opaque items also hold when they actually
+  // render: the viewer identity block and the extension bridge.
+  const viewer = snapshotWith(snap => {
+    snap.view.subject = { kind: 'subagent', id: 'c1', label: 'audit', mode: 'one-shot', activity: 'running' }
+  })
+  assert.equal(renderDensity('view-scope', viewer, { id: 'view-scope' }, 'compact'),
+    renderDensity('view-scope', viewer, { id: 'view-scope' }, 'preferred'))
+  const def = registry.get('ext:*')!
+  const extContext = { ...CONTEXT, extensionFooterText: '[EXT-SEG]' }
+  const extPreferred = def.render(snap, { id: 'ext:*' }, 'preferred', extContext)
+  const extCompact = def.render(snap, { id: 'ext:*' }, 'compact', extContext)
+  assert.equal(extCompact === null ? '' : plain(renderSpans(extCompact.spans)),
+    extPreferred === null ? '' : plain(renderSpans(extPreferred.spans)),
+    'ext:* must never be rewritten by a density pass')
+})
+
+test('density never pollutes the persisted style (Style × Density orthogonal)', () => {
+  const snap = richSnapshot()
+  // context(format=full): preferred full → compact percent → preferred full again.
+  const contextRef: FooterItemRef = { id: 'context', format: 'full' }
+  const contextPreferred = renderDensity('context', snap, contextRef, 'preferred')
+  assert.equal(contextPreferred, '195k/272k (72%)')
+  assert.equal(renderDensity('context', snap, contextRef, 'compact'), 'ctx 72%')
+  assert.equal(renderDensity('context', snap, contextRef, 'preferred'), contextPreferred,
+    'a compact pass must not write back into the persisted format')
+  // model(format=badge): preferred badge → compact id → preferred badge again.
+  const modelRef: FooterItemRef = { id: 'model', format: 'badge' }
+  const modelPreferred = renderDensity('model', snap, modelRef, 'preferred')
+  assert.equal(modelPreferred, '[ollama/deepseek-v4-flash:0731-cloud @max]')
+  assert.equal(renderDensity('model', snap, modelRef, 'compact'), 'deepseek-v4-flash:0731-cloud')
+  assert.equal(renderDensity('model', snap, modelRef, 'preferred'), modelPreferred,
+    'a compact pass must not write back into the persisted format')
+})
+
+test('the width matrix locks preferred → compact → importance-drop → truncate', () => {
+  const snap = richSnapshot()
+  const at = (width: number): string =>
+    plain(composer.render({ snapshot: snap, layout: ROW2_LAYOUT, width, context: CONTEXT }))
+  // Wide: the full stats line renders (preferred).
+  const wide = at(120)
+  assert.ok(wide.includes('LLM 138.8s') && wide.includes('tok/s'), `wide must keep the full stats:\n${wide}`)
+  // Moderate narrow: compact stats + counters (never a straight drop).
+  const moderate = at(30)
+  assert.ok(moderate.includes('↑34k') && moderate.includes('t4/s191'), `moderate must compact first:\n${moderate}`)
+  assert.ok(!moderate.includes('TTFB'), `moderate must not keep the full stats:\n${moderate}`)
+  // Narrower: importance drop (stats-line 10 < turns-steps 45).
+  const narrow = at(15)
+  assert.ok(narrow.includes('t4/s191') && !narrow.includes('↑'), `narrow must drop by importance:\n${narrow}`)
+  // Every width: hard capacity, width-bounded, no broken ANSI.
+  for (const width of [120, 100, 80, 60, 50, 40, 30, 20, 15, 10, 5, 1]) {
+    const text = composer.render({ snapshot: snap, layout: ROW2_LAYOUT, width, context: CONTEXT })
+    const lines = text.split('\n')
+    assert.ok(lines.length <= 4, `hard capacity at ${width}:\n${plain(text)}`)
+    for (const line of lines) {
+      assert.ok(visibleWidth(line) <= Math.max(1, width), `overflow at ${width}: ${JSON.stringify(line)}`)
+      const truncated = line.match(/\x1b\[(?:[0-9;]*[^0-9;m]|[0-9;]*$)/)
+      assert.equal(truncated, null, `truncated ANSI at ${width}: ${JSON.stringify(line)}`)
+    }
+  }
+})
+
+/** Deep-mutable build shape (the snapshot is deeply readonly). */
+function snapshotWith(patch: (snap: DeepMutable<StatusSnapshot>) => void): StatusSnapshot {
+  const snap = emptyStatusSnapshot() as DeepMutable<StatusSnapshot>
+  patch(snap)
+  return snap as StatusSnapshot
+}

--- a/test/footer-density.test.ts
+++ b/test/footer-density.test.ts
@@ -130,18 +130,58 @@ test('every builtin item has an explicit density decision (responsive or intenti
   }
 })
 
-test('responsive items: compact is never wider than preferred (default refs)', () => {
+test('responsive items: compact is never wider than preferred (every declared format)', () => {
   const snap = richSnapshot()
   for (const id of RESPONSIVE_COMPACT_ITEMS) {
-    const preferred = renderDensity(id, snap, { id }, 'preferred')
-    const compact = renderDensity(id, snap, { id }, 'compact')
-    assert.ok(preferred !== '', `${id} must render in the fixture`)
-    assert.ok(compact !== '', `${id} compact must render in the fixture`)
-    assert.ok(
-      visibleWidth(compact) <= visibleWidth(preferred),
-      `${id}: compact (${compact}) must never be wider than preferred (${preferred})`,
-    )
+    const def = registry.get(id)!
+    for (const format of def.formats) {
+      const ref: FooterItemRef = { id, format }
+      const preferred = renderDensity(id, snap, ref, 'preferred')
+      const compact = renderDensity(id, snap, ref, 'compact')
+      assert.ok(preferred !== '', `${id}/${format} must render in the fixture`)
+      assert.ok(compact !== '', `${id}/${format} compact must render in the fixture`)
+      assert.ok(
+        visibleWidth(compact) <= visibleWidth(preferred),
+        `${id}/${format}: compact (${compact}) must never be wider than preferred (${preferred})`,
+      )
+    }
   }
+})
+
+test('performance compact never exceeds a shorter persisted style (speed/latency)', () => {
+  const snap = richSnapshot()
+  // The latency style is already minimal: the compact both-facts form
+  // (`138.8s 659t/s`) is WIDER, so the item must fall back to the
+  // preferred form — a legitimate no-op, never a wider compact.
+  const latencyRef: FooterItemRef = { id: 'performance', format: 'latency' }
+  assert.equal(renderDensity('performance', snap, latencyRef, 'preferred'), '2.6s')
+  assert.equal(renderDensity('performance', snap, latencyRef, 'compact'),
+    renderDensity('performance', snap, latencyRef, 'preferred'),
+    'latency compact must be a no-op (the style is already shorter)')
+  // Same for the speed style.
+  const speedRef: FooterItemRef = { id: 'performance', format: 'speed' }
+  assert.equal(renderDensity('performance', snap, speedRef, 'preferred'), '659 tok/s')
+  assert.equal(renderDensity('performance', snap, speedRef, 'compact'),
+    renderDensity('performance', snap, speedRef, 'preferred'),
+    'speed compact must be a no-op (the style is already shorter)')
+  // The full style still gets the strictly shorter both-facts compact.
+  assert.equal(renderDensity('performance', snap, { id: 'performance', format: 'full' }, 'compact'), '138.8s 659t/s')
+})
+
+test('token-usage compact never exceeds a shorter persisted io style (cache-heavy)', () => {
+  const snap = snapshotWith(s => {
+    s.usage.tokens = { input: 1, output: 1, cacheRead: 1_500_000, cacheWrite: 0 }
+  })
+  // A tiny io pair beside a huge cache total: the io form (`1/1`) is
+  // already shorter than the aggregate compact (`1.5M`) — the item must
+  // fall back to the preferred form, never emit a wider compact.
+  const ioRef: FooterItemRef = { id: 'token-usage', format: 'io' }
+  assert.equal(renderDensity('token-usage', snap, ioRef, 'preferred'), '1/1')
+  assert.equal(renderDensity('token-usage', snap, ioRef, 'compact'),
+    renderDensity('token-usage', snap, ioRef, 'preferred'),
+    'io compact must be a no-op (the style is already shorter)')
+  // The total style still gets the strictly shorter compact aggregate.
+  assert.equal(renderDensity('token-usage', snap, { id: 'token-usage', format: 'total' }, 'compact'), '1.5M')
 })
 
 test('responsive items: compact is STRICTLY shorter under the canonical fixture', () => {

--- a/test/footer-fullscreen-narrow.test.ts
+++ b/test/footer-fullscreen-narrow.test.ts
@@ -86,11 +86,12 @@ function assertPinnedChromeIntact(
   )
   // High-importance footer facts survive every width: the permission badge
   // (importance 110) is the contract's floor — the footer must never be
-  // COMPLETELY gone.
-  assert.ok(view.includes('workspace-write'), `permission badge lost at ${columns}x${viewportRows}:\n${view}`)
+  // COMPLETELY gone. The responsive compact pass may shorten it to `ww`
+  // and the model to its id under pressure.
+  assert.ok(view.includes('workspace-write') || view.includes('ww'), `permission badge lost at ${columns}x${viewportRows}:\n${view}`)
   if (expectModel) {
     assert.ok(
-      view.includes('deepseek'),
+      view.includes('deepseek') || view.includes('flash'),
       `the model badge must survive at ${columns}x${viewportRows}:\n${view}`,
     )
   }
@@ -135,9 +136,10 @@ test('the footer never clips out of a narrow fullscreen viewport', async () => {
   // transcript was already at zero. 20x10 is the documented EXTREME cell:
   // the 20-column todo panel wraps the chrome, so only TWO footer slots
   // remain — the surface hands the composer total=2, the footer renders
-  // status + stats (both one line, both visible) and DROPS the model
-  // (importance order), which the plan's "footer must not disappear +
-  // one high-importance status must survive" contract covers.
+  // status + stats (both one line, both visible) and the status row
+  // COMPACTS (ww/flash/ctx 10%) instead of dropping the model, which the
+  // plan's "footer must not disappear + one high-importance status must
+  // survive" contract covers.
   for (const [columns, viewportRows, expectStats, expectModel] of [
     [80, 24, true, true], [60, 16, true, true], [40, 12, true, true],
     [40, 10, true, true], [30, 10, true, true], [20, 10, true, false],
@@ -166,7 +168,7 @@ test('the armed Ctrl+C instruction never pushes the footer out of a narrow fulls
     const lines = vt.getViewport()
     const view = lines.join('\n')
     assert.ok(view.includes('Press Ctrl+C again to exit'), `the exit hint must stay visible:\n${view}`)
-    assert.ok(view.includes('workspace-write'), `the status row must survive beside the hint:\n${view}`)
+    assert.ok(view.includes('workspace-write') || view.includes('ww'), `the status row must survive beside the hint:\n${view}`)
     assert.ok(view.includes('LLM 12.3s'), `the stats row must survive beside the hint:\n${view}`)
     const footerLines = [...app.footerRenderRowsForTest()]
     assert.equal(footerLines.length, 3, `the footer with its instruction must stay inside the effective budget:\n${view}`)
@@ -208,8 +210,9 @@ test('the armed Ctrl+C instruction on a chrome-heavy 20x10 viewport is NEVER cli
       `the exit hint must be visible in the VIEWPORT (not only in the component):\n${view}`,
     )
     // One high-importance status fact survives beside it (importance
-    // order): the permission badge outranks everything else.
-    assert.ok(view.includes('workspace-write'), `the high-importance status must survive:\n${view}`)
+    // order): the permission badge outranks everything else (the compact
+    // pass may shorten it to `ww`).
+    assert.ok(view.includes('workspace-write') || view.includes('ww'), `the high-importance status must survive:\n${view}`)
     const editorTop = lines.findIndex(line => line.includes('─'.repeat(10)))
     assert.ok(editorTop !== -1, `editor top border missing:\n${view}`)
     assert.ok(

--- a/test/footer-responsive.test.ts
+++ b/test/footer-responsive.test.ts
@@ -183,9 +183,11 @@ test('items drop by importance under pressure (the tail goes first)', () => {
   // A narrow width with a right zone: the left zone must compact/drop the
   // LOWEST-importance items (version 10, performance 40, token-usage 50,
   // cache-hit 55...) while keeping the highest (permission 110, plan 115).
+  // The responsive compact pass shortens the survivors first (yolo/plan
+  // lose their badge brackets), then drops by importance.
   const text = composer.render({ snapshot: snap, layout: RIGHT_ZONE_LAYOUT, width: 40, context: CONTEXT })
-  assert.ok(text.includes('[yolo]'), `the highest-importance item must survive:\n${text}`)
-  assert.ok(text.includes('[plan]'), `the plan badge must survive:\n${text}`)
+  assert.ok(text.includes('yolo'), `the highest-importance item must survive:\n${text}`)
+  assert.ok(text.includes('plan'), `the plan badge must survive:\n${text}`)
   assert.ok(text.includes('focus'), `the right zone must survive:\n${text}`)
   // The lowest-importance items drop first.
   assert.ok(!text.includes('v0.0.0'), `the version item (importance 10) must drop first:\n${text}`)

--- a/test/footer-row-budget.test.ts
+++ b/test/footer-row-budget.test.ts
@@ -115,11 +115,14 @@ test('a caller budget is CLAMPED to the hard capability (perRow ≤ 2, total ≤
   // { perRow: 2, total: 6 } must not raise the composer's ceiling: the
   // effective total clamps to 4. Three rows then share 4 lines with the
   // sequential allocator — every row keeps the SAME 1..2 contract, no
-  // stats-role inference (plan §13.4).
+  // stats-role inference (plan §13.4). The second line the allocator
+  // grants row 2 goes UNUSED here: the responsive compact pass resolves
+  // the row to one line (model id + branch drop), so the render is 3
+  // lines — compact before drop, never a slice of the wrapped lines.
   const snap = busySnapshot()
   const budget: FooterPhysicalLineBudget = { perRow: 2, total: 6 }
   const lines = plainPhysical(snap, THREE_ROW_LAYOUT, 20, { budget })
-  assert.equal(lines.length, 4, `the clamped budget must allow 3 baseline rows + one second line, saw:\n${JSON.stringify(lines)}`)
+  assert.equal(lines.length, 3, `the clamped budget renders 3 compact rows, saw:\n${JSON.stringify(lines)}`)
   for (const line of lines) assert.ok(visibleWidth(line) <= 20, `overflow:\n${JSON.stringify(lines)}`)
 })
 
@@ -160,7 +163,7 @@ test('the Host instruction reserves its line; capacity 4 gives status 2 + stats 
   const lines = plainPhysical(snap, DEFAULT_FOOTER_LAYOUT, 40, { instruction: INSTRUCTION })
   assert.equal(lines.length, 4, `2 + 1 + hint inside the capacity of 4:\n${JSON.stringify(lines)}`)
   assert.ok(lines[lines.length - 1]!.includes('Press Ctrl+C again to exit'), `the hint must be its own line:\n${JSON.stringify(lines)}`)
-  assert.ok(lines.some(line => line.includes('[yolo]')), `the status row must survive:\n${JSON.stringify(lines)}`)
+  assert.ok(lines.some(line => line.includes('yolo')), `the status row must survive:\n${JSON.stringify(lines)}`)
   assert.ok(lines.some(line => line.includes('LLM')), `the stats row must survive (not be replaced):\n${JSON.stringify(lines)}`)
 })
 
@@ -193,7 +196,7 @@ test('a DYNAMIC total of 2 still keeps the instruction and drops the stats tail'
   const lines = plainPhysical(snap, DEFAULT_FOOTER_LAYOUT, 40, { budget, instruction: INSTRUCTION })
   assert.equal(lines.length, 2, `exactly the surface budget, hint included:\n${JSON.stringify(lines)}`)
   assert.ok(lines[lines.length - 1]!.includes('Press Ctrl+C again to exit'), `the hint must be last:\n${JSON.stringify(lines)}`)
-  assert.ok(lines.some(line => line.includes('[yolo]')), `the highest-importance row must survive:\n${JSON.stringify(lines)}`)
+  assert.ok(lines.some(line => line.includes('yolo')), `the highest-importance row must survive:\n${JSON.stringify(lines)}`)
   assert.ok(!lines.some(line => line.includes('LLM')), `the stats tail must drop under height pressure:\n${JSON.stringify(lines)}`)
 })
 

--- a/test/footer-wrap.test.ts
+++ b/test/footer-wrap.test.ts
@@ -161,17 +161,29 @@ test('extension footer segments still merge into the wrapped footer', async () =
   } finally {
     wide.app.stop()
   }
-  // Narrower: the segment (importance 0) participates in the responsive
-  // layout — under pressure it drops FIRST (importance order), never
-  // overflowing or breaking the composed rows.
+  // Narrower: the responsive compact pass shortens the host items FIRST
+  // (ww/flash/proj/ctx 10%) — at 40 columns that frees enough room for
+  // the segment (importance 0) to SURVIVE; the compact-before-drop
+  // discipline only sacrifices it when compact alone cannot fit the row.
   const narrow = await startExtApp(40)
   try {
     const view = narrow.vt.getViewport().join('\n')
-    assert.ok(!view.includes('[EXT-SEG]'), `the low-importance segment must drop under pressure:\n${view}`)
-    assert.ok(view.includes('workspace-write'), `high-importance state must survive:\n${view}`)
+    assert.ok(view.includes('[EXT-SEG]'), `the segment must survive once compact frees the room:\n${view}`)
+    assert.ok(view.includes('workspace-write') || view.includes('ww'), `high-importance state must survive:\n${view}`)
     assert.ok(view.includes('12.3s'), `the stats row must survive:\n${view}`)
   } finally {
     narrow.app.stop()
+  }
+  // Extreme narrow: the segment (importance 0) drops FIRST (importance
+  // order), never overflowing or breaking the composed rows.
+  const extreme = await startExtApp(30)
+  try {
+    const view = extreme.vt.getViewport().join('\n')
+    assert.ok(!view.includes('[EXT-SEG]'), `the low-importance segment must drop under extreme pressure:\n${view}`)
+    assert.ok(view.includes('workspace-write') || view.includes('ww'), `high-importance state must survive:\n${view}`)
+    assert.ok(view.includes('12.3s'), `the stats row must survive:\n${view}`)
+  } finally {
+    extreme.app.stop()
   }
 })
 


### PR DESCRIPTION
## Summary

Wires `FooterDensity.compact` into every builtin footer item so moderate width pressure **shortens items before the importance drop** — the composer's `compact → importance-drop → truncate` ordering was already in place, but none of the 26 builtins actually consumed the density, so narrow screens jumped straight from the full form to dropping items (e.g. Row 2 collapsed to `t4/s191` because `stats-line`'s compact was a no-op).

- **Based directly on `next`** — no main-first implementation, no `main → next` merge.
- **A-class (9):** reuse existing short formatters — `permission-preset` (ww/ro), `plan-state` (plain), `model` (id only), `cwd` (basename), `git-branch` (plain), `context` (`ctx 72%`), `cache-hit` (`91.9%`), `token-usage` (`6.7k`), `agent-preset` (shortLabel).
- **B-class (8):** new pure presentation formatters — `stats-line` pressure form (`↑34k ↓8.1k · LLM 138.8s · 659t/s`), `tasks` (`[1t·2a·↓]`), `sandbox-mode` (ro/ww/yolo), `run-state` phase codes (work/w-approval/…), `queue` (qN), `agents` (aN), `todo` (tdN), `performance` (`8.1s 40t/s`).
- **C-class (9):** intentional no-ops explicitly documented (`turns-steps`, `view-scope`, `ext:*`, `reasoning`, `approval-policy`, `focus-mode`, `focused-seat`, `project`, `version`).
- **Registry-wide density audit:** `RESPONSIVE_COMPACT_ITEMS` + `INTENTIONALLY_STABLE_DENSITY_ITEMS` partition the 26 builtins (union == registry ids, intersection empty) — a future builtin must choose, never "not handled".
- **Row2 regression:** `stats-line + turns-steps` compacts at moderate narrow widths; importance drop only at extreme narrow.
- **Style × Density orthogonal:** a compact pass never writes back into the persisted `format`; a persisted style already shorter than the compact form (performance latency/speed, token-usage io with huge cache) is a legitimate no-op — compact is never wider than preferred.

## Constraints preserved

- `compact → importance-drop → truncate` ordering unchanged
- per-row max 2 / hard total max 4 physical lines unchanged
- fullscreen surface budget, importance values, `FooterLayoutV1`, `/footer` config schema unchanged
- `ext:*` opaque bridge untouched; unknown persisted formats fail-soft unchanged
- preferred output unchanged at wide widths
- no Server/Client boundary changes; no DSH contract changes

## Verification

- Footer suite 281 ✓ · full bundle suite 3322 ✓ · vendored Pi TUI fork 988 ✓ · docs 11 ✓
- typecheck, build, `git diff --check`, naming-gate, `gate:pi-surface-compat`, client-boundary-gate (no new Host coupling)
- `pack:release` (prepack + all postpack smokes) ✓
- DSH 0.1.2-alpha.2 gates: `compat:dsh:npm` (published lane) ✓, `compat:dsh:source` (source lane, full pipeline incl. official preset matrix + old-DSH boundary) ✓
- `smoke:pi2dsh`: pre-existing ecosystem blocker on clean `next` (published `pi2dsh@0.24.0` does not declare DSH 0.1.2-alpha.2 support) — verified identical failure with these changes stashed; out of scope for this PR.
- Review loop: 2 rounds (holistic external review) — Round 1 `needs-fixes` (2 P1: performance/token-usage compact wider than a shorter persisted style), Round 2 `accepted` with no findings.
