### PR TITLE
docs(policy): separate Source dev environment from full Source compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -608,6 +608,135 @@ treated as a durable `READY` cache. The source-mode shell can be entered with
 under `scripts/` is shared by local bootstrap and CI; do not create a second
 source-build implementation.
 
+### Source development environment vs full Source compatibility
+
+The `next` worktree has two distinct Source Mode concepts. Do not conflate
+them.
+
+**A. Materialized Source development environment** — the default daily
+environment for `next` local development. Its entry points are:
+
+```bash
+pnpm dev:doctor
+pnpm dev:bootstrap
+pnpm dev:shell
+```
+
+Its job: confirm the pinned SHA, prepare or reuse the cached source pack,
+materialize the DSH dependencies, and generate the source development
+environment. Once `pnpm dev:doctor` reports `READY`, the Source development
+environment is available. Ordinary development must NOT automatically re-run
+the full compatibility verifier just because the current mode is Source Mode.
+
+**B. Full Source compatibility verification** — the heavy verification run by:
+
+```bash
+pnpm compat:dsh:source -- --dsh-dir ...
+```
+
+Its semantics: re-prove the exact upstream DSH source → official build/pack →
+the full DSH family → TUI build/type/test → candidate/fresh install →
+runtime/preset compatibility. It is not a substitute for the ordinary
+`pnpm test`.
+
+### Hard rules (do not expand the verification scope)
+
+Local Source Mode and Full Source Compatibility are different operations.
+
+The `next` worktree normally uses the materialized pinned-DSH Source
+development environment prepared by `dev:bootstrap`.
+
+If `pnpm dev:doctor` reports READY, reuse that environment.
+
+Do NOT run `pnpm compat:dsh:source` as a routine validation step after
+ordinary TUI changes.
+
+For ordinary development, run the smallest relevant project checks inside
+the existing Source environment, such as targeted tests, `pnpm typecheck`,
+`pnpm test`, `pnpm build`, or `pnpm pack:release` when packaging behavior
+changed.
+
+Full `compat:dsh:source` is a CI-equivalent compatibility proof and should
+only be run locally when the change materially affects the DSH source
+distribution boundary or when explicitly requested.
+
+Pull requests targeting `next` continue to run the full Source compatibility
+lane in GitHub CI; that CI is authoritative for routine PR compatibility.
+
+### When to run the full Source verifier
+
+Only consider running `compat:dsh:source` locally when one of the following
+applies:
+
+1. **The source pin changed** — `ref`, `expectedVersion`, or `repository` in
+   `test/compat/dsh-source.json` was modified.
+2. **DSH distribution infrastructure changed** — e.g. edits to
+   `scripts/dsh-source-pack.mjs`, `scripts/dsh-source-verify.mjs`,
+   `scripts/prepare-dsh-test-environment.mjs`,
+   `scripts/lib/dsh-distribution.mjs`, `scripts/dsh-source-leak-gate.mjs`,
+   or the corresponding compatibility manifest / distribution contract.
+3. **Source/npm behavior discrepancy** — Source Mode PASS/FAIL differs from
+   npm Mode, a package resolution discrepancy, a source-pack artifact
+   discrepancy, or a DSH public export discrepancy.
+4. **Debugging an unpublished DSH commit** — the DSH upstream is not yet
+   published to npm and an exact SHA must be verified.
+5. **Explicitly requested** — the user or task asks for a full source
+   compatibility run, a CI Source Mode reproduction, or verification of a
+   new DSH source SHA.
+
+### When NOT to run the full Source verifier
+
+Ordinary changes must not default to the full verifier:
+
+```text
+TUI rendering
+editor
+footer
+keybindings
+autocomplete
+session picker UI
+transcript rendering/window
+commands
+settings UI
+local presentation logic
+tests only
+docs only
+```
+
+Run the checks matching the change scope instead:
+
+```text
+targeted test
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Add `pnpm pack:release` when pack/public artifacts are involved. Do not
+mechanically append `pnpm compat:dsh:source`.
+
+### Three-layer development model
+
+```text
+Layer 1 — Source environment        dev:doctor / dev:bootstrap / dev:shell
+                                    keeps next local development on the pinned
+                                    DSH environment long-term.
+
+Layer 2 — Daily TUI validation      targeted tests / typecheck / test / build
+                                    / pack when needed
+                                    quickly validates the current TUI change.
+
+Layer 3 — Full Source compatibility compat:dsh:source
+                                    re-proves full compatibility with the
+                                    exact DSH source distribution; PR CI owns
+                                    this layer by default.
+```
+
+The three layers are distinct; do not conflate them. `dev:bootstrap` is
+environment preparation, not a full compatibility run: it already reuses a
+valid per-SHA source pack, and only a missing or invalid cache, a changed
+pin, or a stale environment triggers a rebuild.
+
 ## Docs
 
 - README.md — 简体中文 install and run instructions for humans (the npm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -611,33 +611,17 @@ source-build implementation.
 ### Source development environment vs full Source compatibility
 
 The `next` worktree has two distinct Source Mode concepts. Do not conflate
-them.
+them:
 
-**A. Materialized Source development environment** — the default daily
-environment for `next` local development. Its entry points are:
-
-```bash
-pnpm dev:doctor
-pnpm dev:bootstrap
-pnpm dev:shell
-```
-
-Its job: confirm the pinned SHA, prepare or reuse the cached source pack,
-materialize the DSH dependencies, and generate the source development
-environment. Once `pnpm dev:doctor` reports `READY`, the Source development
-environment is available. Ordinary development must NOT automatically re-run
-the full compatibility verifier just because the current mode is Source Mode.
-
-**B. Full Source compatibility verification** — the heavy verification run by:
-
-```bash
-pnpm compat:dsh:source -- --dsh-dir ...
-```
-
-Its semantics: re-prove the exact upstream DSH source → official build/pack →
-the full DSH family → TUI build/type/test → candidate/fresh install →
-runtime/preset compatibility. It is not a substitute for the ordinary
-`pnpm test`.
+- **Materialized Source development environment** — the default daily
+  environment, entered via `pnpm dev:doctor` / `pnpm dev:bootstrap` /
+  `pnpm dev:shell`. Once `dev:doctor` reports `READY`, the environment is
+  available; ordinary development must NOT re-run the full compatibility
+  verifier just because the mode is Source Mode.
+- **Full Source compatibility verification** — `pnpm compat:dsh:source`,
+  the CI-equivalent proof: exact upstream DSH source → official build/pack →
+  full DSH family → TUI build/type/test → candidate/fresh install →
+  runtime/preset compatibility. Not a substitute for `pnpm test`.
 
 ### Hard rules (do not expand the verification scope)
 
@@ -665,77 +649,31 @@ lane in GitHub CI; that CI is authoritative for routine PR compatibility.
 
 ### When to run the full Source verifier
 
-Only consider running `compat:dsh:source` locally when one of the following
-applies:
+Only consider `compat:dsh:source` locally when one of the following applies:
 
-1. **The source pin changed** — `ref`, `expectedVersion`, or `repository` in
-   `test/compat/dsh-source.json` was modified.
-2. **DSH distribution infrastructure changed** — e.g. edits to
-   `scripts/dsh-source-pack.mjs`, `scripts/dsh-source-verify.mjs`,
-   `scripts/prepare-dsh-test-environment.mjs`,
-   `scripts/lib/dsh-distribution.mjs`, `scripts/dsh-source-leak-gate.mjs`,
-   or the corresponding compatibility manifest / distribution contract.
-3. **Source/npm behavior discrepancy** — Source Mode PASS/FAIL differs from
-   npm Mode, a package resolution discrepancy, a source-pack artifact
-   discrepancy, or a DSH public export discrepancy.
-4. **Debugging an unpublished DSH commit** — the DSH upstream is not yet
-   published to npm and an exact SHA must be verified.
-5. **Explicitly requested** — the user or task asks for a full source
-   compatibility run, a CI Source Mode reproduction, or verification of a
-   new DSH source SHA.
+1. The source pin changed (`ref` / `expectedVersion` / `repository` in
+   `test/compat/dsh-source.json`).
+2. DSH distribution infrastructure changed (`scripts/dsh-source-pack.mjs`,
+   `scripts/dsh-source-verify.mjs`, `scripts/prepare-dsh-test-environment.mjs`,
+   `scripts/lib/dsh-distribution.mjs`, `scripts/dsh-source-leak-gate.mjs`, or
+   the compatibility manifest / distribution contract).
+3. Source/npm behavior discrepancy (PASS/FAIL, resolution, source-pack
+   artifact, or DSH public export).
+4. Debugging an unpublished DSH commit (exact SHA not yet on npm).
+5. Explicitly requested (full source compatibility run, CI Source Mode
+   reproduction, new DSH source SHA).
 
-### When NOT to run the full Source verifier
+Ordinary changes — TUI rendering, editor, footer, keybindings, autocomplete,
+session picker UI, transcript rendering/window, commands, settings UI, local
+presentation logic, tests only, docs only — must NOT default to the full
+verifier. Run targeted tests / `pnpm typecheck` / `pnpm test` / `pnpm build`
+instead, plus `pnpm pack:release` when pack/public artifacts are involved.
+Do not mechanically append `pnpm compat:dsh:source`.
 
-Ordinary changes must not default to the full verifier:
-
-```text
-TUI rendering
-editor
-footer
-keybindings
-autocomplete
-session picker UI
-transcript rendering/window
-commands
-settings UI
-local presentation logic
-tests only
-docs only
-```
-
-Run the checks matching the change scope instead:
-
-```text
-targeted test
-pnpm typecheck
-pnpm test
-pnpm build
-```
-
-Add `pnpm pack:release` when pack/public artifacts are involved. Do not
-mechanically append `pnpm compat:dsh:source`.
-
-### Three-layer development model
-
-```text
-Layer 1 — Source environment        dev:doctor / dev:bootstrap / dev:shell
-                                    keeps next local development on the pinned
-                                    DSH environment long-term.
-
-Layer 2 — Daily TUI validation      targeted tests / typecheck / test / build
-                                    / pack when needed
-                                    quickly validates the current TUI change.
-
-Layer 3 — Full Source compatibility compat:dsh:source
-                                    re-proves full compatibility with the
-                                    exact DSH source distribution; PR CI owns
-                                    this layer by default.
-```
-
-The three layers are distinct; do not conflate them. `dev:bootstrap` is
-environment preparation, not a full compatibility run: it already reuses a
-valid per-SHA source pack, and only a missing or invalid cache, a changed
-pin, or a stale environment triggers a rebuild.
+`dev:bootstrap` is environment preparation, not a full compatibility run: it
+reuses a valid per-SHA source pack; only a missing or invalid cache or a
+changed pin rebuilds DSH, while a stale environment only re-materializes the
+worktree. The daily loop lives in docs/local-development.md.
 
 ## Docs
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -136,6 +136,58 @@ owning worktree root. Generated environment variables are honored only by that
 root, so manually sourcing one worktree's environment cannot select a different
 worktree's DSH mode.
 
+## Daily local loop
+
+The next worktree stays on the pinned Source development environment. The
+daily loop is:
+
+```bash
+cd ~/project/dsh-pi-tui-next
+pnpm dev:doctor
+```
+
+- `READY` → reuse the current environment and run the normal project checks
+  (`pnpm typecheck`, `pnpm test`, targeted tests, `pnpm build`).
+- `STALE` / `MISSING` / `BROKEN` → run `pnpm dev:bootstrap`, then
+  `pnpm dev:doctor` again, then run the normal project checks.
+
+`dev:bootstrap` is environment preparation only, not a full compatibility
+run. It reuses a valid per-SHA source pack from:
+
+```text
+~/.cache/dsh-pi-tui/source-packs/<exact-sha>/
+```
+
+DSH is rebuilt only when the cache is missing or invalid, the pin changed,
+or the environment is stale.
+
+When the source environment must actually be loaded (commands that need the
+source-distribution variables), enter it with:
+
+```bash
+pnpm dev:shell
+```
+
+then continue with the ordinary development commands.
+
+## Full Source compatibility
+
+```bash
+pnpm compat:dsh:source -- --dsh-dir "$HOME/project/deepseek-harness"
+```
+
+This is the CI-equivalent full Source compatibility proof: exact upstream DSH
+source → official build/pack → full DSH family → TUI build/type/test →
+candidate/fresh install → runtime/preset compatibility.
+
+It is NOT part of the routine daily loop. Ordinary TUI changes are validated
+with the normal project checks inside the existing Source environment. Run
+the full verifier only when the change affects the DSH source distribution
+boundary (source pin, distribution infrastructure, source/npm discrepancy,
+unpublished DSH commit) or when explicitly requested. Pull requests targeting
+`next` run this lane in GitHub CI, which is authoritative for routine PR
+compatibility.
+
 ## Safety rules
 
 - Do not run an ordinary `pnpm install` in the source-mode worktree as a repair.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -158,8 +158,11 @@ run. It reuses a valid per-SHA source pack from:
 ~/.cache/dsh-pi-tui/source-packs/<exact-sha>/
 ```
 
-DSH is rebuilt only when the cache is missing or invalid, the pin changed,
-or the environment is stale.
+The cached DSH source pack is rebuilt only when the per-SHA cache is
+missing or invalid (a changed pin selects a different cache key).
+
+A stale local development environment may require re-materializing the
+worktree with `dev:bootstrap`, but a valid source pack is still reused.
 
 When the source environment must actually be loaded (commands that need the
 source-distribution variables), enter it with:

--- a/scripts/dsh-source-verify.mjs
+++ b/scripts/dsh-source-verify.mjs
@@ -32,6 +32,7 @@ import { pnpmExecutable, runBounded } from './lib/process.mjs'
 const PNPM_COMMAND = pnpmExecutable()
 const SCRIPT_PATH = fileURLToPath(import.meta.url)
 const SOURCE_PACK_SCRIPT = fileURLToPath(new URL('./dsh-source-pack.mjs', import.meta.url))
+const DEV_STATE_FILE = '.dsh-dev-state.json'
 const VERIFY_TIMEOUTS = {
   sourcePack: 50 * 60 * 1000,
   preparation: 20 * 60 * 1000,
@@ -284,6 +285,31 @@ async function runSourcePack(values, config) {
   return output
 }
 
+/**
+ * Non-blocking hint: when the current worktree already has a ready
+ * pinned-DSH Source development environment (matching local state, non-
+ * ephemeral, materialized distribution on disk), remind the caller that
+ * routine TUI validation should reuse it instead of this full verifier.
+ * This is a warning only: it never exits, never changes the verifier
+ * semantics, and never reuses the development environment to weaken the
+ * full CI-equivalent verification.
+ */
+function noteReadySourceDevelopmentEnvironment(effective) {
+  try {
+    const statePath = join(PACKAGE_ROOT, DEV_STATE_FILE)
+    if (!existsSync(statePath)) return
+    const state = JSON.parse(readFileSync(statePath, 'utf8'))
+    if (state.mode !== 'source' || state.ephemeral === true) return
+    if (state.repository !== effective.repository || state.ref !== effective.ref) return
+    if (typeof state.distribution !== 'string' || !existsSync(state.distribution)) return
+    console.log('NOTE: A ready pinned-DSH Source development environment already exists.')
+    console.log('For routine TUI validation, reuse it and run normal project checks.')
+    console.log('This command performs the full CI-equivalent Source compatibility verification.')
+  } catch {
+    // The hint must never fail or alter the verifier.
+  }
+}
+
 async function main() {
   const values = resolveSourceVerifyPaths(parseCli())
   const configPath = values.config
@@ -293,6 +319,7 @@ async function main() {
     ref: values.ref ?? tracked.ref,
     expectedVersion: values['expected-version'] ?? tracked.expectedVersion,
   }, tracked.path)
+  noteReadySourceDevelopmentEnvironment(effective)
   if (values.distribution === undefined && (typeof values['dsh-dir'] !== 'string' || values['dsh-dir'].trim() === '')) {
     fail('--dsh-dir is required when --distribution is not provided')
   }

--- a/scripts/dsh-source-verify.mjs
+++ b/scripts/dsh-source-verify.mjs
@@ -32,7 +32,6 @@ import { pnpmExecutable, runBounded } from './lib/process.mjs'
 const PNPM_COMMAND = pnpmExecutable()
 const SCRIPT_PATH = fileURLToPath(import.meta.url)
 const SOURCE_PACK_SCRIPT = fileURLToPath(new URL('./dsh-source-pack.mjs', import.meta.url))
-const DEV_STATE_FILE = '.dsh-dev-state.json'
 const VERIFY_TIMEOUTS = {
   sourcePack: 50 * 60 * 1000,
   preparation: 20 * 60 * 1000,
@@ -285,31 +284,6 @@ async function runSourcePack(values, config) {
   return output
 }
 
-/**
- * Non-blocking hint: when the current worktree already has a ready
- * pinned-DSH Source development environment (matching local state, non-
- * ephemeral, materialized distribution on disk), remind the caller that
- * routine TUI validation should reuse it instead of this full verifier.
- * This is a warning only: it never exits, never changes the verifier
- * semantics, and never reuses the development environment to weaken the
- * full CI-equivalent verification.
- */
-function noteReadySourceDevelopmentEnvironment(effective) {
-  try {
-    const statePath = join(PACKAGE_ROOT, DEV_STATE_FILE)
-    if (!existsSync(statePath)) return
-    const state = JSON.parse(readFileSync(statePath, 'utf8'))
-    if (state.mode !== 'source' || state.ephemeral === true) return
-    if (state.repository !== effective.repository || state.ref !== effective.ref) return
-    if (typeof state.distribution !== 'string' || !existsSync(state.distribution)) return
-    console.log('NOTE: A ready pinned-DSH Source development environment already exists.')
-    console.log('For routine TUI validation, reuse it and run normal project checks.')
-    console.log('This command performs the full CI-equivalent Source compatibility verification.')
-  } catch {
-    // The hint must never fail or alter the verifier.
-  }
-}
-
 async function main() {
   const values = resolveSourceVerifyPaths(parseCli())
   const configPath = values.config
@@ -319,7 +293,6 @@ async function main() {
     ref: values.ref ?? tracked.ref,
     expectedVersion: values['expected-version'] ?? tracked.expectedVersion,
   }, tracked.path)
-  noteReadySourceDevelopmentEnvironment(effective)
   if (values.distribution === undefined && (typeof values['dsh-dir'] !== 'string' || values['dsh-dir'].trim() === '')) {
     fail('--dsh-dir is required when --distribution is not provided')
   }

--- a/test/source-mode-rules.test.mjs
+++ b/test/source-mode-rules.test.mjs
@@ -2,11 +2,10 @@
  * Static audit for the Source Mode verification rules (AGENTS.md "DSH
  * development environment" + docs/local-development.md): the next worktree
  * stays on the pinned Source development environment, a READY environment is
- * reused, ordinary TUI changes must not routinely trigger the full
- * `compat:dsh:source` verifier, and the CI lanes (PR/push to next = Source
- * Mode, release tags = npm Mode) stay intact. The mode resolver itself is
- * unit-tested in dsh-ci-context.test.mjs; this file guards the documented
- * rules and the workflow lanes against regression.
+ * reused, and ordinary TUI changes must not routinely trigger the full
+ * `compat:dsh:source` verifier. The CI mode contract (PR/push to next =
+ * Source Mode, release tags = npm Mode) is NOT re-tested here — it is
+ * authoritatively covered at function level by dsh-ci-context.test.mjs.
  * @module @xmoon76/dsh-pi-tui/source-mode-rules.test
  */
 
@@ -19,7 +18,6 @@ import { fileURLToPath } from 'node:url'
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const agents = readFileSync(join(ROOT, 'AGENTS.md'), 'utf8')
 const localDev = readFileSync(join(ROOT, 'docs', 'local-development.md'), 'utf8')
-const ciWorkflow = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8')
 
 test('Rule 1: next local development stays on the pinned Source development environment', () => {
   assert.match(agents, /dsh-pi-tui-next.*exact source distribution pinned by/u)
@@ -39,16 +37,4 @@ test('Rule 3: AGENTS.md requires reusing a READY source development environment'
 test('Rule 4: AGENTS.md forbids routine compat:dsh:source after ordinary TUI changes', () => {
   assert.match(agents, /Do NOT run `pnpm compat:dsh:source` as a routine validation step after\s+ordinary TUI changes\./u)
   assert.match(agents, /Full `compat:dsh:source` is a CI-equivalent compatibility proof/u)
-})
-
-test('Rule 5: PR/push to next CI keeps the full Source Mode lane', () => {
-  assert.match(ciWorkflow, /prepare-dsh-source/u)
-  assert.match(ciWorkflow, /mode == 'source'/u)
-  assert.match(ciWorkflow, /- next/u)
-})
-
-test('Rule 6: release tags keep npm Mode', () => {
-  assert.match(ciWorkflow, /next-v\*/u)
-  assert.match(ciWorkflow, /npm_tag/u)
-  assert.match(ciWorkflow, /refs\/tags\//u)
 })

--- a/test/source-mode-rules.test.mjs
+++ b/test/source-mode-rules.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Static audit for the Source Mode verification rules (AGENTS.md "DSH
+ * development environment" + docs/local-development.md): the next worktree
+ * stays on the pinned Source development environment, a READY environment is
+ * reused, ordinary TUI changes must not routinely trigger the full
+ * `compat:dsh:source` verifier, and the CI lanes (PR/push to next = Source
+ * Mode, release tags = npm Mode) stay intact. The mode resolver itself is
+ * unit-tested in dsh-ci-context.test.mjs; this file guards the documented
+ * rules and the workflow lanes against regression.
+ * @module @xmoon76/dsh-pi-tui/source-mode-rules.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const agents = readFileSync(join(ROOT, 'AGENTS.md'), 'utf8')
+const localDev = readFileSync(join(ROOT, 'docs', 'local-development.md'), 'utf8')
+const ciWorkflow = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8')
+
+test('Rule 1: next local development stays on the pinned Source development environment', () => {
+  assert.match(agents, /dsh-pi-tui-next.*exact source distribution pinned by/u)
+  assert.match(localDev, /next: pinned DSH source distribution \(source mode\)/u)
+})
+
+test('Rule 2: dev:bootstrap reuses the existing per-SHA source pack', () => {
+  assert.match(localDev, /reuses a valid per-SHA source pack/u)
+  assert.match(localDev, /source-packs\/<exact-sha>/u)
+  assert.match(agents, /reuses a\s+valid per-SHA source pack/u)
+})
+
+test('Rule 3: AGENTS.md requires reusing a READY source development environment', () => {
+  assert.match(agents, /If `pnpm dev:doctor` reports READY, reuse that environment\./u)
+})
+
+test('Rule 4: AGENTS.md forbids routine compat:dsh:source after ordinary TUI changes', () => {
+  assert.match(agents, /Do NOT run `pnpm compat:dsh:source` as a routine validation step after\s+ordinary TUI changes\./u)
+  assert.match(agents, /Full `compat:dsh:source` is a CI-equivalent compatibility proof/u)
+})
+
+test('Rule 5: PR/push to next CI keeps the full Source Mode lane', () => {
+  assert.match(ciWorkflow, /prepare-dsh-source/u)
+  assert.match(ciWorkflow, /mode == 'source'/u)
+  assert.match(ciWorkflow, /- next/u)
+})
+
+test('Rule 6: release tags keep npm Mode', () => {
+  assert.match(ciWorkflow, /next-v\*/u)
+  assert.match(ciWorkflow, /npm_tag/u)
+  assert.match(ciWorkflow, /refs\/tags\//u)
+})


### PR DESCRIPTION
## 背景

`next` 本地继续使用 pinned DSH Source Mode，但 Agent 经常把"在已准备好的 Source 环境中验证 TUI"误解成"重新执行 `pnpm compat:dsh:source` 完整兼容链"，导致普通 TUI 修改也重复跑重型 full verifier。

本次调整只改规则/文档，**不改变任何基础设施行为**：

- `scripts/dsh-dev-context.mjs` / `dev-bootstrap.mjs` / `dev-doctor.mjs` / `dev-shell.mjs` 未动
- `test/compat/dsh-source.json` 未动
- `scripts/dsh-ci-context.mjs` / `.github/workflows/ci.yml` 未动
- `scripts/dsh-source-verify.mjs` 未动（评审后已完全还原）
- per-SHA source-pack cache 与 Source Mode distribution 基础设施未动
- PR/push -> next 仍为 Source Mode；release tag 仍为 npm Mode

## 变更内容

1. **AGENTS.md** — 在 DSH development environment 章节明确区分（压缩至 ~60 行核心 policy，日常流程细节在 docs）：
   - Materialized Source development environment（`dev:doctor` / `dev:bootstrap` / `dev:shell`，READY 即复用）vs Full Source compatibility verification（`compat:dsh:source`，CI-equivalent 重型验证）
   - 硬规则：READY 环境直接复用；普通 TUI 修改不得机械跑 `compat:dsh:source`；PR CI 是 routine 兼容性的 authoritative gate
   - 何时主动跑 full verifier（pin 变化 / distribution 基础设施 / source-npm 差异 / 未发布 DSH commit / 显式要求）
   - 何时不跑（TUI rendering、editor、footer、keybindings、autocomplete、session picker、transcript、commands、settings、tests/docs only 等）
   - `dev:bootstrap` 语义：environment preparation；只有 per-SHA cache 缺失/无效或 pin 变化才 rebuild DSH，环境 stale 只重新 materialize worktree

2. **docs/local-development.md** — 新增 "Daily local loop"（`dev:doctor` READY → 复用环境跑常规检查；STALE/MISSING → `dev:bootstrap` 后重查）与 "Full Source compatibility"（明确不属于日常循环）章节；修正 stale 措辞：cached source pack 只在 per-SHA cache 缺失/无效时重建（pin 变化选择不同 cache key），stale 环境只 re-materialize worktree，有效 pack 仍复用。

3. **test/source-mode-rules.test.mjs**（新增）— 静态守护 4 条文档规则：next 仍 source mode、bootstrap 复用 per-SHA pack、AGENTS.md 明确 READY→reuse、AGENTS.md 明确禁止 routine compat:dsh:source。CI mode contract（PR/push next = source、tag = npm）**不在此重复测试**，由 `dsh-ci-context.test.mjs` 函数级权威覆盖。

## 评审处理记录

- **P1（NOTE 不证明 READY）**：已按建议**直接删除** `dsh-source-verify.mjs` 的 NOTE，verifier 保持单纯；不自行实现第二套 readiness 判断，也不引入对 dev-doctor 的依赖。
- **P1（stale → rebuild 措辞不准确）**：已修正 docs 与 AGENTS.md，明确 stale 只 re-materialize、不 rebuild DSH。
- **P2（Rule 5/6 冗余）**：已删除，注明由 `dsh-ci-context.test.mjs` 权威覆盖。
- **维护性（AGENTS.md 过长）**：已压缩 ~130 → ~60 行，核心 policy 保留，daily workflow 指向 docs/local-development.md。

## 验证

- `node --test test/source-mode-rules.test.mjs test/dsh-ci-context.test.mjs test/dev-environment.test.mjs test/dsh-source-identity.test.mjs` — 63/63 通过
- `pnpm test:bundle` — 3327/3327 通过（含 rebase 后 next 新增 footer 测试）
- `node --check scripts/dsh-source-verify.mjs` — 通过；`git diff next -- scripts/dsh-source-verify.mjs` 为空（与 next 完全一致）
- 分支已 rebase 到最新 `origin/next`（b600738），无冲突

## 验收对照

- [x] next 本地仍默认使用 pinned Source development environment
- [x] dev:bootstrap/source-pack cache 行为没有被削弱
- [x] READY 环境可直接用于普通 build/test/typecheck
- [x] AGENTS.md 明确禁止普通开发机械跑 compat:dsh:source
- [x] docs/local-development.md 清楚区分 env preparation 和 full verification
- [x] compat:dsh:source 仍保留完整 CI-equivalent 语义（verifier 未动）
- [x] PR target next 仍跑 full Source Mode（CI 未动）
- [x] push next 仍跑 full Source Mode（CI 未动）
- [x] release tags 仍跑 npm Mode（CI 未动）
- [x] 未把 next 本地切换成 npm Mode
- [x] 未新增第二套 Source Mode 基础设施
