### PR TITLE
feat(ux): focus chronology + message tail, wheel step, todo states, resume status

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -26,6 +26,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New client-local `FooterDynamicItemRuntime`.** It arms one runner per command item the active layout references (reusing the whole-footer `FooterCommandRunner`'s spawn/shell/stdin/timeout/refresh/generation/sanitize/process-tree-kill), caching the first non-empty sanitized output line; `FooterItemDefinition.render()` reads the cache synchronously and the render path never spawns. Removing/hiding/renaming an item or entering whole-footer command mode disposes the runner and clears the cache immediately; multiple command items are isolated.
 - **`FooterLayoutV1`, perRow=2 / hard total=4, the Host Instruction and the public extension ABI are unchanged.**
 
+### UX improvements
+
+#### Changed
+
+- **Focus expanded view preserves user steer chronology.** Inside an expanded Thought the initial user stays before the Thought, later steers/users return to their actual chronological position (after the tool, after the thinking, …), and the final assistant remains the last settled answer; the collapsed summary semantics are unchanged.
+- **Focus compact Message is the third process slot and shows the latest up to three visual rows.** The slot order is Think → Tool → Message; the Message body is re-wrapped to the current width on every render and cut to the newest three rows, so streaming appends roll toward the latest tail and a resize re-wraps.
+- **The fullscreen mouse-wheel step is configurable.** `/settings` gains a `Mouse wheel lines` row (1/2/3/5/8, default 1) applied through the existing `TuiAltScreenOptions.wheelScrollLines`; a change while fullscreen is active takes effect on the next fullscreen re-entry.
+- **The todo panel skips a redundant full state when five or fewer items exist.** The state machine becomes a two-state summary ↔ list (the second click closes the panel); with more than five items the three-state summary → compact(5) → full(N) → summary stays, and a >5 → ≤5 shrink automatically clears a ghost `todoExpanded`.
+
+#### Fixed
+
+- **Explicit cold resume shows startup progress before the TUI mounts.** `dsh --profile <p> --session <id>` now prints a single-line `Resuming session…` (and `Preparing conversation…` when needed) before mount and clears it completely before the first frame, so the blank terminal no longer reads as a hang; fresh starts emit nothing and non-TTY output stays silent.
+
 ### Migration notes
 
 - **0.4.0-alpha.1 moves to DeepSeek Harness 0.1.2.** The declared support range

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- **Explicit cold resume shows startup progress before the TUI mounts.** `dsh --profile <p> --session <id>` now prints a single-line `Resuming session…` (and `Preparing conversation…` when needed) before mount and clears it completely before the first frame, so the blank terminal no longer reads as a hang; fresh starts emit nothing and non-TTY output stays silent.
+- **Explicit cold resume shows startup progress before the TUI mounts.** `dsh --profile <p> --session <id>` now prints a single-line `Resuming session…` (and `Preparing conversation…` when needed); the `Preparing conversation…` stage stays on screen until the catalog ready barrier completes and is cleared completely before the first frame, so the blank terminal no longer reads as a hang; fresh starts emit nothing, non-TTY output stays silent, and any ordinary log output first suspends the status line (failure logs, preset warnings and catalog warnings all land on a clean line).
 
 ### Migration notes
 

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Focus compact Message is the third process slot and shows the latest up to three visual rows.** The slot order is Think → Tool → Message; the Message body is re-wrapped to the current width on every render and cut to the newest three rows, so streaming appends roll toward the latest tail and a resize re-wraps.
 - **The fullscreen mouse-wheel step is configurable.** `/settings` gains a `Mouse wheel lines` row (1/2/3/5/8, default 1) applied through the existing `TuiAltScreenOptions.wheelScrollLines`; a change while fullscreen is active takes effect on the next fullscreen re-entry.
 - **The todo panel skips a redundant full state when five or fewer items exist.** The state machine becomes a two-state summary ↔ list (the second click closes the panel); with more than five items the three-state summary → compact(5) → full(N) → summary stays, and a >5 → ≤5 shrink automatically clears a ghost `todoExpanded`.
+- **Rapid todo clicks coalesce into one gesture.** The dock summary and the panel rows are ONE semantic target: consecutive clicks within 500ms (including the same-coordinate second click after the layout switches from dock to panel) no longer trigger a second state transition — fixing the todo "flashes and vanishes" on a fast double-click; a click on any other target resets the window.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 #### 修复
 
-- **显式 cold resume 在 TUI mount 前显示启动进度。** `dsh --profile <p> --session <id>` 冷启动时先显示单行 `Resuming session…`（必要时 `Preparing conversation…`），mount 前完全清除，不再让空白终端看起来像卡死；fresh start 不输出任何状态，非 TTY 静默。
+- **显式 cold resume 在 TUI mount 前显示启动进度。** `dsh --profile <p> --session <id>` 冷启动时先显示单行 `Resuming session…`（必要时 `Preparing conversation…`），`Preparing conversation…` 一直保留到 catalog ready barrier 完成，mount 前完全清除，不再让空白终端看起来像卡死；fresh start 不输出任何状态，非 TTY 静默；任何普通日志输出前先 suspend 状态行（失败日志、preset warning、catalog warning 都落在干净行上）。
 
 ### 迁移说明
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@
 - **`FooterLayoutV1`、perRow=2 / hard total=4、Host Instruction 与 public
   extension ABI 均不变。**
 
+### UX 优化
+
+#### 变更
+
+- **Focus 展开视图恢复 steer 时间线。** 展开的 Thought 中，initial user 仍在 Thought 前，后续 steer/user 回到其实际发生的位置（tool 后、thinking 后等），final assistant 仍为最后一条 settled answer；折叠摘要语义不变。
+- **Focus 折叠 Message 成为第三个 process slot 并显示最新最多 3 个 visual rows。** 槽位顺序为 Think → Tool → Message；Message 每次 render 按当前宽度重新 wrap 并取最新尾部 3 行，流式追加自然滚向最新，resize 后重新 wrap。
+- **全屏鼠标滚轮步长可配置。** `/settings` 新增 `Mouse wheel lines`（1/2/3/5/8，默认 1），通过现有 `TuiAltScreenOptions.wheelScrollLines` 生效；fullscreen 已激活时修改在下次重新进入 fullscreen 后生效。
+- **Todo 面板 ≤5 条时去掉冗余 full 状态。** 状态机变为 summary ↔ list 两态（第二次点击即关闭）；>5 条保留 summary → compact(5) → full(N) → summary 三态；列表从 >5 缩到 ≤5 时自动清除 ghost `todoExpanded`。
+
+#### 修复
+
+- **显式 cold resume 在 TUI mount 前显示启动进度。** `dsh --profile <p> --session <id>` 冷启动时先显示单行 `Resuming session…`（必要时 `Preparing conversation…`），mount 前完全清除，不再让空白终端看起来像卡死；fresh start 不输出任何状态，非 TTY 静默。
+
 ### 迁移说明
 
 - **0.4.0-alpha.1 切换到 DeepSeek Harness 0.1.2。** 声明支持范围为

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - **Focus 折叠 Message 成为第三个 process slot 并显示最新最多 3 个 visual rows。** 槽位顺序为 Think → Tool → Message；Message 每次 render 按当前宽度重新 wrap 并取最新尾部 3 行，流式追加自然滚向最新，resize 后重新 wrap。
 - **全屏鼠标滚轮步长可配置。** `/settings` 新增 `Mouse wheel lines`（1/2/3/5/8，默认 1），通过现有 `TuiAltScreenOptions.wheelScrollLines` 生效；fullscreen 已激活时修改在下次重新进入 fullscreen 后生效。
 - **Todo 面板 ≤5 条时去掉冗余 full 状态。** 状态机变为 summary ↔ list 两态（第二次点击即关闭）；>5 条保留 summary → compact(5) → full(N) → summary 三态；列表从 >5 缩到 ≤5 时自动清除 ghost `todoExpanded`。
+- **Todo 快速连点合并为一次手势。** dock summary 与 panel 行属于同一语义目标，500ms 内的连续点击（含布局切换导致的同坐标第二击）不再触发第二次状态切换——修复“快速双击让 Todo 一闪就消失”；点击其它区域后重置。
 
 #### 修复
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1512,7 +1512,7 @@ export function registerTuiCommands(
           {
             id: 'wheel-scroll-lines',
             label: 'Mouse wheel lines',
-            description: 'Number of transcript lines moved per mouse-wheel event in fullscreen',
+            description: 'Number of transcript lines moved per mouse-wheel event in fullscreen; applies on the next fullscreen entry',
             // The fallback applies HERE too: an invalid/missing persisted
             // value must never render as a row outside the values list.
             currentValue: String(wheelScrollLinesOf(settingsDoc?.wheelScrollLines)),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,6 +25,7 @@ import { effectiveApprovalPolicy } from '@deepseek-ai/dsh-user-approval'
 import { SettingsList, type SettingItem } from '@xmoon76/pi-tui'
 import { mergeDraft } from './steer.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
+import { WHEEL_SCROLL_LINE_VALUES, wheelScrollLinesOf } from './wheel-scroll.ts'
 import { iconStyleOf } from './icons.ts'
 import { parseUserKeybindings } from './keybindings/config.ts'
 import { formatKeyId } from './keybindings/hints.ts'
@@ -1508,6 +1509,15 @@ export function registerTuiCommands(
             currentValue: app.isFullscreen() ? 'on' : 'off',
             values: ['off', 'on'],
           },
+          {
+            id: 'wheel-scroll-lines',
+            label: 'Mouse wheel lines',
+            description: 'Number of transcript lines moved per mouse-wheel event in fullscreen',
+            // The fallback applies HERE too: an invalid/missing persisted
+            // value must never render as a row outside the values list.
+            currentValue: String(wheelScrollLinesOf(settingsDoc?.wheelScrollLines)),
+            values: [...WHEEL_SCROLL_LINE_VALUES],
+          },
           // ── read-only session facts ─────────────────────────────
           {
             id: 'separator',
@@ -1821,6 +1831,22 @@ export function registerTuiCommands(
               app.setFullscreen(value === 'on')
               // setFullscreen reports through onFullscreenChange, which
               // persists the same field (this branch is the panel write).
+            }
+          } else if (id === 'wheel-scroll-lines') {
+            // v1 semantics: the fork's wheelScrollLines is a
+            // constructor-time alt-screen option, so the preference
+            // applies on the NEXT fullscreen mount (a change while
+            // fullscreen is active takes effect on re-entry — never a
+            // private-field hack on the live alt screen). Persist through
+            // the shared whole-document transaction.
+            const lines = wheelScrollLinesOf(value)
+            app.setWheelScrollLines(lines)
+            const settings = tuiSettings
+            if (settings !== undefined) {
+              detach('settings wheel scroll lines write', () => serializeTuiSettingsMutation(
+                settings,
+                () => settings.replace(withUserFooterCustomItems({ ...settings.get(), wheelScrollLines: String(lines) }, runner.config)),
+              ), { notify: true })
             }
           }
         },

--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -6,7 +6,8 @@
  *
  * The collapsed card shows: a status header (whale disclosure icon +
  * duration + per-turn token + responsive tool stats) and the three compact
- * process slots — Think / Message / Tool — plus the Error line, all muted,
+ * process slots — Think / Tool / Message (Message shows the latest up to
+ * three visual rows) — plus the Error line, all muted,
  * never competing with the final assistant. The expanded card renders ONLY
  * the header: the hidden process rows render below as ordinary transcript
  * messages (plan §15 — no second renderer family), and inside an open
@@ -20,7 +21,7 @@
  * @module @xmoon76/dsh-pi-tui/focus-activity
  */
 
-import { truncateToWidth, visibleWidth } from '@xmoon76/pi-tui'
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@xmoon76/pi-tui'
 import { color } from './theme.ts'
 import { formatTokens } from './token-usage.ts'
 import { iconFor, type IconSemantic, type IconStyle } from './icons.ts'
@@ -146,6 +147,12 @@ export function formatFocusHeaderLine(
  * (plan §25, aligned by visible width). */
 const FOCUS_SLOT_LABEL_WIDTH = 9
 
+/** The max visual rows the collapsed Message slot renders: the LATEST
+ * tail rows of the bounded message text (plan: Message is the third
+ * process slot and shows up to three terminal rows, always the newest
+ * tail — streaming appends naturally roll toward it). */
+const FOCUS_MESSAGE_MAX_ROWS = 3
+
 /** Collapse arbitrary slot text to ONE physical terminal row: CR/LF
  * sequences (LF, CRLF, lone CR) are normalized to the FIRST line. This is
  * the final boundary the fullscreen compositor depends on — every
@@ -173,11 +180,39 @@ function previewLine(label: string, text: string, width: number): string {
   return truncateToWidth(`${lead}${body}`, Math.max(1, width), '…')
 }
 
+/**
+ * The collapsed Message slot: the bounded message tail wrapped to the
+ * CURRENT width and cut to its LAST `maxRows` visual rows (plan: Message
+ * is the third process slot, up to three rows, always the newest tail).
+ * The wrap happens per render — a resize re-wraps, and streaming appends
+ * roll the tail forward with no scroll index to maintain. Every returned
+ * element is exactly one PHYSICAL framebuffer row: the first carries the
+ * label lead (`Message: `), continuation rows carry a same-width blank
+ * indent, and each row is hard-truncated to the width as the last resort
+ * (the fullscreen row hit-map depends on one row per element).
+ */
+function previewTailLines(label: string, text: string, width: number, maxRows: number): string[] {
+  const lead = `${label}${' '.repeat(Math.max(0, FOCUS_SLOT_LABEL_WIDTH - visibleWidth(label)))}`
+  const bodyBudget = Math.max(1, width - visibleWidth(lead))
+  // ANSI / Unicode-aware wrap (the fork's wrapTextWithAnsi): a single
+  // logical line may wrap into several visual rows, so the tail cut
+  // happens AFTER wrapping — never `text.split('\n').slice(-3)`.
+  const wrapped = wrapTextWithAnsi(text, bodyBudget)
+  const tail = wrapped.slice(-maxRows)
+  const indent = ' '.repeat(visibleWidth(lead))
+  return tail.map((row, index) => {
+    const line = index === 0 ? `${lead}${row}` : `${indent}${row}`
+    return truncateToWidth(line, Math.max(1, width), '…')
+  })
+}
+
 /** The collapsed card body: the three process slots in FIXED order —
- * Think, Message, Tool — then the error reason (plan §24). Each slot is
- * at most ONE visual row; only existing slots render. The Tool line's
- * status prefix follows plan §10: none while running, ✓ settled ok,
- * ✗ settled error. */
+ * Think, Tool, Message — then the error reason (plan §24). Think and
+ * Tool are at most ONE visual row; Message is the third process slot and
+ * shows the latest up to {@link FOCUS_MESSAGE_MAX_ROWS} visual rows of
+ * its bounded tail. Only existing slots render. The Tool line's status
+ * prefix follows plan §10: none while running, ✓ settled ok, ✗ settled
+ * error. */
 export function focusCollapsedBody(
   activity: TurnActivity,
   width: number,
@@ -187,12 +222,12 @@ export function focusCollapsedBody(
   if (activity.think !== undefined) {
     lines.push(previewLine('Think:', activity.think.text, width))
   }
-  if (activity.message !== undefined) {
-    lines.push(previewLine('Message:', activity.message.text, width))
-  }
   if (activity.tool !== undefined && toolDisplay !== undefined) {
     const prefix = activity.tool.status === 'ok' ? '✓ ' : activity.tool.status === 'error' ? '✗ ' : ''
     lines.push(previewLine('Tool:', `${prefix}${toolDisplay}`, width))
+  }
+  if (activity.message !== undefined) {
+    lines.push(...previewTailLines('Message:', activity.message.text, width, FOCUS_MESSAGE_MAX_ROWS))
   }
   const reason = activity.reason
   if (reason?.kind === 'error' && reason.error !== undefined) {
@@ -324,12 +359,6 @@ export function projectFocus(
     index += 1
     const activity = activities.get(turn)
     const expanded = expandedTurns.has(turn)
-    // 1. The user's own messages stay visible (steers included).
-    for (const member of group) {
-      if (member.kind === 'user') out.push({ kind: 'message', message: member })
-    }
-    // 2. The Thought disclosure follows the user rows.
-    if (activity !== undefined) out.push({ kind: 'activity', activity })
     // The final assistant is decided ONCE from the exact last assistant
     // row (shared by the expanded and collapsed branches — one semantic,
     // never two drifting copies).
@@ -340,19 +369,39 @@ export function projectFocus(
       // the final assistant held back and appended LAST (a max-tokens
       // turn's `max tokens reached` system row must never land after the
       // final: the settled order is User → Thought → process → final).
-      // Every revealed process row carries the owner-turn collapse mark:
-      // the user's rows and the FINAL assistant stay unmarked (clicking
-      // them must not collapse the Thought — review P2).
-      for (const member of group) {
-        if (member.kind === 'user') continue
-        if (final !== undefined && member === final.message) continue
-        out.push({ kind: 'message', message: member, collapseFocusOwnerOnClick: turn })
+      // The LEADING user prefix (the initial prompt; multiple consecutive
+      // initial users all stay) precedes the Thought; every later
+      // user/steer returns to its chronological position in the process
+      // (plan: expanded chronology — the projection reorders, never the
+      // session events). Every revealed process row carries the
+      // owner-turn collapse mark; the user's rows and the FINAL assistant
+      // stay unmarked (clicking them must not collapse the Thought —
+      // review P2).
+      const leadingUserCount = countLeadingUsers(group)
+      for (const member of group.slice(0, leadingUserCount)) {
+        out.push({ kind: 'message', message: member })
+      }
+      if (activity !== undefined) out.push({ kind: 'activity', activity })
+      for (const member of group.slice(leadingUserCount)) {
+        if (member.kind === 'user') {
+          out.push({ kind: 'message', message: member })
+        } else {
+          if (final !== undefined && member === final.message) continue
+          out.push({ kind: 'message', message: member, collapseFocusOwnerOnClick: turn })
+        }
       }
       if (final !== undefined) {
         out.push(final.truncated ? { kind: 'message', message: final.message, truncated: true } : { kind: 'message', message: final.message })
       }
       continue
     }
+    // Collapsed: the user's own messages stay visible (steers included)
+    // and ALL of them precede the Thought (summary semantics unchanged).
+    for (const member of group) {
+      if (member.kind === 'user') out.push({ kind: 'message', message: member })
+    }
+    // The Thought disclosure follows the user rows.
+    if (activity !== undefined) out.push({ kind: 'activity', activity })
     // Compaction cards keep their existing lifecycle in the collapsed
     // view (plan §12.3 v1 — never hidden into the Thought).
     for (const member of group) {
@@ -377,6 +426,19 @@ function lastAssistant(
     if (member?.kind === 'assistant') return member
   }
   return undefined
+}
+
+/** The number of CONSECUTIVE user rows at the START of a turn group: the
+ * initial prompt (multiple consecutive initial users all stay before the
+ * Thought in the expanded view). Every user row AFTER this prefix is a
+ * steer and returns to its chronological position. */
+function countLeadingUsers(group: readonly TranscriptMessage[]): number {
+  let count = 0
+  for (const member of group) {
+    if (member.kind !== 'user') break
+    count += 1
+  }
+  return count
 }
 
 /** Whether one assistant message truly renders visible rows. The flat

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,8 @@ import { ImageInputError } from './image/errors.ts'
 import { clipboardBackendOf, commandOnPath, createClipboardRunner, readClipboardImage, type ClipboardEnvironment } from './image/clipboard.ts'
 import { buildOsc52Sequence, copyToClipboard, type CopyEnvironment, type CopyExecutor } from './clipboard.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
+import { wheelScrollLinesOf } from './wheel-scroll.ts'
+import { createStartupStatus } from './startup-status.ts'
 import { iconStyleOf } from './icons.ts'
 import { checkImageLimits } from './image/intake.ts'
 import { ImageLoadError } from './image/errors.ts'
@@ -1534,6 +1536,10 @@ export function apply(ctx: Context, config: Config): void {
         // Focus Mode: 'on' collapses turn-intermediate activity into a
         // live Thought block (default 'off' — Focus OFF == current UI).
         focusMode: z.string(),
+        // Fullscreen mouse-wheel step: '1' (default) | '2' | '3' | '5' |
+        // '8' — the transcript lines moved per wheel event. A Client
+        // preference; wheelScrollLinesOf is the single parsing authority.
+        wheelScrollLines: z.string(),
         // Icon style: 'emoji' (default) or 'symbols' — the first-party
         // structural icon palette (see src/icons.ts). A persisted invalid
         // value fails safe to emoji at consumption.
@@ -1552,7 +1558,7 @@ export function apply(ctx: Context, config: Config): void {
       // The base layout is the builtin default; the schemastery output
       // type is fully-populated, so the cast bridges the sparse literal
       // (the runtime validation accepts missing optional fields).
-      { base: { theme: 'auto', iconStyle: 'emoji', footer: 'full', footerFallbackMode: 'default', footerLayout: DEFAULT_FOOTER_LAYOUT as never, footerCustomItems: undefined as never, footerCommand: undefined as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off' } },
+      { base: { theme: 'auto', iconStyle: 'emoji', footer: 'full', footerFallbackMode: 'default', footerLayout: DEFAULT_FOOTER_LAYOUT as never, footerCustomItems: undefined as never, footerCommand: undefined as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off', wheelScrollLines: '1' } },
     )
     // The ONE authoritative Focus runtime state (plan §5): restored from
     // the persisted document BEFORE the first compose/resume below, mutated
@@ -1869,8 +1875,24 @@ export function apply(ctx: Context, config: Config): void {
     // sessionless (the next input creates a new session); the failure is
     // surfaced as a notify line.
     let resumeFailure: string | undefined
+    // Pre-mount startup status (explicit resume only): the resume
+    // transaction (preflight, lock, DSH resume) and the whenIdle/catalog
+    // barrier run BEFORE the TUI mounts — a single-line TTY hint keeps
+    // the blank terminal from reading as a hang. Pure presentation: it
+    // never owns lifecycle state, and every teardown path (success,
+    // resume reject, abort/signal, HMR unload, startup exception) clears
+    // it — the abort listener covers the teardown paths, the explicit
+    // clear covers the success path.
+    const startupStatus = createStartupStatus({
+      isTTY: process.stdout.isTTY === true,
+      write: (text) => process.stdout.write(text),
+    })
+    lifecycleController.signal.addEventListener('abort', () => startupStatus.clear(), { once: true })
     let handle: SessionHandle | undefined
     if (sessionId !== undefined) {
+      // The explicit-resume path is the ONLY pre-mount wait worth
+      // explaining: deferred / sessionless starts have nothing to resume.
+      startupStatus.show('Resuming session…')
       try {
         // The lock file lives next to the session log, whose path needs the
         // session's stored cwd: resolve the header first (best-effort — an
@@ -1988,6 +2010,10 @@ export function apply(ctx: Context, config: Config): void {
       // The committed live session's lease becomes ACTIVE (a successful
       // launch resume must not stay TOUCHED — review round 32).
       leaseManager.markActive(liveAgent.session.id)
+      // The resume transaction succeeded; the remaining pre-mount wait is
+      // the conversation preparation (whenIdle + catalog barrier) — the
+      // second status stage replaces the first in place.
+      startupStatus.show('Preparing conversation…')
       await liveAgent.whenIdle()
     }
     // Surface catalog resolution BEFORE the TUI mounts (the ready barrier):
@@ -4532,6 +4558,9 @@ export function apply(ctx: Context, config: Config): void {
       isTTY: () => process.stdout.isTTY === true,
       writeOsc52: (text) => process.stdout.write(buildOsc52Sequence(text, (process.env.TMUX ?? '').length > 0)),
     }
+    // The TUI is about to mount: the pre-mount status line must be gone
+    // before the first frame (no stale scrollback line after mount).
+    startupStatus.clear()
     app = startProcessTui({
       onSubmit: (text) => dispatchUserInput(text),
       // The image-only submit gate (plan §11.1): an empty-text draft with
@@ -5456,6 +5485,11 @@ export function apply(ctx: Context, config: Config): void {
     // fullscreen frame so the first frame and later behavior agree (plan
     // §4.8); an invalid persisted value falls back to `viewport`.
     applyHomeEndKeyMode(homeEndKeysModeOf(tuiSettings?.get().homeEndKeys))
+    // The wheel step is a constructor-time alt-screen option: hand the
+    // preference to the app BEFORE the first fullscreen entry, or the
+    // first alt screen would still scroll 1 line per wheel event (the
+    // order matters — never apply after setFullscreen).
+    app.setWheelScrollLines(wheelScrollLinesOf(tuiSettings?.get().wheelScrollLines))
     if (tuiSettings?.get().fullscreen === 'on') app.setFullscreen(true)
     const storedTheme = tuiSettings?.get().theme
     if (storedTheme === 'auto') {
@@ -7012,6 +7046,8 @@ export function apply(ctx: Context, config: Config): void {
     }
     // Startup failure: cancel every in-flight lifecycle load, then tear
     // down. (The runner-internal cleanup() never ran — the body threw.)
+    // The pre-mount status line is cleared by the lifecycle abort
+    // listener registered at startup (idempotent).
     try {
       lifecycleController.abort()
     } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1957,6 +1957,13 @@ export function apply(ctx: Context, config: Config): void {
           // adapter composes this EXACT id, never a re-resolved default.
           agentPreset: launchComposition.agentPreset,
         })
+        // Suspend the pre-mount status before ANY ordinary log output
+        // (uniform rule): the status owns the current terminal line, and
+        // a logger/diag write on a TTY shares the cursor — the status
+        // must be cleared first so the log line is clean and the later
+        // clear can never erase the wrong line. The 'Preparing
+        // conversation…' stage re-arms it.
+        startupStatus.clear()
         diag.info('resume ok', {
           session: sessionId,
           seq: (handle.direct!.agent as Agent).session.events.length,
@@ -1969,16 +1976,24 @@ export function apply(ctx: Context, config: Config): void {
             const outcome = await recomposeBlank(ctx, handle.direct!.agent as Agent, launchPreset)
             if (outcome.kind === 'locked') {
               const message = `session ${sessionId} has started; its agent preset ${recorded} is fixed, ignoring --preset ${launchPreset}`
+              startupStatus.clear()
               ctx.logger.warn(`tui-runner: ${message}`)
               diag.warn('preset ignored on resume', { session: sessionId, preset: launchPreset })
             }
           } catch (error) {
             const message = `--preset ${launchPreset} not applied on resume: ${safeErrorMessage(error)}`
+            startupStatus.clear()
             ctx.logger.warn(`tui-runner: ${message}`)
             diag.warn('preset not applied on resume', { session: sessionId, preset: launchPreset, error: message })
           }
         }
       } catch (error) {
+        // Suspend the pre-mount status BEFORE the failure logs: the
+        // status owns the current terminal line, and the logger/diag
+        // writes below share the TTY cursor — without this clear the
+        // warning would interleave with the status and the later
+        // mount-time clear would erase the wrong line.
+        startupStatus.clear()
         // A lock refusal is NOT recoverable: the user asked for a specific
         // held session. Re-throw so the runner exits with the refusal as
         // the message.
@@ -2015,6 +2030,12 @@ export function apply(ctx: Context, config: Config): void {
       // second status stage replaces the first in place.
       startupStatus.show('Preparing conversation…')
       await liveAgent.whenIdle()
+      // The whenIdle wait is over: suspend the status BEFORE the catalog
+      // resolution (uniform rule — no ordinary log output while the
+      // status owns the terminal line; the catalog block's failure warns
+      // must land on a clean line). The mount-time clear below is then a
+      // no-op.
+      startupStatus.clear()
     }
     // Surface catalog resolution BEFORE the TUI mounts (the ready barrier):
     // a resumed agent prefetches its effective catalog (a live read emits no

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,16 @@ export const inject = ['agentDefaultModel', 'agents', 'sessions', TUI_STARTUP_SE
 export interface Config {
   /** Resumed session id; a fresh session is created when absent. */
   sessionId?: string
+  /** Test seam: the pre-mount status output (defaults to process.stdout,
+   * TTY-gated). Injectable so the runner tests capture the status writes
+   * without patching the global stdout (which would fight the test
+   * reporter's own writes). STRUCTURAL on purpose: the public Config type
+   * must not reference the internal startup-status module (the public
+   * .d.mts leak gate). */
+  startupStatusOutput?: {
+    readonly isTTY?: boolean
+    write(text: string): unknown
+  }
 }
 
 export const Config: z<Config> = z.object({
@@ -616,10 +626,15 @@ export interface ResolveInitialCatalogOptions {
   /** The context surface the collectors read services from. */
   readonly ctx: SurfaceCatalogContext
   readonly diag: Diag
+  /** Suspend the pre-mount startup status before an ordinary log write
+   * (the status owns the current terminal line; a TTY shares one cursor
+   * between stdout and stderr). Called right before every diag.warn this
+   * function may emit. */
+  readonly onLog?: () => void
 }
 
 export async function resolveInitialCatalog(options: ResolveInitialCatalogOptions): Promise<InitialCatalogResolution> {
-  const { liveAgent, presetId, signal, ctx, diag } = options
+  const { liveAgent, presetId, signal, ctx, diag, onLog } = options
   if (liveAgent !== undefined) {
     try {
       const snapshot = await readSurfaceCatalog(liveAgent, signal, ctx)
@@ -632,6 +647,7 @@ export async function resolveInitialCatalog(options: ResolveInitialCatalogOption
     } catch (error) {
       if (isCancellation(error)) return {}
       const message = safeErrorMessage(error)
+      onLog?.()
       diag.warn('surface catalog unavailable', { phase: 'resume', error: message })
       return { notice: `surface catalog unavailable: ${message}` }
     }
@@ -655,6 +671,7 @@ export async function resolveInitialCatalog(options: ResolveInitialCatalogOption
   } catch (error) {
     if (isCancellation(error)) return {}
     const message = safeErrorMessage(error)
+    onLog?.()
     diag.warn('skill catalog unavailable', { phase: 'cold', error: message })
     return { notice: `skill catalog unavailable: ${message}` }
   }
@@ -1883,7 +1900,7 @@ export function apply(ctx: Context, config: Config): void {
     // resume reject, abort/signal, HMR unload, startup exception) clears
     // it — the abort listener covers the teardown paths, the explicit
     // clear covers the success path.
-    const startupStatus = createStartupStatus({
+    const startupStatus = createStartupStatus(config.startupStatusOutput ?? {
       isTTY: process.stdout.isTTY === true,
       write: (text) => process.stdout.write(text),
     })
@@ -2026,16 +2043,12 @@ export function apply(ctx: Context, config: Config): void {
       // launch resume must not stay TOUCHED — review round 32).
       leaseManager.markActive(liveAgent.session.id)
       // The resume transaction succeeded; the remaining pre-mount wait is
-      // the conversation preparation (whenIdle + catalog barrier) — the
-      // second status stage replaces the first in place.
+      // the conversation preparation (whenIdle + the catalog ready
+      // barrier) — the second status stage replaces the first in place
+      // and STAYS until the barrier completes (the catalog prefetch can
+      // take seconds; a cleared line would read as a hang again).
       startupStatus.show('Preparing conversation…')
       await liveAgent.whenIdle()
-      // The whenIdle wait is over: suspend the status BEFORE the catalog
-      // resolution (uniform rule — no ordinary log output while the
-      // status owns the terminal line; the catalog block's failure warns
-      // must land on a clean line). The mount-time clear below is then a
-      // no-op.
-      startupStatus.clear()
     }
     // Surface catalog resolution BEFORE the TUI mounts (the ready barrier):
     // a resumed agent prefetches its effective catalog (a live read emits no
@@ -2061,7 +2074,11 @@ export function apply(ctx: Context, config: Config): void {
         if (launched.failure !== undefined) resumeFailure = launched.failure
         effectivePresetId = launched.composition.agentPreset
       } catch (error) {
+        // Suspend the status before the log, then re-arm it: the catalog
+        // barrier below is still part of the pre-mount wait.
+        startupStatus.clear()
         diag.warn('preset resolution failed at startup', { error: safeErrorMessage(error) })
+        startupStatus.show('Preparing conversation…')
       }
       const resolution = await resolveInitialCatalog({
         liveAgent,
@@ -2069,6 +2086,10 @@ export function apply(ctx: Context, config: Config): void {
         signal: lifecycleController.signal,
         ctx: ctx as unknown as SurfaceCatalogContext,
         diag,
+        // The catalog read may emit its own failure warn: suspend the
+        // status right before it (the barrier itself keeps the status
+        // on screen).
+        onLog: () => startupStatus.clear(),
       })
       initialSnapshot = resolution.snapshot
       initialSkills = resolution.skills

--- a/src/index.ts
+++ b/src/index.ts
@@ -2074,11 +2074,17 @@ export function apply(ctx: Context, config: Config): void {
         if (launched.failure !== undefined) resumeFailure = launched.failure
         effectivePresetId = launched.composition.agentPreset
       } catch (error) {
-        // Suspend the status before the log, then re-arm it: the catalog
-        // barrier below is still part of the pre-mount wait.
+        // Suspend the status before the log, then re-arm it ONLY for a
+        // live resumed session: the catalog barrier below is still part
+        // of the pre-mount wait for a resume, but a fresh/deferred start
+        // (or a failed resume) never shows any startup status — the
+        // "fresh start stays silent" contract must hold on this failure
+        // path too.
         startupStatus.clear()
         diag.warn('preset resolution failed at startup', { error: safeErrorMessage(error) })
-        startupStatus.show('Preparing conversation…')
+        if (liveAgent !== undefined) {
+          startupStatus.show('Preparing conversation…')
+        }
       }
       const resolution = await resolveInitialCatalog({
         liveAgent,

--- a/src/runtime/config-port.ts
+++ b/src/runtime/config-port.ts
@@ -30,8 +30,8 @@ import type { FooterCommandConfig } from '../footer/command-runner.ts'
 import type { FooterCustomItemsParseResult } from '../footer/custom-items.ts'
 
 /** The TUI settings document (theme/iconStyle/footer/footerLayout/
- * footerCustomItems/fullscreen/busyEnter/localShellSandbox/homeEndKeys/focusMode).
- * The old
+ * footerCustomItems/fullscreen/busyEnter/localShellSandbox/homeEndKeys/
+ * focusMode/wheelScrollLines). The old
  * `history` field moved to $DSH_HOME/user-history/*.jsonl and is
  * deliberately NOT part of the document anymore. `footerLayout` is the
  * M2 versioned custom layout (nested settings object), absent when not
@@ -68,6 +68,11 @@ export interface TuiSettingsDoc {
   localShellSandbox: string
   homeEndKeys: string
   focusMode: string
+  /** The fullscreen mouse-wheel step (`1/2/3/5/8`, default `1`). A
+   * Client preference persisted in the TUI settings document — never a
+   * Session / Agent state; a future Remote adapter round-trips it like
+   * every other TUI setting, with no dedicated RPC. */
+  wheelScrollLines: string
   keybindings?: unknown
 }
 

--- a/src/startup-status.ts
+++ b/src/startup-status.ts
@@ -1,0 +1,51 @@
+/**
+ * Pre-mount startup status: a single-line, TTY-only progress hint shown
+ * while the runner waits BEFORE the TUI mounts (the explicit session
+ * resume path). Pure presentation — it never owns session lifecycle
+ * state, never starts timers, never touches the alt screen, and never
+ * appends permanent scrollback.
+ *
+ * The line strategy is CR + erase-current-line: every `show` overwrites
+ * the previous status in place, and `clear` erases the line entirely, so
+ * a successful mount leaves no stale text behind. Non-TTY output is
+ * silent (a pipe / CI must not be polluted).
+ * @module @xmoon76/dsh-pi-tui/startup-status
+ */
+
+/** The output seam the status writes through (injectable for tests). */
+export interface StartupStatusOutput {
+  /** Whether the output is an interactive terminal; false = silent. */
+  readonly isTTY?: boolean
+  write(text: string): unknown
+}
+
+/** The pre-mount status surface. */
+export interface StartupStatus {
+  /** Overwrite the current line with the message (CR + erase-line). */
+  show(message: string): void
+  /** Erase the status line (idempotent; no-op when nothing was shown). */
+  clear(): void
+}
+
+/** The erase-current-line sequence (EL) used to overwrite in place. */
+const ERASE_LINE = '\r\x1b[2K'
+
+/** Create the pre-mount status writer. `isTTY` defaults to true when the
+ * output does not declare itself (the runner passes
+ * `process.stdout.isTTY` explicitly). */
+export function createStartupStatus(output: StartupStatusOutput): StartupStatus {
+  const tty = output.isTTY ?? true
+  let shown = false
+  return {
+    show(message) {
+      if (!tty) return
+      output.write(`${ERASE_LINE}${message}`)
+      shown = true
+    },
+    clear() {
+      if (!tty || !shown) return
+      output.write(ERASE_LINE)
+      shown = false
+    },
+  }
+}

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -151,9 +151,11 @@ export interface TurnActivity {
   /** The Think slot: the latest meaningful line of the bounded reasoning
    * tail (compact preview only — never the raw reasoning stream). */
   readonly think?: { readonly text: string }
-  /** The Message slot: the latest meaningful line of the current
-   * candidate / confirmed intermediate assistant text. The FINAL answer
-   * never enters this slot (it renders outside the Thought). */
+  /** The Message slot: the bounded LATEST TAIL of the current candidate /
+   * confirmed intermediate assistant text, kept MULTILINE (the Focus
+   * renderer wraps it to the current width and shows the last three
+   * visual rows — a single-line flatten would destroy that). The FINAL
+   * answer never enters this slot (it renders outside the Thought). */
   readonly message?: { readonly text: string }
   /** The Tool slot: the LATEST real `tool/call` (any name — event-first
    * classification), settled by its own `tool/result` only. */
@@ -218,7 +220,8 @@ interface MutableTurnActivity {
    * — the turn/end final-answer check compares the candidate's step
    * against this. */
   lastAssistantStep?: number
-  /** The materialized Message slot (candidate ?? confirmed, latest line). */
+  /** The materialized Message slot (candidate ?? confirmed, bounded
+   * multiline tail). */
   message?: { text: string }
   /** The Tool slot: the latest real tool/call, settled by its own result. */
   tool?: {
@@ -628,14 +631,16 @@ export class TranscriptFolder {
   }
 
   /** Materialize the Message slot from the candidate (running) or the
-   * resolved candidate/confirmed pair (settled): the latest meaningful
-   * line, bounded. */
+   * resolved candidate/confirmed pair (settled): the bounded MULTILINE
+   * tail — never a single-line flatten. Both sources are already bounded
+   * to MESSAGE_TAIL_CAP, so the slot stays bounded without a second
+   * copy; terminal-width wrapping is the renderer's job (plan: the fold
+   * never wraps, the renderer re-wraps per frame). */
   private syncMessage(activity: MutableTurnActivity): void {
     const candidate = activity.messageCandidate
     const candidateText = candidate?.tail
     const text = candidateText ?? activity.messageConfirmed
-    const line = text === undefined ? undefined : latestLine(text).slice(0, TranscriptFolder.NARRATIVE_PREVIEW_CAP)
-    activity.message = line === undefined || line === '' ? undefined : { text: line }
+    activity.message = text === undefined || text === '' ? undefined : { text }
   }
 
   /** Resolve the Message slot at turn/end (plan §5.5): for a completed /

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -231,6 +231,11 @@ export type CompactionPhase = 'idle' | 'summarizing' | 'applying'
 /** The indeterminate progress-bar frames shown while a compaction runs:
  * width 12 / block 3, the same visual weight as the footer context bar. */
 const COMPACTION_PROGRESS_FRAMES = indeterminateProgressFrames()
+/** The compact todo panel cap: at most this many rows before the panel
+ * gains a DISTINCT full state. With ≤ this many items the compact and
+ * full lists are visually identical, so the state machine skips the
+ * redundant full state entirely (summary ↔ list only). */
+export const TODO_COMPACT_LIMIT = 5
 /** Folded preview lines for tool results; mirrors pi's RESULT_PREVIEW_LINES. */
 export const RESULT_PREVIEW_LINES = 3
 /** Diff-body cap for default-view tool cards; mirrors kimi COMMAND_PREVIEW_LINES. */
@@ -1796,6 +1801,13 @@ export class TuiApp {
   }
   /** Fullscreen (alt-screen) instance; absent in regular mode. */
   private fullscreen: TuiAltScreen | undefined
+  /** The fullscreen mouse-wheel step (transcript lines per wheel event).
+   * A Client runtime preference: the fork's `wheelScrollLines` is a
+   * constructor-time alt-screen option, so this value feeds the NEXT
+   * TuiAltScreen mount — a change while fullscreen is active applies on
+   * the next fullscreen re-entry (v1 semantics, never a private-field
+   * hack on the live alt screen). */
+  private wheelScrollLines = 1
   /** One shared in-flight autodetect; concurrent callers coalesce onto it
    * (overlapping OSC 11 queries would mis-pair replies by FIFO order). */
   private autoDetectInFlight: Promise<void> | undefined
@@ -3906,6 +3918,15 @@ export class TuiApp {
     return this.fullscreen !== undefined
   }
 
+  /** Set the fullscreen mouse-wheel step (transcript lines per wheel
+   * event) for the NEXT alt-screen mount. Defensive normalize; never
+   * reads Host settings — a pure Client runtime preference. The live
+   * alt screen keeps its constructor-time value until the next
+   * fullscreen re-entry (v1 semantics — the fork exposes no setter). */
+  setWheelScrollLines(lines: number): void {
+    this.wheelScrollLines = Number.isFinite(lines) ? Math.max(1, Math.floor(lines)) : 1
+  }
+
   /**
    * Enter or leave fullscreen (alt screen), reporting the change through
    * {@link TuiAppEvents.onFullscreenChange} so the host can persist it.
@@ -3940,6 +3961,10 @@ export class TuiApp {
       // click reaches us through its onCellClick callback so cards can be
       // expanded individually, exactly like a web disclosure row.
       const alt = new TuiAltScreen(this.terminal, undefined, undefined, {
+        // The fullscreen mouse-wheel step (Client preference): the fork
+        // reads it at construction, so a change while fullscreen is
+        // active applies on the next re-entry.
+        wheelScrollLines: this.wheelScrollLines,
         onCellClick: (x, y) => this.handleFullscreenClick(x, y),
         // Host transcript actions must win before the fork's own viewport
         // key handling. In particular, the fork's Ctrl+Shift+F search only
@@ -8672,10 +8697,14 @@ export class TuiApp {
   /**
    * Reflect the todo list in the dock summary line: active (non-completed)
    * count and, when the list is non-empty, the first active item's text.
+   * A list that shrank to the compact cap (or below) has no distinct full
+   * state: the ghost `todoExpanded` is cleared so the panel never shows a
+   * visually identical "full" list (plan: >5 → ≤5 auto-normalizes).
    * @param todos - the latest todo/write snapshot.
    */
   setTodoSummary(todos: readonly TodoItem[]): void {
     this.todoItems = todos
+    if (!this.hasTodoOverflow()) this.todoExpanded = false
     // The activity notify re-renders the footer.
     this.projectActivity()
     this.renderDock()
@@ -8697,22 +8726,46 @@ export class TuiApp {
   }
 
   /** Toggle the todo panel between the compact five rows and the full list
-   * (fullscreen click on the panel's area). */
+   * (fullscreen click on the panel's area). Fail-closed: without overflow
+   * the compact and full lists are visually identical, so the expansion
+   * never enters a meaningless state (other callers cannot manufacture
+   * one either). */
   toggleTodoExpanded(): boolean {
     if (!this.todoPanelVisible) return false
+    if (!this.hasTodoOverflow()) {
+      this.todoExpanded = false
+      return false
+    }
     this.todoExpanded = !this.todoExpanded
     this.renderTodoPanel()
     this.requestRender()
     return this.todoExpanded
   }
 
-  /** The fullscreen click loop over the todo panel's own rows: compact →
-   * full list → back to the summary row (the panel closes). The mouse thus
-   * opens AND closes the panel without Ctrl+T; the dock summary row itself
-   * opens it (handleFullscreenClick's dock region). */
+  /** Whether the todo list exceeds the compact cap (the full state would
+   * actually differ from the compact list). All todos enter the ordered
+   * render list, so the raw length is the renderable count. */
+  private hasTodoOverflow(): boolean {
+    return this.todoItems.length > TODO_COMPACT_LIMIT
+  }
+
+  /** The fullscreen click loop over the todo panel's own rows: with ≤5
+   * items the panel is a two-state summary ↔ list (a second click closes
+   * it — never a visually identical intermediate full state); with >5
+   * items it keeps the three-state summary → compact → full → summary.
+   * The mouse thus opens AND closes the panel without Ctrl+T; the dock
+   * summary row itself opens it (handleFullscreenClick's dock region). */
   private handleTodoPanelClick(): void {
-    if (this.todoExpanded) this.toggleTodoPanel()
-    else this.toggleTodoExpanded()
+    if (this.todoExpanded) {
+      // full -> summary
+      this.toggleTodoPanel()
+    } else if (this.hasTodoOverflow()) {
+      // compact -> full, only when full actually differs
+      this.toggleTodoExpanded()
+    } else {
+      // <=5: list -> summary directly
+      this.toggleTodoPanel()
+    }
   }
 
   /** Whether the todo panel is currently shown. */
@@ -8727,9 +8780,9 @@ export class TuiApp {
 
   /**
    * Rebuild the todo panel text: a border rule + `Todo` title (both indented
-   * one cell) plus up to five rows by default (in_progress first, then
-   * pending, then completed (strikethrough)); the full list when expanded
-   * (fullscreen click on the panel toggles).
+   * one cell) plus up to {@link TODO_COMPACT_LIMIT} rows by default
+   * (in_progress first, then pending, then completed (strikethrough)); the
+   * full list when expanded (fullscreen click on the panel toggles).
    */
   private renderTodoPanel(): void {
     if (!this.todoPanelVisible) {
@@ -8744,7 +8797,7 @@ export class TuiApp {
       ...this.todoItems.filter(todo => todo.status === 'pending'),
       ...this.todoItems.filter(todo => todo.status === 'completed'),
     ]
-    const shown = this.todoExpanded ? ordered : ordered.slice(0, 5)
+    const shown = this.todoExpanded ? ordered : ordered.slice(0, TODO_COMPACT_LIMIT)
     const width = Math.max(1, this.terminal.columns)
     const border = color.border(` ${'─'.repeat(Math.max(0, width - 2))} `)
     // Title: bold, two-cell indent.

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -236,6 +236,16 @@ const COMPACTION_PROGRESS_FRAMES = indeterminateProgressFrames()
  * full lists are visually identical, so the state machine skips the
  * redundant full state entirely (summary ↔ list only). */
 export const TODO_COMPACT_LIMIT = 5
+/** The todo click-coalescing window: rapid clicks on the todo SEMANTIC
+ * target (dock summary + panel rows) within this window are treated as
+ * ONE gesture. The fullscreen layout MUTATES between the clicks — the
+ * first click on the dock summary opens the panel, the dock vanishes and
+ * the panel takes its rows — so Pi's word-based double-click detection
+ * (same row + same word range) cannot see the pair: the second click at
+ * the same coordinate lands on a panel row and immediately undoes the
+ * first (the todo "flashes and vanishes"). Matches Pi's
+ * DOUBLE_CLICK_INTERVAL_MS. */
+const TODO_CLICK_COALESCE_MS = 500
 /** Folded preview lines for tool results; mirrors pi's RESULT_PREVIEW_LINES. */
 export const RESULT_PREVIEW_LINES = 3
 /** Diff-body cap for default-view tool cards; mirrors kimi COMMAND_PREVIEW_LINES. */
@@ -1738,6 +1748,10 @@ export class TuiApp {
   /** Fullscreen click on the todo panel (or the panel's own expand verb):
    * whether the panel shows the FULL list or the compact five rows. */
   private todoExpanded = false
+  /** Until this timestamp, todo-target clicks are coalesced into the
+   * previous gesture (see {@link TODO_CLICK_COALESCE_MS}); a click on
+   * any OTHER target resets it. */
+  private todoClickCoalesceUntil = 0
   /** The todo panel Text; empty when hidden. */
   private readonly todoPanel: Text
   /**
@@ -5402,17 +5416,30 @@ export class TuiApp {
     // is hidden while the panel is open, so the dock renders zero rows and
     // this branch is inert — the two regions never fight.
     const dockHeight = this.dock.render(width).length
-    if (dockHeight > 0 && y >= todoTop - dockHeight && y < todoTop) {
-      this.toggleTodoPanel()
+    const inDock = dockHeight > 0 && y >= todoTop - dockHeight && y < todoTop
+    // A click on the todo panel's own rows runs the state loop (compact →
+    // full list → back to the summary row), so the mouse opens AND closes
+    // the panel without the todo-toggle action.
+    const inPanel = todoTop < todoBottom && y >= todoTop && y < todoBottom
+    if (inDock || inPanel) {
+      // The dock and the panel are ONE semantic target, and the first
+      // click MUTATES the layout (the dock vanishes, the panel takes its
+      // rows): a rapid second click at the same coordinate would land on
+      // the panel and immediately undo the first — the todo "flashes and
+      // vanishes". Pi's double-click detection cannot see the pair (the
+      // word range under the coordinate changed), so coalesce the whole
+      // target here: a second todo click inside the window is one gesture.
+      const now = Date.now()
+      if (now < this.todoClickCoalesceUntil) return
+      this.todoClickCoalesceUntil = now + TODO_CLICK_COALESCE_MS
+      if (inDock) this.toggleTodoPanel()
+      else this.handleTodoPanelClick()
       return
     }
-    // A click on the todo panel's own rows runs the three-state loop
-    // (compact → full list → back to the summary row), so the mouse opens
-    // AND closes the panel without the todo-toggle action.
-    if (todoTop < todoBottom && y >= todoTop && y < todoBottom) {
-      this.handleTodoPanelClick()
-      return
-    }
+    // Any other click is a DIFFERENT gesture: the next todo click starts
+    // a fresh coalescing window (a deliberate open after a transcript
+    // click must never be swallowed).
+    this.todoClickCoalesceUntil = 0
     // Fullscreen layout: header row(s), then the transcript scroll pane.
     const scroll = this.fullscreenScroll
     if (scroll === undefined) return

--- a/src/wheel-scroll.ts
+++ b/src/wheel-scroll.ts
@@ -1,0 +1,32 @@
+/**
+ * The fullscreen mouse-wheel step preference: the number of transcript
+ * lines moved per wheel event. A pure Client preference — the schema, the
+ * `/settings` row, the startup apply, the TuiApp and the tests all share
+ * ONE parsing semantic (never a copied parseInt / fallback).
+ *
+ * The value rides the TUI settings document (persisted through the
+ * ConfigPort like every other TUI preference) but is applied ONLY to the
+ * alt screen's constructor option (`TuiAltScreenOptions.wheelScrollLines`)
+ * — the fork's wheel handling is never reimplemented here.
+ * @module @xmoon76/dsh-pi-tui/wheel-scroll
+ */
+
+/** The selectable wheel steps, in display order. */
+export const WHEEL_SCROLL_LINE_VALUES = ['1', '2', '3', '5', '8'] as const
+
+/** The accepted wheel step values. */
+export type WheelScrollLines = 1 | 2 | 3 | 5 | 8
+
+/** The fallback for a missing / invalid persisted value (default 1 —
+ * the fork's own default, so an old settings file keeps the current
+ * behavior). */
+const WHEEL_SCROLL_LINES_FALLBACK: WheelScrollLines = 1
+
+/** Parse a persisted wheel-scroll-lines value: `1/2/3/5/8` pass through,
+ * anything else (missing, empty, malformed) falls back to 1. */
+export function wheelScrollLinesOf(value: string | undefined): WheelScrollLines {
+  if (value === '1' || value === '2' || value === '3' || value === '5' || value === '8') {
+    return Number(value) as WheelScrollLines
+  }
+  return WHEEL_SCROLL_LINES_FALLBACK
+}

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -986,7 +986,13 @@ test('a long confirmed intermediate message previews its TAIL, never the stale h
     eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1006, 6),
   ])
   const activity = folder.turnActivity(0)!
-  assert.equal(activity.message?.text, 'THE END MARKER', 'the preview must come from the message TAIL')
+  // The slot keeps the bounded MULTILINE tail (never a single-line
+  // flatten): the renderer wraps it to the current width and shows the
+  // last three visual rows, so the fold must preserve the tail's line
+  // structure and its newest content.
+  assert.ok(activity.message?.text.endsWith('THE END MARKER'), 'the preview must come from the message TAIL')
+  assert.ok(activity.message !== undefined && activity.message.text.length <= 400, 'the slot stays bounded to MESSAGE_TAIL_CAP')
+  assert.ok(activity.message?.text.includes('\n'), 'the multiline tail structure must survive the fold')
 })
 
 test('a settled message without any prior candidate is still the final when the turn ends (no phantom slot)', () => {
@@ -1315,7 +1321,7 @@ test('the header never wraps: every candidate fits its width', () => {
   }
 })
 
-test('the collapsed body renders the three slots in fixed order, one line each (plan §24/§25/§47)', () => {
+test('the collapsed body renders the three slots in fixed order — Think, Tool, Message (plan §24/§25/§47)', () => {
   const folder = new TranscriptFolder()
   folder.apply([
     eventAt('turn/start', { turn: 0 }, 1000, 0),
@@ -1327,9 +1333,9 @@ test('the collapsed body renders the three slots in fixed order, one line each (
   const body = focusCollapsedBody(activity, 60, focusToolDisplay(activity.tool!, {}))
   assert.equal(body.length, 3, `exactly the three slots:\n${body.join('\n')}`)
   assert.ok(body[0]!.startsWith('Think:   '), body[0])
-  assert.ok(body[1]!.startsWith('Message: '), body[1])
-  assert.ok(body[2]!.startsWith('Tool:    '), body[2])
-  assert.ok(body[2]!.includes('Read src/present.ts'), body[2])
+  assert.ok(body[1]!.startsWith('Tool:    '), body[1])
+  assert.ok(body[1]!.includes('Read src/present.ts'), body[1])
+  assert.ok(body[2]!.startsWith('Message: '), body[2])
   // The labels align at the same column (visible width 9).
   for (const line of body) {
     const lead = line.slice(0, 9)
@@ -1339,6 +1345,134 @@ test('the collapsed body renders the three slots in fixed order, one line each (
   for (const line of body) {
     assert.ok(visibleWidth(line) <= 60, `line exceeds width: ${JSON.stringify(line)}`)
   }
+})
+
+// ── Message slot: the third process slot, latest up to 3 visual rows ────
+
+/** A running activity whose Message candidate streams the given text. */
+function messageActivity(text: string): ReturnType<TranscriptFolder['turnActivity']> {
+  return activityOf(0, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text } }, 1001, 1),
+  ])
+}
+
+test('the Message slot is the THIRD process slot: Think, Tool, Message', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'think' } }, 1001, 1),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'message body' } }, 1002, 2),
+    eventAt('tool/call', { turn: 0, step: 0, callId: ToolCallId('c'), name: 'read', arguments: '{}' }, 1003, 3),
+  ])
+  const activity = folder.turnActivity(0)!
+  const body = focusCollapsedBody(activity, 60, focusToolDisplay(activity.tool!, {}))
+  assert.ok(body[0]!.startsWith('Think:   '), body[0])
+  assert.ok(body[1]!.startsWith('Tool:    '), body[1])
+  assert.ok(body[2]!.startsWith('Message: '), body[2])
+})
+
+test('the Message slot renders 1, 2 and 3 visual rows; more than 3 keeps only the last 3', () => {
+  // One short line → one row.
+  const one = focusCollapsedBody(messageActivity('short message')!, 60)
+  assert.equal(one.length, 1)
+  assert.ok(one[0]!.startsWith('Message: '), one[0])
+  // Two logical lines → two rows.
+  const two = focusCollapsedBody(messageActivity('first line\nsecond line')!, 60)
+  assert.equal(two.length, 2, two.join('|'))
+  assert.ok(two[0]!.startsWith('Message: '), two[0])
+  assert.ok(two[1]!.startsWith('         '), `continuation rows carry the blank indent: ${two[1]}`)
+  // Three logical lines → three rows.
+  const three = focusCollapsedBody(messageActivity('a\nb\nc')!, 60)
+  assert.equal(three.length, 3, three.join('|'))
+  // Four logical lines → only the LAST three rows.
+  const four = focusCollapsedBody(messageActivity('a\nb\nc\nd')!, 60)
+  assert.equal(four.length, 3, four.join('|'))
+  assert.ok(four[0]!.includes('b'), `the oldest row drops: ${four.join('|')}`)
+  assert.ok(four[2]!.includes('d'), `the newest row stays: ${four.join('|')}`)
+})
+
+test('a single over-long logical line wraps and the LAST three visual rows survive', () => {
+  const long = 'word '.repeat(40) // 200 chars, wraps at width 60
+  const body = focusCollapsedBody(messageActivity(long)!, 60)
+  assert.equal(body.length, 3, `wrapped tail must be 3 rows:\n${body.join('\n')}`)
+  // The tail rows are the NEWEST content: the last row ends with the
+  // text's own tail (the wrap never invents content).
+  const last = body[2]!
+  assert.ok(last.endsWith('word'), `the newest row carries the text tail: ${last}`)
+  for (const line of body) {
+    assert.ok(visibleWidth(line) <= 60, `row exceeds width: ${JSON.stringify(line)}`)
+  }
+})
+
+test('multiline + wrapped mix: the tail cut happens AFTER wrapping', () => {
+  const text = 'head\n' + 'word '.repeat(30) + 'tail'
+  const body = focusCollapsedBody(messageActivity(text)!, 40)
+  assert.equal(body.length, 3, `mixed wrap must still cap at 3 rows:\n${body.join('\n')}`)
+  assert.ok(body[2]!.includes('tail'), `the newest content survives: ${body[2]}`)
+  for (const line of body) {
+    assert.ok(visibleWidth(line) <= 40, `row exceeds width: ${JSON.stringify(line)}`)
+  }
+})
+
+test('the Message slot handles ANSI, CJK and emoji/ZWJ by CELL width', () => {
+  const ansi = focusCollapsedBody(messageActivity('\x1b[31mred line\x1b[0m\nplain')!, 60)
+  assert.equal(ansi.length, 2, ansi.join('|'))
+  for (const line of ansi) {
+    assert.ok(visibleWidth(line) <= 60, `ANSI row exceeds width: ${JSON.stringify(line)}`)
+  }
+  const cjk = focusCollapsedBody(messageActivity('中文第一行\n中文第二行\n中文第三行\n中文第四行')!, 40)
+  assert.equal(cjk.length, 3, cjk.join('|'))
+  assert.ok(cjk[2]!.includes('第四行'), `CJK newest row: ${cjk[2]}`)
+  for (const line of cjk) {
+    assert.ok(visibleWidth(line) <= 40, `CJK row exceeds width: ${JSON.stringify(line)}`)
+  }
+  const emoji = focusCollapsedBody(messageActivity('👨‍👩‍👧‍👦 family\n👍 done')!, 30)
+  assert.equal(emoji.length, 2, emoji.join('|'))
+  for (const line of emoji) {
+    assert.ok(visibleWidth(line) <= 30, `emoji row exceeds width: ${JSON.stringify(line)}`)
+  }
+})
+
+test('a very narrow width never produces a negative budget or an over-wide row', () => {
+  for (const width of [1, 2, 3, 4, 8]) {
+    const body = focusCollapsedBody(messageActivity('a\nb\nc\nd')!, width)
+    assert.ok(body.length >= 1 && body.length <= 3, `width ${width}: ${body.length} rows`)
+    for (const line of body) {
+      assert.ok(visibleWidth(line) <= width, `width ${width}: ${JSON.stringify(line)} (${visibleWidth(line)})`)
+    }
+  }
+})
+
+test('resize re-wraps: the same text yields different row counts at different widths', () => {
+  const text = 'word '.repeat(30)
+  const wide = focusCollapsedBody(messageActivity(text)!, 120)
+  const narrow = focusCollapsedBody(messageActivity(text)!, 30)
+  // At 120 cols the text fits in fewer rows than at 30 cols; both cap at 3.
+  assert.equal(wide.length, 2, `wide wrap: ${wide.join('|')}`)
+  assert.equal(narrow.length, 3, `narrow wrap: ${narrow.join('|')}`)
+  // The narrow wrap keeps LESS content per row: its last row is shorter
+  // than the wide wrap's last row (the wide row holds more of the tail).
+  const wideLast = wide[wide.length - 1]!
+  const narrowLast = narrow[narrow.length - 1]!
+  assert.ok(visibleWidth(wideLast) > visibleWidth(narrowLast),
+    `a wider terminal must hold more of the tail per row (wide ${visibleWidth(wideLast)} vs narrow ${visibleWidth(narrowLast)})`)
+})
+
+test('streaming appends roll the Message tail forward (no scroll index)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'first\nsecond\nthird\nfourth' } }, 1001, 1),
+  ])
+  const before = focusCollapsedBody(folder.turnActivity(0)!, 60)
+  assert.ok(before[2]!.includes('fourth'), `before append: ${before.join('|')}`)
+  folder.apply([
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: '\nfifth' } }, 1002, 2),
+  ])
+  const after = focusCollapsedBody(folder.turnActivity(0)!, 60)
+  assert.ok(after[2]!.includes('fifth'), `after append the newest row updates: ${after.join('|')}`)
+  assert.ok(!after[0]!.includes('first'), `the oldest row rolls out: ${after.join('|')}`)
 })
 
 test('the Tool slot line carries the status prefix: none running, ✓ ok, ✗ error (plan §10)', () => {
@@ -1887,6 +2021,143 @@ test('window summaries (turn-less entries) pass through the projection', () => {
   const windowed = [{ kind: 'summary', text: '… 3 earlier turns' }, ...folder.messages()] as TranscriptMessage[]
   const blocks = projectFocus(windowed, folder.turnActivities(), new Set(), true)
   assert.equal(blocks[0]?.kind === 'message' ? blocks[0].message.kind : '', 'summary')
+})
+
+// ── expanded chronology (plan: steer rows return to their position) ─────
+
+/** A turn with an initial user, thinking, a tool, a MID-TURN steer, and a
+ * final answer: user → thinking → tool → user(steer) → assistant → end. */
+function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionEvent[] {
+  return [
+    eventAt('turn/start', { turn }, startTime, baseSeq),
+    eventAt('user/message', {
+      id: MessageId(`msg-u-${turn}`), role: 'user',
+      content: [{ type: 'text', text: `initial prompt ${turn}` }],
+      source: { kind: 'user' },
+    }, startTime + 1, baseSeq + 1),
+    eventAt('assistant/chunk', { turn, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, startTime + 2, baseSeq + 2),
+    eventAt('tool/call', { turn, step: 0, callId: ToolCallId(`c-${turn}-1`), name: 'read', arguments: '{}' }, startTime + 3, baseSeq + 3),
+    eventAt('tool/result', {
+      turn, step: 0,
+      message: {
+        id: MessageId(`r-${turn}`), role: 'user',
+        content: [{ type: 'tool-result', toolCallId: ToolCallId(`c-${turn}-1`), content: [{ type: 'text', text: 'ok' }] }],
+        source: { kind: 'tool', callId: ToolCallId(`c-${turn}-1`) },
+      },
+    }, startTime + 4, baseSeq + 4),
+    eventAt('user/message', {
+      id: MessageId(`msg-s-${turn}`), role: 'user',
+      content: [{ type: 'text', text: `steer ${turn}` }],
+      source: { kind: 'user' },
+    }, startTime + 5, baseSeq + 5),
+    eventAt('assistant/message', {
+      turn, step: 1,
+      message: {
+        id: MessageId(`msg-a-${turn}`), role: 'assistant',
+        content: [{ type: 'text', text: `final answer ${turn}` }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+    }, startTime + 6, baseSeq + 6),
+    eventAt('turn/end', { turn, reason: { kind: 'completed' } }, startTime + 6000, baseSeq + 7),
+  ]
+}
+
+test('expanded: the initial user stays before the Thought; a mid-turn steer returns to its chronological position', () => {
+  const folder = new TranscriptFolder()
+  folder.apply(steeredTurn(0, 0, 1000))
+  const blocks = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  const kinds = blockKinds(blocks)
+  // user(initial) → activity → thinking → tool → user(steer) → assistant(final)
+  assert.deepEqual(kinds, ['user', 'activity', 'thinking', 'tool', 'user', 'assistant'],
+    `expanded chronology broken: ${kinds.join(',')}`)
+  const userTexts = blocks.flatMap(b => b.kind === 'message' && b.message.kind === 'user' ? [b.message.text] : [])
+  assert.deepEqual(userTexts, ['initial prompt 0', 'steer 0'],
+    'the initial user precedes the Thought; the steer follows the tool that preceded it')
+})
+
+test('expanded: multiple steers keep their relative chronology', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    ...steeredTurn(0, 0, 1000).slice(0, -1),
+    eventAt('user/message', {
+      id: MessageId('msg-s2'), role: 'user',
+      content: [{ type: 'text', text: 'second steer' }],
+      source: { kind: 'user' },
+    }, 2000, 50),
+    eventAt('assistant/message', {
+      turn: 0, step: 2,
+      message: { id: MessageId('a2'), role: 'assistant', content: [{ type: 'text', text: 'final after second steer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 2001, 51),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 2002, 52),
+  ])
+  const blocks = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  const userTexts = blocks.flatMap(b => b.kind === 'message' && b.message.kind === 'user' ? [b.message.text] : [])
+  assert.deepEqual(userTexts, ['initial prompt 0', 'steer 0', 'second steer'], 'steers keep their order')
+  const kinds = blockKinds(blocks)
+  const userIndexes = kinds.map((kind, index) => kind === 'user' ? index : -1).filter(index => index >= 0)
+  // The initial user stays at 0 (before the Thought); both steers land
+  // AFTER the tool (index 3) in their original order — the second steer
+  // follows the first assistant that preceded it (index 6).
+  assert.deepEqual(userIndexes, [0, 4, 6],
+    `steer chronology broken: ${kinds.join(',')}`)
+})
+
+test('expanded: user rows never carry the owner collapse mark; process rows always do', () => {
+  const folder = new TranscriptFolder()
+  folder.apply(steeredTurn(0, 0, 1000))
+  const blocks = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  for (const block of blocks) {
+    if (block.kind !== 'message') continue
+    if (block.message.kind === 'user') {
+      assert.equal(block.collapseFocusOwnerOnClick, undefined,
+        `a user row must never collapse the owner Thought: ${block.message.text}`)
+    } else if (block.message.kind === 'assistant') {
+      assert.equal(block.collapseFocusOwnerOnClick, undefined, 'the final assistant never carries the owner mark')
+    } else {
+      assert.equal(block.collapseFocusOwnerOnClick, 0,
+        `a process row must carry the owner-turn collapse mark: ${block.message.kind}`)
+    }
+  }
+})
+
+test('expanded: a turn with NO initial user starts with the Thought (chronology intact)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1001, 1),
+    eventAt('user/message', {
+      id: MessageId('late'), role: 'user',
+      content: [{ type: 'text', text: 'late steer' }],
+      source: { kind: 'user' },
+    }, 1002, 2),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1003, 3),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1004, 4),
+  ])
+  const blocks = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  assert.deepEqual(blockKinds(blocks), ['activity', 'thinking', 'user', 'assistant'],
+    'no initial user → the Thought leads and the steer stays chronological')
+})
+
+test('fold → expand → fold projection is reversible (same collapsed output)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply(steeredTurn(0, 0, 1000))
+  const collapsed = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  const refolded = projectFocus(
+    expanded.map(block => block.kind === 'message' ? block.message : null).filter((m): m is TranscriptMessage => m !== null),
+    folder.turnActivities(),
+    new Set(),
+    true,
+  )
+  // The collapsed projection of the expanded output equals the original
+  // collapsed projection: user rows first, then the Thought, then the final.
+  assert.deepEqual(blockKinds(refolded), blockKinds(collapsed), 'refold must reproduce the collapsed summary')
+  const collapsedUsers = collapsed.flatMap(b => b.kind === 'message' && b.message.kind === 'user' ? [b.message.text] : [])
+  const refoldedUsers = refolded.flatMap(b => b.kind === 'message' && b.message.kind === 'user' ? [b.message.text] : [])
+  assert.deepEqual(refoldedUsers, collapsedUsers, 'the collapsed user-first summary is stable')
 })
 
 // ── system prompt (plan §55) ────────────────────────────────────────────

--- a/test/footer-command-trust.test.ts
+++ b/test/footer-command-trust.test.ts
@@ -209,6 +209,7 @@ test('TuiSettingsDoc round-trip: a whole-document replace never wipes the truste
     localShellSandbox: 'bypass',
     homeEndKeys: 'input',
     focusMode: 'off',
+    wheelScrollLines: '1',
     keybindings: { version: 1, bindings: {} },
   }
   const port = new DirectConfigPort({ get: () => ({ describe: () => [{ ns: 'dsh-pi-tui', user: { footerCommand } }] }) } as never, {

--- a/test/footer-command.test.ts
+++ b/test/footer-command.test.ts
@@ -102,7 +102,7 @@ function fakeSettings(initial: { footer: string; footerLayout?: unknown; footerF
         busyEnter: 'queue',
         localShellSandbox: 'bypass',
         homeEndKeys: 'viewport',
-        focusMode: 'off',
+        focusMode: 'off', wheelScrollLines: '1',
       }),
       replace: (next: { footer: string; footerLayout?: unknown; footerFallbackMode?: string; footerCustomItems?: unknown }) => {
         doc.footer = next.footer
@@ -126,7 +126,7 @@ test('footer, focus, and fullscreen writes share one FIFO at the live commit poi
     busyEnter: 'queue',
     localShellSandbox: 'bypass',
     homeEndKeys: 'viewport',
-    focusMode: 'off',
+    focusMode: 'off', wheelScrollLines: '1',
   }
   const pending: Array<{ next: ReturnType<TuiSettingsLike['get']>; resolve: () => void }> = []
   const settings: TuiSettingsLike = {
@@ -170,7 +170,7 @@ test('a failed whole-document settings write does not block later queued writes'
     busyEnter: 'queue',
     localShellSandbox: 'bypass',
     homeEndKeys: 'viewport',
-    focusMode: 'off',
+    focusMode: 'off', wheelScrollLines: '1',
   }
   let calls = 0
   let rejectFirst: (error: Error) => void = () => {}
@@ -348,7 +348,7 @@ test('/footer serializes overlapping saves and re-reads future USER definitions'
     busyEnter: 'queue',
     localShellSandbox: 'bypass',
     homeEndKeys: 'viewport',
-    focusMode: 'off',
+    focusMode: 'off', wheelScrollLines: '1',
     footerCustomItems: userRaw,
   }
   const pendingWrites: Array<{ next: ReturnType<TuiSettingsLike['get']>; resolve: () => void }> = []
@@ -766,7 +766,7 @@ test('/footer Enter with a FAILED settings write keeps the old layout and notifi
   // A settings document whose replace REJECTS (the write fails).
   const doc = { footer: 'default' as string, footerLayout: undefined as unknown }
   const failingSettings: TuiSettingsLike = {
-    get: () => ({ theme: 'auto', iconStyle: 'emoji', footer: doc.footer, footerLayout: doc.footerLayout, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }),
+    get: () => ({ theme: 'auto', iconStyle: 'emoji', footer: doc.footer, footerLayout: doc.footerLayout, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1' }),
     replace: () => { throw new Error('write failed') },
   }
   const applied: Array<{ footer: string }> = []
@@ -850,7 +850,7 @@ test('/settings footer change is PERSIST-FIRST: a failed write keeps the old lay
   ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
   const doc = { footer: 'default' as string, footerLayout: undefined as unknown }
   const failingSettings: TuiSettingsLike = {
-    get: () => ({ theme: 'auto', iconStyle: 'emoji', footer: doc.footer, footerLayout: doc.footerLayout, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }),
+    get: () => ({ theme: 'auto', iconStyle: 'emoji', footer: doc.footer, footerLayout: doc.footerLayout, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1' }),
     replace: () => { throw new Error('write failed') },
   }
   const applied: Array<{ footer: string }> = []
@@ -1023,7 +1023,7 @@ test('/footer save failures notify exactly once (validation and write failures)'
     get: () => ({
       theme: 'auto', iconStyle: 'emoji', footer: 'default', fullscreen: 'on',
       busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport',
-      focusMode: 'off', footerCustomItems: [known],
+      focusMode: 'off', wheelScrollLines: '1', footerCustomItems: [known],
     }),
     replace: () => new Promise<void>((_resolve, reject) => { rejectReplace = reject }),
   }
@@ -1249,7 +1249,7 @@ test('PR D: a FAILED save never executes the new command (draft preserved, marke
     ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
     const doc = { footer: 'default' as string, footerLayout: undefined as unknown, footerCustomItems: undefined as unknown }
     const failingSettings: TuiSettingsLike = {
-      get: () => ({ theme: 'auto', iconStyle: 'emoji', footer: doc.footer, footerLayout: doc.footerLayout, footerCustomItems: doc.footerCustomItems as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }),
+      get: () => ({ theme: 'auto', iconStyle: 'emoji', footer: doc.footer, footerLayout: doc.footerLayout, footerCustomItems: doc.footerCustomItems as never, fullscreen: 'on', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1' }),
       replace: () => { throw new Error('write failed') },
     }
     const applied: Array<{ footer: string }> = []

--- a/test/icon-style-settings.test.ts
+++ b/test/icon-style-settings.test.ts
@@ -66,6 +66,7 @@ function setupSettings(options: { iconStyle?: string } = {}) {
     localShellSandbox: 'bypass',
     homeEndKeys: 'viewport',
     focusMode: 'off',
+    wheelScrollLines: '1',
     ...(options.iconStyle === undefined ? {} : { iconStyle: options.iconStyle }),
   })
   const runner: TuiCommandRunner = {

--- a/test/keybinding-ui-controller.test.ts
+++ b/test/keybinding-ui-controller.test.ts
@@ -23,6 +23,7 @@ function settingsFixture(initialKeybindings: unknown, footerCustomItems?: unknow
     localShellSandbox: 'off',
     homeEndKeys: 'off',
     focusMode: 'off',
+    wheelScrollLines: '1',
     footerCommand: { command: 'printf status', intervalMs: 1000 },
     ...footerCustomItems === undefined ? {} : { footerCustomItems },
     unrelated: 'preserved',
@@ -325,6 +326,7 @@ test('shared settings mutations serialize and preserve both concurrent edits', a
     localShellSandbox: 'off',
     homeEndKeys: 'off',
     focusMode: 'off',
+    wheelScrollLines: '1',
   }
   let gets = 0
   let replaces = 0
@@ -386,6 +388,7 @@ test('the shared queue also preserves an unrelated whole-document settings write
     localShellSandbox: 'off',
     homeEndKeys: 'off',
     focusMode: 'off',
+    wheelScrollLines: '1',
   }
   let replaces = 0
   const firstReplaceStarted = deferred<void>()

--- a/test/preset-command.test.ts
+++ b/test/preset-command.test.ts
@@ -322,6 +322,7 @@ test('/keybindings opens sessionless without creating a session', async () => {
       localShellSandbox: 'bypass',
       homeEndKeys: 'viewport',
       focusMode: 'off',
+    wheelScrollLines: '1',
       iconStyle: 'emoji',
       keybindings: undefined,
     }),
@@ -663,7 +664,7 @@ function reloadSettings(theme: string, onGet?: (count: number) => void): TuiSett
     get: () => {
       reads += 1
       onGet?.(reads)
-      return { theme: currentTheme, iconStyle: 'emoji', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off' }
+      return { theme: currentTheme, iconStyle: 'emoji', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1' }
     },
     replace: doc => { currentTheme = doc.theme as string },
   }
@@ -820,7 +821,7 @@ test('/keybindings reload re-reads the settings document LAZILY (the explicit re
   // reload time (a stale cached parse would miss a later settings edit).
   let settingsDoc = {
     theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue',
-    localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off',
+    localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1',
     iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' },
   }
   let reads = 0
@@ -859,6 +860,7 @@ test('/keybindings reload queues behind an editor write and applies the latest d
     localShellSandbox: 'bypass',
     homeEndKeys: 'viewport',
     focusMode: 'off',
+    wheelScrollLines: '1',
     iconStyle: 'emoji',
     keybindings: { 'app.input.steer': 'ctrl+x' },
   }
@@ -922,6 +924,7 @@ test('/keybindings reset queues behind an editor write and keeps the final reset
     localShellSandbox: 'bypass',
     homeEndKeys: 'viewport',
     focusMode: 'off',
+    wheelScrollLines: '1',
     iconStyle: 'emoji',
     keybindings: undefined,
   }
@@ -976,7 +979,7 @@ test('/keybindings reset awaits the settings write, applies the cleared config, 
   // now-keybindings-less document.
   let replaced = 0
   const failing: TuiSettingsLike = {
-    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }),
+    get: () => ({ theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }),
     replace: async () => { replaced += 1; throw new Error('write refused') },
   }
   let t = setup({ tuiSettings: failing })
@@ -1003,7 +1006,7 @@ test('/keybindings reset awaits the settings write, applies the cleared config, 
     get: () => {
       okReads += 1
       if (okReads > 1) throw new Error('no second read allowed')
-      return { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }
+      return { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }
     },
     replace: async () => { okReplaced += 1 },
   }
@@ -1064,7 +1067,7 @@ test('/keybindings reload is fail-soft: a throwing settings read keeps the last-
   const tuiSettings: TuiSettingsLike = {
     get: () => {
       if (failing) throw new Error('settings read exploded')
-      return { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }
+      return { theme: 'auto', footer: 'full', fullscreen: 'off', busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'viewport', focusMode: 'off', wheelScrollLines: '1', iconStyle: 'emoji', keybindings: { 'app.input.steer': 'ctrl+x' } }
     },
     replace: async () => {},
   }

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -1015,24 +1015,19 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
   const previousHome = process.env.DSH_HOME
   process.env.DSH_HOME = home
   const probe = installProbe()
-  // Capture the runner's DIRECT stdout writes (the status seam) and the
-  // cordis logger messages into ONE ordered log: the TUI itself writes
-  // through the ProcessTerminal, so filtering for the status strings
-  // isolates exactly the pre-mount status lines, and the shared order
-  // lets the failure path assert that the status is suspended BEFORE the
-  // failure logs (a TTY shares one cursor between stdout and stderr).
+  // Capture the runner's status writes through the INJECTED output seam
+  // (never a global process.stdout patch — that would fight the test
+  // reporter's own writes) and the cordis logger messages into ONE
+  // ordered log: the shared order lets the failure path assert that the
+  // status is suspended BEFORE the failure logs (a TTY shares one cursor
+  // between stdout and stderr).
   const orderedLog: string[] = []
-  const originalWrite = process.stdout.write.bind(process.stdout)
-  process.stdout.write = ((text: unknown) => {
-    const line = String(text)
-    orderedLog.push(`stdout:${line}`)
-    return true
-  }) as typeof process.stdout.write
-  // The status seam is TTY-gated: force the test runner's piped stdout to
-  // look interactive so the wiring is exercised (the pure helper tests
-  // cover the non-TTY silence).
-  const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
-  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+  const statusOutput = {
+    isTTY: true,
+    write: (text: string) => {
+      orderedLog.push(`stdout:${text}`)
+    },
+  }
   let resumeContext: Context | undefined
   let deferredContext: Context | undefined
   let failContext: Context | undefined
@@ -1047,7 +1042,7 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
     }
     const resumeHarness = makeHarness(home, resumed)
     resumeContext = new Context()
-    resumeFiber = await mountRunner(resumeContext, home, resumeHarness, { sessionId: resumed.id }, { sessionId: resumed.id })
+    resumeFiber = await mountRunner(resumeContext, home, resumeHarness, { sessionId: resumed.id }, { sessionId: resumed.id, startupStatusOutput: statusOutput })
     const statusWrites = orderedLog
       .filter(write => write.startsWith('stdout:') && (write.includes('Resuming session') || write.includes('Preparing conversation') || write === 'stdout:\r\x1b[2K'))
       .map(write => write.slice('stdout:'.length))
@@ -1079,7 +1074,7 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
     orderedLog.length = 0
     const deferredHarness = makeHarness(home)
     deferredContext = new Context()
-    deferredFiber = await mountRunner(deferredContext, home, deferredHarness, {}, {})
+    deferredFiber = await mountRunner(deferredContext, home, deferredHarness, {}, { startupStatusOutput: statusOutput })
     assert.ok(!orderedLog.some(write => write.includes('Resuming session')),
       `a fresh start must stay silent: ${JSON.stringify(orderedLog)}`)
 
@@ -1112,7 +1107,7 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
       })
     })
     await exporterFiber
-    failFiber = await mountRunner(failContext, home, failHarness, { sessionId: 'missing-session' }, { sessionId: 'missing-session' })
+    failFiber = await mountRunner(failContext, home, failHarness, { sessionId: 'missing-session' }, { sessionId: 'missing-session', startupStatusOutput: statusOutput })
     const failWrites = orderedLog.filter(write => write.includes('Resuming session') || write === 'stdout:\r\x1b[2K')
     assert.ok(failWrites.some(write => write.includes('Resuming session…')),
       `the failed resume still shows the status: ${JSON.stringify(failWrites)}`)
@@ -1130,9 +1125,89 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
     if (deferredContext !== undefined) await disposeContext(deferredContext)
     if (failContext !== undefined) await disposeContext(failContext)
     probe.restore()
-    process.stdout.write = originalWrite
-    if (originalIsTTY === undefined) delete (process.stdout as { isTTY?: boolean }).isTTY
-    else Object.defineProperty(process.stdout, 'isTTY', originalIsTTY)
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+
+test('the Preparing status stays on screen through the catalog ready barrier', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-catalog-barrier-'))
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  const probe = installProbe()
+  const orderedLog: string[] = []
+  const statusOutput = {
+    isTTY: true,
+    write: (text: string) => {
+      orderedLog.push(`stdout:${text}`)
+    },
+  }
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  try {
+    const resumed: FakeSession = {
+      id: 'slow-catalog-session',
+      header: { id: 'slow-catalog-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+      events: sessionEvents('resumed answer'),
+    }
+    const harness = makeHarness(home, resumed)
+    context = new Context()
+    // A SLOW skills service: the catalog ready barrier (resolveInitialCatalog
+    // → readSurfaceCatalog → readHumanSkillCatalog) takes ~300ms, so the
+    // test can observe the status while the barrier is still pending.
+    context.provide('skills', {
+      snapshot: async () => {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        return { skills: [], complete: true }
+      },
+    } as never)
+    // Start the mount WITHOUT awaiting: the barrier is in flight while
+    // the assertions below run.
+    const mountPromise = mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id, startupStatusOutput: statusOutput })
+    const statusWrites = (): string[] => orderedLog
+      .filter(write => write.startsWith('stdout:') && (write.includes('Preparing conversation') || write === 'stdout:\r\x1b[2K'))
+      .map(write => write.slice('stdout:'.length))
+    // Wait until the Preparing stage is on screen — the barrier is still
+    // pending (its slow skills read has not settled yet).
+    const deadline = Date.now() + 5000
+    let observed = false
+    while (Date.now() < deadline) {
+      const writes = statusWrites()
+      if (writes.some(write => write.includes('Preparing conversation'))) {
+        const last = writes[writes.length - 1]!
+        assert.ok(last.includes('Preparing conversation'),
+          `the status must STAY on screen through the catalog barrier (last write: ${JSON.stringify(last)}): ${JSON.stringify(writes)}`)
+        observed = true
+        break
+      }
+      await new Promise(resolve => setTimeout(resolve, 20))
+    }
+    assert.ok(observed, 'the Preparing stage must appear while the barrier is pending')
+    fiber = await mountPromise
+    // The fiber load settles when applyRunner returns (the startup IIFE
+    // is fire-and-forget), so the mount promise resolves BEFORE the
+    // barrier completes: wait for the runner to actually reach the
+    // mount-time clear — the barrier resolved and the TUI is about to
+    // mount.
+    const deadline2 = Date.now() + 5000
+    while (Date.now() < deadline2) {
+      const writes = statusWrites()
+      if (writes[writes.length - 1] === '\r\x1b[2K') break
+      await new Promise(resolve => setTimeout(resolve, 20))
+    }
+    const writes = statusWrites()
+    const last = writes[writes.length - 1]!
+    assert.equal(last, '\r\x1b[2K',
+      `the status must be cleared before mount: ${JSON.stringify(writes)}`)
+    // Let the post-mount wiring settle before the finally disposes the
+    // context (the runner's startup IIFE is fire-and-forget).
+    await new Promise(resolve => setTimeout(resolve, 200))
+  } finally {
+    if (fiber !== undefined) await fiber.dispose()
+    if (context !== undefined) await disposeContext(context)
+    probe.restore()
     if (previousHome === undefined) delete process.env.DSH_HOME
     else process.env.DSH_HOME = previousHome
     rmSync(home, { recursive: true, force: true })

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -511,6 +511,7 @@ test('the real runner hydrates resume, deferred create, and switch exactly once 
   }
 })
 
+
 test('switching between two old Sessions restores each Session own model', async () => {
   const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-runner-switch-'))
   const previousHome = process.env.DSH_HOME
@@ -557,10 +558,12 @@ test('/new without an explicit default intent observes the persisted default, ne
   const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-runner-new-default-'))
   const previousHome = process.env.DSH_HOME
   process.env.DSH_HOME = home
+
   const probe = installProbe()
   let context: Context | undefined
   let fiber: { dispose: () => Promise<unknown> } | undefined
   try {
+
     const resumed: FakeSession = {
       id: 'new-default-session',
       header: { id: 'new-default-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
@@ -875,6 +878,63 @@ test('a live /model choice survives an immediate exit and resume', async () => {
   }
 })
 
+test('startup applies the persisted wheel step BEFORE the first fullscreen mount', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-wheel-startup-'))
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  const vt = new VirtualTerminal(100, 30)
+  const restoreTerminal = installVirtualProcessTerminal(vt)
+
+  const probe = installProbe()
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  try {
+
+    // A long transcript so the first fullscreen frame can scroll.
+    const longText = Array.from({ length: 60 }, (_, index) => `line ${index}`).join('\n')
+    const resumed: FakeSession = {
+      id: 'wheel-startup-session',
+      header: { id: 'wheel-startup-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+      events: sessionEvents(longText),
+    }
+    const harness = makeHarness(home, resumed)
+    context = new Context()
+    // A settings service carrying the persisted wheel step AND fullscreen
+    // 'on': the runner must hand the step to the app BEFORE the first
+    // alt-screen mount (the fork reads it at construction).
+    const doc: Record<string, unknown> = {
+      theme: 'auto', iconStyle: 'emoji', footer: 'full', fullscreen: 'on',
+      busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input',
+      focusMode: 'off', wheelScrollLines: '8',
+    }
+    context.provide('settings', {
+      register: () => ({
+        get: () => ({ ...doc }),
+        replace: async (next: Record<string, unknown>) => { Object.assign(doc, next) },
+      }),
+    } as never)
+    fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+    const app = probe.apps.at(-1)
+    assert.ok(app, 'the production runner must create a TuiApp')
+    await vt.waitForRender()
+    const bottom = app.fullscreenScrollForTest()
+    assert.ok(bottom !== undefined && bottom.maxScrollTop > 0, 'precondition: scrollable transcript')
+    vt.sendInput('\x1b[<64;50;10M') // wheel up over the transcript pane
+    await vt.waitForRender()
+    const after = app.fullscreenScrollForTest()
+    assert.equal(after?.scrollTop, bottom.maxScrollTop - 8,
+      'the FIRST fullscreen mount must already use the persisted wheel step (apply before setFullscreen)')
+  } finally {
+    if (fiber !== undefined) await fiber.dispose()
+    if (context !== undefined) await disposeContext(context)
+    probe.restore()
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+
 test('live repaint preserves manual scrolling in the latest window', async () => {
   const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-live-follow-'))
   const previousHome = process.env.DSH_HOME
@@ -944,6 +1004,104 @@ test('live repaint preserves manual scrolling in the latest window', async () =>
     if (context !== undefined) await disposeContext(context)
     probe.restore()
     restoreTerminal()
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('explicit cold resume shows the pre-mount status and clears it before mount; fresh start stays silent', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-startup-status-'))
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  const probe = installProbe()
+  // Capture the runner's DIRECT stdout writes (the status seam). The TUI
+  // itself writes through the ProcessTerminal, so filtering for the status
+  // strings isolates exactly the pre-mount status lines.
+  const stdoutWrites: string[] = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((text: unknown) => {
+    stdoutWrites.push(String(text))
+    return true
+  }) as typeof process.stdout.write
+  // The status seam is TTY-gated: force the test runner's piped stdout to
+  // look interactive so the wiring is exercised (the pure helper tests
+  // cover the non-TTY silence).
+  const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+  let resumeContext: Context | undefined
+  let deferredContext: Context | undefined
+  let failContext: Context | undefined
+  let resumeFiber: { dispose: () => Promise<unknown> } | undefined
+  let deferredFiber: { dispose: () => Promise<unknown> } | undefined
+  let failFiber: { dispose: () => Promise<unknown> } | undefined
+  try {
+    const resumed: FakeSession = {
+      id: 'startup-status-session',
+      header: { id: 'startup-status-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+      events: sessionEvents('resumed answer'),
+    }
+    const resumeHarness = makeHarness(home, resumed)
+    resumeContext = new Context()
+    resumeFiber = await mountRunner(resumeContext, home, resumeHarness, { sessionId: resumed.id }, { sessionId: resumed.id })
+    const statusWrites = stdoutWrites.filter(write =>
+      write.includes('Resuming session') || write.includes('Preparing conversation') || write === '\r\x1b[2K')
+    assert.ok(statusWrites.some(write => write.includes('Resuming session…')),
+      `the resume status must be written before mount: ${JSON.stringify(statusWrites)}`)
+    assert.ok(statusWrites.some(write => write.includes('Preparing conversation…')),
+      `the preparing stage must replace the resume line: ${JSON.stringify(statusWrites)}`)
+    const showIndexes = statusWrites
+      .map((write, index) => write.includes('Resuming') || write.includes('Preparing') ? index : -1)
+      .filter(index => index >= 0)
+    const clearIndex = statusWrites.findIndex(write => write === '\r\x1b[2K')
+    assert.ok(clearIndex > showIndexes[showIndexes.length - 1]!,
+      `the status must be cleared after the last show (before mount): ${JSON.stringify(statusWrites)}`)
+    // The resume lifecycle is untouched: exactly one hydration, no extra
+    // transcript rows.
+    assert.equal(probe.transcriptHydrateCount, 1)
+    assert.equal(probe.statsHydrateCount, 1)
+    assert.equal(probe.transcriptApplyCount, 1)
+
+    await resumeFiber.dispose()
+    await disposeContext(resumeContext)
+    resumeFiber = undefined
+    resumeContext = undefined
+
+    // A fresh (deferred) start must not emit the resume status.
+    stdoutWrites.length = 0
+    const deferredHarness = makeHarness(home)
+    deferredContext = new Context()
+    deferredFiber = await mountRunner(deferredContext, home, deferredHarness, {}, {})
+    assert.ok(!stdoutWrites.some(write => write.includes('Resuming session')),
+      `a fresh start must stay silent: ${JSON.stringify(stdoutWrites)}`)
+
+    await deferredFiber.dispose()
+    await disposeContext(deferredContext)
+    deferredFiber = undefined
+    deferredContext = undefined
+
+    // A FAILED resume also clears the status (the surface starts
+    // sessionless — no stale line may survive).
+    stdoutWrites.length = 0
+    const failHarness = makeHarness(home) // no persisted session
+    failContext = new Context()
+    failFiber = await mountRunner(failContext, home, failHarness, { sessionId: 'missing-session' }, { sessionId: 'missing-session' })
+    const failWrites = stdoutWrites.filter(write => write.includes('Resuming session') || write === '\r\x1b[2K')
+    assert.ok(failWrites.some(write => write.includes('Resuming session…')),
+      `the failed resume still shows the status: ${JSON.stringify(failWrites)}`)
+    assert.ok(failWrites.some(write => write === '\r\x1b[2K'),
+      `the failed resume clears the status: ${JSON.stringify(failWrites)}`)
+  } finally {
+    if (resumeFiber !== undefined) await resumeFiber.dispose()
+    if (deferredFiber !== undefined) await deferredFiber.dispose()
+    if (failFiber !== undefined) await failFiber.dispose()
+    if (resumeContext !== undefined) await disposeContext(resumeContext)
+    if (deferredContext !== undefined) await disposeContext(deferredContext)
+    if (failContext !== undefined) await disposeContext(failContext)
+    probe.restore()
+    process.stdout.write = originalWrite
+    if (originalIsTTY === undefined) delete (process.stdout as { isTTY?: boolean }).isTTY
+    else Object.defineProperty(process.stdout, 'isTTY', originalIsTTY)
     if (previousHome === undefined) delete process.env.DSH_HOME
     else process.env.DSH_HOME = previousHome
     rmSync(home, { recursive: true, force: true })

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -378,7 +378,7 @@ async function mountRunner(
   ctx: Context,
   home: string,
   harness: RunnerHarness,
-  startup: { sessionId?: string },
+  startup: { sessionId?: string; presetId?: string },
   config: Config,
 ) {
   ctx.provide('appExit', () => {})
@@ -1204,6 +1204,48 @@ test('the Preparing status stays on screen through the catalog ready barrier', a
     // Let the post-mount wiring settle before the finally disposes the
     // context (the runner's startup IIFE is fire-and-forget).
     await new Promise(resolve => setTimeout(resolve, 200))
+  } finally {
+    if (fiber !== undefined) await fiber.dispose()
+    if (context !== undefined) await disposeContext(context)
+    probe.restore()
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('a fresh start with a FAILING preset resolution stays silent (no Preparing status)', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-pi-tui-fresh-preset-fail-'))
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  const probe = installProbe()
+  const orderedLog: string[] = []
+  const statusOutput = {
+    isTTY: true,
+    write: (text: string) => {
+      orderedLog.push(`stdout:${text}`)
+    },
+  }
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  try {
+    // Deferred start (no sessionId) with a BROKEN agentPresets roster:
+    // every compose throws (the launch-preset fallback AND the default
+    // fallback), so the catalog block's catch runs. The failure path
+    // must NOT re-arm the startup status — a fresh start never shows
+    // any status, on the happy path OR the failure path.
+    const harness = makeHarness(home)
+    context = new Context()
+    context.provide('agentPresets', {
+      defaultId: 'standard',
+      resolve: async () => { throw new Error('roster broken') },
+    } as never)
+    fiber = await mountRunner(context, home, harness, {}, { startupStatusOutput: statusOutput })
+    assert.ok(!orderedLog.some(write => write.includes('Resuming session') || write.includes('Preparing conversation')),
+      `a fresh start with a failing preset must not show any startup status: ${JSON.stringify(orderedLog)}`)
+    // The TUI still mounts (degraded — the failure is a one-shot warn).
+    const app = probe.apps.at(-1)
+    assert.ok(app, 'the production runner must still create a TuiApp')
   } finally {
     if (fiber !== undefined) await fiber.dispose()
     if (context !== undefined) await disposeContext(context)

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -1015,13 +1015,17 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
   const previousHome = process.env.DSH_HOME
   process.env.DSH_HOME = home
   const probe = installProbe()
-  // Capture the runner's DIRECT stdout writes (the status seam). The TUI
-  // itself writes through the ProcessTerminal, so filtering for the status
-  // strings isolates exactly the pre-mount status lines.
-  const stdoutWrites: string[] = []
+  // Capture the runner's DIRECT stdout writes (the status seam) and the
+  // cordis logger messages into ONE ordered log: the TUI itself writes
+  // through the ProcessTerminal, so filtering for the status strings
+  // isolates exactly the pre-mount status lines, and the shared order
+  // lets the failure path assert that the status is suspended BEFORE the
+  // failure logs (a TTY shares one cursor between stdout and stderr).
+  const orderedLog: string[] = []
   const originalWrite = process.stdout.write.bind(process.stdout)
   process.stdout.write = ((text: unknown) => {
-    stdoutWrites.push(String(text))
+    const line = String(text)
+    orderedLog.push(`stdout:${line}`)
     return true
   }) as typeof process.stdout.write
   // The status seam is TTY-gated: force the test runner's piped stdout to
@@ -1044,8 +1048,9 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
     const resumeHarness = makeHarness(home, resumed)
     resumeContext = new Context()
     resumeFiber = await mountRunner(resumeContext, home, resumeHarness, { sessionId: resumed.id }, { sessionId: resumed.id })
-    const statusWrites = stdoutWrites.filter(write =>
-      write.includes('Resuming session') || write.includes('Preparing conversation') || write === '\r\x1b[2K')
+    const statusWrites = orderedLog
+      .filter(write => write.startsWith('stdout:') && (write.includes('Resuming session') || write.includes('Preparing conversation') || write === 'stdout:\r\x1b[2K'))
+      .map(write => write.slice('stdout:'.length))
     assert.ok(statusWrites.some(write => write.includes('Resuming session…')),
       `the resume status must be written before mount: ${JSON.stringify(statusWrites)}`)
     assert.ok(statusWrites.some(write => write.includes('Preparing conversation…')),
@@ -1053,8 +1058,11 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
     const showIndexes = statusWrites
       .map((write, index) => write.includes('Resuming') || write.includes('Preparing') ? index : -1)
       .filter(index => index >= 0)
-    const clearIndex = statusWrites.findIndex(write => write === '\r\x1b[2K')
-    assert.ok(clearIndex > showIndexes[showIndexes.length - 1]!,
+    // The status is suspended before the success log (a mid-resume clear)
+    // and cleared again before mount: the LAST clear must follow the last
+    // show.
+    const lastClearIndex = statusWrites.map((write, index) => write === '\r\x1b[2K' ? index : -1).filter(index => index >= 0).at(-1)
+    assert.ok(lastClearIndex !== undefined && lastClearIndex > showIndexes[showIndexes.length - 1]!,
       `the status must be cleared after the last show (before mount): ${JSON.stringify(statusWrites)}`)
     // The resume lifecycle is untouched: exactly one hydration, no extra
     // transcript rows.
@@ -1068,12 +1076,12 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
     resumeContext = undefined
 
     // A fresh (deferred) start must not emit the resume status.
-    stdoutWrites.length = 0
+    orderedLog.length = 0
     const deferredHarness = makeHarness(home)
     deferredContext = new Context()
     deferredFiber = await mountRunner(deferredContext, home, deferredHarness, {}, {})
-    assert.ok(!stdoutWrites.some(write => write.includes('Resuming session')),
-      `a fresh start must stay silent: ${JSON.stringify(stdoutWrites)}`)
+    assert.ok(!orderedLog.some(write => write.includes('Resuming session')),
+      `a fresh start must stay silent: ${JSON.stringify(orderedLog)}`)
 
     await deferredFiber.dispose()
     await disposeContext(deferredContext)
@@ -1081,16 +1089,39 @@ test('explicit cold resume shows the pre-mount status and clears it before mount
     deferredContext = undefined
 
     // A FAILED resume also clears the status (the surface starts
-    // sessionless — no stale line may survive).
-    stdoutWrites.length = 0
+    // sessionless — no stale line may survive), and the clear happens
+    // BEFORE the failure logs: the status owns the current terminal
+    // line, so a logger write must never interleave with it (a TTY
+    // shares one cursor between stdout and stderr).
+    orderedLog.length = 0
     const failHarness = makeHarness(home) // no persisted session
-    failContext = new Context()
+    const failCtx = new Context()
+    failContext = failCtx
+    // Capture the runner's failure logs through the cordis logger
+    // exporter (the same sink a real deployment registers). The exporter
+    // threshold lives in `levels.default` (the MAXIMUM level exported):
+    // WARN (2) admits the runner's warn/error lines (the default INFO
+    // threshold would drop them). Registered inside a fiber — cordis
+    // registers exporters through ctx.effect.
+    const exporterFiber = failCtx.plugin(() => {
+      failCtx.logger.exporter({
+        levels: { default: 2 },
+        export: (message) => {
+          orderedLog.push(`log:${message.name}:${message.args.map(String).join(' ')}`)
+        },
+      })
+    })
+    await exporterFiber
     failFiber = await mountRunner(failContext, home, failHarness, { sessionId: 'missing-session' }, { sessionId: 'missing-session' })
-    const failWrites = stdoutWrites.filter(write => write.includes('Resuming session') || write === '\r\x1b[2K')
+    const failWrites = orderedLog.filter(write => write.includes('Resuming session') || write === 'stdout:\r\x1b[2K')
     assert.ok(failWrites.some(write => write.includes('Resuming session…')),
       `the failed resume still shows the status: ${JSON.stringify(failWrites)}`)
-    assert.ok(failWrites.some(write => write === '\r\x1b[2K'),
+    assert.ok(failWrites.some(write => write === 'stdout:\r\x1b[2K'),
       `the failed resume clears the status: ${JSON.stringify(failWrites)}`)
+    const clearIndexInLog = orderedLog.findIndex(write => write === 'stdout:\r\x1b[2K')
+    const warnIndexInLog = orderedLog.findIndex(write => write.startsWith('log:') && write.includes('resume missing-session failed'))
+    assert.ok(clearIndexInLog >= 0 && warnIndexInLog > clearIndexInLog,
+      `the status must be cleared BEFORE the failure log (clear at ${clearIndexInLog}, warn at ${warnIndexInLog}): ${JSON.stringify(orderedLog)}`)
   } finally {
     if (resumeFiber !== undefined) await resumeFiber.dispose()
     if (deferredFiber !== undefined) await deferredFiber.dispose()

--- a/test/session-state.test.ts
+++ b/test/session-state.test.ts
@@ -1630,7 +1630,7 @@ test('/settings theme pick persists the BUILTIN choice too (review P1: the trans
   const runner = stubRunner(ctx, app, { agent: fakeAgent('session-a'), generation: 1 })
   const doc: Record<string, unknown> = {
     theme: 'dark', iconStyle: 'emoji', footer: 'default', fullscreen: 'off',
-    busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off',
+    busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off', wheelScrollLines: '1',
     footerCustomItems: projectFooterCustomItems,
   }
   const persisted: Array<{ theme: unknown; footerCustomItems: unknown }> = []
@@ -1691,7 +1691,7 @@ test('/settings theme write aborts when USER custom storage is unavailable', asy
   const projectFooterCustomItems = [{ schemaVersion: 1, id: 'user:project', kind: 'text', text: 'PROJECT' }]
   const doc: Record<string, unknown> = {
     theme: 'dark', iconStyle: 'emoji', footer: 'default', fullscreen: 'off',
-    busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off',
+    busyEnter: 'queue', localShellSandbox: 'bypass', homeEndKeys: 'input', focusMode: 'off', wheelScrollLines: '1',
     footerCustomItems: projectFooterCustomItems,
   }
   const persisted: Record<string, unknown>[] = []

--- a/test/startup-status.test.ts
+++ b/test/startup-status.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Pre-mount startup status helper tests: TTY show/update/clear, clear
+ * idempotence, non-TTY silence, and no stale text after clear.
+ * @module @xmoon76/dsh-pi-tui/startup-status.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createStartupStatus, type StartupStatusOutput } from '../src/startup-status.ts'
+
+/** A recording output seam. */
+function recordingOutput(isTTY = true): { writes: string[]; output: StartupStatusOutput } {
+  const writes: string[] = []
+  return {
+    writes,
+    output: {
+      isTTY,
+      write: (text) => {
+        writes.push(text)
+        return undefined
+      },
+    },
+  }
+}
+
+test('TTY show writes CR + erase-line + message', () => {
+  const { writes, output } = recordingOutput()
+  const status = createStartupStatus(output)
+  status.show('Resuming session…')
+  assert.deepEqual(writes, ['\r\x1b[2KResuming session…'])
+})
+
+test('TTY update overwrites the line in place (no accumulation)', () => {
+  const { writes, output } = recordingOutput()
+  const status = createStartupStatus(output)
+  status.show('Resuming session…')
+  status.show('Preparing conversation…')
+  assert.deepEqual(writes, [
+    '\r\x1b[2KResuming session…',
+    '\r\x1b[2KPreparing conversation…',
+  ])
+})
+
+test('clear erases the line and is idempotent', () => {
+  const { writes, output } = recordingOutput()
+  const status = createStartupStatus(output)
+  status.show('Resuming session…')
+  status.clear()
+  status.clear()
+  assert.deepEqual(writes, ['\r\x1b[2KResuming session…', '\r\x1b[2K'])
+})
+
+test('clear before any show writes nothing', () => {
+  const { writes, output } = recordingOutput()
+  const status = createStartupStatus(output)
+  status.clear()
+  assert.deepEqual(writes, [])
+})
+
+test('non-TTY output is completely silent', () => {
+  const { writes, output } = recordingOutput(false)
+  const status = createStartupStatus(output)
+  status.show('Resuming session…')
+  status.show('Preparing conversation…')
+  status.clear()
+  assert.deepEqual(writes, [], 'a pipe / CI must never see the status')
+})
+
+test('show after clear re-arms the line (a later clear erases again)', () => {
+  const { writes, output } = recordingOutput()
+  const status = createStartupStatus(output)
+  status.show('Resuming session…')
+  status.clear()
+  status.show('Preparing conversation…')
+  status.clear()
+  assert.deepEqual(writes, [
+    '\r\x1b[2KResuming session…',
+    '\r\x1b[2K',
+    '\r\x1b[2KPreparing conversation…',
+    '\r\x1b[2K',
+  ])
+})
+
+test('isTTY defaults to true when the output does not declare it', () => {
+  const writes: string[] = []
+  const status = createStartupStatus({ write: (text) => { writes.push(text) } })
+  status.show('Resuming session…')
+  assert.deepEqual(writes, ['\r\x1b[2KResuming session…'])
+})

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -1610,5 +1610,95 @@ test('a replacement assistant/message does not mutate Focus activity', () => {
   assert.equal(assistant.text, 'first answer', 'append-origin assistant text must survive')
 })
 
+// ── Focus Message slot: bounded multiline tail (plan: the fold keeps
+// the tail's line structure; the renderer wraps and shows the last rows) ──
+
+test('the Message slot keeps a MULTILINE candidate tail (never flattened to one line)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'line one\nline two\nline three' } }, 1),
+  ])
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message?.text, 'line one\nline two\nline three',
+    'syncMessage must preserve the multiline tail for the renderer')
+})
+
+test('a confirmed intermediate message keeps its bounded LATEST tail (multiline)', () => {
+  const folder = new TranscriptFolder()
+  const long = 'head\n' + 'x'.repeat(600) + '\ntail marker'
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: long } }, 1),
+    // A tool call confirms the candidate as an intermediate message.
+    event('tool/call', { turn: 0, step: 0, callId: ToolCallId('c1'), name: 'read', arguments: '{}' }, 2),
+  ])
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  const message = activity.message
+  const length = message?.text.length ?? 0
+  assert.ok(message?.text.endsWith('tail marker'), 'the confirmed slot keeps the newest content')
+  assert.ok(message !== undefined && length <= 400,
+    `the confirmed slot stays bounded to MESSAGE_TAIL_CAP (${length})`)
+  assert.ok(message?.text.includes('\n'), 'the confirmed multiline structure survives')
+})
+
+test('a later authoritative message updates the correct step in place (multiline tail)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'streamed\nfragment' } }, 1),
+    event('assistant/message', {
+      turn: 0, step: 0,
+      message: { id: MessageId('a1'), role: 'assistant', content: [{ type: 'text', text: 'settled\nmultiline\nanswer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 2),
+  ])
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message?.text, 'settled\nmultiline\nanswer',
+    'the authoritative text replaces the streamed tail in place')
+})
+
+test('a stale older step never resurrects the Message slot', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'step zero text' } }, 1),
+    event('assistant/message', {
+      turn: 0, step: 0,
+      message: { id: MessageId('a0'), role: 'assistant', content: [{ type: 'text', text: 'step zero settled' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 2),
+    event('assistant/chunk', { turn: 0, step: 1, chunk: { type: 'text-delta', index: 0, text: 'step one text' } }, 3),
+    event('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('a1'), role: 'assistant', content: [{ type: 'text', text: 'step one settled' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 4),
+  ])
+  const before = folder.turnActivity(0)
+  assert.ok(before !== undefined)
+  assert.equal(before.message?.text, 'step one settled', 'the LATEST intermediate wins')
+  // A late replay for the OLDER step must not roll the slot back.
+  folder.apply([event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'stale replay' } }, 5)])
+  const after = folder.turnActivity(0)
+  assert.equal(after?.message?.text, 'step one settled', 'a stale older-step delta never resurrects the slot')
+})
+
+test('the final answer never enters the Message slot (multiline final included)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'final\nanswer\nlines' } }, 1),
+    event('assistant/message', {
+      turn: 0, step: 0,
+      message: { id: MessageId('a1'), role: 'assistant', content: [{ type: 'text', text: 'final\nanswer\nlines' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 2),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 3),
+  ])
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message, undefined, 'a completed turn whose candidate IS the final leaves the slot empty')
+})
+
 
 

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -642,7 +642,7 @@ test('a tiny terminal clamps the todo click geometry to the visible screen', asy
   app.start()
   await vt.waitForRender()
   const todos = Array.from({ length: 3 }, (_, i) => ({
-    id: `t-${i}`, content: `todo item ${i}`,
+    content: `todo item ${i}`,
     status: i === 0 ? ('in_progress' as const) : ('pending' as const),
   }))
   app.setTodoSummary(todos)
@@ -652,17 +652,163 @@ test('a tiny terminal clamps the todo click geometry to the visible screen', asy
   assert.ok(!app.isTodoPanelExpanded(), 'starts compact')
   // Row 0 (SGR y=1) sits inside the clamped region [0, todoBottom): with
   // the footer (2) + editor seat (3) on the 6-row terminal, todoBottom
-  // clamps to 1 — expand.
+  // clamps to 1. With 3 todos (≤5) the panel is a two-state summary ↔
+  // list — the click CLOSES it directly (no redundant full state).
   vt.sendInput('\x1b[<0;40;1M')
   vt.sendInput('\x1b[<0;40;1m')
   await vt.waitForRender()
-  assert.ok(app.isTodoPanelExpanded(), 'a click inside the clamped region must expand')
-  // Row 5 (SGR y=6) sits in the editor/footer rows below the region: ignored.
+  assert.ok(!app.isTodoPanelVisible(), 'a click inside the clamped region closes the ≤5 panel (list → summary)')
+  // Reopen, then row 5 (SGR y=6) sits in the editor/footer rows below the
+  // region: ignored.
+  app.toggleTodoPanel()
+  await vt.waitForRender()
   vt.sendInput('\x1b[<0;40;6M')
   vt.sendInput('\x1b[<0;40;6m')
   await vt.waitForRender()
-  assert.ok(app.isTodoPanelExpanded(), 'a click outside the clamped region must be ignored')
+  assert.ok(app.isTodoPanelVisible(), 'a click outside the clamped region must be ignored')
   app.setFullscreen(false)
+  app.stop()
+})
+
+test('todo state machine: ≤5 items is a two-state summary ↔ list (no redundant full state)', async () => {
+  const { vt, app } = startApp()
+  await vt.waitForRender()
+  const todos = Array.from({ length: 5 }, (_, i) => ({
+    content: `todo item ${i}`,
+    status: i === 0 ? ('in_progress' as const) : ('pending' as const),
+  }))
+  app.setTodoSummary(todos)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  // The dock summary row sits at 0-based row 18 (editor seat 3 + footer 2
+  // at the bottom on the 80x24 test terminal; the closed panel renders
+  // zero rows, so the todo region clamps to [18, 19) — exactly the dock
+  // row). Click it: summary → list.
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(app.isTodoPanelVisible(), 'dock click opens the panel')
+  assert.ok(!app.isTodoPanelExpanded(), 'opens compact (visually identical to full at ≤5)')
+  // With the panel open (border + title + 5 rows = rows 15..21) the same
+  // cell is a panel row: the click must close the panel DIRECTLY — the
+  // second click returns to the summary, no third click needed, and no
+  // intermediate todoExpanded state exists.
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(!app.isTodoPanelVisible(), 'second click closes the panel (list → summary)')
+  assert.ok(!app.isTodoPanelExpanded(), 'no ghost expanded state at ≤5')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('todo state machine: 1 item also closes on the second click (boundary)', async () => {
+  const { vt, app } = startApp()
+  await vt.waitForRender()
+  app.setTodoSummary([{ content: 'only todo', status: 'in_progress' }])
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(app.isTodoPanelVisible(), 'dock click opens the panel')
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(!app.isTodoPanelVisible(), 'second click closes the 1-item panel')
+  assert.ok(!app.isTodoPanelExpanded(), 'no expanded state with 1 item')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('todo state machine: 0 items never shows an empty full state', async () => {
+  const { vt, app } = startApp()
+  await vt.waitForRender()
+  app.setTodoSummary([])
+  app.toggleTodoPanel()
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  assert.ok(app.isTodoPanelVisible(), 'the empty panel can open (border + title only)')
+  assert.ok(!app.isTodoPanelExpanded(), 'no full state with 0 items')
+  // A panel-row click with 0 items closes the panel (no overflow → no
+  // expansion step).
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(!app.isTodoPanelVisible(), 'a click on the empty panel closes it')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('todo state machine: >5 items keeps summary → compact → full → summary', async () => {
+  const { vt, app } = startApp()
+  await vt.waitForRender()
+  const todos = Array.from({ length: 6 }, (_, i) => ({
+    content: `todo item ${i}`,
+    status: i === 0 ? ('in_progress' as const) : ('pending' as const),
+  }))
+  app.setTodoSummary(todos)
+  app.toggleTodoPanel()
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('todo item 0'), `compact panel shows the first rows:\n${view}`)
+  assert.ok(!view.includes('todo item 5'), `compact panel hides the 6th row:\n${view}`)
+  assert.ok(!app.isTodoPanelExpanded(), 'starts compact')
+  // Compact panel (border + title + 5 rows = 7) occupies rows 15..21 —
+  // click row 18: compact → full.
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(app.isTodoPanelExpanded(), 'click must expand (compact → full)')
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('todo item 5'), `expanded panel shows the full list:\n${view}`)
+  // Full panel (8 rows) occupies rows 14..21 — click a DIFFERENT row
+  // (17): full → summary.
+  vt.sendInput('\x1b[<0;30;18M')
+  vt.sendInput('\x1b[<0;30;18m')
+  await vt.waitForRender()
+  assert.ok(!app.isTodoPanelVisible(), 'third click closes the panel (full → summary)')
+  assert.ok(!app.isTodoPanelExpanded(), 'closing resets the expansion')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('todo state machine: a >5 → ≤5 shrink clears the ghost expanded state', async () => {
+  const { vt, app } = startApp()
+  await vt.waitForRender()
+  const six = Array.from({ length: 6 }, (_, i) => ({
+    content: `todo item ${i}`,
+    status: i === 0 ? ('in_progress' as const) : ('pending' as const),
+  }))
+  app.setTodoSummary(six)
+  app.toggleTodoPanel()
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  // Expand to full.
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(app.isTodoPanelExpanded(), 'fixture: the 6-item panel is full')
+  // The host updates the list to 5: the ghost expansion must clear.
+  app.setTodoSummary(six.slice(0, 5))
+  await vt.waitForRender()
+  assert.ok(!app.isTodoPanelExpanded(), 'a shrink to the compact cap clears todoExpanded')
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('todo item 0'), 'the panel still renders the list')
+  assert.ok(!view.includes('todo item 5'), 'the 6th item is gone')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('todo state machine: toggleTodoExpanded is fail-closed without overflow', async () => {
+  const { vt, app } = startApp()
+  await vt.waitForRender()
+  app.setTodoSummary([{ content: 'one', status: 'in_progress' }])
+  app.toggleTodoPanel()
+  await vt.waitForRender()
+  assert.equal(app.toggleTodoExpanded(), false, 'no overflow → the toggle refuses to expand')
+  assert.ok(!app.isTodoPanelExpanded(), 'no meaningless expanded state')
   app.stop()
 })
 

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -33,6 +33,12 @@ function startApp(): { vt: VirtualTerminal; app: TuiApp; submitted: string[]; ge
   return { vt, app, submitted, get exits(): number { return exits } }
 }
 
+/** Pause longer than the todo click-coalescing window (500ms): a
+ * deliberate second todo click must be a NEW gesture, never coalesced. */
+function sleepBeyondTodoCoalesce(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 550))
+}
+
 test('renders the header and the editor frame', async () => {
   const { vt } = startApp()
   await vt.waitForRender()
@@ -563,8 +569,10 @@ test('fullscreen click on the todo panel toggles its compact/full expansion', as
   // 80x24 terminal: footer (2) + editor seat (3) at the bottom, so the
   // expanded panel (11 rows) spans 0-based rows 8..19 — click row 17 (a
   // different row from the first click, so the fork never reads a
-  // double-click).
+  // double-click). Paced beyond the todo click-coalescing window: this is
+  // a DELIBERATE second gesture, not a rapid double-click.
   await vt.waitForRender()
+  await sleepBeyondTodoCoalesce()
   vt.sendInput('\x1b[<0;30;18M')
   vt.sendInput('\x1b[<0;30;18m')
   await vt.waitForRender()
@@ -601,7 +609,9 @@ test('fullscreen click on the todo summary dock row opens the todo panel', async
   assert.ok(view.includes('todo item 0'), `compact panel must show after the click:\n${view}`)
   // With the panel open the summary is hidden and the panel owns rows
   // 12..19 — the same cell is now a panel row, so the next click runs the
-  // compact → full step of the loop.
+  // compact → full step of the loop. Paced beyond the todo click-coalescing
+  // window: a DELIBERATE second gesture, not a rapid double-click.
+  await sleepBeyondTodoCoalesce()
   vt.sendInput('\x1b[<0;20;19M')
   vt.sendInput('\x1b[<0;20;19m')
   await vt.waitForRender()
@@ -690,14 +700,56 @@ test('todo state machine: ≤5 items is a two-state summary ↔ list (no redunda
   assert.ok(app.isTodoPanelVisible(), 'dock click opens the panel')
   assert.ok(!app.isTodoPanelExpanded(), 'opens compact (visually identical to full at ≤5)')
   // With the panel open (border + title + 5 rows = rows 15..21) the same
-  // cell is a panel row: the click must close the panel DIRECTLY — the
-  // second click returns to the summary, no third click needed, and no
-  // intermediate todoExpanded state exists.
+  // cell is a panel row: a DELIBERATE second click (paced beyond the
+  // coalescing window) must close the panel DIRECTLY — the second click
+  // returns to the summary, no third click needed, and no intermediate
+  // todoExpanded state exists.
+  await sleepBeyondTodoCoalesce()
   vt.sendInput('\x1b[<0;20;19M')
   vt.sendInput('\x1b[<0;20;19m')
   await vt.waitForRender()
   assert.ok(!app.isTodoPanelVisible(), 'second click closes the panel (list → summary)')
   assert.ok(!app.isTodoPanelExpanded(), 'no ghost expanded state at ≤5')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('todo rapid double-click at the SAME coordinate is ONE gesture (no flash open/close)', async () => {
+  const { vt, app } = startApp()
+  await vt.waitForRender()
+  const todos = Array.from({ length: 5 }, (_, i) => ({
+    content: `todo item ${i}`,
+    status: i === 0 ? ('in_progress' as const) : ('pending' as const),
+  }))
+  app.setTodoSummary(todos)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  // The dock summary row sits at 0-based row 18. Two press/release groups
+  // at the SAME coordinate, the first render landing between them, both
+  // inside the double-click window (no pacing): the first click opens the
+  // panel, the layout mutates (the dock vanishes, the panel takes its
+  // rows), and the second click would land on a panel row — WITHOUT the
+  // todo coalescing it would immediately close the panel (the todo
+  // "flashes and vanishes"). The coalesced pair must leave the todo in
+  // the state the FIRST click produced.
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(app.isTodoPanelVisible(), 'fixture: the first click opens the panel')
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(app.isTodoPanelVisible(), 'the rapid second click must be coalesced — the panel stays open')
+  assert.ok(!app.isTodoPanelExpanded(), 'and stays in the first click\'s state (compact)')
+  // A click on the TRANSCRIPT (a different target) resets the coalescing:
+  // the next todo click is a fresh gesture and closes the panel.
+  vt.sendInput('\x1b[<0;40;5M')
+  vt.sendInput('\x1b[<0;40;5m')
+  await vt.waitForRender()
+  vt.sendInput('\x1b[<0;20;19M')
+  vt.sendInput('\x1b[<0;20;19m')
+  await vt.waitForRender()
+  assert.ok(!app.isTodoPanelVisible(), 'after a different-target click the next todo click works')
   app.setFullscreen(false)
   app.stop()
 })
@@ -712,6 +764,8 @@ test('todo state machine: 1 item also closes on the second click (boundary)', as
   vt.sendInput('\x1b[<0;20;19m')
   await vt.waitForRender()
   assert.ok(app.isTodoPanelVisible(), 'dock click opens the panel')
+  // Deliberate second gesture (paced beyond the coalescing window).
+  await sleepBeyondTodoCoalesce()
   vt.sendInput('\x1b[<0;20;19M')
   vt.sendInput('\x1b[<0;20;19m')
   await vt.waitForRender()
@@ -764,7 +818,9 @@ test('todo state machine: >5 items keeps summary → compact → full → summar
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('todo item 5'), `expanded panel shows the full list:\n${view}`)
   // Full panel (8 rows) occupies rows 14..21 — click a DIFFERENT row
-  // (17): full → summary.
+  // (17): full → summary. Paced beyond the todo click-coalescing window:
+  // a DELIBERATE third gesture, not a rapid double-click.
+  await sleepBeyondTodoCoalesce()
   vt.sendInput('\x1b[<0;30;18M')
   vt.sendInput('\x1b[<0;30;18m')
   await vt.waitForRender()

--- a/test/wheel-scroll-settings.test.ts
+++ b/test/wheel-scroll-settings.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Mouse-wheel step preference tests: the pure parsing helper
+ * (wheelScrollLinesOf), the /settings row (values, fallback, whole-doc
+ * persistence), and the TuiApp wiring (the preference reaches the
+ * TuiAltScreen constructor — one wheel event scrolls the configured
+ * number of lines; a change while fullscreen is active applies on the
+ * NEXT re-entry, v1 semantics).
+ * @module @xmoon76/dsh-pi-tui/wheel-scroll-settings.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ToolCallId, MessageId } from '@deepseek-ai/dsh-llm'
+import { CommandId } from '@deepseek-ai/dsh-commands'
+import { Context } from '@deepseek-ai/cordis'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { TranscriptFolder } from '../src/transcript.ts'
+import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from '../src/commands.ts'
+import type { TuiSettingsDoc } from '../src/runtime/config-port.ts'
+import { createDiag } from '../src/diag.ts'
+import { DraftImageStore } from '../src/image/draft-store.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { stripTerminalSequences } from '@xmoon76/pi-tui'
+import { VirtualTerminal } from './virtual-terminal.ts'
+import { DirectCatalogPort } from '../src/runtime/direct/catalog-direct.ts'
+import { DirectConfigPort } from '../src/runtime/direct/config-direct.ts'
+import { DirectHostFilePort } from '../src/runtime/direct/host-file-direct.ts'
+import { WHEEL_SCROLL_LINE_VALUES, wheelScrollLinesOf } from '../src/wheel-scroll.ts'
+
+// ── the pure parsing helper ──────────────────────────────────────────────
+
+test('wheelScrollLinesOf: missing and invalid values fall back to 1', () => {
+  assert.equal(wheelScrollLinesOf(undefined), 1)
+  assert.equal(wheelScrollLinesOf(''), 1)
+  assert.equal(wheelScrollLinesOf('0'), 1)
+  assert.equal(wheelScrollLinesOf('4'), 1)
+  assert.equal(wheelScrollLinesOf('9'), 1)
+  assert.equal(wheelScrollLinesOf('garbage'), 1)
+  assert.equal(wheelScrollLinesOf('ON'), 1)
+})
+
+test('wheelScrollLinesOf: the accepted values pass through', () => {
+  assert.equal(wheelScrollLinesOf('1'), 1)
+  assert.equal(wheelScrollLinesOf('2'), 2)
+  assert.equal(wheelScrollLinesOf('3'), 3)
+  assert.equal(wheelScrollLinesOf('5'), 5)
+  assert.equal(wheelScrollLinesOf('8'), 8)
+})
+
+test('WHEEL_SCROLL_LINE_VALUES lists exactly the accepted steps in display order', () => {
+  assert.deepEqual([...WHEEL_SCROLL_LINE_VALUES], ['1', '2', '3', '5', '8'])
+})
+
+// ── the /settings row ───────────────────────────────────────────────────
+
+/** A fake TuiSettingsLike recording every replace. */
+function fakeSettings(doc: Record<string, unknown>) {
+  const writes: Array<Record<string, unknown>> = []
+  return {
+    writes,
+    value: {
+      get: () => ({ ...doc }) as unknown as TuiSettingsLike['get'] extends () => infer R ? R : never,
+      replace: (next: TuiSettingsDoc) => {
+        writes.push({ ...next })
+        Object.assign(doc, next)
+        return undefined as unknown
+      },
+    },
+  }
+}
+
+/** Register the TUI commands with a stubbed runner and return /settings. */
+function setupSettings(options: { wheelScrollLines?: string } = {}) {
+  const ctx = new Context()
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const defs: { name: string; handler?: unknown }[] = []
+  ctx.provide('commands', {
+    register: (def: { name: string; handler?: unknown }): (() => void) => {
+      defs.push(def)
+      return () => {}
+    },
+    list: () => [],
+    find: () => undefined,
+    execute: async () => undefined,
+  } as never)
+  ctx.provide('settings', { describe: () => [{ ns: 'dsh-pi-tui', user: {} }] } as never)
+  // The fake document starts from the FULL default shape. When no
+  // wheelScrollLines is passed, the field is OMITTED entirely — the exact
+  // shape of an old settings file written before the preference existed.
+  const settings = fakeSettings({
+    theme: 'auto',
+    footer: 'full',
+    fullscreen: 'on',
+    busyEnter: 'queue',
+    localShellSandbox: 'bypass',
+    homeEndKeys: 'viewport',
+    focusMode: 'off',
+    ...(options.wheelScrollLines === undefined ? {} : { wheelScrollLines: options.wheelScrollLines }),
+  })
+  const runner: TuiCommandRunner = {
+    ctx,
+    app,
+    diag: createDiag({ filePath: undefined, stderrLevel: 'off' }),
+    get liveAgent() { return undefined },
+    ensureSession: async () => {},
+    get selected() { return { current: undefined, assembled: undefined, saveSelection: async () => {} } },
+    defaultSelection: () => undefined,
+    defaultIntent: undefined,
+    setDefaultIntent: () => {},
+    defaultIntentRecord: undefined,
+    settleIntent: () => {},
+    tuiSettings: settings.value,
+    agents: {} as never,
+    sessionReader: {
+      list: async () => [],
+      search: async () => [],
+      titles: async () => new Map(),
+      measureContext: () => undefined,
+      readExportData: async () => ({ kind: 'none' }),
+    },
+    catalog: new DirectCatalogPort(ctx as never, () => undefined),
+    config: new DirectConfigPort(ctx as never, undefined, () => undefined),
+    commandRegistry: ctx.get('commands') as import('../src/commands.ts').CommandRegistryLike | undefined,
+    hostFile: new DirectHostFilePort(() => undefined),
+    interaction: {
+      registerQuestionProvider: () => true,
+      onApprovalRequest: () => {},
+      setApprovalPolicy: () => true,
+    },
+    sessionWriter: {
+      followup: () => {},
+      steer: () => {},
+      dequeue: () => {},
+      cancel: () => {},
+      rename: () => true,
+      refreshTitle: async () => ({ kind: 'ok' as const, title: undefined }),
+    },
+    cwd: '/ws',
+    sessionCwd: () => '/ws',
+    imageStore: new DraftImageStore(),
+    copyToClipboard: async () => true,
+    imageLimits: () => undefined,
+    insertIntoEditor: () => {},
+    prepareDraftMessage: async (text) => ({ role: 'user', id: `u:${text}`, content: [{ type: 'text', text }], source: { kind: 'user' } }) as never,
+    signal: new AbortController().signal,
+    get sessionGeneration() { return 0 },
+    switchSession: async () => undefined,
+    transitionTo: async <T>(steps: { target?: { id: string; header?: { cwd?: string } }; prepare?: () => Promise<void> | void; create: () => Promise<T> }) => {
+      await steps.prepare?.()
+      return { ok: true, next: await steps.create() }
+    },
+    currentPreset: () => undefined,
+    get pendingPreset() { return undefined },
+    set pendingPreset(_id: string | undefined) {},
+    get effectivePresetId() { return undefined },
+    refreshCatalog: async () => ({ kind: 'failed', error: 'not wired in tests' }),
+    recomposeBlank: async () => ({ kind: 'switched', preset: 'standard' }),
+    refreshStatus: () => {},
+    applyFooterSettings: () => {},
+    focusEnabled: () => false,
+    setFocusMode: () => {},
+    updateWelcomeCard: () => {},
+    openJobView: () => {},
+    openTasksBrowser: () => {},
+    openRewindPicker: () => {},
+    sessionTransitionPending: () => false,
+    withSessionTransition: async <T>(task: () => T | Promise<T>) => task(),
+    withSessionWriter: async <T>(_sessionId: string, task: () => T | Promise<T>) => task(),
+    enterView: async () => {},
+    requestExit: () => {},
+    extensions: undefined,
+    exit: () => {},
+  }
+  registerTuiCommands(runner)
+  const def = defs.find(entry => entry.name === 'settings')
+  assert.ok(def?.handler !== undefined, 'settings handler missing')
+  const run = async (): Promise<void> => {
+    await (def!.handler as (inv: { commandId: string; agent: never; rawInput: string; signal: AbortSignal }) => unknown)({
+      commandId: CommandId('cmd-wheel-test'),
+      agent: undefined as never,
+      rawInput: '',
+      signal: new AbortController().signal,
+    })
+  }
+  const view = async (): Promise<string> => {
+    await vt.waitForRender()
+    return vt.getViewport().join('\n')
+  }
+  return { vt, app, settings, run, view }
+}
+
+test('/settings lists the Mouse wheel lines row; missing and invalid persisted values fall back to 1', async () => {
+  // Missing field (old settings file): the row reads 1.
+  const t = setupSettings({})
+  await t.run()
+  await t.view()
+  for (let i = 0; i < 10; i += 1) t.vt.sendInput('\x1b[B')
+  const view = await t.view()
+  assert.ok(view.includes('Mouse wheel lines'), `row missing:\n${view}`)
+  const row = stripTerminalSequences(view).split('\n').find(line => line.includes('Mouse wheel lines'))
+  assert.ok(row !== undefined && row.includes('1'),
+    `missing persisted value must fall back to 1 (row: ${row}):\n${view}`)
+  t.app.stop()
+
+  // An invalid persisted value never renders outside the values list.
+  const t2 = setupSettings({ wheelScrollLines: 'garbage' })
+  await t2.run()
+  await t2.view()
+  for (let i = 0; i < 10; i += 1) t2.vt.sendInput('\x1b[B')
+  const view2 = await t2.view()
+  assert.ok(stripTerminalSequences(view2).split('\n').some(line => line.includes('Mouse wheel lines') && line.includes('1')),
+    `invalid persisted value must fall back to 1:\n${view2}`)
+  assert.ok(!view2.includes('garbage'), `the raw invalid value must never render:\n${view2}`)
+  t2.app.stop()
+
+  // A persisted 8 renders as 8.
+  const t3 = setupSettings({ wheelScrollLines: '8' })
+  await t3.run()
+  await t3.view()
+  for (let i = 0; i < 10; i += 1) t3.vt.sendInput('\x1b[B')
+  const view3 = await t3.view()
+  assert.ok(stripTerminalSequences(view3).split('\n').some(line => line.includes('Mouse wheel lines') && line.includes('8')),
+    `persisted 8 must render on the row:\n${view3}`)
+  t3.app.stop()
+})
+
+test('the Mouse wheel lines row toggle persists without dropping other fields', async () => {
+  const t = setupSettings({ wheelScrollLines: '1' })
+  await t.run()
+  await t.view()
+  for (let i = 0; i < 10; i += 1) t.vt.sendInput('\x1b[B') // move to the wheel row
+  await t.view()
+  t.vt.sendInput('\r') // toggle 1 -> 2
+  await t.view()
+  assert.ok(t.settings.writes.length >= 1, 'the toggle must persist a write')
+  const last = t.settings.writes[t.settings.writes.length - 1]
+  assert.equal(last?.wheelScrollLines, '2', `wrote: ${JSON.stringify(last)}`)
+  // A replace is wholesale: every other field rides along untouched.
+  assert.equal(last?.theme, 'auto')
+  assert.equal(last?.footer, 'full')
+  assert.equal(last?.fullscreen, 'on')
+  assert.equal(last?.focusMode, 'off')
+  t.app.stop()
+})
+
+// ── the TuiApp wiring (the preference reaches the alt screen) ────────────
+
+const T0 = Date.now() - 60_000
+
+function eventAt(type: string, data: Record<string, unknown>, time: number, seq: number): SessionEvent {
+  return { type, seq, time, data } as SessionEvent
+}
+
+function completedTurn(turn: number, baseSeq: number, startTime: number): SessionEvent[] {
+  return [
+    eventAt('turn/start', { turn }, startTime, baseSeq),
+    eventAt('user/message', {
+      id: MessageId(`u${turn}`), role: 'user',
+      content: [{ type: 'text', text: `prompt ${turn}` }],
+      source: { kind: 'user' },
+    }, startTime + 1, baseSeq + 1),
+    eventAt('assistant/message', {
+      turn, step: 1,
+      message: { id: MessageId(`a${turn}`), role: 'assistant', content: [{ type: 'text', text: `answer ${turn}` }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, startTime + 2, baseSeq + 2),
+    eventAt('turn/end', { turn, reason: { kind: 'completed' } }, startTime + 3, baseSeq + 3),
+  ]
+}
+
+function longTranscript(): TranscriptFolder {
+  const folder = new TranscriptFolder()
+  for (let turn = 0; turn < 25; turn += 1) {
+    folder.apply(completedTurn(turn, turn * 10, T0 + turn * 1000))
+  }
+  return folder
+}
+
+test('the default wheel step is 1: one wheel event scrolls one line', async () => {
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  app.setTranscript(longTranscript().messages(), longTranscript().turnActivities())
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  const bottom = app.fullscreenScrollForTest()
+  assert.ok(bottom !== undefined && bottom.maxScrollTop > 0, 'precondition: scrollable transcript')
+  vt.sendInput('\x1b[<64;50;10M') // wheel up over the transcript pane
+  await vt.waitForRender()
+  const after = app.fullscreenScrollForTest()
+  assert.equal(after?.scrollTop, bottom.maxScrollTop - 1, 'default wheel step is exactly 1 line')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('setWheelScrollLines reaches the NEXT alt-screen mount (one wheel event scrolls N lines)', async () => {
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  app.setTranscript(longTranscript().messages(), longTranscript().turnActivities())
+  app.setWheelScrollLines(3)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  const bottom = app.fullscreenScrollForTest()
+  assert.ok(bottom !== undefined && bottom.maxScrollTop > 0, 'precondition: scrollable transcript')
+  vt.sendInput('\x1b[<64;50;10M')
+  await vt.waitForRender()
+  const after = app.fullscreenScrollForTest()
+  assert.equal(after?.scrollTop, bottom.maxScrollTop - 3, 'one wheel event with step 3 scrolls 3 lines')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('a change while fullscreen is ACTIVE applies on the next re-entry (v1 semantics)', async () => {
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  app.setTranscript(longTranscript().messages(), longTranscript().turnActivities())
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  // Change the preference while the alt screen is live: the CURRENT
+  // instance keeps its constructor-time step (1)…
+  app.setWheelScrollLines(8)
+  const bottom = app.fullscreenScrollForTest()
+  vt.sendInput('\x1b[<64;50;10M')
+  await vt.waitForRender()
+  const after = app.fullscreenScrollForTest()
+  assert.equal(after?.scrollTop, bottom!.maxScrollTop - 1,
+    'the live alt screen keeps its constructor-time step (no immediate effect)')
+  // …and the NEXT fullscreen mount uses the new step.
+  app.setFullscreen(false)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  const bottom2 = app.fullscreenScrollForTest()
+  vt.sendInput('\x1b[<64;50;10M')
+  await vt.waitForRender()
+  const after2 = app.fullscreenScrollForTest()
+  assert.equal(after2?.scrollTop, bottom2!.maxScrollTop - 8, 'the re-entered alt screen uses the new step')
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('setWheelScrollLines normalizes defensively', async () => {
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  app.setTranscript(longTranscript().messages(), longTranscript().turnActivities())
+  app.setWheelScrollLines(0)
+  app.setWheelScrollLines(-5)
+  app.setWheelScrollLines(2.9)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  const bottom = app.fullscreenScrollForTest()
+  vt.sendInput('\x1b[<64;50;10M')
+  await vt.waitForRender()
+  const after = app.fullscreenScrollForTest()
+  assert.equal(after?.scrollTop, bottom!.maxScrollTop - 2, '0/-5 clamp to 1, 2.9 floors to 2')
+  app.setFullscreen(false)
+  app.stop()
+})


### PR DESCRIPTION
## Summary

Next-only UX 优化（计划 `temp/1.2-new/dsh-pi-tui-next-only-focus-resume-wheel-todo-plan.md`），三个语义 commit group，全部 base `next`：

- **Focus**：展开视图恢复 steer chronology（initial user 在 Thought 前，后续 steer 回到实际位置，final assistant 单一且最后）；折叠 Message 成为第三 process slot（Think → Tool → Message），显示最新最多 3 个 visual rows（每次 render 按当前宽度重 wrap）
- **Wheel**：`/settings` 新增 `Mouse wheel lines`（1/2/3/5/8，默认 1），startup 在首次 fullscreen 前应用；fullscreen 激活中修改按 v1 语义下次 re-entry 生效（无 fork 改动）
- **Todo**：≤5 条两态 summary ↔ list（去掉视觉相同的冗余 full 状态）；>5 条保留三态；>5→≤5 自动清 ghost `todoExpanded`
- **Resume**：显式 cold resume 在 TUI mount 前显示单行 `Resuming session…`（必要时 `Preparing conversation…`），mount 前完全清除；fresh start 无输出、非 TTY 静默；success/failure/abort/HMR/startup exception 全部清理

## Architecture

- 无新增 Host coupling（`gate:boundary` ok）
- `TuiSettingsDoc` 新增 `wheelScrollLines`（Client preference 持久化字段，无新 RPC）
- Pi fork 零改动；`src/startup.ts` 零改动（新 helper 独立文件）
- migration milestone 不变

## Tests

- `pnpm test:bundle` PASS（3368）
- `pnpm test:fork` PASS（988）
- `pnpm typecheck:bundle` / `typecheck:fork` PASS
- `pnpm gate:boundary` / `gate:keybindings` / `gate:pi-surface-compat` / `naming-gate` PASS
- `pnpm verify:prepush` PASS（完整 pack lifecycle + smokes + audit）
- `pnpm dev:doctor` READY（source mode，DSH 0.1.2-alpha.2）

## Review

- review-fix loop 1 轮：openai-codex/gpt-5.6-luna 全 diff 扫描（22 文件）→ **accepted，无 findings**

## Changelog

- `CHANGELOG.md` / `CHANGELOG.en.md` Unreleased 新增「UX 优化 / UX improvements」