### PR TITLE
docs(footer): add user customization guide

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -183,134 +183,25 @@ Slash Commands registered by other plugins through `ctx.commands` are discovered
 
 ### Footer customization
 
-The status line is a **composable surface** — no plugin or shell needed
-for the common cases.
+`/footer` is the interactive Footer editor. You can combine builtin status items, change their side and order, choose a Style and Tone, edit Prefix/Suffix and Importance, and create your own Footer items.
 
-`/settings` → Status line (or the `footer` key in the `dsh-pi-tui`
-settings document) selects the preset:
+Four item sources are supported:
 
-| Value | Meaning |
-|---|---|
-| `default` (legacy `full`) | the classic two-row footer (status + stats) |
-| `compact` | the status row only (stats line hidden) |
-| `custom` | a versioned `footerLayout` (see below) |
-| `command` | a user-configured command renders the status surface (see below) |
+- **Builtin Item** — Model, Context, Token, Tasks, Git branch, and other built-in status facts;
+- **Custom Text** — a user-created static text item;
+- **Custom Command Item** — a user-created dynamic command output that can be composed with other items;
+- **Extension Item** — a Footer item contributed by a plugin through the Stable Extension API.
 
-The first three values are selectable in the `/settings` panel; `command`
-is NOT in the panel — it can only be enabled through the USER-layer
-settings document (`footer: "command"` + `footerCommand`). The `/settings`
-Status line row offers exactly `default / compact / custom`.
+On narrow terminals, builtins with compact forms shorten before lower-importance content is dropped. Runtime compaction never rewrites the Style you saved.
 
-`/footer` is a hierarchical interactive configurator: pick a row first
-(Row Selector), then edit that row's items — `↑/↓` walks every item of
-the row in order (Left/Right are visual grouping only), `←/→` moves an
-item across sides, `Space` removes it, `A` opens a searchable Add Picker
-(filtered by label / id / description, with the highlighted item's
-description below), `M` enters Move Mode to reorder, and `Enter` opens
-the Item Editor (Style candidates previewed with the item's real render;
-semantic tones; Advanced edits prefix / suffix / importance with a
-one-keystroke Reset). The preview is composed by the real footer engine
-and — with the contextual help — pinned to the top of the panel; it never
-scrolls away at any terminal size. `S` on the Row Selector saves
-(persisted); `Esc` walks back page by page and closes on the first page
-without touching the active layout. With dirty changes, `Esc` first offers
-Save & Exit, Discard & Exit, or Keep Editing; saving waits for the settings
-write to succeed. Usable before any session exists.
+A `/footer` Custom Command Item is different from `footer: command`: the former is one dynamic item that can sit next to Model, Context, and other items; the latter hands the whole Footer status surface to one user command.
 
-The Add Picker also offers `+ Create Custom Text` for user-defined static text items. Their text, default semantic tone, display name, and deletion are editable; definitions are read and persisted only from the USER layer. The definition tone is separate from the placement Tone, and the item can otherwise be shown/hidden, moved, and reordered like any other footer item.
+For the full `/footer` workflow, Custom Text / Command items, YAML reference, security model, and troubleshooting, see:
 
-`footerLayout` is a nested settings object (schemaVersion 1, 1–2 rows,
-left/right zones, a separator, finite formatters, semantic tones,
-prefix/suffix, importance). The `/footer` configurator builds it
-interactively; the YAML shape is:
+- [Footer customization guide](docs/footer-customization.md)
+- [Extension API for plugin authors](docs/extension-api.md)
 
-```yaml
-footer: custom
-footerLayout:
-  schemaVersion: 1
-  rows:
-    - left:
-        - id: agent-preset
-          format: compact
-        - id: model
-        - id: project
-        - id: context
-          format: full
-        - id: cache-hit
-        - id: token-usage
-          format: io
-        - id: performance
-          format: speed
-        - id: version
-          format: tui
-      right:
-        - id: focus-mode
-      separator:
-        text: " │ "
-        tone: textDim
-```
-
-Builtin format choices are finite and use the existing `format` field (no
-second style schema): Model `badge` / `plain` / `compact`; Permission preset
-`badge` / `plain` / `compact`; Plan state `badge` / `plain`; Working directory
-`short` / `basename` / `full`; Git branch `plain` / `label`; Context `bar` /
-`percent` / `full`; Token usage `io` / `total` / `compact`; Cache hit `full` /
-`compact`; Performance `full` / `speed` / `latency` measures average time
-to first token; Turns/steps `both` / `turns` / `steps`; Version keeps `tui` / `dsh` /
-`both`. Omitting `format` continues to use each item's legacy default.
-
-Builtin item ids: `agent-preset`, `model`, `reasoning`,
-`permission-preset`, `sandbox-mode`, `approval-policy`, `plan-state`,
-`focus-mode`, `focused-seat`, `view-scope`, `cwd`, `project`,
-`git-branch`, `run-state`, `queue`, `tasks`, `agents`, `todo`,
-`context`, `cache-hit`, `token-usage`, `performance`, `turns-steps`,
-`stats-line`, `version`, `ext:*` (the legacy extension segments).
-An invalid `footerLayout` warns once and falls back to the default — the
-TUI always starts.
-
-`footer: command` hands the Status Surface to a user-configured command
-(Claude/Kimi style): the current status snapshot is serialized to JSON on
-the command's stdin (schemaVersion 1 — no secrets, no credentials, no
-prompts), and the command's stdout (sanitized: SGR colors and OSC 8
-hyperlinks only) renders the status surface. The Host's instruction
-surface (e.g. the Ctrl+C exit hint) always survives on top.
-
-```yaml
-footer: command
-footerCommand:
-  schemaVersion: 1
-  command: "~/.config/dsh/statusline.sh"
-  timeoutMs: 300        # default 300, max 1000
-  refreshIntervalMs: 1000  # min 1000
-  maxRows: 1            # 1..2
-```
-
-**Security:** the command is executed ONLY when it lives in the USER
-layer of your settings document. A repository/project-supplied
-`footerCommand` is never executed — command mode is disabled and the
-native layout applies. The command refreshes periodically according to
-`refreshIntervalMs` and renders at most two rows; failures (empty output,
-non-zero exit, timeout) fall back to the native layout automatically.
-
-### Extension footer items
-
-Plugins can contribute **configurable footer items** through the Stable
-extension API (`@xmoon76/dsh-pi-tui/extensions`): register a
-`FooterItemContribution` on the `chrome.footer.item` slot — a label and a
-plain-data `segment` (styled spans; the host strips any terminal control
-sequence, plugins never style the terminal). Users show/hide, reorder and
-zone-place the item in `/footer` exactly like a builtin item. Feature-detect
-the `slot.chrome.footer.item` capability before registering (it is
-advertised before any surface exists). The item's config identity is the
-canonical key `ext:<owner>/<id>` where the owner is the plugin's stable
-name — **stable across HMR**: a layout referencing an unloaded plugin's
-item keeps the reference and recovers automatically when the plugin
-reloads. An npm-scoped plugin name (`@scope/name`) is legal: its `/` is
-percent-encoded via `encodeURIComponent` in the key
-(`ext:%40scope%2Fname/<id>`); the id itself must
-not contain `/`. The legacy `chrome.footer.status` slot is unchanged: its
-segments aggregate into the single `ext:*` item. Full author guide:
-[docs/extension-api.md](docs/extension-api.md).
+`/statusline` is an alias of `/footer`.
 
 ## Common keys
 

--- a/README.md
+++ b/README.md
@@ -182,118 +182,25 @@ TUI 使用 DSH 提供的模型和设置服务。
 
 ### Footer 自定义
 
-状态行是一个**可组合表面**——常见场景无需插件或 shell。
+`/footer` 提供交互式 Footer 编辑器。你可以组合内置状态条目，调整左右位置、顺序、Style、Tone、Prefix/Suffix 和 Importance，也可以创建自己的 Footer 条目。
 
-`/settings` → Status line(或 `dsh-pi-tui` 设置文档中的 `footer` 键)
-选择预设:
+支持四类条目：
 
-| 值 | 含义 |
-|---|---|
-| `default`(旧名 `full`) | 经典两行 Footer(状态 + 统计) |
-| `compact` | 仅状态行(隐藏统计行) |
-| `custom` | 版本化 `footerLayout`(见下) |
-| `command` | 用户配置的命令渲染状态表面(见下) |
+- **Builtin Item**：Model、Context、Token、Tasks、Git branch 等内置状态；
+- **Custom Text**：用户创建的固定文本；
+- **Custom Command Item**：用户创建的动态命令输出，可和其他条目一起排列；
+- **Extension Item**：插件通过 Stable Extension API 提供的 Footer 条目。
 
-前三个值可在 `/settings` 面板选择;`command` **不在面板中**——它只能
-通过 USER 层设置文档(`footer: "command"` + `footerCommand`)启用,
-`/settings` 的 Status line 行只有 `default / compact / custom` 三个选项。
+在窄终端中，支持 compact 的内置条目会先自动缩短；空间仍不足时再按 Importance 隐藏低优先级内容。运行时 compact 不会修改你保存的 Style。
 
-`/footer` 是层级式交互配置器:先选行(Row Selector),再编辑该行的
-条目——`↑/↓` 在整行条目间顺序移动(Left/Right 只是视觉分组),
-`←/→` 左右换侧,`Space` 移除,`A` 打开可搜索的 Add Picker(按
-label / id / 描述过滤,选中项下方显示描述),`M` 进入 Move Mode
-排序,`Enter` 打开 Item Editor(Style 候选以条目的真实渲染作示例;
-Tone 语义色;Advanced 编辑 prefix / suffix / importance 并可一键
-Reset)。预览由真实 Footer 引擎合成,与 contextual help 一起固定在
-面板顶部,任何终端尺寸下都不会随列表滚动消失。Row Selector 页 `S`
-保存(持久化),`Esc` 逐页返回、在首页关闭且不影响当前生效布局。存在未保存改动时，
-`Esc` 会先显示 Save & Exit、Discard & Exit 或 Keep Editing；保存会等待设置写入成功。
-无会话时也可使用。
+`/footer` 的 Custom Command Item 和 `footer: command` 是两种不同能力：前者只是一个可以与 Model、Context 等混排的动态条目；后者把整个 Footer 状态表面交给一个用户命令。
 
-Add Picker 的末尾还可以选择 `+ Create Custom Text`,创建用户自定义的静态文本条目。创建后可编辑文本、默认语义色、显示名称,也可以删除;条目定义只从 USER 层读取并持久化。定义 Tone 与布局中的放置 Tone 分开,条目仍可在 `/footer` 中显示/隐藏、移动和排序。
+完整的 `/footer` 使用方法、Custom Text / Command、YAML 配置、安全模型和排错说明见：
 
-`footerLayout` 是嵌套设置对象(schemaVersion 1,1–2 行,左/右区域,
-分隔符,有限 formatter,语义 tone,prefix/suffix,importance)。
-`/footer` 配置器可交互地构建它;YAML 形状如下:
+- [Footer 自定义完整指南](docs/footer-customization.md)
+- [Extension API（插件作者）](docs/extension-api.md)
 
-```yaml
-footer: custom
-footerLayout:
-  schemaVersion: 1
-  rows:
-    - left:
-        - id: agent-preset
-          format: compact
-        - id: model
-        - id: project
-        - id: context
-          format: full
-        - id: cache-hit
-        - id: token-usage
-          format: io
-        - id: performance
-          format: speed
-        - id: version
-          format: tui
-      right:
-        - id: focus-mode
-      separator:
-        text: " │ "
-        tone: textDim
-```
-
-内置 format 是有限集合,继续使用现有的 `format` 字段(不新增第二套
-style schema):Model 为 `badge` / `plain` / `compact`;Permission preset
-为 `badge` / `plain` / `compact`;Plan state 为 `badge` / `plain`;Working
-directory 为 `short` / `basename` / `full`;Git branch 为 `plain` / `label`;
-Context 为 `bar` / `percent` / `full`;Token usage 为 `io` / `total` /
-`compact`;Cache hit 为 `full` / `compact`;Performance 为 `full` / `speed` /
-`latency`(平均首 token 时间);Turns/steps 为 `both` / `turns` / `steps`;
-Version 保留 `tui` / `dsh` / `both`。省略 `format` 时仍使用各条目的旧默认值。
-
-内置条目 id:`agent-preset`、`model`、`reasoning`、
-`permission-preset`、`sandbox-mode`、`approval-policy`、`plan-state`、
-`focus-mode`、`focused-seat`、`view-scope`、`cwd`、`project`、
-`git-branch`、`run-state`、`queue`、`tasks`、`agents`、`todo`、
-`context`、`cache-hit`、`token-usage`、`performance`、`turns-steps`、
-`stats-line`、`version`、`ext:*`(旧扩展段)。非法的 `footerLayout`
-会警告一次并回退到默认布局——TUI 始终能启动。
-
-`footer: command` 把状态表面交给用户配置的命令(Claude/Kimi 风格):
-当前状态快照以 JSON 序列化到命令的 stdin(schemaVersion 1——不含
-secret、凭据、提示词),命令的 stdout(经过净化:仅保留 SGR 颜色与
-OSC 8 超链接)渲染状态表面。Host 的指令表面(如 Ctrl+C 退出提示)
-始终叠加在最上层。
-
-```yaml
-footer: command
-footerCommand:
-  schemaVersion: 1
-  command: "~/.config/dsh/statusline.sh"
-  timeoutMs: 300        # 默认 300,最大 1000
-  refreshIntervalMs: 1000  # 最小 1000
-  maxRows: 1            # 1..2
-```
-
-**安全:** 只有当命令位于你的设置文档的 USER 层时才会被执行。
-仓库/项目提供的 `footerCommand` 永远不会被执行——命令模式被禁用并
-回退到原生布局。命令按 `refreshIntervalMs` 周期刷新,每次最多输出 2 行;失败(空输出、非零退出、超时)自动回退到原生布局。
-
-### 扩展 Footer 条目
-
-插件可以通过 Stable 扩展 API(`@xmoon76/dsh-pi-tui/extensions`)贡献
-**可配置的 Footer 条目**:在 `chrome.footer.item` 槽位注册一个
-`FooterItemContribution`——包含 label 与纯数据 `segment`(带样式的
-span;Host 会剥离任何终端控制序列,插件永远不能直接给终端上样式)。
-用户可在 `/footer` 中像内置条目一样开关、排序、左右放置。注册前请
-先 feature-detect `slot.chrome.footer.item` 能力(该能力在任何 surface
-存在之前就已声明)。条目的配置身份是规范键 `ext:<owner>/<id>`,其中
-owner 是插件的稳定名称——**跨 HMR 稳定**:引用已卸载插件条目的布局
-保留引用,插件重载后自动恢复。npm scoped 插件名(`@scope/name`)合法:
-其 `/` 在键中按 `encodeURIComponent` 百分号编码(`ext:%40scope%2Fname/<id>`);
-id 本身不得包含 `/`。旧的 `chrome.footer.status` 槽位不变:
-其 segment 聚合为单一的 `ext:*` 条目。完整作者指南:
-[docs/extension-api.md](docs/extension-api.md)。
+`/statusline` 是 `/footer` 的别名。
 
 ## 常用按键
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ knows where the rest lives.
 | `client-server-coupling.md` | contributors | The migration coupling allowlist: the (file, pattern) baseline enforced by `scripts/client-boundary-gate.mjs`, the four categories (DIRECT_HOST_REQUIRED / MIGRATABLE / CLIENT_LOCAL / TEMPORARY_EXCEPTION), and the locality rules for new features |
 | `perf-baseline.md` | contributors | Measured rendering performance before/after the incremental read grouping + render-cache optimization, and how to re-run it |
 | `tmux-testing.md` | contributors | When to test in tmux instead of headless, the manual verification flows, and every trap hit while real-testing |
+| `footer-customization.md` | users | User guide for `/footer`: builtin items and styles, Custom Text, trusted Custom Command Items, whole-footer commands, extension items, responsive behavior, raw settings reference, and troubleshooting |
 | `extension-api.md` | plugin authors | The extension API v1 author guide: import rules, the surface table, lifecycle/render contracts, deprecation policy, stability |
 | `extension-advanced.md` | plugin authors | The ADVANCED tier author guide (Phase 2/4): normalized input capture, focused interactive surfaces, advanced editor control, the imperative UI broker, custom UI and the host-state facade — the Host-mediated contract and the capture ladder position |
 | `extension-capability-matrix.md` | plugin authors | The Pi capability reference: Pi capability → dsh equivalent → tier → status (roadmap, not a hash gate) |

--- a/docs/footer-customization.md
+++ b/docs/footer-customization.md
@@ -1,0 +1,652 @@
+# Footer customization
+
+`dsh-pi-tui` has a composable Footer rather than a fixed status line.
+
+For most users, `/footer` is the only entry point you need. It lets you arrange
+builtin status items, create your own text or command items, and place
+plugin-provided items without editing YAML by hand.
+
+This guide covers the user-facing Footer surface. Plugin authors should also
+read [Extension API v1](extension-api.md).
+
+## Quick start
+
+Open the editor:
+
+```text
+/footer
+```
+
+`/statusline` is an alias of `/footer`.
+
+A typical workflow is:
+
+1. Select a row and press `Enter`.
+2. Press `A` to open the Add picker.
+3. Add builtin, custom, or extension items.
+4. Use `Left` / `Right` to move an item between sides.
+5. Use Move Mode to reorder items.
+6. Open the Item Editor to change Style, Tone, Prefix/Suffix, or Importance.
+7. Return to the first page and choose **Save changes**, or press `S`.
+
+The preview is rendered by the real Footer composer, so it follows the same
+layout and width rules as the live Footer.
+
+If you leave with unsaved changes, the editor asks whether to save, discard,
+or keep editing. A failed settings write keeps the editor open and preserves
+the draft.
+
+## Choose a footer mode
+
+The Footer has four top-level modes:
+
+| Value | Meaning |
+| --- | --- |
+| `default` | The classic two-row native Footer. The historical `full` value is treated as the same mode where supported. |
+| `compact` | Native Footer with the statistics row hidden. |
+| `custom` | A user-composed `footerLayout`, normally edited through `/footer`. |
+| `command` | One trusted user command owns the whole status surface. This mode is configured manually rather than selected from the ordinary `/settings` Footer picker. |
+
+For interactive customization, use `custom`.
+
+## The four kinds of Footer items
+
+A custom layout can contain items from four sources.
+
+### Builtin Item
+
+First-party status facts such as Model, Context, Token usage, Tasks, Git branch,
+run state, and version.
+
+Builtin items may expose more than one Style.
+
+### Custom Text
+
+A user-owned static text value created from `/footer`.
+
+Examples:
+
+```text
+prod
+VPN
+west-us
+```
+
+### Custom Command Item
+
+A user-owned command whose cached output becomes one ordinary Footer item.
+
+Examples:
+
+```text
+09:41
+battery 82%
+vpn up
+```
+
+A Custom Command Item can sit next to builtin, Custom Text, and extension
+items. It does **not** replace the whole Footer.
+
+### Extension Item
+
+A plugin can contribute a configurable item through the Stable
+`chrome.footer.item` extension slot.
+
+Once the plugin is installed, the item appears in `/footer` and can be
+shown, hidden, ordered, and placed like a builtin item.
+
+## Using `/footer`
+
+The editor is hierarchical rather than one large form.
+
+### Row Selector
+
+The first page selects a logical Footer row.
+
+Use it to:
+
+- enter a row;
+- inspect whether there are unsaved changes;
+- choose **Save changes**;
+- press `S` as the save shortcut.
+
+### Edit Row
+
+The row is presented as one ordered list. Left and Right are placement groups,
+not separate cursor modes.
+
+Common actions:
+
+- `Up` / `Down` — move the cursor;
+- `Left` / `Right` — move the selected item between sides;
+- `Space` — remove the selected item from the row;
+- `A` — open the searchable Add picker;
+- `M` — enter Move Mode;
+- `Enter` — open the Item Editor;
+- `F` — cycle an item's Style when that shortcut is available.
+
+### Add picker
+
+The Add picker searches labels, ids, and descriptions.
+
+In addition to builtin and extension items, it contains:
+
+```text
++ Create Custom Text
++ Create Custom Command
+```
+
+Creating a Custom Command asks for its name, command, refresh interval,
+timeout, and default tone.
+
+### Item Editor
+
+Depending on the selected item, the editor exposes:
+
+- Style;
+- Tone;
+- Prefix;
+- Suffix;
+- Importance;
+- Reset to default;
+- Custom Text editing;
+- Custom Command editing (command, refresh, timeout);
+- Rename / Delete for user-owned custom items.
+
+`Tone` is semantic rather than arbitrary RGB/ANSI. The Host remains responsible
+for the actual terminal styling.
+
+## Builtin items and styles
+
+Builtin ids currently include:
+
+```text
+agent-preset
+model
+reasoning
+permission-preset
+sandbox-mode
+approval-policy
+plan-state
+focus-mode
+focused-seat
+view-scope
+cwd
+project
+git-branch
+run-state
+queue
+tasks
+agents
+todo
+context
+cache-hit
+token-usage
+performance
+turns-steps
+stats-line
+version
+ext:*
+```
+
+`ext:*` is the compatibility bridge for the legacy aggregate extension Footer
+segment. First-class extension items use their own `ext:<owner>/<id>` identity.
+
+Common builtin Style sets include:
+
+| Item | Styles |
+| --- | --- |
+| Agent preset | `badge`, `compact` |
+| Model | `badge`, `plain`, `compact` |
+| Permission preset | `badge`, `plain`, `compact` |
+| Plan state | `badge`, `plain` |
+| Working directory | `short`, `basename`, `full` |
+| Git branch | `plain`, `label` |
+| Context | `bar`, `percent`, `full` |
+| Token usage | `io`, `total`, `compact` |
+| Cache hit | `full`, `compact` |
+| Performance | `full`, `speed`, `latency` |
+| Turns / steps | `both`, `turns`, `steps` |
+| Version | `tui`, `dsh`, `both` |
+
+Omitting `format` keeps that item's default Style.
+
+The selected Style is a persisted preference. On a narrow terminal the runtime
+may render a shorter density form to preserve more useful information; that
+does not rewrite the saved Style.
+
+## Custom Text items
+
+Create a Custom Text item from the Add picker:
+
+```text
+/footer
+→ select row
+→ A
+→ + Create Custom Text
+```
+
+A Custom Text definition belongs to the USER settings layer and uses the
+`user:*` id namespace.
+
+A hand-written equivalent looks like:
+
+```yaml
+footer: custom
+
+footerCustomItems:
+  - schemaVersion: 1
+    id: user:environment
+    kind: text
+    text: prod
+    tone: warning
+
+footerLayout:
+  schemaVersion: 1
+  rows:
+    - left:
+        - id: model
+        - id: user:environment
+      right:
+        - id: context
+```
+
+The custom definition and its placement are separate facts:
+
+- `footerCustomItems` defines what `user:environment` is;
+- `footerLayout` decides whether it is visible, where it appears, and whether
+  the placement overrides its Tone / Prefix / Suffix / Importance.
+
+Deleting or renaming a custom item through `/footer` also updates the managed
+layout references.
+
+## Custom Command Items
+
+Create one from:
+
+```text
+/footer
+→ select row
+→ A
+→ + Create Custom Command
+```
+
+A Custom Command Item is an ordinary one-line Footer item backed by a local
+command.
+
+Example:
+
+```yaml
+footer: custom
+
+footerCustomItems:
+  - schemaVersion: 1
+    id: user:clock
+    kind: command
+    command: "date '+%H:%M'"
+    refreshIntervalMs: 5000
+    timeoutMs: 300
+    tone: textDim
+
+footerLayout:
+  schemaVersion: 1
+  rows:
+    - left:
+        - id: model
+        - id: git-branch
+      right:
+        - id: user:clock
+        - id: context
+```
+
+The current defaults are:
+
+| Setting | Default / bounds |
+| --- | --- |
+| `refreshIntervalMs` | default 5000 ms; runtime minimum 1000 ms |
+| `timeoutMs` | default 300 ms; runtime range 1..1000 ms |
+| rows contributed by one item | exactly 1 |
+
+The cached value is the **first non-empty sanitized stdout line**.
+
+An unsaved command draft is never executed. The configurator can show a
+placeholder while editing, but execution starts only after the settings write
+succeeds and the committed item is actually authorized and visible.
+
+If an item is hidden, removed, renamed, deleted, or no longer part of the
+rendered layout, its per-item runner is stopped and its cache is cleared.
+
+Changing a saved command invalidates the previous generation and starts the new
+configuration promptly; stale output from the old process cannot overwrite the
+new value.
+
+### Command examples
+
+The exact shell is platform-dependent. On a POSIX shell, simple examples are:
+
+```sh
+date '+%H:%M'
+```
+
+```sh
+git branch --show-current
+```
+
+```sh
+printf 'vpn up\n'
+```
+
+Keep Footer commands fast. A Footer is chrome, not a task runner.
+
+For expensive information, prefer a cheap cached helper command or a plugin
+that maintains its own state and only publishes plain Footer data.
+
+## Custom Command Item vs whole-footer command
+
+These are intentionally different features.
+
+| | Custom Command Item | Whole-footer command |
+| --- | --- | --- |
+| Created in `/footer` | Yes | No |
+| Replaces the whole Footer | No | Yes |
+| Mixes with builtin items | Yes | No |
+| Multiple commands | Multiple items may coexist | One surface command |
+| Output rows | One item line | Configurable whole-surface rows |
+| Native layout | Still the active layout | Used as fallback |
+| Typical use | Clock, branch helper, VPN/battery/build status | Fully custom status-line renderer |
+
+Use a **Custom Command Item** when you only need one dynamic fact.
+
+Use **whole-footer command mode** when you deliberately want to own the entire
+status surface.
+
+## Whole-footer command
+
+Whole-footer command mode is configured in the USER settings layer:
+
+```yaml
+footer: command
+
+footerCommand:
+  schemaVersion: 1
+  command: "~/.config/dsh/statusline.sh"
+  timeoutMs: 300
+  refreshIntervalMs: 1000
+  maxRows: 1
+```
+
+Current bounds are:
+
+| Setting | Default / bounds |
+| --- | --- |
+| `refreshIntervalMs` | default 1000 ms; minimum 1000 ms |
+| `timeoutMs` | default 300 ms; range 1..1000 ms |
+| `maxRows` | default 1; range 1..2 |
+
+The command receives a safe JSON status snapshot on stdin and writes the
+surface text to stdout.
+
+Stdout is sanitized before rendering. The Footer accepts the supported styling
+subset rather than arbitrary terminal control sequences.
+
+If the command is unavailable, invalid, times out, exits unsuccessfully, or
+produces no usable output, the TUI falls back to the native Footer surface.
+
+The Host instruction surface remains Host-owned; a command Footer cannot take
+over exit/cancellation instructions.
+
+## Status JSON on stdin
+
+Custom Command Items and the whole-footer command use the same safe status
+projection.
+
+The v1 payload has these top-level sections:
+
+```text
+schemaVersion
+surface
+view
+composition
+access
+collaboration
+interaction
+workspace
+activity
+usage
+host
+```
+
+`collaboration` currently carries only `plan`. For example, `workspace.cwd`
+is the current display subject's working directory, while
+`composition.model` describes the current model when known.
+
+The payload deliberately contains no:
+
+- secrets;
+- credentials;
+- raw user prompts;
+- tool arguments;
+- environment dump;
+- raw Session events.
+
+A small POSIX example using `jq`:
+
+```sh
+#!/bin/sh
+payload=$(cat)
+cwd=$(printf '%s' "$payload" | jq -r '.workspace.cwd // "-"')
+model=$(printf '%s' "$payload" | jq -r '.composition.model.id // "-"')
+printf '%s · %s\n' "$model" "$cwd"
+```
+
+The protocol is versioned with `schemaVersion: 1`. Scripts should tolerate
+optional facts being absent.
+
+## Extension-provided Footer items
+
+Plugins can contribute first-class configurable Footer items through the Stable
+extension API:
+
+```text
+@xmoon76/dsh-pi-tui/extensions
+```
+
+and the slot:
+
+```text
+chrome.footer.item
+```
+
+From the user's point of view:
+
+- the installed plugin's item appears in `/footer`;
+- it can be shown or hidden;
+- it can move between Left and Right;
+- it can be reordered with builtin and custom items;
+- an unloaded plugin leaves the persisted layout reference intact;
+- reloading the same plugin can restore the item automatically.
+
+The persisted identity is a canonical key such as:
+
+```text
+ext:plugin-name/quota
+```
+
+Users normally do not need to write that key by hand.
+
+Extension Footer items are plain Host-rendered data. They do not receive direct
+terminal ownership, arbitrary ANSI, cursor control, shell execution, or
+keyboard focus through this slot.
+
+Plugin authors should use the full contract in
+[Extension API v1](extension-api.md) rather than copying internal TUI code.
+
+## Responsive and narrow-terminal behavior
+
+The Footer is responsive.
+
+For native layouts, width pressure follows this general order:
+
+```text
+preferred presentation
+→ compact presentation where the item supports one
+→ drop lower-importance items
+→ safe truncation as the final fallback
+```
+
+This means a saved item can become shorter or disappear temporarily when the
+terminal is narrow.
+
+That is presentation only:
+
+- the saved Style is not changed;
+- the item is not deleted from the layout;
+- widening the terminal restores richer output when space is available.
+
+A layout currently contains one or two logical rows. Physical wrapping is
+bounded by the Footer's surface budget so Footer chrome cannot grow without
+limit and crowd the transcript/editor off screen.
+
+## Raw settings reference
+
+Most users should prefer `/footer`. The raw settings form is useful for
+dotfile management or debugging.
+
+### Native custom layout
+
+```yaml
+footer: custom
+
+footerLayout:
+  schemaVersion: 1
+  rows:
+    - left:
+        - id: agent-preset
+          format: compact
+        - id: model
+        - id: project
+        - id: context
+          format: full
+      right:
+        - id: focus-mode
+      separator:
+        text: " │ "
+        tone: textDim
+```
+
+Each item reference may also carry supported placement overrides such as Tone,
+Prefix, Suffix, and Importance.
+
+Invalid layouts fail soft rather than preventing the TUI from starting.
+
+### Custom definitions
+
+Custom definitions are stored separately from layout references:
+
+```yaml
+footerCustomItems:
+  - schemaVersion: 1
+    id: user:environment
+    kind: text
+    text: prod
+
+  - schemaVersion: 1
+    id: user:clock
+    kind: command
+    command: "date '+%H:%M'"
+    refreshIntervalMs: 5000
+    timeoutMs: 300
+```
+
+Keeping definition and placement separate lets the same custom definition
+survive show/hide/reorder operations without changing what it means.
+
+## Security model
+
+Footer commands are executable local code. Treat them like shell scripts you
+chose to run yourself.
+
+The important trust boundary is:
+
+> Repository or project settings must not be able to silently turn Footer
+> configuration into shell execution.
+
+For whole-footer command mode, both the mode and command must be owned by the
+USER settings layer.
+
+For Custom Command Items, a command definition must be USER-owned and committed,
+the USER's current Footer mode/layout must authorize it, and the item must also
+be part of the currently rendered layout.
+
+As a result:
+
+- a project cannot provide a command string for execution;
+- a project cannot resurrect a dormant command left in USER settings;
+- an unsaved `/footer` draft never executes;
+- a failed save never executes the draft;
+- hiding/removing an item stops its runner;
+- whole-footer command mode suspends per-item command runners.
+
+The stdin payload is intentionally free of secrets and prompts, but this does
+**not** sandbox the command itself. A local command still runs with the
+permissions and environment available to the TUI process.
+
+Keep commands small, auditable, and side-effect-free whenever possible.
+
+## Troubleshooting
+
+### My Custom Command shows nothing
+
+Check, in order:
+
+1. The item was actually saved.
+2. `footer` is using the layout that contains the item.
+3. The item is present in the currently rendered layout.
+4. The command exits successfully.
+5. It prints at least one non-empty stdout line.
+6. It finishes before `timeoutMs`.
+7. Its output is not only unsupported terminal control data.
+
+Prefer testing the command directly in the same shell environment first.
+
+### The command ran in my shell but not from a project config
+
+That is expected.
+
+Executable Footer commands are USER-trusted configuration. Repository/project
+configuration is intentionally unable to trigger shell execution.
+
+### An item disappears when I resize the terminal
+
+That is expected responsive behavior.
+
+Builtin items may compact first; lower-importance items may then be omitted
+until more width is available. The saved layout is unchanged.
+
+### A plugin Footer item disappeared
+
+The plugin may be unloaded or unavailable.
+
+The layout reference is preserved. Re-enabling/reloading the same plugin can
+restore its item without rebuilding the layout.
+
+### I changed a Style but narrow output looks different
+
+Style is the saved preferred presentation. Runtime density may choose a shorter
+form under width pressure without modifying that preference.
+
+## Plugin authors
+
+Do not import repository-private TUI internals to add a Footer item.
+
+Use the Stable package boundary:
+
+```text
+@xmoon76/dsh-pi-tui/extensions
+```
+
+and feature-detect the configurable Footer item capability before relying on
+it.
+
+See [Extension API v1](extension-api.md) for the authoritative registration,
+ownership, lifecycle, HMR identity, sanitization, and compatibility contract.


### PR DESCRIPTION
## What

Docs-only change that closes the Footer documentation gap: users previously
had to dig through the root README's long reference section or read source.

- **New** `docs/footer-customization.md` — user-facing Footer customization
  guide: quick start, the four item sources (Builtin / Custom Text / Custom
  Command Item / Extension Item), `/footer` editor walkthrough, builtin items
  and styles, Custom Text & Custom Command Items, the Custom Command Item vs
  whole-footer command distinction, whole-footer command config, the status
  JSON stdin protocol, extension-provided items, responsive/narrow-terminal
  behavior, raw settings reference, security model, troubleshooting.
- **Slimmed** `README.md` / `README.en.md` Footer sections (1:1 bilingual) —
  the README now points at the guide instead of duplicating the reference
  (full builtin ids, format/style enums, `footerLayout` YAML,
  `footerCommand` bounds, extension identity/HMR details moved out).
- `docs/README.md` index gains the `footer-customization.md` row (audience: users).

## Fact-checking

Every default/bound in the guide was verified against current sources:

- Custom Command Item: refresh default 5000 ms / runtime min 1000 ms,
  timeout default 300 ms / range 1..1000 ms, exactly 1 row,
  first non-empty sanitized stdout line (`custom-items.ts`,
  `command-runner.ts`, `command-trust.ts`).
- Whole-footer command: refresh default/min 1000 ms, timeout default 300 ms /
  1..1000 ms, `maxRows` 1..2, native fallback on any failure,
  Host instruction surface stays host-owned (`command-runner.ts`,
  `composer.ts`).
- stdin payload: v1 top-level sections match `FooterCommandInputV1`
  (`command-protocol.ts`); `workspace.cwd` / `composition.model.id` exist.
- Trust model: USER-layer ownership for command mode and custom items,
  activation = trusted USER definition ∩ USER-authorized layout ∩ rendered
  layout; unsaved/failed-save drafts never execute; hidden items stop their
  runner; command mode suspends per-item runners (`command-trust.ts`,
  `dynamic-item-runtime.ts`).
- Builtin ids (26 + `ext:*`) and style tables match `builtin-items.ts`
  (added the `agent-preset` badge/compact row).
- `/footer` UI strings/keys match the configurator (`+ Create Custom Text`,
  `+ Create Custom Command`, `S` / Save changes, dirty Esc guard,
  Move Mode, Item Editor).

## Verification

- `git diff --check` clean
- `node --test docs/tmux/*.test.mjs` (the `test:docs` target) — 11/11 pass
- New guide is CJK-free; relative links resolve; README bilingual structure 1:1

## Scope

Docs-only: no `packages/pi-tui` diff, no public API/schema/package.json/
CHANGELOG changes.