### PR TITLE
perf: long-session full-history search index + context measurement decoupling (PR D)

### DIFF
--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -660,21 +660,25 @@ async function main(): Promise<void> {
       row(`  normalized text recomputes during queries`, `${afterQueries.normalizedRefreshes - diag.normalizedRefreshes} (must stay 0)`)
     }
     // Incremental typing with prefix refinement: n -> ne -> nee -> need ->
-    // needle. Full scans happen once per corpus; every extension refines.
+    // needle. EACH sample starts from a FRESH 'n' full scan and refines the
+    // four extensions (a sample that carried the previous sample's needle
+    // candidates would measure a cheaper, unreal typing sequence — the
+    // candidates must always be the previous prefix's).
     for (const turns of [1000, 10_000]) {
       const folder = new TranscriptFolder()
       folder.hydrate(buildSearchEvents(turns))
       const diag = folder.searchDiagnosticsForTest()
-      let matches = folder.search('n')
-      let revision = folder.searchRevision()
       const sequence = timeIt(FAST ? 10 : 20, () => {
+        let matches = folder.search('n')
+        let revision = folder.searchRevision()
         for (const partial of ['ne', 'nee', 'need', 'needle']) {
           matches = folder.search(partial, { previousQuery: partial.slice(0, -1), previousMatches: matches, revision })
           revision = folder.searchRevision()
         }
       })
       const after = folder.searchDiagnosticsForTest()
-      row(`incremental typing ${turns} turns (5 queries, refined)`, `${fmt(stats(sequence))} · fullScans ${after.fullScans - diag.fullScans} · refinedScans ${after.refinedScans - diag.refinedScans}`)
+      const samples = FAST ? 10 : 20
+      row(`incremental typing ${turns} turns (5 queries ×${samples} samples, refined)`, `${fmt(stats(sequence))} · fullScans ${after.fullScans - diag.fullScans} (${samples} fresh 'n' scans) · refinedScans ${after.refinedScans - diag.refinedScans}`)
     }
   }
 

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -729,11 +729,16 @@ async function main(): Promise<void> {
     const coordinator = new ContextMeasurementCoordinator()
     coordinator.bind('bench-session')
     let measureCalls = 0
+    // The Direct tokenMeter scan walks the live session's requests: model
+    // it as a scan proportional to the historical context (synthetic but
+    // non-trivial — the point is the cost is paid ONLY on explicit
+    // measures, never on cheap refreshes).
+    const history = new Array<number>(10_000).fill(1)
     const reader = (_sessionId: string): number => {
       measureCalls += 1
-      // The tokenMeter scan walks live session requests: model it as real
-      // work proportional to the historical context.
-      return 81_000
+      let scanned = 0
+      for (let i = 0; i < history.length; i += 1) scanned += history[i]!
+      return 81_000 + scanned
     }
     // Cheap-only phase: measure once (initial), then 1000 UI-only refreshes.
     coordinator.measure('bench-session', reader)
@@ -759,6 +764,39 @@ async function main(): Promise<void> {
       coordinator.measure('bench-session', reader)
     })
     row(`explicit measureContext ×${FAST ? 20 : 50} (dirty each call)`, fmt(stats(explicit)))
+  }
+
+  // 9. PR D1 LIVE hot-path maintenance (the review's P1 blockers): the
+  //    search projection must NOT make streaming or read-grouping
+  //    quadratic. The acceptance is the GROWTH CURVE, not a millisecond
+  //    threshold: size x10 must not come close to x100 time. (A 1 MiB
+  //    assistant streamed in 1 KiB chunks used to pay ~512 MiB of
+  //    lowercase work; a 1000-read group used to re-scan the whole merged
+  //    text per append.)
+  {
+    // Streaming: one growing assistant message, fixed 1 KiB chunks.
+    for (const totalKiB of [10, 100, 1000]) {
+      const events: SessionEvent[] = []
+      pushEvent(events, 'turn/start', { turn: 0 })
+      const chunk = 'x'.repeat(1024)
+      for (let i = 0; i < totalKiB; i += 1) {
+        pushEvent(events, 'assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: i, text: chunk } })
+      }
+      const apply = warmedP50(FAST ? 3 : 5, () => {
+        const folder = new TranscriptFolder()
+        folder.apply(events)
+      })
+      row(`streaming search-index maintenance (${totalKiB} KiB assistant, 1 KiB chunks)`, fmtMs(apply))
+    }
+    // Live adjacent read grouping: one growing merged read group.
+    for (const reads of [10, 100, 1000]) {
+      const events = buildReadHeavyEvents(1, reads)
+      const apply = warmedP50(FAST ? 3 : 5, () => {
+        const folder = new TranscriptFolder()
+        folder.apply(events)
+      })
+      row(`live read-group append (${reads} adjacent reads)`, fmtMs(apply))
+    }
   }
 
   console.log(rows.join('\n'))

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -27,8 +27,11 @@ import { TuiApp } from '../src/tui-app.ts'
 import { TranscriptFolder } from '../src/transcript.ts'
 import { StatsFolder } from '../src/stats.ts'
 import { TranscriptWindowController } from '../src/transcript-window.ts'
+import { ContextMeasurementCoordinator } from '../src/status/context-measurement.ts'
+import { usageFromStats } from '../src/status/derive-usage.ts'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { TranscriptMessage } from '../src/transcript.ts'
+import type { SessionStats } from '../src/stats.ts'
 
 const XtermTerminal = xterm.Terminal
 
@@ -690,6 +693,61 @@ async function main(): Promise<void> {
       void controller
       row(`window nav ×50 older / ×50 newer @${turns} turns`, `older ${fmt(stats(older))} · newer ${fmt(stats(newer))}`)
     }
+  }
+
+  // 8. PR D2 — status/context measurement decoupling: cheap status refresh
+  //    (cached facts + usage projection) must NEVER call the measurement
+  //    reader; lifecycle triggers measure a bounded number of times; the
+  //    explicit measurement cost is exposed separately (it is real work —
+  //    the point is that UI-only refreshes no longer pay it).
+  {
+    const CHEAP_SAMPLES = FAST ? 200 : 1000
+    const sessionStats: SessionStats = {
+      turns: 5000,
+      steps: 12_000,
+      llmMs: 900_000,
+      firstTokenMsAvg: 2100,
+      tokensPerSec: 14,
+      cacheHitPct: 62,
+      inputTokens: 48_000_000,
+      outputTokens: 2_100_000,
+      cacheReadTokens: 30_000_000,
+      cacheWriteTokens: 9_000_000,
+      contextWindow: 128_000,
+    }
+    const coordinator = new ContextMeasurementCoordinator()
+    coordinator.bind('bench-session')
+    let measureCalls = 0
+    const reader = (_sessionId: string): number => {
+      measureCalls += 1
+      // The tokenMeter scan walks live session requests: model it as real
+      // work proportional to the historical context.
+      return 81_000
+    }
+    // Cheap-only phase: measure once (initial), then 1000 UI-only refreshes.
+    coordinator.measure('bench-session', reader)
+    const cheap = timeIt(CHEAP_SAMPLES, () => {
+      usageFromStats(sessionStats, coordinator.valueFor('bench-session'))
+    })
+    row(`cheap status refresh ×${CHEAP_SAMPLES} (cached measurement)`, `${fmt(stats(cheap))} · measureContextCalls ${measureCalls - 1} (must stay 0)`)
+    // Mixed realistic loop: 100 UI-only refreshes + 10 lifecycle triggers.
+    const lifecycle = new ContextMeasurementCoordinator()
+    lifecycle.bind('bench-session')
+    let mixedMeasureCalls = 0
+    for (let i = 0; i < 100; i += 1) {
+      usageFromStats(sessionStats, lifecycle.valueFor('bench-session'))
+      if (i % 10 === 0) {
+        lifecycle.markDirty()
+        lifecycle.measure('bench-session', () => { mixedMeasureCalls += 1; return 82_000 })
+      }
+    }
+    row('mixed loop (100 UI-only + 10 lifecycle refreshes)', `measureContextCalls ${mixedMeasureCalls} (expect 10, never 110)`)
+    // Explicit measurement cost, exposed separately (the Direct reader scan).
+    const explicit = timeIt(FAST ? 20 : 50, () => {
+      coordinator.markDirty()
+      coordinator.measure('bench-session', reader)
+    })
+    row(`explicit measureContext ×${FAST ? 20 : 50} (dirty each call)`, fmt(stats(explicit)))
   }
 
   console.log(rows.join('\n'))

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -26,6 +26,7 @@ import xterm from '@xterm/headless'
 import { TuiApp } from '../src/tui-app.ts'
 import { TranscriptFolder } from '../src/transcript.ts'
 import { StatsFolder } from '../src/stats.ts'
+import { TranscriptWindowController } from '../src/transcript-window.ts'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { TranscriptMessage } from '../src/transcript.ts'
 
@@ -269,6 +270,51 @@ function buildTextHeavyEvents(turns: number, assistantChars: number, resultChars
         id: `text-heavy-result-${turn}`,
         role: 'user',
         content: [{ type: 'tool-result', toolCallId: callId, content: [{ type: 'text', text: repeatedText(resultChars) }] }],
+        source: { kind: 'tool', callId },
+      },
+    })
+    pushEvent(events, 'turn/end', { turn, reason: { kind: 'completed' } })
+  }
+  return events
+}
+
+/** Build a search-focused log: every turn hits a COMMON needle, one early
+ * turn holds a RARE needle, and no turn holds the MISS needle. */
+function buildSearchEvents(turns: number): SessionEvent[] {
+  const events: SessionEvent[] = []
+  for (let turn = 0; turn < turns; turn += 1) {
+    pushEvent(events, 'turn/start', { turn })
+    pushEvent(events, 'user/message', {
+      id: `search-user-${turn}`,
+      role: 'user',
+      content: [{ type: 'text', text: `user prompt ${turn} with needle ${turn} and filler text` }],
+      source: { kind: 'user' },
+    })
+    pushEvent(events, 'assistant/message', {
+      turn,
+      step: 0,
+      message: {
+        id: `search-answer-${turn}`,
+        role: 'assistant',
+        content: [{ type: 'text', text: `assistant answer ${turn} with a common needle phrase and ${turn === 0 ? 'the-rare-needle sits here' : 'ordinary tail'}` }],
+        source: { kind: 'model', provider: 'bench', model: 'bench' },
+      },
+    })
+    const callId = `search-tool-${turn}`
+    pushEvent(events, 'tool/call', {
+      turn,
+      step: 0,
+      callId,
+      name: 'read',
+      arguments: JSON.stringify({ file: `src/file-${turn}.ts` }),
+    })
+    pushEvent(events, 'tool/result', {
+      turn,
+      step: 0,
+      message: {
+        id: `search-result-${turn}`,
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId: callId, content: [{ type: 'text', text: `read output for turn ${turn} with needle payload` }] }],
         source: { kind: 'tool', callId },
       },
     })
@@ -576,6 +622,75 @@ async function main(): Promise<void> {
   for (let index = 0; index < 100; index += 1) batcher.invalidate()
   await Promise.resolve()
   row('invalidation burst coalescing (100 in one tick)', `${flushCount} flush(es)`)
+
+  // 6. PR D1 — indexed full-history search: cold index build (allowed
+  //    O(history)), then query classes over the LIGHTWEIGHT projection
+  //    (never messages()/grouping/materialization), plus the incremental
+  //    typing sequence with refinement. The structural counters prove the
+  //    query path does not rebuild projection work.
+  {
+    const SEARCH_SAMPLES = FAST ? 100 : 400
+    for (const turns of [100, 1000, 10_000]) {
+      const folder = new TranscriptFolder()
+      folder.hydrate(buildSearchEvents(turns))
+      const messages = folder.messages()
+      const diag = folder.searchDiagnosticsForTest()
+      const cold = timeIt(1, () => {
+        const candidate = new TranscriptFolder()
+        candidate.hydrate(buildSearchEvents(turns))
+      })
+      const q = (query: string): number[] => timeIt(SEARCH_SAMPLES, () => { folder.search(query) })
+      const miss = q('unlikely-needle-not-present')
+      const common = q('needle')
+      const rare = q('the-rare-needle')
+      const afterQueries = folder.searchDiagnosticsForTest()
+      row(`search ${turns} turns (${messages.length} logical messages, ${afterQueries.entries} entries)`, `common hits ${folder.search('needle').length} · fullScans ${afterQueries.fullScans - diag.fullScans}`)
+      row('  cold hydrate + index build', fmtMs(cold[0]!))
+      row(`  query miss ×${SEARCH_SAMPLES}`, fmt(stats(miss)))
+      row(`  query common ×${SEARCH_SAMPLES}`, fmt(stats(common)))
+      row(`  query rare ×${SEARCH_SAMPLES}`, fmt(stats(rare)))
+      row(`  normalized text recomputes during queries`, `${afterQueries.normalizedRefreshes - diag.normalizedRefreshes} (must stay 0)`)
+    }
+    // Incremental typing with prefix refinement: n -> ne -> nee -> need ->
+    // needle. Full scans happen once per corpus; every extension refines.
+    for (const turns of [1000, 10_000]) {
+      const folder = new TranscriptFolder()
+      folder.hydrate(buildSearchEvents(turns))
+      const diag = folder.searchDiagnosticsForTest()
+      let matches = folder.search('n')
+      let revision = folder.searchRevision()
+      const sequence = timeIt(FAST ? 10 : 20, () => {
+        for (const partial of ['ne', 'nee', 'need', 'needle']) {
+          matches = folder.search(partial, { previousQuery: partial.slice(0, -1), previousMatches: matches, revision })
+          revision = folder.searchRevision()
+        }
+      })
+      const after = folder.searchDiagnosticsForTest()
+      row(`incremental typing ${turns} turns (5 queries, refined)`, `${fmt(stats(sequence))} · fullScans ${after.fullScans - diag.fullScans} · refinedScans ${after.refinedScans - diag.refinedScans}`)
+    }
+  }
+
+  // 7. PR C navigation baseline (unchanged by D1/D2 — recorded so a
+  //    regression in grouped/window indexes or a D2 measurement leak into
+  //    navigation stays visible): moveOlder ×50 + moveNewer ×50.
+  {
+    const NAV_SAMPLES = FAST ? 20 : 50
+    for (const turns of [100, 1000, 10_000]) {
+      const folder = new TranscriptFolder()
+      folder.hydrate(buildEvents(turns))
+      const controller = new TranscriptWindowController({ turns: folder.groupedTurns() })
+      const older = timeIt(NAV_SAMPLES, () => {
+        const c = new TranscriptWindowController({ turns: folder.groupedTurns() })
+        for (let i = 0; i < 50; i += 1) c.moveOlder()
+      })
+      const newer = timeIt(NAV_SAMPLES, () => {
+        const c = new TranscriptWindowController({ turns: folder.groupedTurns() })
+        for (let i = 0; i < 50; i += 1) c.moveNewer()
+      })
+      void controller
+      row(`window nav ×50 older / ×50 newer @${turns} turns`, `older ${fmt(stats(older))} · newer ${fmt(stats(newer))}`)
+    }
+  }
 
   console.log(rows.join('\n'))
 }

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -649,6 +649,11 @@ async function main(): Promise<void> {
       const afterQueries = folder.searchDiagnosticsForTest()
       row(`search ${turns} turns (${messages.length} logical messages, ${afterQueries.entries} entries)`, `common hits ${folder.search('needle').length} · fullScans ${afterQueries.fullScans - diag.fullScans}`)
       row('  cold hydrate + index build', fmtMs(cold[0]!))
+      // Plan §8.3 counters: the cold full projection count (logical
+      // messages), the one-time normalized rebuild work at hydrate, and the
+      // grouping rebuild count (all MUST stay flat across queries — the
+      // query rows above prove it).
+      row('  cold projection counters (fullProjectionCount / normalizedRebuilds / groupingRebuilds)', `${messages.length} / ${diag.normalizedRefreshes} / ${diag.groupingRebuilds}`)
       row(`  query miss ×${SEARCH_SAMPLES}`, fmt(stats(miss)))
       row(`  query common ×${SEARCH_SAMPLES}`, fmt(stats(common)))
       row(`  query rare ×${SEARCH_SAMPLES}`, fmt(stats(rare)))

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -649,21 +649,23 @@ async function main(): Promise<void> {
       const afterQueries = folder.searchDiagnosticsForTest()
       row(`search ${turns} turns (${messages.length} logical messages, ${afterQueries.entries} entries)`, `common hits ${folder.search('needle').length} · fullScans ${afterQueries.fullScans - diag.fullScans}`)
       row('  cold hydrate + index build', fmtMs(cold[0]!))
-      // Plan §8.3 counters: the cold full projection count (logical
-      // messages), the one-time normalized rebuild work at hydrate, and the
-      // grouping rebuild count (all MUST stay flat across queries — the
-      // query rows above prove it).
-      row('  cold projection counters (fullProjectionCount / normalizedRebuilds / groupingRebuilds)', `${messages.length} / ${diag.normalizedRefreshes} / ${diag.groupingRebuilds}`)
+      // Plan §8.3 structural counters: the REAL full-projection size
+      // (search entries — one per raw item), the logical-card count, the
+      // one-time normalized rebuild work at hydrate, and the grouping
+      // rebuild count (all MUST stay flat across queries — the query rows
+      // above prove it).
+      row('  cold projection counters (fullProjectionEntries / logicalMessages / normalizedRebuilds / groupingRebuilds)', `${diag.entries} / ${messages.length} / ${diag.normalizedRefreshes} / ${diag.groupingRebuilds}`)
       row(`  query miss ×${SEARCH_SAMPLES}`, fmt(stats(miss)))
       row(`  query common ×${SEARCH_SAMPLES}`, fmt(stats(common)))
       row(`  query rare ×${SEARCH_SAMPLES}`, fmt(stats(rare)))
       row(`  normalized text recomputes during queries`, `${afterQueries.normalizedRefreshes - diag.normalizedRefreshes} (must stay 0)`)
     }
-    // Incremental typing with prefix refinement: n -> ne -> nee -> need ->
-    // needle. EACH sample starts from a FRESH 'n' full scan and refines the
-    // four extensions (a sample that carried the previous sample's needle
-    // candidates would measure a cheaper, unreal typing sequence — the
-    // candidates must always be the previous prefix's).
+    // Incremental typing with prefix refinement, the plan §8.2 sequence:
+    // n -> ne -> nee -> need -> needl -> needle. EACH sample starts from a
+    // FRESH 'n' full scan and refines the five extensions (a sample that
+    // carried the previous sample's final candidates would measure a
+    // cheaper, unreal typing sequence — the candidates must always be the
+    // previous prefix's).
     for (const turns of [1000, 10_000]) {
       const folder = new TranscriptFolder()
       folder.hydrate(buildSearchEvents(turns))
@@ -671,14 +673,14 @@ async function main(): Promise<void> {
       const sequence = timeIt(FAST ? 10 : 20, () => {
         let matches = folder.search('n')
         let revision = folder.searchRevision()
-        for (const partial of ['ne', 'nee', 'need', 'needle']) {
+        for (const partial of ['ne', 'nee', 'need', 'needl', 'needle']) {
           matches = folder.search(partial, { previousQuery: partial.slice(0, -1), previousMatches: matches, revision })
           revision = folder.searchRevision()
         }
       })
       const after = folder.searchDiagnosticsForTest()
       const samples = FAST ? 10 : 20
-      row(`incremental typing ${turns} turns (5 queries ×${samples} samples, refined)`, `${fmt(stats(sequence))} · fullScans ${after.fullScans - diag.fullScans} (${samples} fresh 'n' scans) · refinedScans ${after.refinedScans - diag.refinedScans}`)
+      row(`incremental typing ${turns} turns (6 queries ×${samples} samples, refined)`, `${fmt(stats(sequence))} · fullScans ${after.fullScans - diag.fullScans} (${samples} fresh 'n' scans) · refinedScans ${after.refinedScans - diag.refinedScans}`)
     }
   }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -433,6 +433,15 @@ export interface TuiCommandRunner {
   /** Re-compose a still-blank session onto another preset (see recomposeBlank). */
   recomposeBlank(presetId: string): Promise<{ kind: 'switched'; preset: string } | { kind: 'locked' }>
   refreshStatus(): void
+  /** PR D2: the /status explicit context force — measures NOW through the
+   * runner's context coordinator (mark dirty + semantic SessionReader),
+   * repaints the footer cheaply, and returns the fresh (or last-good)
+   * value for the panel. Panel and footer share ONE cached measurement —
+   * a caller SHOULD prefer this over a direct sessionReader read (which
+   * would bypass the cache and could duplicate an in-flight measurement).
+   * Optional: stubs without the coordinator fall back to a direct
+   * sessionReader read. */
+  forceContextMeasurement?(): number | undefined
   /** Whether Focus Mode is currently on (the authoritative runtime state). */
   focusEnabled(): boolean
   /** The UNIFIED Focus setter: mutates the runtime state and the TUI
@@ -3288,10 +3297,13 @@ export function registerTuiCommands(
     handler: async () => {
       const liveAgent = await requireAgent()
       const stats = computeStats(liveAgent.session.events)
-      // Best-effort context measurement through the session-read port
-      // (migration M1.11): unavailable/unmeasurable → the panel falls back
-      // to unmeasured — never a crash.
-      const contextTokens = runner.sessionReader.measureContext(liveAgent.session.id)
+      // Explicit status: measure NOW through the runner's context
+      // coordinator — the panel and the cached footer value share ONE
+      // measurement (no duplicate reads, no stale footer). Stubs without
+      // the coordinator fall back to a direct session-read port read
+      // (best-effort, migration M1.11): unavailable/unmeasurable → the
+      // panel falls back to unmeasured — never a crash.
+      const contextTokens = runner.forceContextMeasurement?.() ?? runner.sessionReader.measureContext(liveAgent.session.id)
       app.openSettings(
         [
           {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3303,7 +3303,17 @@ export function registerTuiCommands(
       // the coordinator fall back to a direct session-read port read
       // (best-effort, migration M1.11): unavailable/unmeasurable → the
       // panel falls back to unmeasured — never a crash.
-      const contextTokens = runner.forceContextMeasurement?.() ?? runner.sessionReader.measureContext(liveAgent.session.id)
+      // Explicit status: measure NOW through the runner's context
+      // coordinator — the panel and the cached footer value share ONE
+      // measurement (no duplicate reads, no stale footer). The direct
+      // session-read port is used ONLY when the coordinator is absent
+      // (stubs): an explicit presence check, never a `??` fallback — a
+      // force returning undefined (no live session / measurement failure)
+      // must not trigger a second, uncached measurement (round-9 finding).
+      const forceContext = runner.forceContextMeasurement
+      const contextTokens = forceContext === undefined
+        ? runner.sessionReader.measureContext(liveAgent.session.id)
+        : forceContext()
       app.openSettings(
         [
           {

--- a/src/footer/command-runner.ts
+++ b/src/footer/command-runner.ts
@@ -233,6 +233,15 @@ export class FooterCommandRunner {
     // writes enough stderr to fill the pipe buffer would BLOCK and get
     // misjudged as a timeout otherwise).
     child.stderr?.on('data', () => {})
+    // Defensive stream-error handling (round-3 finding): the stdout/stderr
+    // read streams carry 'data' listeners but no 'error' listener — an
+    // unhandled EventEmitter 'error' would crash the process, violating
+    // the runner's fail-soft contract. The errors are SWALLOWED, not
+    // settled early: the close/timeout machinery below already settles
+    // every run, and settling from a stream error would clear `this.child`
+    // and let a still-running child escape the timeout's kill.
+    child.stdout?.on('error', () => {})
+    child.stderr?.on('error', () => {})
     let output = ''
     let outputBytes = 0
     // The decoder buffers a PARTIAL multibyte sequence across chunks, so a
@@ -288,6 +297,13 @@ export class FooterCommandRunner {
       this.options.width(),
       this.options.height(),
     ))
+    // An instant-exit child (e.g. `true` via the shell) can close its
+    // stdin before the JSON payload flushes: the async EPIPE on the
+    // parent's stdin stream is an unhandled 'error' event without a
+    // listener and would crash the whole process (the same round-3
+    // finding as the clipboard helper). Swallow it — the child's close
+    // handler settles the result.
+    child.stdin?.on('error', () => {})
     try {
       child.stdin?.write(input)
       child.stdin?.end()

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ import type { CredentialRef } from '@deepseek-ai/dsh-credentials'
 import type {} from '@deepseek-ai/dsh-credentials'
 import { TUI_STARTUP_SERVICE } from './startup.ts'
 import { toolPresenterFrom, type ToolDefinitionLike } from './present.ts'
-import { childOwnEvents, searchTranscript, textOf, TranscriptFolder } from './transcript.ts'
+import { childOwnEvents, textOf, TranscriptFolder, type TranscriptSearchMatch } from './transcript.ts'
 import type { TranscriptMessage, TranscriptWindow } from './transcript.ts'
 import { TranscriptWindowController } from './transcript-window.ts'
 import type { TranscriptWindowState } from './transcript-window.ts'
@@ -3317,10 +3317,29 @@ export function apply(ctx: Context, config: Config): void {
     // The in-flight compaction's id (paired start/end in the firehose): a
     // stale end must never clear a NEWER compaction's footer/busy state.
     let compactingId: string | undefined
-    // Transcript-search state (see the onSearch* events below).
-    let searchMatches: TranscriptMessage[] = []
+    // Transcript-search state (see the onSearch* events below). Matches are
+    // LIGHTWEIGHT stable identities ({id, turn} — never full message
+    // objects): the full-history search runs over the folder's incremental
+    // projection, so a query change never materializes the grouped
+    // transcript nor re-lowercases history.
+    let searchMatches: TranscriptSearchMatch[] = []
     let searchCurrent = -1
      let searchOrigin: { controller: TranscriptWindowController; state: TranscriptWindowState } | undefined
+    // Query-refinement state (D1): the previous query's matches are reused
+    // only when the new query PREFIX-extends the previous one on the SAME
+    // folder with an UNCHANGED projection revision (the folder validates
+    // both; the folder identity guard keeps a subagent viewer's matches
+    // from ever being reused for the parent session or vice versa).
+    let lastSearchQuery = ''
+    let lastSearchRevision = 0
+    let lastSearchFolder: TranscriptFolder | undefined
+    const resetSearchState = (): void => {
+      searchMatches = []
+      searchCurrent = -1
+      lastSearchQuery = ''
+      lastSearchRevision = 0
+      lastSearchFolder = undefined
+    }
     // Monotonic session generation: bumped on EVERY session swap (switch,
     // resume, deferred creation). Late async work (the skill command
     // catalog refresh, model-menu info, title folds) captures the
@@ -3339,8 +3358,7 @@ export function apply(ctx: Context, config: Config): void {
       // and dead callId→child maps would silently disable the auto-pop.
       pendingSubagentCalls.length = 0
       viewCallToChild.clear()
-      searchMatches = []
-      searchCurrent = -1
+      resetSearchState()
       searchOrigin = undefined
       windowController.latest()
       windowController.setTurns(folder.groupedTurns())
@@ -3395,15 +3413,14 @@ export function apply(ctx: Context, config: Config): void {
     const jumpToSearchMatch = (): void => {
       const match = searchMatches[searchCurrent]
       if (match === undefined) return
-      const turn = 'turn' in match ? match.turn : undefined
       // ONE fold snapshot: the anchored message window and the activities
       // come from the same folder call (plan §19 — a jump must never
       // combine a fresh window with stale activity data).
       const folder = activeFolder()
       const controller = activeWindow()
-       if (turn !== undefined) controller.anchorAt(turn)
-       repaint(app, folder, controller)
-       app.scrollToBottom({ disableFollow: !controller.isLatest() })
+      controller.anchorAt(match.turn)
+      repaint(app, folder, controller)
+      app.scrollToBottom({ disableFollow: !controller.isLatest() })
 
       // Focus Mode: the search hits the FULL transcript (hidden process
       // rows included — plan §23), so a jump into a collapsed turn must
@@ -3411,9 +3428,13 @@ export function apply(ctx: Context, config: Config): void {
       // SECONDARY card must full-reveal that card (plan §28; the compact
       // timeline is a FULLSCREEN property — regular Focus full-reveals
       // any expanded root anyway). The disclosure is not reverted when
-      // search closes.
-      if (turn !== undefined && app.isFocusModeEnabled()) {
-        app.revealSearchMatch(match)
+      // search closes. The match resolves to its CURRENT visible card: a
+      // group reflow after the query may have replaced the card object —
+      // resolving by stable id fails soft (the turn jump above already
+      // landed the window; only the exact-card reveal is skipped).
+      if (app.isFocusModeEnabled()) {
+        const message = folder.resolveSearchMatch(match)
+        if (message !== undefined) app.revealSearchMatch(message)
       }
       app.setSearchResult(searchCurrent + 1, searchMatches.length)
     }
@@ -4878,8 +4899,7 @@ export function apply(ctx: Context, config: Config): void {
         // the search origin before closing the overlay so its close callback
         // cannot restore the historical anchor we are explicitly leaving.
         searchOrigin = undefined
-        searchMatches = []
-        searchCurrent = -1
+        resetSearchState()
         const closedSearch = app.closeTranscriptSearch()
         const controller = activeWindow()
         const changed = controller.latest()
@@ -4903,14 +4923,25 @@ export function apply(ctx: Context, config: Config): void {
         }
       },
       // Transcript search: matches run over the FULL folded
-      // transcript; each jump re-windows the view so the matched turn is
-      // visible (older turns collapse above it into the summary entry).
+      // transcript (lightweight indexed projection — never a full
+      // materialization); each jump re-windows the view so the matched turn
+      // is visible (older turns collapse above it into the summary entry).
       onSearchOpen: () => {
         const controller = activeWindow()
         searchOrigin = { controller, state: controller.state() }
       },
       onSearchQuery: (query) => {
-        searchMatches = searchTranscript(activeFolder(), query)
+        const folder = activeFolder()
+        // Prefix refinement reuses the previous candidate set only when the
+        // query EXTENDS it on the SAME folder; the folder itself also
+        // requires an unchanged projection revision (a live append or group
+        // reflow between queries invalidates the candidates).
+        searchMatches = folder.search(query, lastSearchQuery !== '' && folder === lastSearchFolder
+          ? { previousQuery: lastSearchQuery, previousMatches: searchMatches, revision: lastSearchRevision }
+          : undefined)
+        lastSearchQuery = query
+        lastSearchRevision = folder.searchRevision()
+        lastSearchFolder = folder
         searchCurrent = searchMatches.length > 0 ? 0 : -1
         app.setSearchResult(searchCurrent + 1, searchMatches.length)
         if (searchCurrent >= 0) jumpToSearchMatch()
@@ -4926,8 +4957,7 @@ export function apply(ctx: Context, config: Config): void {
         jumpToSearchMatch()
       },
       onSearchClose: () => {
-        searchMatches = []
-        searchCurrent = -1
+        resetSearchState()
         const origin = searchOrigin
         searchOrigin = undefined
         const controller = activeWindow()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1268,11 +1268,14 @@ export function refreshedSearchState(
   const matches = activeFolder.search(state.query)
   const revision = activeFolder.searchRevision()
   let current: number
-  if (previousId !== undefined) {
+  if (matches.length === 0) {
+    // An emptied result set clamps to -1 (the 0/0 counter), never 0.
+    current = -1
+  } else if (previousId !== undefined) {
     const found = matches.findIndex(match => match.id === previousId)
-    current = found >= 0 ? found : Math.min(state.current, Math.max(0, matches.length - 1))
+    current = found >= 0 ? found : Math.min(state.current, matches.length - 1)
   } else {
-    current = matches.length > 0 ? 0 : -1
+    current = 0
   }
   return { matches, current, revision, changed: true }
 }
@@ -5093,11 +5096,16 @@ export function apply(ctx: Context, config: Config): void {
         if (searchCurrent >= 0) jumpToSearchMatch()
       },
       onSearchNext: () => {
+        // PR D1 P1: refresh BEFORE the empty guard — a search that began
+        // with zero matches must discover a match that arrived while the
+        // overlay stayed open.
+        refreshSearchMatchesIfStale()
         if (searchMatches.length === 0) return
         searchCurrent = (searchCurrent + 1) % searchMatches.length
         jumpToSearchMatch()
       },
       onSearchPrev: () => {
+        refreshSearchMatchesIfStale()
         if (searchMatches.length === 0) return
         searchCurrent = (searchCurrent - 1 + searchMatches.length) % searchMatches.length
         jumpToSearchMatch()

--- a/src/index.ts
+++ b/src/index.ts
@@ -2850,6 +2850,13 @@ export function apply(ctx: Context, config: Config): void {
         (callback) => setImmediate(callback),
         () => generation === sessionGeneration && liveAgent?.session.id === sessionId,
         () => {
+          // A measurement that already SUCCEEDED for this session (an
+          // explicit /status force, a compaction settle, or a lifecycle
+          // trigger before the deferred callback ran) cleared the dirty
+          // flag — the deferred initial measure is then redundant and must
+          // NOT re-measure (round-9 finding). A FAILED earlier attempt
+          // stays dirty, so the deferred callback retries it.
+          if (!contextMeasurement.isDirty()) return
           markContextDirty()
           refreshContextMeasurement('initial')
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1215,6 +1215,25 @@ export function busyAfterTurnBoundary(eventType: 'turn/start' | 'turn/end', comp
   return eventType === 'turn/start' || compacting
 }
 
+/** PR D2 test seam: whether a session event type marks the model-visible
+ * context dirty (re-measure through the SessionReader port) or only
+ * repaints cheaply (cached measurement). The firehose routes every event
+ * through this classification — the single source of truth for the
+ * status/measurement split. `compaction/end` is classified 'measure' but
+ * the firehose deliberately SKIPS it here: a matched compaction settle
+ * re-measures through the fold-outcome path (settleCompactionSurface), so
+ * a STALE compaction/end can never trigger a measurement. */
+export function contextRefreshKind(eventType: string): 'measure' | 'cheap' {
+  switch (eventType) {
+    case 'step/start':
+    case 'turn/end':
+    case 'compaction/end':
+      return 'measure'
+    default:
+      return 'cheap'
+  }
+}
+
 /**
  * The in-flight compaction state a resumed session log implies: the newest
  * compaction bracket decides. A `session/end-seed` boundary makes any
@@ -7039,6 +7058,15 @@ export function apply(ctx: Context, config: Config): void {
         settleCompactionSurface(app, () => { markContextDirty(); refreshContextMeasurement('compaction-end') }, workingFromLog(liveAgent.session.events))
       }
       if (compacted.notify !== undefined) app.notify(compacted.notify.text, compacted.notify.kind)
+      // PR D2: route the context re-measure decision through the single
+      // classifier (test seam). compaction/end is NOT routed here — its
+      // re-measure is driven by the MATCHED compaction fold above (a stale
+      // compaction/end must never re-measure).
+      const eventType = String(event.type)
+      if (eventType !== 'compaction/end' && contextRefreshKind(eventType) === 'measure') {
+        markContextDirty()
+        refreshContextMeasurement(eventType === 'turn/end' ? 'turn-end' : 'step-start')
+      }
       // Persist each completed turn so a crash loses at most the live turn.
       // The busy indicator follows turn boundaries: on from the moment a
       // turn starts (model wait + tool calls), off when it ends.
@@ -7063,9 +7091,6 @@ export function apply(ctx: Context, config: Config): void {
         // compaction settles) — the single-Esc cancel stays armed.
         app.setBusy(busyAfterTurnBoundary('turn/end', compactingId !== undefined))
         paintNow()
-        // A turn ended: the context composition settled — measure once.
-        markContextDirty()
-        refreshContextMeasurement('turn-end')
         // Persist each completed turn so a crash loses at most the live
         // turn. Detached: a flush rejection must never surface as an
         // unhandled rejection in the event firehose. An ENOENT flush (the
@@ -7082,11 +7107,6 @@ export function apply(ctx: Context, config: Config): void {
           ),
           recoverable: (error) => (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT',
         })
-      } else if (event.type === 'step/start') {
-        // A step is about to run: the model-visible context may have
-        // changed (new user message, tool results, compositions).
-        markContextDirty()
-        refreshContextMeasurement('step-start')
       }
     })
     // Subagent lifecycle events drive the continuable-children half of the

--- a/src/index.ts
+++ b/src/index.ts
@@ -2819,6 +2819,22 @@ export function apply(ctx: Context, config: Config): void {
       refreshStatusCheap()
     }
 
+    // The /status explicit force: a user asking for status expects the
+    // FRESH context (plan §15.1 — explicit-status may force). Measures now
+    // through the coordinator so the panel AND the cached footer value
+    // agree (round-8 finding: a direct sessionReader read from the command
+    // surface bypassed the cache and could duplicate the deferred initial
+    // measurement).
+    const forceContextMeasurement = (): number | undefined => {
+      const session = liveAgent?.session
+      if (session === undefined) return undefined
+      contextMeasurement.bind(session.id)
+      contextMeasurement.markDirty()
+      const value = contextMeasurement.measure(session.id, (id) => backend.sessionReader.measureContext(id))
+      refreshStatusCheap()
+      return value
+    }
+
     // The initial/post-switch measurement is deferred one event-loop turn
     // past the first usable paint: cold resume must never block the first
     // frame on a long-session context scan (plan §16.2 — setImmediate, not
@@ -6827,6 +6843,13 @@ export function apply(ctx: Context, config: Config): void {
       // the title batches, the context measurement and the export read go
       // through the port, never ctx directly.
       sessionReader: backend.sessionReader,
+      // PR D2: the /status explicit force — measure NOW through the
+      // coordinator (mark dirty + semantic reader), repaint the footer
+      // cheaply, and return the fresh (or last-good) value for the panel.
+      // Panel and footer share ONE cached measurement: no duplicate reads
+      // against the coordinator's cache, no stale footer after an explicit
+      // status (round-8 finding).
+      forceContextMeasurement,
       // The session WRITE port (migration M1.4): follow-up delivery, steer,
       // queue pull-back, cancel and title ops go through the port.
       sessionWriter: backend.sessionWriter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1234,6 +1234,49 @@ export function contextRefreshKind(eventType: string): 'measure' | 'cheap' {
   }
 }
 
+/** The runner's search-overlay state (the input of {@link refreshedSearchState}). */
+export interface SearchOverlayState {
+  readonly matches: readonly TranscriptSearchMatch[]
+  readonly current: number
+  readonly query: string
+  readonly revision: number
+  /** The folder the query ran on (identity guard: another folder's
+   * revision must never be considered current). */
+  readonly folder: TranscriptFolder | undefined
+}
+
+/** PR D1 P1: the search-overlay refresh policy. While the overlay is open
+ * the transcript keeps changing under it (settlements, read-group reflow,
+ * new messages), so Next/Prev must never jump with a stale candidate list
+ * or a stale turn. `changed: false` means the stored state is still
+ * current; otherwise the SAME query is re-run as a lightweight scan (never
+ * the previous candidates — a foreign folder or a moved revision must not
+ * refine against them), the previously current match is recovered by
+ * stable id when it still matches, and the current index is clamped
+ * otherwise. Returns the refreshed state the runner commits. */
+export function refreshedSearchState(
+  state: SearchOverlayState,
+  activeFolder: TranscriptFolder,
+): { matches: TranscriptSearchMatch[]; current: number; revision: number; changed: boolean } {
+  if (state.folder === activeFolder && activeFolder.searchRevision() === state.revision) {
+    return { matches: state.matches as TranscriptSearchMatch[], current: state.current, revision: state.revision, changed: false }
+  }
+  if (state.query === '') {
+    return { matches: [], current: -1, revision: activeFolder.searchRevision(), changed: true }
+  }
+  const previousId = state.current >= 0 ? state.matches[state.current]?.id : undefined
+  const matches = activeFolder.search(state.query)
+  const revision = activeFolder.searchRevision()
+  let current: number
+  if (previousId !== undefined) {
+    const found = matches.findIndex(match => match.id === previousId)
+    current = found >= 0 ? found : Math.min(state.current, Math.max(0, matches.length - 1))
+  } else {
+    current = matches.length > 0 ? 0 : -1
+  }
+  return { matches, current, revision, changed: true }
+}
+
 /**
  * The in-flight compaction state a resumed session log implies: the newest
  * compaction bracket decides. A `session/end-seed` boundary makes any
@@ -2721,7 +2764,16 @@ export function apply(ctx: Context, config: Config): void {
         // extension snapshot (a state transition where the permission
         // preset service or the live agent is momentarily gone).
         permission: deriveRunnerPermission(permission, liveAgent),
-        ...contextTokens !== undefined ? { contextTokens, contextWindow: stats.contextWindow } : {},
+        // EXPLICITLY CLEAR the legacy context fields when unmeasured: the
+        // TuiApp merge keeps old fields otherwise, and the session
+        // switch / cold-resume window before the deferred measurement
+        // would show the PREVIOUS session's context pressure — exactly the
+        // permission policy above (P1 finding: the previous conditional
+        // spread skipped the fields, leaving session A's measurement on
+        // session B's first frames, indefinitely when B's measurement
+        // fails).
+        contextTokens,
+        contextWindow: contextTokens === undefined ? undefined : stats.contextWindow,
       })
     }
 
@@ -3484,7 +3536,27 @@ export function apply(ctx: Context, config: Config): void {
       })
       return sessionGeneration
     }
+    // PR D1 P1: while the search overlay is open the transcript keeps
+    // changing (settlements, read-group reflow, new messages), so Next/Prev
+    // must never jump with a stale candidate list or a stale turn. This
+    // re-runs the SAME lightweight query when the active folder's
+    // projection revision moved (or the folder itself changed), recovers
+    // the previously current match by stable id, and clamps the index.
+    const refreshSearchMatchesIfStale = (): void => {
+      const folder = activeFolder()
+      const refreshed = refreshedSearchState(
+        { matches: searchMatches, current: searchCurrent, query: lastSearchQuery, revision: lastSearchRevision, folder: lastSearchFolder },
+        folder,
+      )
+      if (!refreshed.changed) return
+      searchMatches = refreshed.matches
+      searchCurrent = refreshed.current
+      lastSearchRevision = refreshed.revision
+      lastSearchFolder = folder
+      app.setSearchResult(searchCurrent + 1, searchMatches.length)
+    }
     const jumpToSearchMatch = (): void => {
+      refreshSearchMatchesIfStale()
       const match = searchMatches[searchCurrent]
       if (match === undefined) return
       // ONE fold snapshot: the anchored message window and the activities

--- a/src/index.ts
+++ b/src/index.ts
@@ -2850,12 +2850,17 @@ export function apply(ctx: Context, config: Config): void {
         (callback) => setImmediate(callback),
         () => generation === sessionGeneration && liveAgent?.session.id === sessionId,
         () => {
-          // A measurement that already SUCCEEDED for this session (an
-          // explicit /status force, a compaction settle, or a lifecycle
-          // trigger before the deferred callback ran) cleared the dirty
-          // flag — the deferred initial measure is then redundant and must
-          // NOT re-measure (round-9 finding). A FAILED earlier attempt
-          // stays dirty, so the deferred callback retries it.
+          // Bind the captured session BEFORE the dirty guard: on a cold
+          // resume the coordinator is still UNBOUND (reads as not dirty),
+          // and on a switch it is still bound to the PREVIOUS session —
+          // guarding before the bind would turn the deferred initial
+          // measure into a permanent no-op (round-10 finding). Binding a
+          // new identity clears the old value and arms a fresh measure;
+          // binding the same session is a no-op, so an earlier successful
+          // force/lifecycle measurement (dirty cleared) still makes this
+          // deferral redundant (round-9 finding), while a FAILED earlier
+          // attempt (dirty stays) is retried here.
+          contextMeasurement.bind(sessionId)
           if (!contextMeasurement.isDirty()) return
           markContextDirty()
           refreshContextMeasurement('initial')

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ import { derivePlanStatus, projectedPlanActive, type PlanProjectionLike } from '
 import { usageFromStats } from './status/derive-usage.ts'
 import { resolveDisplaySubject } from './status/resolve-subject.ts'
 import { ContextMeasurementCoordinator, deferInitialContextMeasure, type ContextMeasureReason } from './status/context-measurement.ts'
+import { refreshedSearchState, steppedSearchOverlayState, type SearchOverlayState } from './search-overlay.ts'
 import type { CompositionStatus, HostStatus, WorkspaceStatus } from './status/types.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
 import { parseFooterLayout, isFooterLayout, resolveCommandFooterFallback } from './footer/layout.ts'
@@ -1232,75 +1233,6 @@ export function contextRefreshKind(eventType: string): 'measure' | 'cheap' {
     default:
       return 'cheap'
   }
-}
-
-/** The runner's search-overlay state (the input of {@link refreshedSearchState}). */
-export interface SearchOverlayState {
-  readonly matches: readonly TranscriptSearchMatch[]
-  readonly current: number
-  readonly query: string
-  readonly revision: number
-  /** The folder the query ran on (identity guard: another folder's
-   * revision must never be considered current). */
-  readonly folder: TranscriptFolder | undefined
-}
-
-/** PR D1 P1: the search-overlay refresh policy. While the overlay is open
- * the transcript keeps changing under it (settlements, read-group reflow,
- * new messages), so Next/Prev must never jump with a stale candidate list
- * or a stale turn. `changed: false` means the stored state is still
- * current; otherwise the SAME query is re-run as a lightweight scan (never
- * the previous candidates — a foreign folder or a moved revision must not
- * refine against them), the previously current match is recovered by
- * stable id when it still matches, and the current index is clamped
- * otherwise. Returns the refreshed state the runner commits. */
-export function refreshedSearchState(
-  state: SearchOverlayState,
-  activeFolder: TranscriptFolder,
-): { matches: TranscriptSearchMatch[]; current: number; revision: number; changed: boolean } {
-  if (state.folder === activeFolder && activeFolder.searchRevision() === state.revision) {
-    return { matches: state.matches as TranscriptSearchMatch[], current: state.current, revision: state.revision, changed: false }
-  }
-  if (state.query === '') {
-    return { matches: [], current: -1, revision: activeFolder.searchRevision(), changed: true }
-  }
-  const previousId = state.current >= 0 ? state.matches[state.current]?.id : undefined
-  const matches = activeFolder.search(state.query)
-  const revision = activeFolder.searchRevision()
-  let current: number
-  if (matches.length === 0) {
-    // An emptied result set clamps to -1 (the 0/0 counter), never 0.
-    current = -1
-  } else if (previousId !== undefined) {
-    const found = matches.findIndex(match => match.id === previousId)
-    current = found >= 0 ? found : Math.min(state.current, matches.length - 1)
-  } else {
-    current = 0
-  }
-  return { matches, current, revision, changed: true }
-}
-
-/** PR D1 P1: the Next/Prev stepping policy — the search overlay state MUST
- * be refreshed BEFORE stepping (an empty candidate list still refreshes,
- * so a match that arrived while the overlay stayed open is discoverable),
- * then steps by one. An EMPTY refreshed list steps to -1 (the 0/0
- * counter). The runner's onSearchNext/onSearchPrev handlers call exactly
- * this seam. */
-export function steppedSearchOverlayState(
-  state: SearchOverlayState,
-  activeFolder: TranscriptFolder,
-  direction: 1 | -1,
-): { matches: TranscriptSearchMatch[]; current: number; revision: number; changed: boolean } {
-  const refreshed = refreshedSearchState(state, activeFolder)
-  if (refreshed.matches.length === 0) {
-    return { matches: refreshed.matches, current: -1, revision: refreshed.revision, changed: refreshed.changed }
-  }
-  const count = refreshed.matches.length
-  // A fresh list with no current item starts stepping from the first
-  // match (Next) / last match (Prev), mirroring the query-flow semantics.
-  const base = refreshed.current < 0 ? 0 : refreshed.current
-  const current = (base + direction + count) % count
-  return { matches: refreshed.matches, current, revision: refreshed.revision, changed: refreshed.changed }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1280,6 +1280,29 @@ export function refreshedSearchState(
   return { matches, current, revision, changed: true }
 }
 
+/** PR D1 P1: the Next/Prev stepping policy — the search overlay state MUST
+ * be refreshed BEFORE stepping (an empty candidate list still refreshes,
+ * so a match that arrived while the overlay stayed open is discoverable),
+ * then steps by one. An EMPTY refreshed list steps to -1 (the 0/0
+ * counter). The runner's onSearchNext/onSearchPrev handlers call exactly
+ * this seam. */
+export function steppedSearchOverlayState(
+  state: SearchOverlayState,
+  activeFolder: TranscriptFolder,
+  direction: 1 | -1,
+): { matches: TranscriptSearchMatch[]; current: number; revision: number; changed: boolean } {
+  const refreshed = refreshedSearchState(state, activeFolder)
+  if (refreshed.matches.length === 0) {
+    return { matches: refreshed.matches, current: -1, revision: refreshed.revision, changed: refreshed.changed }
+  }
+  const count = refreshed.matches.length
+  // A fresh list with no current item starts stepping from the first
+  // match (Next) / last match (Prev), mirroring the query-flow semantics.
+  const base = refreshed.current < 0 ? 0 : refreshed.current
+  const current = (base + direction + count) % count
+  return { matches: refreshed.matches, current, revision: refreshed.revision, changed: refreshed.changed }
+}
+
 /**
  * The in-flight compaction state a resumed session log implies: the newest
  * compaction bracket decides. A `session/end-seed` boundary makes any
@@ -5096,18 +5119,38 @@ export function apply(ctx: Context, config: Config): void {
         if (searchCurrent >= 0) jumpToSearchMatch()
       },
       onSearchNext: () => {
-        // PR D1 P1: refresh BEFORE the empty guard — a search that began
-        // with zero matches must discover a match that arrived while the
-        // overlay stayed open.
-        refreshSearchMatchesIfStale()
-        if (searchMatches.length === 0) return
-        searchCurrent = (searchCurrent + 1) % searchMatches.length
+        // PR D1 P1: refresh BEFORE stepping — an empty candidate list
+        // still refreshes (a match that arrived while the overlay stayed
+        // open must be discoverable), and the step is computed on the
+        // REFRESHED list. The policy lives in steppedSearchOverlayState,
+        // shared by both handlers.
+        const folder = activeFolder()
+        const stepped = steppedSearchOverlayState(
+          { matches: searchMatches, current: searchCurrent, query: lastSearchQuery, revision: lastSearchRevision, folder: lastSearchFolder },
+          folder,
+          1,
+        )
+        searchMatches = stepped.matches
+        searchCurrent = stepped.current
+        lastSearchRevision = stepped.revision
+        lastSearchFolder = folder
+        app.setSearchResult(searchCurrent + 1, searchMatches.length)
+        if (stepped.current < 0) return
         jumpToSearchMatch()
       },
       onSearchPrev: () => {
-        refreshSearchMatchesIfStale()
-        if (searchMatches.length === 0) return
-        searchCurrent = (searchCurrent - 1 + searchMatches.length) % searchMatches.length
+        const folder = activeFolder()
+        const stepped = steppedSearchOverlayState(
+          { matches: searchMatches, current: searchCurrent, query: lastSearchQuery, revision: lastSearchRevision, folder: lastSearchFolder },
+          folder,
+          -1,
+        )
+        searchMatches = stepped.matches
+        searchCurrent = stepped.current
+        lastSearchRevision = stepped.revision
+        lastSearchFolder = folder
+        app.setSearchResult(searchCurrent + 1, searchMatches.length)
+        if (stepped.current < 0) return
         jumpToSearchMatch()
       },
       onSearchClose: () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ import { deriveAccessStatus } from './status/derive-access.ts'
 import { derivePlanStatus, projectedPlanActive, type PlanProjectionLike } from './status/derive-plan.ts'
 import { usageFromStats } from './status/derive-usage.ts'
 import { resolveDisplaySubject } from './status/resolve-subject.ts'
+import { ContextMeasurementCoordinator, deferInitialContextMeasure, type ContextMeasureReason } from './status/context-measurement.ts'
 import type { CompositionStatus, HostStatus, WorkspaceStatus } from './status/types.ts'
 import { DEFAULT_FOOTER_LAYOUT } from './footer/presets.ts'
 import { parseFooterLayout, isFooterLayout, resolveCommandFooterFallback } from './footer/layout.ts'
@@ -2598,20 +2599,31 @@ export function apply(ctx: Context, config: Config): void {
       // when the runner is already torn down (the detached task outlives
       // the surface — a stale refresh would touch disposed state).
       if (signal.aborted) return
-      refreshStatus()
+      refreshStatusCheap()
     }
     runDetached('sandbox fold probe', resolveSandboxFold, { diag })
-    const refreshStatus = (): void => {
+    // PR D2: the session-bound context-measurement cache. The coordinator
+    // owns the value/dirty/session identity; the runner owns the event
+    // classification (which events mark dirty, which only repaint cheaply).
+    const contextMeasurement = new ContextMeasurementCoordinator()
+    const markContextDirty = (): void => { contextMeasurement.markDirty() }
+
+    // PR D2: the cheap status refresh NEVER measures context. UI-only
+    // events (theme, keybinding, permission, focus, resize, search,
+    // credential/llm surface changes, …) read the CACHED measurement; the
+    // only measuring path is refreshContextMeasurement below, driven by
+    // model-visible lifecycle events through the semantic SessionReader
+    // port (never a direct ctx.get('tokenMeter') read — the Direct adapter
+    // owns that coupling).
+    const refreshStatusCheap = (): void => {
       const stats = statsFolder.snapshot()
-      let contextTokens: number | undefined
-      const meter = ctx.get('tokenMeter')
-      if (meter !== undefined && liveAgent !== undefined) {
-        try {
-          contextTokens = meter.measure(liveAgent.session).totalTokens
-        } catch {
-          // Measurement is best-effort; the footer falls back to no context.
-        }
-      }
+      // The CACHED context pressure of the live session (the only measured
+      // subject — never a fresh measurement here). While the subagent
+      // viewer is open, the usage PROJECTION below still refuses to ride
+      // the parent's measurement on the child's stats (same rule as before
+      // the split); the legacy setStatus field keeps carrying the parent's
+      // cached value exactly like the old path.
+      const contextTokens = contextMeasurement.valueFor(liveAgent?.session.id)
       // The footer's [yolo]/[workspace-write]/[read-only]/[custom] mode badge
       // rides the effective preset (derived from the sandbox+approval knob
       // folds).
@@ -2692,6 +2704,43 @@ export function apply(ctx: Context, config: Config): void {
         permission: deriveRunnerPermission(permission, liveAgent),
         ...contextTokens !== undefined ? { contextTokens, contextWindow: stats.contextWindow } : {},
       })
+    }
+
+    // PR D2: the explicit, event-driven context measurement path. Call
+    // sites FIRST mark the cache dirty (markContextDirty — only
+    // model-visible lifecycle events may), then this function measures
+    // through the semantic SessionReader port and repaints cheaply. A
+    // clean cache skips the reader (same-sync-chain dedupe); a failed or
+    // unavailable measurement keeps the last-good value and the footer
+    // falls back — never a dialog, never a stale foreign session value
+    // (the coordinator is session-bound).
+    const refreshContextMeasurement = (_reason: ContextMeasureReason): void => {
+      const session = liveAgent?.session
+      if (session === undefined) return
+      contextMeasurement.bind(session.id)
+      contextMeasurement.measure(session.id, (id) => backend.sessionReader.measureContext(id))
+      refreshStatusCheap()
+    }
+
+    // The initial/post-switch measurement is deferred one event-loop turn
+    // past the first usable paint: cold resume must never block the first
+    // frame on a long-session context scan (plan §16.2 — setImmediate, not
+    // a microtask). The fence captures the session generation + id: a
+    // switch,/new, viewer swap or dispose before the callback runs makes it
+    // a no-op (a stale deferred measurement can never commit).
+    let cancelDeferredContextMeasure: (() => void) | undefined
+    const scheduleInitialContextMeasure = (agent: Agent): void => {
+      const generation = sessionGeneration
+      const sessionId = agent.session.id
+      cancelDeferredContextMeasure?.()
+      cancelDeferredContextMeasure = deferInitialContextMeasure(
+        (callback) => setImmediate(callback),
+        () => generation === sessionGeneration && liveAgent?.session.id === sessionId,
+        () => {
+          markContextDirty()
+          refreshContextMeasurement('initial')
+        },
+      )
     }
 
     let app: TuiApp
@@ -2840,6 +2889,10 @@ export function apply(ctx: Context, config: Config): void {
       // Abort any in-flight catalog refresh: its late result must never
       // register commands or repaint after the app is gone.
       catalogCoordinator?.dispose()
+      // PR D2: cancel the deferred initial context measure — a stale
+      // callback must never measure/repaint into the disposed surface.
+      cancelDeferredContextMeasure?.()
+      cancelDeferredContextMeasure = undefined
       // M5: release the footer command surface BEFORE the app dies — a
       // late status-store notification must not refresh into a disposed
       // surface. The lifecycle abort above already disposes an armed
@@ -3406,7 +3459,9 @@ export function apply(ctx: Context, config: Config): void {
         app.discardFocusViewerScope()
         repaint(app, folder, windowController)
         windowController.isLatest() ? app.scrollToBottom() : app.scrollToTop({ disableFollow: true })
-        refreshStatus()
+        // The new session's own measurement comes from its initLiveSession
+        // deferred path — the teardown refresh is UI-only.
+        refreshStatusCheap()
       })
       return sessionGeneration
     }
@@ -3595,7 +3650,7 @@ export function apply(ctx: Context, config: Config): void {
       // child's result, the parent's streaming): restore the parent's semantic latest/history position
       // so the pop never loses an intentional history anchor.
       windowController.isLatest() ? app.scrollToBottom() : app.scrollToTop({ disableFollow: true })
-      refreshStatus()
+      refreshStatusCheap()
       return true
     }
     /** Error sink for a failed session creation: restore the draft and
@@ -4776,7 +4831,7 @@ export function apply(ctx: Context, config: Config): void {
               ? `⚠ ${next} — no approvals`
               : `permission: ${next}`,
             next === 'danger-full-access' ? 'error' : 'info')
-            refreshStatus()
+            refreshStatusCheap()
             break
           }
         }
@@ -4994,7 +5049,7 @@ export function apply(ctx: Context, config: Config): void {
           ? `⚠ ${next} — no approvals`
           : `permission: ${next}`,
         next === 'danger-full-access' ? 'error' : 'info')
-        refreshStatus()
+        refreshStatusCheap()
       },
       // Alt+↑: pull every QUEUED USER message back into the editor draft
       // (pi's dequeue). Only user-origin rows are the user's own input —
@@ -6235,8 +6290,12 @@ export function apply(ctx: Context, config: Config): void {
       // settlements must notify again.
       notifiedSubagentNotices.clear()
       repaint(app, folder, windowController)
-      refreshStatus()
+      // PR D2: the first usable frame paints with the cached measurement
+      // (or none); the context measure is deferred one event-loop turn so
+      // cold resume never blocks first paint on a long-session scan.
+      refreshStatusCheap()
       refreshQueue()
+      scheduleInitialContextMeasure(agent)
       // Repaint both background channels: the dock/badge are owner-fenced,
       // and a session switch must not leave the previous session's tasks
       // or subagents on screen until the next registry event.
@@ -6471,7 +6530,7 @@ export function apply(ctx: Context, config: Config): void {
       app.setFocusMode(enabled)
       // The footer's focus-mode item reads the store: repaint it right
       // away (no session event is guaranteed to follow an idle toggle).
-      refreshStatus()
+      refreshStatusCheap()
       const settings = tuiSettings
       if (settings !== undefined) {
         runDetached('settings focus write', () => serializeTuiSettingsMutation(
@@ -6704,7 +6763,10 @@ export function apply(ctx: Context, config: Config): void {
       transitionTo,
       currentPreset,
       recomposeBlank: (id) => recomposeBlank(ctx, liveAgent as Agent, id),
-      refreshStatus,
+      // PR D2: the command surface's generic refresh is UI-only (a
+      // measurement-triggering command uses refreshContextMeasurement or
+      // the /status port call directly).
+      refreshStatus: refreshStatusCheap,
       updateWelcomeCard,
       openJobView,
       openTasksBrowser,
@@ -6785,7 +6847,7 @@ export function apply(ctx: Context, config: Config): void {
       await initLiveSession(liveAgent)
     } else {
       app.setWelcomeIdle(true)
-      refreshStatus()
+      refreshStatusCheap()
       refreshTerminalTitle()
     }
     // Command registration is sessionless: it must run on BOTH startup
@@ -6920,7 +6982,9 @@ export function apply(ctx: Context, config: Config): void {
       // knob events between turns: refresh the footer mode badge right away
       // instead of waiting for the next step/turn boundary.
       if (isKnob) {
-        refreshStatus()
+        // Knob events are UI-only: the permission badge repaints from
+        // cached facts — never a context measurement.
+        refreshStatusCheap()
       }
       // Every durable inbox mutation (followup, steer, splice) commits
       // an agent/inbox/spliced event. The upstream Inbox commits the event
@@ -6969,7 +7033,10 @@ export function apply(ctx: Context, config: Config): void {
         // turn/end. The working row hands back to the turn state: a
         // turn-enclosed compaction keeps the turn animation, a standalone
         // one clears.
-        settleCompactionSurface(app, refreshStatus, workingFromLog(liveAgent.session.events))
+        // Compaction rewrites the model-visible surface: re-measure NOW
+        // (the footer would otherwise show stale pressure until the next
+        // step/start or turn/end).
+        settleCompactionSurface(app, () => { markContextDirty(); refreshContextMeasurement('compaction-end') }, workingFromLog(liveAgent.session.events))
       }
       if (compacted.notify !== undefined) app.notify(compacted.notify.text, compacted.notify.kind)
       // Persist each completed turn so a crash loses at most the live turn.
@@ -6996,7 +7063,9 @@ export function apply(ctx: Context, config: Config): void {
         // compaction settles) — the single-Esc cancel stays armed.
         app.setBusy(busyAfterTurnBoundary('turn/end', compactingId !== undefined))
         paintNow()
-        refreshStatus()
+        // A turn ended: the context composition settled — measure once.
+        markContextDirty()
+        refreshContextMeasurement('turn-end')
         // Persist each completed turn so a crash loses at most the live
         // turn. Detached: a flush rejection must never surface as an
         // unhandled rejection in the event firehose. An ENOENT flush (the
@@ -7014,7 +7083,10 @@ export function apply(ctx: Context, config: Config): void {
           recoverable: (error) => (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT',
         })
       } else if (event.type === 'step/start') {
-        refreshStatus()
+        // A step is about to run: the model-visible context may have
+        // changed (new user message, tool results, compositions).
+        markContextDirty()
+        refreshContextMeasurement('step-start')
       }
     })
     // Subagent lifecycle events drive the continuable-children half of the
@@ -7052,14 +7124,14 @@ export function apply(ctx: Context, config: Config): void {
     // The credential update surface has reference and durable-record events;
     // both change the same footer/welcome state, so they share one refresh
     // callback.
-    ctx.on('llm/adapters-updated', () => { refreshStatus(); updateWelcomeCard() })
+    ctx.on('llm/adapters-updated', () => { refreshStatusCheap(); updateWelcomeCard() })
     ctx.on('settings/document-updated', (ns) => {
       if (ns === 'llm-pi-ai' || ns === 'llm-deepseek') {
-        refreshStatus()
+        refreshStatusCheap()
         updateWelcomeCard()
       }
     })
-    const refreshCredentialSurface = (): void => { refreshStatus(); updateWelcomeCard() }
+    const refreshCredentialSurface = (): void => { refreshStatusCheap(); updateWelcomeCard() }
     // The credential event wiring is the config port's (migration M1.9):
     // reference- and record-updated both change the same surface. The
     // subscription is DISPOSED on teardown — a remount/HMR must never

--- a/src/search-overlay.ts
+++ b/src/search-overlay.ts
@@ -1,0 +1,83 @@
+/**
+ * The search-overlay refresh/stepping policy (PR D1 P1): while the overlay
+ * is open the transcript keeps changing under it (settlements, read-group
+ * reflow, new messages), so Next/Prev must never jump with a stale
+ * candidate list or a stale turn.
+ *
+ * This is an INTERNAL module on purpose: the runner and the headless tests
+ * are its only consumers, and its signatures reference `TranscriptFolder`
+ * — exporting it from the runner's public entry (src/index.ts) would drag
+ * the private transcript declaration into the published `.d.mts` and fail
+ * the tarball-smoke "no private pi-tui / internal path leaks" gate.
+ * @module @xmoon76/dsh-pi-tui/search-overlay
+ */
+
+import { TranscriptFolder, type TranscriptSearchMatch } from './transcript.ts'
+
+/** The runner's search-overlay state (the input of
+ * {@link refreshedSearchState} / {@link steppedSearchOverlayState}). */
+export interface SearchOverlayState {
+  readonly matches: readonly TranscriptSearchMatch[]
+  readonly current: number
+  readonly query: string
+  readonly revision: number
+  /** The folder the query ran on (identity guard: another folder's
+   * revision must never be considered current). */
+  readonly folder: TranscriptFolder | undefined
+}
+
+/** PR D1 P1: the search-overlay refresh policy. `changed: false` means the
+ * stored state is still current; otherwise the SAME query is re-run as a
+ * lightweight scan (never the previous candidates — a foreign folder or a
+ * moved revision must not refine against them), the previously current
+ * match is recovered by stable id when it still matches, and the current
+ * index is clamped otherwise (an EMPTIED result set clamps to -1 — the
+ * 0/0 counter, never 0). Returns the refreshed state the runner commits. */
+export function refreshedSearchState(
+  state: SearchOverlayState,
+  activeFolder: TranscriptFolder,
+): { matches: TranscriptSearchMatch[]; current: number; revision: number; changed: boolean } {
+  if (state.folder === activeFolder && activeFolder.searchRevision() === state.revision) {
+    return { matches: state.matches as TranscriptSearchMatch[], current: state.current, revision: state.revision, changed: false }
+  }
+  if (state.query === '') {
+    return { matches: [], current: -1, revision: activeFolder.searchRevision(), changed: true }
+  }
+  const previousId = state.current >= 0 ? state.matches[state.current]?.id : undefined
+  const matches = activeFolder.search(state.query)
+  const revision = activeFolder.searchRevision()
+  let current: number
+  if (matches.length === 0) {
+    // An emptied result set clamps to -1 (the 0/0 counter), never 0.
+    current = -1
+  } else if (previousId !== undefined) {
+    const found = matches.findIndex(match => match.id === previousId)
+    current = found >= 0 ? found : Math.min(state.current, matches.length - 1)
+  } else {
+    current = 0
+  }
+  return { matches, current, revision, changed: true }
+}
+
+/** PR D1 P1: the Next/Prev stepping policy — the search overlay state MUST
+ * be refreshed BEFORE stepping (an empty candidate list still refreshes,
+ * so a match that arrived while the overlay stayed open is discoverable),
+ * then steps by one. An EMPTY refreshed list steps to -1 (the 0/0
+ * counter). The runner's onSearchNext/onSearchPrev handlers call exactly
+ * this seam. */
+export function steppedSearchOverlayState(
+  state: SearchOverlayState,
+  activeFolder: TranscriptFolder,
+  direction: 1 | -1,
+): { matches: TranscriptSearchMatch[]; current: number; revision: number; changed: boolean } {
+  const refreshed = refreshedSearchState(state, activeFolder)
+  if (refreshed.matches.length === 0) {
+    return { matches: refreshed.matches, current: -1, revision: refreshed.revision, changed: refreshed.changed }
+  }
+  const count = refreshed.matches.length
+  // A fresh list with no current item starts stepping from the first
+  // match (Next) / last match (Prev), mirroring the query-flow semantics.
+  const base = refreshed.current < 0 ? 0 : refreshed.current
+  const current = (base + direction + count) % count
+  return { matches: refreshed.matches, current, revision: refreshed.revision, changed: refreshed.changed }
+}

--- a/src/search-overlay.ts
+++ b/src/search-overlay.ts
@@ -75,9 +75,17 @@ export function steppedSearchOverlayState(
     return { matches: refreshed.matches, current: -1, revision: refreshed.revision, changed: refreshed.changed }
   }
   const count = refreshed.matches.length
-  // A fresh list with no current item starts stepping from the first
-  // match (Next) / last match (Prev), mirroring the query-flow semantics.
-  const base = refreshed.current < 0 ? 0 : refreshed.current
-  const current = (base + direction + count) % count
+  let current: number
+  if (state.current < 0) {
+    // The overlay had NO current match before this step (an empty search
+    // that gained matches while open): the step is the ENTRY into the
+    // fresh list — Next lands on the FIRST match, Prev on the LAST.
+    // Stepping from a synthetic 0 would skip the first newly discovered
+    // match (round-12 finding).
+    current = direction === 1 ? 0 : count - 1
+  } else {
+    const base = refreshed.current < 0 ? 0 : refreshed.current
+    current = (base + direction + count) % count
+  }
   return { matches: refreshed.matches, current, revision: refreshed.revision, changed: refreshed.changed }
 }

--- a/src/status/context-measurement.ts
+++ b/src/status/context-measurement.ts
@@ -1,0 +1,165 @@
+/**
+ * Context-measurement coordinator (PR D2): the single cached, session-bound
+ * context-pressure value behind the footer's status surface.
+ *
+ * The runner NEVER measures context in a generic status refresh — a UI-only
+ * refresh (theme, keybinding, permission, focus, resize, search, …) reads the
+ * cache and never touches a reader. Model-visible lifecycle events
+ * (step/start, turn/end, compaction/end, session identity change) mark the
+ * cache dirty and re-measure through the semantic `SessionReader` port
+ * (`measureContext`), so the future Remote adapter can serve measurements
+ * over the wire while the TUI stays transport-neutral.
+ *
+ * Policy (plan §17):
+ *
+ * ```text
+ * session generation owns the cache
+ * model-visible lifecycle events mark dirty
+ * a measure clears dirty
+ * UI-only events never mark dirty
+ * ```
+ *
+ * A measurement FAILURE keeps the last-good value (never clears it) and
+ * stays dirty, so the next lifecycle trigger retries. A session identity
+ * change clears the old session's value — the new session can never inherit
+ * the old measurement.
+ * @module @xmoon76/dsh-pi-tui/status/context-measurement
+ */
+
+/** Why the runner is (re)measuring context — informational today, the seam
+ * for future coalescing/force policies. */
+export type ContextMeasureReason =
+  | 'initial'
+  | 'step-start'
+  | 'turn-end'
+  | 'compaction-end'
+  | 'explicit-status'
+  | 'session-switch'
+
+/** The coordinator's observable state (test seam). */
+export interface ContextMeasurementSnapshot {
+  readonly sessionId: string | undefined
+  readonly value: number | undefined
+  readonly dirty: boolean
+}
+
+/** The session-bound context measurement cache. Pure and synchronous —
+ * the Direct `measureContext` port is sync today, and the coordinator must
+ * not assume a future wire backend stays sync (the runner's generation
+ * fence owns stale-result protection across async deferrals). */
+export class ContextMeasurementCoordinator {
+  private sessionId: string | undefined
+  private value: number | undefined
+  private dirty = false
+
+  /** Rebind to a new session identity. A DIFFERENT session clears the old
+   * value (an old session's contextTokens must never ride a new session);
+   * the same session is a no-op, so a same-session refresh cycle keeps the
+   * last-good value without re-marking. `undefined` (no live session)
+   * clears everything. */
+  bind(sessionId: string | undefined): void {
+    if (sessionId === this.sessionId) return
+    this.sessionId = sessionId
+    this.value = undefined
+    this.dirty = sessionId !== undefined
+  }
+
+  /** Mark the bound session's context possibly changed (model-visible
+   * lifecycle events only). No-op without a bound session — UI-only
+   * refresh cycles must not be able to arm a measurement. */
+  markDirty(): void {
+    if (this.sessionId === undefined) return
+    this.dirty = true
+  }
+
+  /** Whether a measurement is pending for the bound session. */
+  isDirty(): boolean {
+    return this.dirty
+  }
+
+  /** The cached value, ONLY for the given session identity — any other
+   * session (or none) reads `undefined`, never a foreign measurement. */
+  valueFor(sessionId: string | undefined): number | undefined {
+    return sessionId !== undefined && sessionId === this.sessionId ? this.value : undefined
+  }
+
+  /**
+   * Measure the given session through the reader port WHEN DIRTY; a clean
+   * cache skips the reader entirely (same-sync-chain dedupe — plan §17).
+   *
+   * Only the BOUND session can be measured: a different (stale/foreign)
+   * session id is refused outright — a deferred caller that slipped past
+   * the runner's generation fence can never commit a measurement under the
+   * wrong identity, because `bind()` is the ONLY way the cache changes
+   * session.
+   *
+   * Failure semantics: the reader returning `undefined` (or throwing — the
+   * coordinator swallows best-effort) keeps the last-good value and the
+   * dirty flag stays set, so the next trigger retries; a successful number
+   * commits and clears dirty. The cached value (fresh or last-good) is
+   * returned.
+   *
+   * @param sessionId - the session to measure (the runner's CURRENT live
+   * session; must match the bound identity).
+   * @param reader - the semantic measurement port call.
+   */
+  measure(sessionId: string | undefined, reader: (sessionId: string) => number | undefined): number | undefined {
+    if (sessionId === undefined || sessionId !== this.sessionId) return undefined
+    if (!this.dirty) return this.value
+    let fresh: number | undefined
+    try {
+      fresh = reader(sessionId)
+    } catch {
+      // Best-effort: a throwing reader/backend must never crash the TUI.
+      // The last-good value survives and the dirty flag stays for a retry.
+      fresh = undefined
+    }
+    if (fresh !== undefined) {
+      this.value = fresh
+      this.dirty = false
+    }
+    return this.value
+  }
+
+  /** The full observable state (test seam). */
+  snapshot(): ContextMeasurementSnapshot {
+    return { sessionId: this.sessionId, value: this.value, dirty: this.dirty }
+  }
+}
+
+/**
+ * Defer one context measurement past the first usable paint (plan §16.2):
+ * hydrate → bounded repaint → cheap status → THIS deferral → measure on the
+ * next event-loop turn. The runner captures the session generation + id and
+ * provides the fence; the callback is a no-op when the captured session no
+ * longer owns the surface (switch, /new, viewer swap, dispose).
+ *
+ * Returns a cancel function (the runner's cleanup path).
+ *
+ * @param schedule - the deferral primitive (the runner injects
+ * `setImmediate`; tests inject a fake to drive the callback deterministically).
+ * @param fence - true only while the captured session still owns the surface.
+ * @param run - the measurement + cheap repaint (markContextDirty +
+ * refreshContextMeasurement('initial') in the runner).
+ */
+export function deferInitialContextMeasure(
+  schedule: (callback: () => void) => unknown,
+  fence: () => boolean,
+  run: () => void,
+): () => void {
+  let handle: unknown
+  handle = schedule(() => {
+    handle = undefined
+    if (fence()) run()
+  })
+  return () => {
+    const current = handle
+    handle = undefined
+    if (current === undefined || current === null) return
+    if (typeof current === 'object' && 'cancel' in current && typeof (current as { cancel?: unknown }).cancel === 'function') {
+      ;(current as { cancel: () => void }).cancel()
+    } else {
+      clearImmediate(current as NodeJS.Immediate)
+    }
+  }
+}

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -110,6 +110,42 @@ export interface WorkflowMemberView {
   status: 'ok' | 'error' | 'running'
 }
 
+/** Stable identity of one raw transcript item within ONE TranscriptFolder
+ * lifetime. The raw item's index doubles as its id: `items` is strictly
+ * append-only, so an id keeps pointing at the same logical source through
+ * streaming, settlement and read-group reflow — the visible card OBJECT may
+ * be replaced (or merged into a group), the id never is. Ids are
+ * session-local by construction: a new folder starts a fresh namespace.
+ * @see TranscriptSearchMatch
+ */
+export type TranscriptItemId = number
+
+/** One full-history search hit: the CURRENT visible representative of the
+ * matched logical card plus its visible turn. Matches deliberately never
+ * carry `TranscriptMessage` objects: live settlement replaces items and
+ * grouping reflow replaces merged cards, so an object-based match would
+ * pin stale state and break Next/Prev navigation. */
+export interface TranscriptSearchMatch {
+  readonly id: TranscriptItemId
+  readonly turn: number
+}
+
+/** The searchable text of one message — the SINGLE source of truth for the
+ * search corpus (the legacy full-history search semantics: tools search
+ * `name args result`, every other kind searches `text`). `summary` rows
+ * never reach `items`, so the projection never indexes them. */
+export function transcriptSearchText(message: TranscriptMessage): string {
+  if (message.kind === 'tool') return `${message.name} ${message.args} ${message.result}`
+  return message.text ?? ''
+}
+
+/** Normalize search text exactly like the legacy query path did (JS String
+ * `toLowerCase`, no locale options). Applied ONCE per entry at build/refresh
+ * time — never per query. */
+function normalizeSearchText(text: string): string {
+  return text.toLowerCase()
+}
+
 /** The turn-end reason surface Focus reads (structural — never a full
  * dsh type import; the official kind names are kept verbatim). */
 export interface TurnEndReason {
@@ -432,6 +468,21 @@ interface ReadGroupMeta {
   spansTurns: boolean
 }
 
+/** One lightweight searchable entry, index-aligned with `items` (the raw
+ * item index IS the stable {@link TranscriptItemId}). `normalizedText` is
+ * lowercased exactly once at build/refresh time, so a query scans
+ * normalized strings only — no full message materialization, no grouping,
+ * no re-lowercasing per query. */
+interface TranscriptSearchEntry {
+  /** The CURRENT visible turn of the card this entry mirrors. */
+  turn: number
+  /** The normalized searchable text of the CURRENT visible card. Merged
+   * read groups share ONE normalized string (built once per group mutation
+   * in {@link TranscriptFolder.refreshSearchRange}) so N members never hold
+   * N copies of the merged card text. */
+  normalizedText: string
+}
+
 export class TranscriptFolder {
   private readonly items: TranscriptMessage[] = []
   /** The assistant message object per (turn, step); streaming text lands in place. */
@@ -473,6 +524,24 @@ export class TranscriptFolder {
    * groups in one linear pass once the event fold is complete. */
   private hydrating = false
   private groupingDirty = false
+
+  /** The incremental full-history search projection (stage D1): one entry
+   * per raw item, index-aligned with {@link items}. Query-time cost is a
+   * lightweight scan of normalized strings — never `messages()`, never a
+   * per-query lowercase pass over the whole history. */
+  private readonly searchEntries: TranscriptSearchEntry[] = []
+  /** Bumped on EVERY entry mutation (append, settlement, group reflow):
+   * query refinement must not reuse previous candidates across a revision. */
+  private searchRevisionCounter = 0
+  /** Step key → raw item index, for in-place streaming text updates. */
+  private readonly searchIndexByStepKey = new Map<string, number>()
+  /** Workflow run card indices by runId (run-end fills the result text). */
+  private readonly workflowRunIndex = new Map<string, number>()
+  // Test-only counters exposed by searchDiagnosticsForTest().
+  private searchRefreshCount = 0
+  private searchFullScanCount = 0
+  private searchRefineCount = 0
+  private groupingRebuildCount = 0
 
   /**
    * Turn index for the display window (stage J): the first item index of
@@ -678,9 +747,18 @@ export class TranscriptFolder {
     this.turnValueSet.add(turn)
   }
 
-  /** Append one folded message, maintaining the window projections. */
-  private appendItem(message: TranscriptMessage): void {
+  /** Append one folded message, maintaining the window projections. Returns
+   * the raw item index (the stable search identity). */
+  private appendItem(message: TranscriptMessage): number {
     this.items.push(message)
+    const index = this.items.length - 1
+    // The searchable projection mirrors the item's own text until a group
+    // merge or settlement refreshes it (see refreshSearchRange).
+    this.searchEntries.push({
+      turn: 'turn' in message ? message.turn : 0,
+      normalizedText: normalizeSearchText(transcriptSearchText(message)),
+    })
+    this.searchRevisionCounter += 1
     const turn = 'turn' in message ? message.turn : undefined
     if (turn !== undefined) {
       if (this.turnValues.length === 0) {
@@ -701,6 +779,77 @@ export class TranscriptFolder {
     }
     if (turn !== undefined) this.addGroupedTurn(turn)
     if (message.kind === 'tool') this.groupedToolCount += 1
+    return index
+  }
+
+  /** Refresh ONE search entry from its CURRENT visible card (the merged
+   * read group when the item is a member, else the raw item). Used for
+   * ungrouped settlements (assistant/message replacement, tool results);
+   * group mutations go through {@link refreshSearchRange} which preserves
+   * the shared normalized string of a merged group. */
+  private refreshSearchEntry(index: number): void {
+    const item = this.items[index]
+    if (item === undefined) return
+    const entry = this.searchEntries[index]
+    if (entry === undefined) return
+    const group = this.groupOf.get(index)
+    const card = group ?? item
+    entry.turn = 'turn' in card ? card.turn : 0
+    entry.normalizedText = normalizeSearchText(transcriptSearchText(card))
+    this.searchRefreshCount += 1
+    this.searchRevisionCounter += 1
+  }
+
+  /** Refresh the search entries of a raw-item range from their CURRENT
+   * visible cards. Merged read groups get their shared normalized text
+   * ONCE per range pass — every member entry points at the same string
+   * reference, so N members never hold N copies of the merged card text. */
+  private refreshSearchRange(start: number, end: number): void {
+    const sharedByGroup = new Map<ReadGroupCard, string>()
+    for (let index = start; index <= end; index += 1) {
+      const item = this.items[index]
+      if (item === undefined) continue
+      const entry = this.searchEntries[index]
+      if (entry === undefined) continue
+      const group = this.groupOf.get(index)
+      const card = group ?? item
+      entry.turn = 'turn' in card ? card.turn : 0
+      if (group !== undefined) {
+        let shared = sharedByGroup.get(group)
+        if (shared === undefined) {
+          shared = normalizeSearchText(transcriptSearchText(group))
+          sharedByGroup.set(group, shared)
+        }
+        entry.normalizedText = shared
+      } else {
+        entry.normalizedText = normalizeSearchText(transcriptSearchText(card))
+      }
+      this.searchRefreshCount += 1
+      this.searchRevisionCounter += 1
+    }
+  }
+
+  /** Append a lowercased text delta to one entry's normalized text (the
+   * streaming hot path: O(delta) per chunk, never a full re-lowercase). */
+  private appendSearchTextDelta(key: string, delta: string): void {
+    const index = this.searchIndexByStepKey.get(key)
+    if (index === undefined) return
+    const entry = this.searchEntries[index]
+    if (entry === undefined) return
+    entry.normalizedText += delta.toLowerCase()
+    this.searchRevisionCounter += 1
+  }
+
+  /** The CURRENT output representative of one raw item id: the first member
+   * of its merged read group when grouped, else the item itself. Search
+   * results are deduplicated by representative so a merged read card yields
+   * exactly ONE visible match no matter how many members hit. */
+  private representativeOf(id: number): number {
+    const group = this.groupOf.get(id)
+    if (group === undefined) return id
+    const members = this.groupMembers.get(group)
+    const first = members === undefined ? undefined : members[0]
+    return first === undefined ? id : first
   }
 
   /** Whether an item is groupable as a consecutive read (settled ok). */
@@ -916,6 +1065,11 @@ export class TranscriptFolder {
       if (built.spansTurns) this.crossTurnGroups += 1
       start = end
     }
+    // The cold finalize rebuilds every group: refresh the whole search
+    // projection in one pass (the allowed one-time O(history) cost) so
+    // every merged read card's members share its normalized text.
+    this.groupingRebuildCount += 1
+    this.refreshSearchRange(0, this.items.length - 1)
   }
 
 
@@ -954,6 +1108,9 @@ export class TranscriptFolder {
       this.groupMeta.set(previousGroup, { firstTurn, spansTurns })
       if (!wasCross && spansTurns) this.crossTurnGroups += 1
       this.groupedToolCount -= 1
+      // The merged card's text changed (args count + result): refresh every
+      // member entry to the SHARED group text (one lowercase per group).
+      this.refreshSearchRange(previousIndex, index)
       return true
     }
 
@@ -974,6 +1131,7 @@ export class TranscriptFolder {
      this.addGroupedTurn(group.turn)
     if (previous.turn !== item.turn) this.crossTurnGroups += 1
     this.groupedToolCount -= 1
+    this.refreshSearchRange(previousIndex, index)
     return true
   }
 
@@ -1031,6 +1189,10 @@ export class TranscriptFolder {
         this.groupOf.delete(i)
       }
     }
+    // After the detach, the run's items stand alone: refresh their search
+    // entries from the raw item text (the rebuilt group below re-refreshes
+    // them to the shared merged text when the run still merges).
+    this.refreshSearchRange(start, end)
     if (start === end) return
     // Rebuild the whole run as one group. The result is assembled with one
     // final join so a long adjacent-read run stays linear in the cold path.
@@ -1043,6 +1205,7 @@ export class TranscriptFolder {
     // The whole run collapsed into one output card.
     this.groupedToolCount -= built.members.length - 1
     if (built.spansTurns) this.crossTurnGroups += 1
+    this.refreshSearchRange(start, end)
   }
 
   /** Whether the members at these indices span more than one turn. */
@@ -1285,6 +1448,91 @@ export class TranscriptFolder {
     return this.window({ maxTurns, ...options }).messages
   }
 
+  /** The search-projection revision: bumped on EVERY entry mutation
+   * (append, settlement, group reflow). The runner's query refinement must
+   * never reuse previous candidates across a revision — the projection may
+   * hold new matches the old candidate list cannot see. */
+  searchRevision(): number {
+    return this.searchRevisionCounter
+  }
+
+  /** Full-history transcript search over the lightweight projection — same
+   * corpus and ORDER as the legacy full search (`messages()` + filter +
+   * per-message lowercase), but never materializes the grouped transcript
+   * and never re-lowercases history per query. Results are deduplicated by
+   * CURRENT group representative: a merged read card yields exactly ONE
+   * visible match no matter how many members hit, and Next/Prev never loop
+   * on one card. `refinement` (optional) narrows a previous result set when
+   * the new query extends it AND the projection revision is unchanged —
+   * otherwise the full lightweight scan runs.
+   * @param query - the raw query (trimmed + lowercased here, like legacy).
+   * @param refinement - the previous query's matches for prefix refinement;
+   * the folder validates the prefix AND the revision internally.
+   */
+  search(
+    query: string,
+    refinement?: {
+      previousQuery: string
+      previousMatches: readonly TranscriptSearchMatch[]
+      revision: number
+    },
+  ): TranscriptSearchMatch[] {
+    const needle = query.trim().toLowerCase()
+    if (needle === '') return []
+    const previousNeedle = refinement?.previousQuery.trim().toLowerCase() ?? ''
+    const canRefine = refinement !== undefined
+      && previousNeedle !== ''
+      && needle.startsWith(previousNeedle)
+      && this.searchRevisionCounter === refinement.revision
+    const matches: TranscriptSearchMatch[] = []
+    const seen = new Set<number>()
+    const consider = (id: number): void => {
+      const entry = this.searchEntries[id]
+      if (entry === undefined) return
+      if (!entry.normalizedText.includes(needle)) return
+      const representative = this.representativeOf(id)
+      if (seen.has(representative)) return
+      seen.add(representative)
+      matches.push({ id: representative, turn: this.searchEntries[representative]?.turn ?? 0 })
+    }
+    if (canRefine) {
+      for (const match of refinement.previousMatches) consider(match.id)
+      this.searchRefineCount += 1
+    } else {
+      for (let id = 0; id < this.searchEntries.length; id += 1) consider(id)
+      this.searchFullScanCount += 1
+    }
+    return matches
+  }
+
+  /** Resolve one search match to its CURRENT visible card: the merged read
+   * group when the matched item is a member now, else the raw item. A group
+   * reflow AFTER the query may have replaced the representative card — the
+   * id still resolves (fail-soft; never a throw or a stale object). */
+  resolveSearchMatch(match: TranscriptSearchMatch): TranscriptMessage | undefined {
+    const item = this.items[match.id]
+    if (item === undefined) return undefined
+    return this.groupOf.get(match.id) ?? item
+  }
+
+  /** Test-only structural counters: prove the query path never falls back
+   * to full projection/lowercase work (the 10k-turn complexity gate). */
+  searchDiagnosticsForTest(): {
+    entries: number
+    groupingRebuilds: number
+    normalizedRefreshes: number
+    fullScans: number
+    refinedScans: number
+  } {
+    return {
+      entries: this.searchEntries.length,
+      groupingRebuilds: this.groupingRebuildCount,
+      normalizedRefreshes: this.searchRefreshCount,
+      fullScans: this.searchFullScanCount,
+      refinedScans: this.searchRefineCount,
+    }
+  }
+
   /** Remove one thinking entry from the open-lifecycle index. */
   private closeThinking(entry: Extract<TranscriptMessage, { kind: 'thinking' }>): void {
     entry.running = false
@@ -1309,13 +1557,13 @@ export class TranscriptFolder {
     if (entry === undefined) {
       entry = { kind: 'thinking', turn, text: '', running: true }
       this.thinkingEntries.set(key, entry)
+      this.searchIndexByStepKey.set(key, this.appendItem(entry))
       let open = this.openThinkingByTurn.get(turn)
       if (open === undefined) {
         open = new Set()
         this.openThinkingByTurn.set(turn, open)
       }
       open.add(entry)
-      this.appendItem(entry)
     }
     return entry
   }
@@ -1327,7 +1575,7 @@ export class TranscriptFolder {
     if (entry === undefined) {
       entry = { kind: 'assistant', turn, text: '' }
       this.assistantEntries.set(key, entry)
-      this.appendItem(entry)
+      this.searchIndexByStepKey.set(key, this.appendItem(entry))
     }
     return entry
   }
@@ -1376,6 +1624,8 @@ export class TranscriptFolder {
       const tokens = data.shadowedTokenCount
       if (Array.isArray(summary)) {
         entry.text = textOf(summary as readonly ContentBlock[])
+        // The summary body became searchable: mirror it in the projection.
+        this.refreshSearchEntry(index)
       }
       if (Array.isArray(seqs)) entry.items = seqs.length
       if (typeof tokens === 'number') entry.tokens = tokens
@@ -1510,6 +1760,8 @@ export class TranscriptFolder {
         // once, not twice.
         if (chunk.type === 'text-delta') {
           this.assistantEntry(event.data.turn, step).text += chunk.text
+          // Search projection: O(delta) incremental lowercase append.
+          this.appendSearchTextDelta(stepKey(event.data.turn, step), chunk.text)
           // Focus aggregation: the streaming assistant text feeds the
           // Message candidate IMMEDIATELY (no assistant/message wait —
           // plan §5.2), so the running card previews the intermediate
@@ -1517,6 +1769,8 @@ export class TranscriptFolder {
           this.foldMessageCandidate(this.activityFor(event.data.turn), step, chunk.text)
         } else if (chunk.type === 'reasoning-delta') {
           this.thinkingEntry(event.data.turn, step).text += chunk.text
+          // Search projection: O(delta) incremental lowercase append.
+          this.appendSearchTextDelta(stepKey(event.data.turn, step), chunk.text)
           // Focus aggregation: keep a compact reasoning preview (the
           // rolling tail — never the full stream, plan §10.6/§42).
           this.foldThinking(this.activityFor(event.data.turn), chunk.text)
@@ -1544,6 +1798,10 @@ export class TranscriptFolder {
           // The settled full blocks (kept when the step carried images or
           // other non-text blocks — text-only steps stay on the text path).
           if (messageBlocks.some(block => block.type !== 'text')) entry.content = messageBlocks
+          // The settled text REPLACES the streamed tail: the search
+          // projection must mirror the authoritative text, not the chunks.
+          const searchIndex = this.searchIndexByStepKey.get(key)
+          if (searchIndex !== undefined) this.refreshSearchEntry(searchIndex)
         } else {
           // ALWAYS preserve the entry — an empty settled message with no
           // preceding chunk (replay edge) must still own the exact-last
@@ -1700,6 +1958,9 @@ export class TranscriptFolder {
           card.resultBlocks = block?.content
           card.meta = event.data.meta
           card.error = event.data.error
+          // The result text landed: mirror it in the search projection
+          // (the grouping hooks below re-refresh merged read cards).
+          this.refreshSearchEntry(pending.index)
           // A settled read may now be groupable: reflow the run it belongs
           // to (bounded by the nearest non-read cards).
           this.scheduleGrouping(pending.index)
@@ -1719,6 +1980,7 @@ export class TranscriptFolder {
               running.resultBlocks = block?.content
               running.meta = event.data.meta
               running.error = event.data.error
+              this.refreshSearchEntry(runningIndex)
               this.scheduleGrouping(runningIndex)
             }
           } else {
@@ -1807,7 +2069,7 @@ export class TranscriptFolder {
           members: [],
         }
         this.workflowRuns.set(event.data.runId, card)
-        this.appendItem(card)
+        this.workflowRunIndex.set(event.data.runId, this.appendItem(card))
         // Focus aggregation: a workflow run is a durable lifecycle event,
         // NOT a model tool/call — it never touches the Tool slot or the
         // tool count (plan §17).
@@ -1840,10 +2102,14 @@ export class TranscriptFolder {
         if (card !== undefined) {
           card.status = event.data.stopReason === 'completed' ? 'ok' : 'error'
           card.result = `stop: ${event.data.stopReason}`
+          // The run result became searchable: mirror it in the projection.
+          const index = this.workflowRunIndex.get(event.data.runId)
+          if (index !== undefined) this.refreshSearchEntry(index)
         }
         // The run's bookkeeping is done: drop the run card and every member
         // card keyed under it so long sessions do not accumulate stale maps.
         this.workflowRuns.delete(event.data.runId)
+        this.workflowRunIndex.delete(event.data.runId)
         for (const memberKey of this.workflowMembers.keys()) {
           if (memberKey.startsWith(`${event.data.runId}/`)) this.workflowMembers.delete(memberKey)
         }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -486,9 +486,6 @@ interface TranscriptSearchEntry {
    * only; non-representative members keep their own raw text and are
    * skipped at scan time. */
   normalizedText: string
-  /** The authoritative text changed since the last normalization: the
-   * entry is re-normalized (whole-string) at the next search. */
-  dirty: boolean
 }
 
 export class TranscriptFolder {
@@ -538,6 +535,10 @@ export class TranscriptFolder {
    * lightweight scan of normalized strings — never `messages()`, never a
    * per-query lowercase pass over the whole history. */
   private readonly searchEntries: TranscriptSearchEntry[] = []
+  /** The dirty search entries (raw item indices): the discovery structure
+   * for query-time lazy normalization — a query normalizes exactly these,
+   * never a full-history scan. */
+  private readonly dirtySearchEntries = new Set<number>()
   /** Bumped on EVERY entry mutation (append, settlement, group reflow):
    * query refinement must not reuse previous candidates across a revision. */
   private searchRevisionCounter = 0
@@ -551,6 +552,9 @@ export class TranscriptFolder {
   private readonly workflowRunIndex = new Map<string, number>()
   // Test-only counters exposed by searchDiagnosticsForTest().
   private searchRefreshCount = 0
+  /** Test-only: the number of dirty entries scanned by lazy normalization
+   * (proves the query path is O(#dirty), never O(history)). */
+  private searchDirtyScanCount = 0
   private searchFullScanCount = 0
   private searchRefineCount = 0
   private groupingRebuildCount = 0
@@ -770,7 +774,6 @@ export class TranscriptFolder {
     this.searchEntries.push({
       turn: 'turn' in message ? message.turn : 0,
       normalizedText: normalizeSearchText(transcriptSearchText(message)),
-      dirty: false,
     })
     this.searchRevisionCounter += 1
     const turn = 'turn' in message ? message.turn : undefined
@@ -798,11 +801,12 @@ export class TranscriptFolder {
 
   /** Mark ONE search entry dirty (O(1) — the live hot path): the
    * authoritative text changed; the entry is re-normalized lazily at the
-   * next search. */
+   * next search. The dirty SET is the discovery structure — a query
+   * normalizes exactly the dirty entries, never a full-history scan. */
   private markSearchEntryDirty(index: number): void {
     const entry = this.searchEntries[index]
     if (entry === undefined) return
-    entry.dirty = true
+    this.dirtySearchEntries.add(index)
     this.searchRevisionCounter += 1
   }
 
@@ -820,23 +824,25 @@ export class TranscriptFolder {
 
   /** Query-time lazy normalization: every DIRTY entry is re-normalized as a
    * WHOLE string from its CURRENT authoritative card (Unicode whole-string
-   * semantics — never per-chunk lowercase, never history). Non-
-   * representative group members are skipped: the merged group's text
-   * lives ONLY on the representative entry, so a group expansion marks
-   * exactly one entry. */
+   * semantics — never per-chunk lowercase, never history). The dirty SET
+   * bounds the work to O(#dirty) — a query with no mutations normalizes
+   * nothing and never scans the history. Non-representative group members
+   * are skipped: the merged group's text lives ONLY on the representative
+   * entry, so a group expansion marks exactly one entry. */
   private normalizeDirtySearchEntries(): void {
-    for (let index = 0; index < this.searchEntries.length; index += 1) {
+    for (const index of this.dirtySearchEntries) {
+      this.searchDirtyScanCount += 1
       const entry = this.searchEntries[index]
-      if (entry === undefined || !entry.dirty) continue
+      if (entry === undefined) continue
       const group = this.groupOf.get(index)
       if (group !== undefined && this.representativeOf(index) !== index) continue
       const card = group ?? this.items[index]
       if (card === undefined) continue
       entry.turn = 'turn' in card ? card.turn : 0
       entry.normalizedText = normalizeSearchText(transcriptSearchText(card))
-      entry.dirty = false
       this.searchRefreshCount += 1
     }
+    this.dirtySearchEntries.clear()
   }
 
   /** The CURRENT output representative of one raw item id: the first member
@@ -1077,7 +1083,7 @@ export class TranscriptFolder {
       if (entry === undefined) continue
       entry.turn = group.turn
       entry.normalizedText = normalizeSearchText(transcriptSearchText(group))
-      entry.dirty = false
+      this.dirtySearchEntries.delete(first)
       this.searchRefreshCount += 1
     }
   }
@@ -1558,6 +1564,7 @@ export class TranscriptFolder {
     entries: number
     groupingRebuilds: number
     normalizedRefreshes: number
+    dirtyScans: number
     fullScans: number
     refinedScans: number
   } {
@@ -1565,6 +1572,7 @@ export class TranscriptFolder {
       entries: this.searchEntries.length,
       groupingRebuilds: this.groupingRebuildCount,
       normalizedRefreshes: this.searchRefreshCount,
+      dirtyScans: this.searchDirtyScanCount,
       fullScans: this.searchFullScanCount,
       refinedScans: this.searchRefineCount,
     }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -470,17 +470,25 @@ interface ReadGroupMeta {
 
 /** One lightweight searchable entry, index-aligned with `items` (the raw
  * item index IS the stable {@link TranscriptItemId}). `normalizedText` is
- * lowercased exactly once at build/refresh time, so a query scans
- * normalized strings only — no full message materialization, no grouping,
- * no re-lowercasing per query. */
+ * lowercased as a WHOLE string, lazily: a mutation only marks the entry
+ * dirty (O(1) bookkeeping on the live hot path — streaming chunks and
+ * read-group expansions never pay per-chunk/per-member lowercase), and the
+ * next query re-normalizes exactly the dirty entries. A merged read
+ * group's searchable text lives ONLY on its representative entry;
+ * non-representative members are skipped at scan time, so a group
+ * expansion marks exactly one entry. */
 interface TranscriptSearchEntry {
-  /** The CURRENT visible turn of the card this entry mirrors. */
+  /** The CURRENT visible turn of the card this entry mirrors (refreshed
+   * when the entry is normalized). */
   turn: number
-  /** The normalized searchable text of the CURRENT visible card. Merged
-   * read groups share ONE normalized string (built once per group mutation
-   * in {@link TranscriptFolder.refreshSearchRange}) so N members never hold
-   * N copies of the merged card text. */
+  /** The normalized searchable text of the CURRENT visible card. For a
+   * merged read group this is the group's text on the representative entry
+   * only; non-representative members keep their own raw text and are
+   * skipped at scan time. */
   normalizedText: string
+  /** The authoritative text changed since the last normalization: the
+   * entry is re-normalized (whole-string) at the next search. */
+  dirty: boolean
 }
 
 export class TranscriptFolder {
@@ -756,11 +764,13 @@ export class TranscriptFolder {
   private appendItem(message: TranscriptMessage): number {
     this.items.push(message)
     const index = this.items.length - 1
-    // The searchable projection mirrors the item's own text until a group
-    // merge or settlement refreshes it (see refreshSearchRange).
+    // The searchable projection mirrors the item's own text (eager at
+    // append — the cold path); later mutations mark the entry dirty and
+    // re-normalize lazily at the next search.
     this.searchEntries.push({
       turn: 'turn' in message ? message.turn : 0,
       normalizedText: normalizeSearchText(transcriptSearchText(message)),
+      dirty: false,
     })
     this.searchRevisionCounter += 1
     const turn = 'turn' in message ? message.turn : undefined
@@ -786,71 +796,47 @@ export class TranscriptFolder {
     return index
   }
 
-  /** Refresh ONE search entry from its CURRENT visible card (the merged
-   * read group when the item is a member, else the raw item). Used for
-   * ungrouped settlements (assistant/message replacement, tool results);
-   * group mutations go through {@link refreshSearchRange} which preserves
-   * the shared normalized string of a merged group. */
-  private refreshSearchEntry(index: number): void {
-    const item = this.items[index]
-    if (item === undefined) return
+  /** Mark ONE search entry dirty (O(1) — the live hot path): the
+   * authoritative text changed; the entry is re-normalized lazily at the
+   * next search. */
+  private markSearchEntryDirty(index: number): void {
     const entry = this.searchEntries[index]
     if (entry === undefined) return
-    const group = this.groupOf.get(index)
-    const card = group ?? item
-    entry.turn = 'turn' in card ? card.turn : 0
-    entry.normalizedText = normalizeSearchText(transcriptSearchText(card))
-    this.searchRefreshCount += 1
+    entry.dirty = true
     this.searchRevisionCounter += 1
   }
 
-  /** Refresh the search entries of a raw-item range from their CURRENT
-   * visible cards. Merged read groups get their shared normalized text
-   * ONCE per range pass — every member entry points at the same string
-   * reference, so N members never hold N copies of the merged card text. */
-  private refreshSearchRange(start: number, end: number): void {
-    const sharedByGroup = new Map<ReadGroupCard, string>()
-    for (let index = start; index <= end; index += 1) {
-      const item = this.items[index]
-      if (item === undefined) continue
-      const entry = this.searchEntries[index]
-      if (entry === undefined) continue
-      const group = this.groupOf.get(index)
-      const card = group ?? item
-      entry.turn = 'turn' in card ? card.turn : 0
-      if (group !== undefined) {
-        let shared = sharedByGroup.get(group)
-        if (shared === undefined) {
-          shared = normalizeSearchText(transcriptSearchText(group))
-          sharedByGroup.set(group, shared)
-        }
-        entry.normalizedText = shared
-      } else {
-        entry.normalizedText = normalizeSearchText(transcriptSearchText(card))
-      }
-      this.searchRefreshCount += 1
-      this.searchRevisionCounter += 1
-    }
+  /** Mark a raw-item range dirty (the DEFENSIVE reflow path — O(run), rare;
+   * the live tail-append path marks only the group representative). */
+  private markSearchRangeDirty(start: number, end: number): void {
+    for (let index = start; index <= end; index += 1) this.markSearchEntryDirty(index)
   }
 
-  /** Append a lowercased text delta to one entry's normalized text (the
-   * streaming hot path: O(delta) per chunk, never a full re-lowercase). */
-  /** Re-normalize ONE active streaming entry from its authoritative item
-   * text (assistant/thinking). Unicode lowercasing is NOT chunk-splittable
-   * — lower('ΟΣ') is 'ος' but lower('Ο') + lower('Σ') is 'οσ' (Greek
-   * sigma) — so a streaming entry is lowercased as a WHOLE string on every
-   * delta (O(one active message), never history). A settled entry is
-   * refreshed by its settlement path instead; historical entries never
-   * touch this path. */
-  private refreshStreamingEntry(key: string): void {
+  /** Mark the streaming entry of one step key dirty (O(1) per chunk). */
+  private markStreamingEntryDirty(key: string): void {
     const index = this.searchIndexByStepKey.get(key)
-    if (index === undefined) return
-    const entry = this.searchEntries[index]
-    if (entry === undefined) return
-    const item = this.items[index]
-    if (item === undefined || !('text' in item)) return
-    entry.normalizedText = item.text.toLowerCase()
-    this.searchRevisionCounter += 1
+    if (index !== undefined) this.markSearchEntryDirty(index)
+  }
+
+  /** Query-time lazy normalization: every DIRTY entry is re-normalized as a
+   * WHOLE string from its CURRENT authoritative card (Unicode whole-string
+   * semantics — never per-chunk lowercase, never history). Non-
+   * representative group members are skipped: the merged group's text
+   * lives ONLY on the representative entry, so a group expansion marks
+   * exactly one entry. */
+  private normalizeDirtySearchEntries(): void {
+    for (let index = 0; index < this.searchEntries.length; index += 1) {
+      const entry = this.searchEntries[index]
+      if (entry === undefined || !entry.dirty) continue
+      const group = this.groupOf.get(index)
+      if (group !== undefined && this.representativeOf(index) !== index) continue
+      const card = group ?? this.items[index]
+      if (card === undefined) continue
+      entry.turn = 'turn' in card ? card.turn : 0
+      entry.normalizedText = normalizeSearchText(transcriptSearchText(card))
+      entry.dirty = false
+      this.searchRefreshCount += 1
+    }
   }
 
   /** The CURRENT output representative of one raw item id: the first member
@@ -1078,11 +1064,22 @@ export class TranscriptFolder {
       if (built.spansTurns) this.crossTurnGroups += 1
       start = end
     }
-    // The cold finalize rebuilds every group: refresh the whole search
-    // projection in one pass (the allowed one-time O(history) cost) so
-    // every merged read card's members share its normalized text.
+    // The cold finalize rebuilds every group: eagerly normalize each
+    // merged card's REPRESENTATIVE entry to the shared group text (one
+    // normalize per group — the allowed one-time O(history) cost).
+    // Non-representative members keep their own raw entries and are
+    // skipped at scan time.
     this.groupingRebuildCount += 1
-    this.refreshSearchRange(0, this.items.length - 1)
+    for (const [group, members] of this.groupMembers) {
+      const first = members[0]
+      if (first === undefined) continue
+      const entry = this.searchEntries[first]
+      if (entry === undefined) continue
+      entry.turn = group.turn
+      entry.normalizedText = normalizeSearchText(transcriptSearchText(group))
+      entry.dirty = false
+      this.searchRefreshCount += 1
+    }
   }
 
 
@@ -1121,13 +1118,15 @@ export class TranscriptFolder {
       this.groupMeta.set(previousGroup, { firstTurn, spansTurns })
       if (!wasCross && spansTurns) this.crossTurnGroups += 1
       this.groupedToolCount -= 1
-      // The merged card's text changed (args count + result): refresh the
-      // WHOLE group's entries to the SHARED group text (one lowercase per
-      // group). The range starts at the FIRST member — earlier members
-      // would otherwise keep the stale pre-merge text and turn, and a
-      // match deduplicated to the first member would anchor the wrong
-      // turn (round-4 finding).
-      this.refreshSearchRange(members[0]!, index)
+      // The merged card's text changed (args count + result): mark the
+      // group REPRESENTATIVE dirty — O(1), never a per-member refresh
+      // (the live tail-append hot path must stay near-constant; the
+      // representative is the FIRST member and never changes on a tail
+      // append, and non-representative members are skipped at scan time).
+      // The lazy normalization reads the CURRENT group card, so the
+      // earlier members' stale text/turn can never leak (round-4
+      // finding).
+      this.markSearchEntryDirty(members[0]!)
       return true
     }
 
@@ -1148,7 +1147,9 @@ export class TranscriptFolder {
      this.addGroupedTurn(group.turn)
     if (previous.turn !== item.turn) this.crossTurnGroups += 1
     this.groupedToolCount -= 1
-    this.refreshSearchRange(previousIndex, index)
+    // The promoted singleton becomes the new group's representative: its
+    // entry must carry the merged text (lazy — mark dirty, O(1)).
+    this.markSearchEntryDirty(previousIndex)
     return true
   }
 
@@ -1206,10 +1207,11 @@ export class TranscriptFolder {
         this.groupOf.delete(i)
       }
     }
-    // After the detach, the run's items stand alone: refresh their search
-    // entries from the raw item text (the rebuilt group below re-refreshes
-    // them to the shared merged text when the run still merges).
-    this.refreshSearchRange(start, end)
+    // After the detach, the run's items stand alone: mark their search
+    // entries dirty (the rebuilt group below re-marks the representative
+    // when the run still merges). The defensive reflow path is O(run) —
+    // rare, correctness-first.
+    this.markSearchRangeDirty(start, end)
     if (start === end) return
     // Rebuild the whole run as one group. The result is assembled with one
     // final join so a long adjacent-read run stays linear in the cold path.
@@ -1222,7 +1224,10 @@ export class TranscriptFolder {
     // The whole run collapsed into one output card.
     this.groupedToolCount -= built.members.length - 1
     if (built.spansTurns) this.crossTurnGroups += 1
-    this.refreshSearchRange(start, end)
+    // The rebuilt group's representative may have MOVED (a late settle can
+    // extend the run backwards): mark the whole run dirty so the lazy
+    // normalization re-derives every entry from its current card.
+    this.markSearchRangeDirty(start, end)
   }
 
   /** Whether the members at these indices span more than one turn. */
@@ -1265,6 +1270,11 @@ export class TranscriptFolder {
         this.rebuildGrouping()
         this.groupingDirty = false
       }
+      // Seal the search projection: the cold fold marked settlements dirty
+      // (tool results, assistant/message replacements, compaction
+      // summaries) even when no read group formed. Normalize them once —
+      // the COLD path may pay O(history), the live path never does.
+      this.normalizeDirtySearchEntries()
     }
   }
 
@@ -1497,6 +1507,11 @@ export class TranscriptFolder {
   ): TranscriptSearchMatch[] {
     const needle = query.trim().toLowerCase()
     if (needle === '') return []
+    // Lazy normalization: only DIRTY entries are re-normalized (whole-
+    // string Unicode semantics) — streaming chunks and read-group
+    // expansions never pay per-chunk/per-member lowercase, and a query
+    // after no mutations pays nothing.
+    this.normalizeDirtySearchEntries()
     const previousNeedle = refinement?.previousQuery.trim().toLowerCase() ?? ''
     const canRefine = refinement !== undefined
       && previousNeedle !== ''
@@ -1507,11 +1522,15 @@ export class TranscriptFolder {
     const consider = (id: number): void => {
       const entry = this.searchEntries[id]
       if (entry === undefined) return
-      if (!entry.normalizedText.includes(needle)) return
       const representative = this.representativeOf(id)
+      // Non-representative group members carry no searchable text: the
+      // merged group's text lives ONLY on the representative entry (a
+      // group expansion marks exactly that one entry dirty).
+      if (representative !== id) return
+      if (!entry.normalizedText.includes(needle)) return
       if (seen.has(representative)) return
       seen.add(representative)
-      matches.push({ id: representative, turn: this.searchEntries[representative]?.turn ?? 0 })
+      matches.push({ id: representative, turn: entry.turn })
     }
     if (canRefine) {
       for (const match of refinement.previousMatches) consider(match.id)
@@ -1642,8 +1661,8 @@ export class TranscriptFolder {
       const tokens = data.shadowedTokenCount
       if (Array.isArray(summary)) {
         entry.text = textOf(summary as readonly ContentBlock[])
-        // The summary body became searchable: mirror it in the projection.
-        this.refreshSearchEntry(index)
+        // The summary body became searchable: mark the entry dirty (lazy).
+        this.markSearchEntryDirty(index)
       }
       if (Array.isArray(seqs)) entry.items = seqs.length
       if (typeof tokens === 'number') entry.tokens = tokens
@@ -1778,9 +1797,11 @@ export class TranscriptFolder {
         // once, not twice.
         if (chunk.type === 'text-delta') {
           this.assistantEntry(event.data.turn, step).text += chunk.text
-          // Search projection: whole-string re-normalization (Unicode
-          // lowercasing is not chunk-splittable — Greek sigma).
-          this.refreshStreamingEntry(`assistant:${stepKey(event.data.turn, step)}`)
+          // Search projection: O(1) dirty mark — the entry is re-normalized
+          // as a WHOLE string at the next search (Unicode lowercasing is
+          // not chunk-splittable — Greek sigma — but the live streaming
+          // path must never pay per-chunk lowercase).
+          this.markStreamingEntryDirty(`assistant:${stepKey(event.data.turn, step)}`)
           // Focus aggregation: the streaming assistant text feeds the
           // Message candidate IMMEDIATELY (no assistant/message wait —
           // plan §5.2), so the running card previews the intermediate
@@ -1788,9 +1809,8 @@ export class TranscriptFolder {
           this.foldMessageCandidate(this.activityFor(event.data.turn), step, chunk.text)
         } else if (chunk.type === 'reasoning-delta') {
           this.thinkingEntry(event.data.turn, step).text += chunk.text
-          // Search projection: whole-string re-normalization (Unicode
-          // lowercasing is not chunk-splittable — Greek sigma).
-          this.refreshStreamingEntry(`thinking:${stepKey(event.data.turn, step)}`)
+          // Search projection: O(1) dirty mark (see the text-delta path).
+          this.markStreamingEntryDirty(`thinking:${stepKey(event.data.turn, step)}`)
           // Focus aggregation: keep a compact reasoning preview (the
           // rolling tail — never the full stream, plan §10.6/§42).
           this.foldThinking(this.activityFor(event.data.turn), chunk.text)
@@ -1819,9 +1839,10 @@ export class TranscriptFolder {
           // other non-text blocks — text-only steps stay on the text path).
           if (messageBlocks.some(block => block.type !== 'text')) entry.content = messageBlocks
           // The settled text REPLACES the streamed tail: the search
-          // projection must mirror the authoritative text, not the chunks.
+          // projection must mirror the authoritative text, not the chunks
+          // (lazy — mark dirty, O(1)).
           const searchIndex = this.searchIndexByStepKey.get(`assistant:${key}`)
-          if (searchIndex !== undefined) this.refreshSearchEntry(searchIndex)
+          if (searchIndex !== undefined) this.markSearchEntryDirty(searchIndex)
         } else {
           // ALWAYS preserve the entry — an empty settled message with no
           // preceding chunk (replay edge) must still own the exact-last
@@ -1982,9 +2003,10 @@ export class TranscriptFolder {
           card.resultBlocks = block?.content
           card.meta = event.data.meta
           card.error = event.data.error
-          // The result text landed: mirror it in the search projection
-          // (the grouping hooks below re-refresh merged read cards).
-          this.refreshSearchEntry(pending.index)
+          // The result text landed: mark the search entry dirty (lazy
+          // normalization; the grouping hooks below mark the merged
+          // representative when the read joins a group).
+          this.markSearchEntryDirty(pending.index)
           // A settled read may now be groupable: reflow the run it belongs
           // to (bounded by the nearest non-read cards).
           this.scheduleGrouping(pending.index)
@@ -2004,7 +2026,7 @@ export class TranscriptFolder {
               running.resultBlocks = block?.content
               running.meta = event.data.meta
               running.error = event.data.error
-              this.refreshSearchEntry(runningIndex)
+              this.markSearchEntryDirty(runningIndex)
               this.scheduleGrouping(runningIndex)
             }
           } else {
@@ -2126,9 +2148,9 @@ export class TranscriptFolder {
         if (card !== undefined) {
           card.status = event.data.stopReason === 'completed' ? 'ok' : 'error'
           card.result = `stop: ${event.data.stopReason}`
-          // The run result became searchable: mirror it in the projection.
+          // The run result became searchable: mark the entry dirty (lazy).
           const index = this.workflowRunIndex.get(event.data.runId)
-          if (index !== undefined) this.refreshSearchEntry(index)
+          if (index !== undefined) this.markSearchEntryDirty(index)
         }
         // The run's bookkeeping is done: drop the run card and every member
         // card keyed under it so long sessions do not accumulate stale maps.

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -533,7 +533,11 @@ export class TranscriptFolder {
   /** Bumped on EVERY entry mutation (append, settlement, group reflow):
    * query refinement must not reuse previous candidates across a revision. */
   private searchRevisionCounter = 0
-  /** Step key → raw item index, for in-place streaming text updates. */
+  /** Step key → raw item index, for in-place streaming text updates.
+   * Namespaced by entry kind (`assistant:` / `thinking:`): a step streams
+   * BOTH reasoning and text, and the two entries share the same
+   * stepKey(turn, step) — an un-namespaced map would let one kind's deltas
+   * land on the other kind's searchable entry. */
   private readonly searchIndexByStepKey = new Map<string, number>()
   /** Workflow run card indices by runId (run-end fills the result text). */
   private readonly workflowRunIndex = new Map<string, number>()
@@ -1558,7 +1562,7 @@ export class TranscriptFolder {
     if (entry === undefined) {
       entry = { kind: 'thinking', turn, text: '', running: true }
       this.thinkingEntries.set(key, entry)
-      this.searchIndexByStepKey.set(key, this.appendItem(entry))
+      this.searchIndexByStepKey.set(`thinking:${key}`, this.appendItem(entry))
       let open = this.openThinkingByTurn.get(turn)
       if (open === undefined) {
         open = new Set()
@@ -1576,7 +1580,7 @@ export class TranscriptFolder {
     if (entry === undefined) {
       entry = { kind: 'assistant', turn, text: '' }
       this.assistantEntries.set(key, entry)
-      this.searchIndexByStepKey.set(key, this.appendItem(entry))
+      this.searchIndexByStepKey.set(`assistant:${key}`, this.appendItem(entry))
     }
     return entry
   }
@@ -1762,7 +1766,7 @@ export class TranscriptFolder {
         if (chunk.type === 'text-delta') {
           this.assistantEntry(event.data.turn, step).text += chunk.text
           // Search projection: O(delta) incremental lowercase append.
-          this.appendSearchTextDelta(stepKey(event.data.turn, step), chunk.text)
+          this.appendSearchTextDelta(`assistant:${stepKey(event.data.turn, step)}`, chunk.text)
           // Focus aggregation: the streaming assistant text feeds the
           // Message candidate IMMEDIATELY (no assistant/message wait —
           // plan §5.2), so the running card previews the intermediate
@@ -1771,7 +1775,7 @@ export class TranscriptFolder {
         } else if (chunk.type === 'reasoning-delta') {
           this.thinkingEntry(event.data.turn, step).text += chunk.text
           // Search projection: O(delta) incremental lowercase append.
-          this.appendSearchTextDelta(stepKey(event.data.turn, step), chunk.text)
+          this.appendSearchTextDelta(`thinking:${stepKey(event.data.turn, step)}`, chunk.text)
           // Focus aggregation: keep a compact reasoning preview (the
           // rolling tail — never the full stream, plan §10.6/§42).
           this.foldThinking(this.activityFor(event.data.turn), chunk.text)
@@ -1801,7 +1805,7 @@ export class TranscriptFolder {
           if (messageBlocks.some(block => block.type !== 'text')) entry.content = messageBlocks
           // The settled text REPLACES the streamed tail: the search
           // projection must mirror the authoritative text, not the chunks.
-          const searchIndex = this.searchIndexByStepKey.get(key)
+          const searchIndex = this.searchIndexByStepKey.get(`assistant:${key}`)
           if (searchIndex !== undefined) this.refreshSearchEntry(searchIndex)
         } else {
           // ALWAYS preserve the entry — an empty settled message with no
@@ -1810,7 +1814,11 @@ export class TranscriptFolder {
           // earlier answer (review finding).
           const created: TranscriptMessage = { kind: 'assistant', turn: event.data.turn, text, ...(messageBlocks.some(block => block.type !== 'text') ? { content: messageBlocks } : {}) }
           this.assistantEntries.set(key, created)
-          this.appendItem(created)
+          // The created entry must register its search index too: a later
+          // replay replacement or text delta mutates this entry in place
+          // and must be able to refresh its searchable entry (review
+          // finding — the streaming-created path already registers).
+          this.searchIndexByStepKey.set(`assistant:${key}`, this.appendItem(created))
         }
         // The step is complete: its thinking entry stops streaming and leaves
         // the open-lifecycle index, so a later turn/end never revisits it.

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -835,12 +835,21 @@ export class TranscriptFolder {
 
   /** Append a lowercased text delta to one entry's normalized text (the
    * streaming hot path: O(delta) per chunk, never a full re-lowercase). */
-  private appendSearchTextDelta(key: string, delta: string): void {
+  /** Re-normalize ONE active streaming entry from its authoritative item
+   * text (assistant/thinking). Unicode lowercasing is NOT chunk-splittable
+   * — lower('ΟΣ') is 'ος' but lower('Ο') + lower('Σ') is 'οσ' (Greek
+   * sigma) — so a streaming entry is lowercased as a WHOLE string on every
+   * delta (O(one active message), never history). A settled entry is
+   * refreshed by its settlement path instead; historical entries never
+   * touch this path. */
+  private refreshStreamingEntry(key: string): void {
     const index = this.searchIndexByStepKey.get(key)
     if (index === undefined) return
     const entry = this.searchEntries[index]
     if (entry === undefined) return
-    entry.normalizedText += delta.toLowerCase()
+    const item = this.items[index]
+    if (item === undefined || !('text' in item)) return
+    entry.normalizedText = item.text.toLowerCase()
     this.searchRevisionCounter += 1
   }
 
@@ -1769,8 +1778,9 @@ export class TranscriptFolder {
         // once, not twice.
         if (chunk.type === 'text-delta') {
           this.assistantEntry(event.data.turn, step).text += chunk.text
-          // Search projection: O(delta) incremental lowercase append.
-          this.appendSearchTextDelta(`assistant:${stepKey(event.data.turn, step)}`, chunk.text)
+          // Search projection: whole-string re-normalization (Unicode
+          // lowercasing is not chunk-splittable — Greek sigma).
+          this.refreshStreamingEntry(`assistant:${stepKey(event.data.turn, step)}`)
           // Focus aggregation: the streaming assistant text feeds the
           // Message candidate IMMEDIATELY (no assistant/message wait —
           // plan §5.2), so the running card previews the intermediate
@@ -1778,8 +1788,9 @@ export class TranscriptFolder {
           this.foldMessageCandidate(this.activityFor(event.data.turn), step, chunk.text)
         } else if (chunk.type === 'reasoning-delta') {
           this.thinkingEntry(event.data.turn, step).text += chunk.text
-          // Search projection: O(delta) incremental lowercase append.
-          this.appendSearchTextDelta(`thinking:${stepKey(event.data.turn, step)}`, chunk.text)
+          // Search projection: whole-string re-normalization (Unicode
+          // lowercasing is not chunk-splittable — Greek sigma).
+          this.refreshStreamingEntry(`thinking:${stepKey(event.data.turn, step)}`)
           // Focus aggregation: keep a compact reasoning preview (the
           // rolling tail — never the full stream, plan §10.6/§42).
           this.foldThinking(this.activityFor(event.data.turn), chunk.text)

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -1444,7 +1444,8 @@ export class TranscriptFolder {
     if (maxTurns === undefined || maxTurns <= 0) return this.groupedMessages()
     // The indexed path is group-aware, including cross-turn read cards, and
     // falls back only for genuinely non-monotonic/corrupt logs. Full history
-    // remains available through the no-maxTurns call used by search.
+    // remains available through the no-maxTurns call (search uses the
+    // lightweight projection instead — it never materializes this list).
     return this.window({ maxTurns, ...options }).messages
   }
 
@@ -2170,16 +2171,6 @@ export class TranscriptFolder {
         break
     }
   }
-}
-
-/** Search the complete folded transcript, never a bounded presentation window. */
-export function searchTranscript(folder: TranscriptFolder, query: string): TranscriptMessage[] {
-  const needle = query.trim().toLowerCase()
-  if (needle === '') return []
-  return folder.messages().filter(message => {
-    const text = message.kind === 'tool' ? `${message.name} ${message.args} ${message.result}` : message.text
-    return text.toLowerCase().includes(needle)
-  })
 }
 
 /**

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -1112,9 +1112,13 @@ export class TranscriptFolder {
       this.groupMeta.set(previousGroup, { firstTurn, spansTurns })
       if (!wasCross && spansTurns) this.crossTurnGroups += 1
       this.groupedToolCount -= 1
-      // The merged card's text changed (args count + result): refresh every
-      // member entry to the SHARED group text (one lowercase per group).
-      this.refreshSearchRange(previousIndex, index)
+      // The merged card's text changed (args count + result): refresh the
+      // WHOLE group's entries to the SHARED group text (one lowercase per
+      // group). The range starts at the FIRST member — earlier members
+      // would otherwise keep the stale pre-merge text and turn, and a
+      // match deduplicated to the first member would anchor the wrong
+      // turn (round-4 finding).
+      this.refreshSearchRange(members[0]!, index)
       return true
     }
 

--- a/test/context-measurement.test.ts
+++ b/test/context-measurement.test.ts
@@ -373,38 +373,73 @@ test('P2: /status forces ONE measurement through the coordinator, never a duplic
     execute: async () => undefined,
   } as never)
   const agent = { session: { id: 'session-b', events: [], header: { cwd: '/ws' } } } as unknown as Agent
-  let forceCalls = 0
-  let directReads = 0
-  const runner = {
-    ctx,
-    app,
-    cwd: '/ws',
-    signal: new AbortController().signal,
-    diag: { warn: () => {}, error: () => {}, info: () => {} },
-    commandRegistry: ctx.get('commands'),
-    recordExtensionError: () => {},
-    clearExtensionError: () => {},
-    captureExtensionHealthRef: () => {},
-    ensureSession: async () => {},
-    sessionCwd: () => '/ws',
-    get liveAgent() { return agent },
-    extensions: undefined,
-    forceContextMeasurement: () => { forceCalls += 1; return 42_000 },
-    sessionReader: {
-      measureContext: () => { directReads += 1; return 99_000 },
-      list: async () => [], search: async () => [], titles: async () => new Map(), readExportData: async () => ({ kind: 'none' }),
-    },
-  } as unknown as TuiCommandRunner
   try {
-    registerTuiCommands(runner)
-    const statusDef = defs.find(entry => entry.name === 'status')
-    assert.ok(statusDef?.handler, 'the /status command is registered')
-    await (statusDef.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
-    assert.equal(forceCalls, 1, 'the explicit status forces exactly one measurement through the coordinator')
-    assert.equal(directReads, 0, 'the direct reader is never called when the coordinator is available (no duplicate measurement)')
+    // Run the handler under BOTH force outcomes: a measured value AND an
+    // undefined force (no live session / measurement failure). The direct
+    // reader must NEVER run while the coordinator is present — the old
+    // `??` fallback triggered a second, uncached measurement when the
+    // force returned undefined (round-9 finding).
+    for (const forceValue of [42_000, undefined]) {
+      defs.length = 0 // re-register per round so the fresh handler is found
+      let forceCalls = 0
+      let directReads = 0
+      const runner = {
+        ctx,
+        app,
+        cwd: '/ws',
+        signal: new AbortController().signal,
+        diag: { warn: () => {}, error: () => {}, info: () => {} },
+        commandRegistry: ctx.get('commands'),
+        recordExtensionError: () => {},
+        clearExtensionError: () => {},
+        captureExtensionHealthRef: () => {},
+        ensureSession: async () => {},
+        sessionCwd: () => '/ws',
+        get liveAgent() { return agent },
+        extensions: undefined,
+        forceContextMeasurement: () => { forceCalls += 1; return forceValue },
+        sessionReader: {
+          measureContext: () => { directReads += 1; return 99_000 },
+          list: async () => [], search: async () => [], titles: async () => new Map(), readExportData: async () => ({ kind: 'none' }),
+        },
+      } as unknown as TuiCommandRunner
+      registerTuiCommands(runner)
+      const statusDef = defs.find(entry => entry.name === 'status')
+      assert.ok(statusDef?.handler, 'the /status command is registered')
+      await (statusDef.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
+      assert.equal(forceCalls, 1, 'the explicit status forces exactly one measurement through the coordinator')
+      assert.equal(directReads, 0, `the direct reader is never called while the coordinator is present (force returned ${String(forceValue)})`)
+    }
   } finally {
     app.stop()
   }
+})
+
+test('P2: the deferred initial measure skips a session an earlier force already measured', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(50_000)
+  coordinator.bind('session-a')
+  // The runner's deferred-callback shape (deferInitialContextMeasure run):
+  // skip when an earlier measurement already succeeded for this session.
+  const deferredRun = (): void => {
+    if (!coordinator.isDirty()) return
+    coordinator.markDirty()
+    coordinator.measure('session-a', counting.reader)
+  }
+  // An explicit /status force runs BEFORE the deferred setImmediate
+  // callback: one measurement, dirty cleared.
+  coordinator.markDirty()
+  coordinator.measure('session-a', counting.reader)
+  assert.equal(counting.measureCalls, 1)
+  deferredRun()
+  assert.equal(counting.measureCalls, 1, 'the deferred measure must not double-measure after an explicit force')
+  // A FAILED earlier attempt keeps the last-good value AND stays dirty:
+  // the deferred callback retries.
+  coordinator.markDirty()
+  assert.equal(coordinator.measure('session-a', () => undefined), 50_000, 'a failed measure keeps the last-good value')
+  assert.equal(coordinator.isDirty(), true, 'a failed measure stays dirty')
+  deferredRun()
+  assert.equal(counting.measureCalls, 2, 'a failed attempt is retried by the deferred callback')
 })
 
 test('D2 structural gate: the runner source keeps measurement out of cheap refreshes', () => {
@@ -429,4 +464,12 @@ test('D2 structural gate: the runner source keeps measurement out of cheap refre
   // previous session's context on the new session's first frames.
   assert.ok(cheapBlock.includes('contextTokens,'), 'setStatus must always carry the contextTokens field (undefined clears)')
   assert.ok(cheapBlock.includes('contextWindow: contextTokens === undefined ? undefined :'), 'an unmeasured session must clear the window too')
+  // P2: the deferred initial measure must skip a session that an earlier
+  // force/lifecycle measurement already succeeded for — the callback first
+  // checks the coordinator's dirty flag instead of re-measuring blindly.
+  const deferStart = stripped.indexOf('const scheduleInitialContextMeasure =')
+  const deferEnd = stripped.indexOf('let app: TuiApp')
+  assert.ok(deferStart !== -1 && deferEnd > deferStart, 'the deferred-measure scheduler exists')
+  const deferBlock = stripped.slice(deferStart, deferEnd)
+  assert.ok(deferBlock.includes('.isDirty()'), 'the deferred initial measure must skip an already-measured session')
 })

--- a/test/context-measurement.test.ts
+++ b/test/context-measurement.test.ts
@@ -415,31 +415,48 @@ test('P2: /status forces ONE measurement through the coordinator, never a duplic
   }
 })
 
-test('P2: the deferred initial measure skips a session an earlier force already measured', () => {
+test('the deferred initial measure binds the captured session FIRST, then skips only an already-measured one', () => {
   const coordinator = new ContextMeasurementCoordinator()
   const counting = countingReader(50_000)
-  coordinator.bind('session-a')
-  // The runner's deferred-callback shape (deferInitialContextMeasure run):
-  // skip when an earlier measurement already succeeded for this session.
-  const deferredRun = (): void => {
+  // The runner's deferred-callback shape (deferInitialContextMeasure run),
+  // verbatim: bind the captured session BEFORE the dirty guard — an
+  // UNBOUND coordinator (cold resume) or a coordinator still bound to the
+  // PREVIOUS session (switch) reads as not dirty, and guarding before the
+  // bind would make the initial measure a permanent no-op (round-10
+  // finding).
+  const deferredRun = (sessionId: string): void => {
+    coordinator.bind(sessionId)
     if (!coordinator.isDirty()) return
     coordinator.markDirty()
-    coordinator.measure('session-a', counting.reader)
+    coordinator.measure(sessionId, counting.reader)
   }
-  // An explicit /status force runs BEFORE the deferred setImmediate
-  // callback: one measurement, dirty cleared.
-  coordinator.markDirty()
-  coordinator.measure('session-a', counting.reader)
-  assert.equal(counting.measureCalls, 1)
-  deferredRun()
-  assert.equal(counting.measureCalls, 1, 'the deferred measure must not double-measure after an explicit force')
+  // Cold resume: the coordinator is UNBOUND when the deferred callback
+  // runs — the measure must still happen once.
+  deferredRun('session-cold')
+  assert.equal(counting.measureCalls, 1, 'the cold-resume deferred measure must run')
+  assert.equal(coordinator.valueFor('session-cold'), 50_000)
+  // A second deferral for the same already-measured session is a no-op
+  // (the round-9 force-then-deferred dedupe).
+  deferredRun('session-cold')
+  assert.equal(counting.measureCalls, 1, 'no re-measure for an already-measured session')
   // A FAILED earlier attempt keeps the last-good value AND stays dirty:
   // the deferred callback retries.
   coordinator.markDirty()
-  assert.equal(coordinator.measure('session-a', () => undefined), 50_000, 'a failed measure keeps the last-good value')
+  assert.equal(coordinator.measure('session-cold', () => undefined), 50_000, 'a failed measure keeps the last-good value')
   assert.equal(coordinator.isDirty(), true, 'a failed measure stays dirty')
-  deferredRun()
+  deferredRun('session-cold')
   assert.equal(counting.measureCalls, 2, 'a failed attempt is retried by the deferred callback')
+  // Session switch: the coordinator is still bound to the OLD session when
+  // the NEW session's deferred callback runs — binding the new id clears
+  // the old value and arms exactly one fresh measure.
+  coordinator.bind('session-old')
+  coordinator.markDirty()
+  coordinator.measure('session-old', counting.reader)
+  const afterSwitchMeasure = counting.measureCalls
+  deferredRun('session-new')
+  assert.equal(counting.measureCalls, afterSwitchMeasure + 1, 'the switched session measures exactly once')
+  assert.equal(coordinator.valueFor('session-new'), 50_000)
+  assert.equal(coordinator.valueFor('session-old'), undefined, 'the old session value is cleared by the bind')
 })
 
 test('D2 structural gate: the runner source keeps measurement out of cheap refreshes', () => {

--- a/test/context-measurement.test.ts
+++ b/test/context-measurement.test.ts
@@ -15,6 +15,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { readFileSync } from 'node:fs'
+import { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
 import {
   ContextMeasurementCoordinator,
   deferInitialContextMeasure,
@@ -27,6 +29,7 @@ import { plainSectionEqual } from '../src/status/equal.ts'
 import type { SessionStats } from '../src/stats.ts'
 import { TuiApp } from '../src/tui-app.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
+import { registerTuiCommands, type TuiCommandRunner } from '../src/commands.ts'
 import { contextRefreshKind } from '../src/index.ts'
 
 /** A counting reader standing in for SessionReader.measureContext. */
@@ -347,6 +350,58 @@ test('P1: a session switch never shows the OLD session context through the statu
     assert.equal(later, 12_000)
     refreshCheap('session-b', stats(3_000))
     assert.equal(store.snapshot().usage?.context?.usedTokens, 12_000)
+  } finally {
+    app.stop()
+  }
+})
+
+test('P2: /status forces ONE measurement through the coordinator, never a duplicate direct read', async () => {
+  // The real /status handler must route through the runner's
+  // forceContextMeasurement (mark dirty + semantic reader + cache + cheap
+  // repaint) — a direct sessionReader read from the command surface would
+  // bypass the coordinator cache and could duplicate the deferred initial
+  // measurement (round-8 finding).
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  const ctx = new Context()
+  const defs: Array<{ name: string; handler?: unknown }> = []
+  ctx.provide('commands', {
+    register: (def: { name: string; handler?: unknown }): (() => void) => { defs.push(def); return () => {} },
+    list: () => [],
+    find: () => undefined,
+    execute: async () => undefined,
+  } as never)
+  const agent = { session: { id: 'session-b', events: [], header: { cwd: '/ws' } } } as unknown as Agent
+  let forceCalls = 0
+  let directReads = 0
+  const runner = {
+    ctx,
+    app,
+    cwd: '/ws',
+    signal: new AbortController().signal,
+    diag: { warn: () => {}, error: () => {}, info: () => {} },
+    commandRegistry: ctx.get('commands'),
+    recordExtensionError: () => {},
+    clearExtensionError: () => {},
+    captureExtensionHealthRef: () => {},
+    ensureSession: async () => {},
+    sessionCwd: () => '/ws',
+    get liveAgent() { return agent },
+    extensions: undefined,
+    forceContextMeasurement: () => { forceCalls += 1; return 42_000 },
+    sessionReader: {
+      measureContext: () => { directReads += 1; return 99_000 },
+      list: async () => [], search: async () => [], titles: async () => new Map(), readExportData: async () => ({ kind: 'none' }),
+    },
+  } as unknown as TuiCommandRunner
+  try {
+    registerTuiCommands(runner)
+    const statusDef = defs.find(entry => entry.name === 'status')
+    assert.ok(statusDef?.handler, 'the /status command is registered')
+    await (statusDef.handler as (invocation: { rawInput: string }) => Promise<unknown>)({ rawInput: '' })
+    assert.equal(forceCalls, 1, 'the explicit status forces exactly one measurement through the coordinator')
+    assert.equal(directReads, 0, 'the direct reader is never called when the coordinator is available (no duplicate measurement)')
   } finally {
     app.stop()
   }

--- a/test/context-measurement.test.ts
+++ b/test/context-measurement.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Context-measurement coordinator tests (PR D2): the cheap status refresh
+ * must NEVER trigger a measurement (UI-only events keep measureCalls at 0),
+ * model-visible lifecycle events trigger bounded measurements through the
+ * semantic reader seam, session switches never leak an old session's value,
+ * failures keep last-good semantics, and the deferred initial measure runs
+ * only after the first usable paint and only for the session that was
+ * captured (generation fence).
+ *
+ * The coordinator + defer helper ARE the production seam the runner drives
+ * (the same pattern as settleCompactionSurface / foldCompactionEvent).
+ * @module @xmoon76/dsh-pi-tui/context-measurement.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  ContextMeasurementCoordinator,
+  deferInitialContextMeasure,
+  type ContextMeasureReason,
+} from '../src/status/context-measurement.ts'
+
+/** A counting reader standing in for SessionReader.measureContext. */
+function countingReader(initial = 42_000): {
+  measureCalls: number
+  value: number
+  reader: (sessionId: string) => number | undefined
+} {
+  const state = { measureCalls: 0, value: initial }
+  return {
+    get measureCalls() { return state.measureCalls },
+    set value(next: number) { state.value = next },
+    reader: (_sessionId: string) => {
+      state.measureCalls += 1
+      return state.value
+    },
+  }
+}
+
+/** The runner's exact UI-only pattern: a cheap refresh cycle. */
+function cheapRefresh(coordinator: ContextMeasurementCoordinator, sessionId: string | undefined): number | undefined {
+  return coordinator.valueFor(sessionId)
+}
+
+/** The runner's exact model-visible pattern: mark dirty, then measure. */
+function measuredRefresh(
+  coordinator: ContextMeasurementCoordinator,
+  sessionId: string,
+  reader: (sessionId: string) => number | undefined,
+): number | undefined {
+  coordinator.markDirty()
+  return coordinator.measure(sessionId, reader)
+}
+
+test('initial measure happens once; the value is cached for cheap refreshes', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(50_000)
+  coordinator.bind('session-a')
+  assert.equal(coordinator.isDirty(), true, 'a fresh session starts dirty')
+  const first = coordinator.measure('session-a', counting.reader)
+  assert.equal(first, 50_000)
+  assert.equal(counting.measureCalls, 1)
+  assert.equal(coordinator.isDirty(), false, 'a successful measure clears dirty')
+  // Cheap refreshes read the cache: no reader call.
+  for (let i = 0; i < 100; i += 1) {
+    assert.equal(cheapRefresh(coordinator, 'session-a'), 50_000)
+  }
+  assert.equal(counting.measureCalls, 1, '100 cheap refreshes never measure')
+})
+
+test('19.2 hard gate: 100 UI-only refresh cycles -> measureCalls stays 0', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(42_000)
+  coordinator.bind('session-a')
+  // UI-only events repaint from the cache; they never mark dirty.
+  for (let i = 0; i < 100; i += 1) {
+    cheapRefresh(coordinator, 'session-a')
+    coordinator.valueFor(undefined)
+  }
+  assert.equal(counting.measureCalls, 0, 'UI-only refreshes never reach the reader')
+  assert.equal(coordinator.valueFor('session-a'), undefined, 'no measurement was ever made')
+})
+
+test('19.3 long-session independence: cheap refresh cost never touches the reader', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  // The reader's cost grows with session length — but it must never run
+  // for cheap refreshes, so the cost is irrelevant.
+  let measuredTurns = 0
+  const expensiveReader = (_sessionId: string): number => {
+    measuredTurns += 1
+    return 10_000 + measuredTurns
+  }
+  coordinator.bind('session-a')
+  for (let i = 0; i < 10_000; i += 1) cheapRefresh(coordinator, 'session-a')
+  assert.equal(measuredTurns, 0, '10k cheap refreshes produce zero measurements, any session length')
+})
+
+test('lifecycle trigger matrix: bounded measurements per model-visible event', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(40_000)
+  coordinator.bind('session-a')
+  // initial
+  coordinator.measure('session-a', counting.reader)
+  assert.equal(counting.measureCalls, 1, 'initial post-paint measure: 1')
+  // UI-only interlude
+  for (let i = 0; i < 20; i += 1) cheapRefresh(coordinator, 'session-a')
+  assert.equal(counting.measureCalls, 1, 'UI-only events after the initial measure: 0 growth')
+  // step/start
+  measuredRefresh(coordinator, 'session-a', counting.reader)
+  assert.equal(counting.measureCalls, 2, 'step/start: bounded +1')
+  // turn/end
+  measuredRefresh(coordinator, 'session-a', counting.reader)
+  assert.equal(counting.measureCalls, 3, 'turn/end: bounded +1 when dirty')
+  // compaction/end
+  measuredRefresh(coordinator, 'session-a', counting.reader)
+  assert.equal(counting.measureCalls, 4, 'compaction/end: +1')
+  // keybinding/theme/focus (UI-only) again
+  cheapRefresh(coordinator, 'session-a')
+  cheapRefresh(coordinator, 'session-a')
+  assert.equal(counting.measureCalls, 4, 'keybinding/theme/focus-style refreshes: 0')
+  // same-sync-chain dedupe: a second measure with NO dirty mark skips.
+  coordinator.measure('session-a', counting.reader)
+  assert.equal(counting.measureCalls, 4, 'a clean cache skips the reader (dirty=false -> skip)')
+})
+
+test('session switch: the old session value never leaks into the new session', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(100_000)
+  coordinator.bind('session-old')
+  coordinator.measure('session-old', counting.reader)
+  assert.equal(coordinator.valueFor('session-old'), 100_000)
+  // Switch: bind the new identity — the old value is gone.
+  coordinator.bind('session-new')
+  assert.equal(coordinator.snapshot().value, undefined, 'bind clears the old value')
+  assert.equal(coordinator.valueFor('session-new'), undefined, 'the new session starts unmeasured')
+  assert.equal(coordinator.valueFor('session-old'), undefined, 'the old session id reads nothing after the switch')
+  // The new session measures once.
+  measuredRefresh(coordinator, 'session-new', counting.reader)
+  assert.equal(counting.measureCalls, 2)
+  assert.equal(coordinator.valueFor('session-new'), 100_000)
+  assert.equal(coordinator.valueFor('session-old'), undefined, 'old-session reads stay empty forever')
+})
+
+test('a stale/foreign session id is refused: no measurement can commit under the wrong identity', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(7_000)
+  coordinator.bind('session-current')
+  const stale = coordinator.measure('session-old', counting.reader)
+  assert.equal(stale, undefined)
+  assert.equal(counting.measureCalls, 0, 'a foreign session id never reaches the reader')
+  assert.equal(coordinator.snapshot().sessionId, 'session-current', 'the bound identity never changed')
+})
+
+test('19.6 failure regression: undefined and throwing readers keep last-good, recover later', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  let calls = 0
+  let fail = true
+  const flaky = (_sessionId: string): number | undefined => {
+    calls += 1
+    if (fail) return undefined
+    return 66_000
+  }
+  coordinator.bind('session-a')
+  const first = coordinator.measure('session-a', flaky)
+  assert.equal(first, undefined, 'measurement failure falls back to no context')
+  assert.equal(calls, 1)
+  assert.equal(coordinator.isDirty(), true, 'a failed measure stays dirty for the next trigger')
+  // Subsequent triggers retry — still failing, still not crashing.
+  assert.equal(coordinator.measure('session-a', flaky), undefined)
+  assert.equal(calls, 2)
+  // Success recovers.
+  fail = false
+  assert.equal(coordinator.measure('session-a', flaky), 66_000)
+  assert.equal(coordinator.isDirty(), false)
+  assert.equal(coordinator.valueFor('session-a'), 66_000)
+
+  // A THROWING reader: swallowed, last-good stays, dirty stays.
+  const throwing = new ContextMeasurementCoordinator()
+  const counting = countingReader(9_000)
+  throwing.bind('session-a')
+  throwing.measure('session-a', counting.reader)
+  assert.equal(throwing.valueFor('session-a'), 9_000)
+  throwing.markDirty()
+  const afterThrow = throwing.measure('session-a', () => { throw new Error('backend exploded') })
+  assert.equal(afterThrow, 9_000, 'a throwing reader keeps the last-good value')
+  assert.equal(throwing.isDirty(), true, 'the dirty flag survives the throw (retry armed)')
+})
+
+test('19.5 first-paint ordering: the deferred measure runs AFTER the paint turn, fenced', () => {
+  const order: string[] = []
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(30_000)
+  coordinator.bind('session-a')
+
+  // The runner paints + cheap-refreshes FIRST, then defers the measure.
+  let scheduled: (() => void) | undefined
+  const cancel = deferInitialContextMeasure(
+    (callback) => { scheduled = callback; return { cancel: () => { scheduled = undefined } } },
+    () => true,
+    () => {
+      order.push('measure')
+      measuredRefresh(coordinator, 'session-a', counting.reader)
+    },
+  )
+  order.push('paint')
+  order.push('cheap-status')
+  assert.ok(typeof scheduled === 'function', 'the deferral is scheduled, not run inline')
+  assert.deepEqual(order, ['paint', 'cheap-status'], 'nothing measured before the deferred turn')
+  scheduled!()
+  assert.deepEqual(order, ['paint', 'cheap-status', 'measure'], 'the measure runs in its own turn')
+  assert.equal(counting.measureCalls, 1)
+  cancel()
+})
+
+test('deferred initial measure is a no-op when the session changed before it ran', () => {
+  const order: string[] = []
+  let generation = 1
+  let liveSession = 'session-a'
+  // The runner captures generation + session id and fences against both.
+  const capturedGeneration = generation
+  const capturedSession = liveSession
+  let scheduled: (() => void) | undefined
+  const cancel = deferInitialContextMeasure(
+    (callback) => { scheduled = callback; return { cancel: () => { scheduled = undefined } } },
+    () => capturedGeneration === generation && liveSession === capturedSession,
+    () => { order.push('measure-ran') },
+  )
+  // Session switch BEFORE the deferred callback fires.
+  generation += 1
+  liveSession = 'session-b'
+  scheduled!()
+  assert.deepEqual(order, [], 'a stale deferred measure never commits')
+  cancel()
+})
+
+test('defer cancel clears the pending callback (dispose path)', () => {
+  let scheduled: (() => void) | undefined
+  let cancelled = false
+  const cancel = deferInitialContextMeasure(
+    (callback) => { scheduled = callback; return { cancel: () => { cancelled = true } } },
+    () => true,
+    () => { throw new Error('must never run after cancel') },
+  )
+  cancel()
+  assert.equal(cancelled, true)
+})
+
+test('bind(undefined) clears everything (deferred start, no live session)', () => {
+  const coordinator = new ContextMeasurementCoordinator()
+  const counting = countingReader(0)
+  coordinator.bind('session-a')
+  coordinator.measure('session-a', counting.reader)
+  assert.equal(coordinator.valueFor('session-a'), 0)
+  coordinator.bind(undefined)
+  assert.equal(coordinator.snapshot().value, undefined)
+  assert.equal(coordinator.measure('session-a', counting.reader), undefined, 'no session -> no measure')
+  assert.equal(counting.measureCalls, 1, 'the cleared coordinator never reaches the reader')
+})
+
+test('reason names are the documented model-visible triggers', () => {
+  const reasons: ContextMeasureReason[] = [
+    'initial', 'step-start', 'turn-end', 'compaction-end', 'explicit-status', 'session-switch',
+  ]
+  assert.equal(reasons.length, 6)
+  assert.ok(reasons.includes('step-start') && reasons.includes('compaction-end'))
+})

--- a/test/context-measurement.test.ts
+++ b/test/context-measurement.test.ts
@@ -14,11 +14,13 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { readFileSync } from 'node:fs'
 import {
   ContextMeasurementCoordinator,
   deferInitialContextMeasure,
   type ContextMeasureReason,
 } from '../src/status/context-measurement.ts'
+import { contextRefreshKind } from '../src/index.ts'
 
 /** A counting reader standing in for SessionReader.measureContext. */
 function countingReader(initial = 42_000): {
@@ -263,4 +265,36 @@ test('reason names are the documented model-visible triggers', () => {
   ]
   assert.equal(reasons.length, 6)
   assert.ok(reasons.includes('step-start') && reasons.includes('compaction-end'))
+})
+
+test('contextRefreshKind classifier: model-visible events measure, UI-only events repaint cheaply', () => {
+  assert.equal(contextRefreshKind('step/start'), 'measure')
+  assert.equal(contextRefreshKind('turn/end'), 'measure')
+  assert.equal(contextRefreshKind('compaction/end'), 'measure', 'classified measure; the firehose skips it (fold-outcome path)')
+  for (const uiOnly of [
+    'turn/start', 'user/message', 'assistant/chunk', 'assistant/message',
+    'tool/call', 'tool/result', 'subagent/start', 'subagent/end', 'agent/status',
+    'session/end-seed', 'compaction/start', 'llm/retry', 'command/run',
+  ]) {
+    assert.equal(contextRefreshKind(uiOnly), 'cheap', `${uiOnly} must only repaint cheaply`)
+  }
+})
+
+test('D2 structural gate: the runner source keeps measurement out of cheap refreshes', () => {
+  // The same source-audit style as test/rules.test.ts: a regression that
+  // reintroduces a measuring reader (or the direct tokenMeter service)
+  // into a generic status refresh fails here instead of waiting for a
+  // review round. Comments are stripped so documentation cannot mask code.
+  const source = readFileSync(new URL('../src/index.ts', import.meta.url), 'utf8')
+  const stripped = source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ')
+  const cheapStart = stripped.indexOf('const refreshStatusCheap =')
+  const cheapEnd = stripped.indexOf('const refreshContextMeasurement =')
+  assert.ok(cheapStart !== -1 && cheapEnd > cheapStart, 'both status functions exist')
+  const cheapBlock = stripped.slice(cheapStart, cheapEnd)
+  assert.ok(!cheapBlock.includes('measureContext'), 'the cheap refresh must never call a measurement reader')
+  assert.ok(!cheapBlock.includes('tokenMeter'), 'the cheap refresh must never read the tokenMeter service')
+  assert.ok(!stripped.includes("ctx.get('tokenMeter')"), 'the runner no longer reads tokenMeter directly (the Direct adapter owns it)')
+  assert.ok(stripped.includes('backend.sessionReader.measureContext'), 'measurement goes through the SessionReader port')
 })

--- a/test/context-measurement.test.ts
+++ b/test/context-measurement.test.ts
@@ -20,6 +20,13 @@ import {
   deferInitialContextMeasure,
   type ContextMeasureReason,
 } from '../src/status/context-measurement.ts'
+import { emptyStatusSnapshot } from '../src/status/types.ts'
+import { StatusStore } from '../src/status/store.ts'
+import { usageFromStats } from '../src/status/derive-usage.ts'
+import { plainSectionEqual } from '../src/status/equal.ts'
+import type { SessionStats } from '../src/stats.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
 import { contextRefreshKind } from '../src/index.ts'
 
 /** A counting reader standing in for SessionReader.measureContext. */
@@ -280,6 +287,71 @@ test('contextRefreshKind classifier: model-visible events measure, UI-only event
   }
 })
 
+test('P1: a session switch never shows the OLD session context through the status chain', () => {
+  // The FULL projection chain, replayed with the runner's exact
+  // refreshStatusCheap semantics: coordinator->valueFor, the store usage
+  // projection (usageFromStats + plainSectionEqual patch, like the runner),
+  // then app.setStatus with the legacy context fields. TuiApp.setStatus
+  // MERGES into its legacy status and usageFromStatus() falls back to the
+  // store's current usage — so BOTH the legacy fields AND the store
+  // projection must be driven by the CURRENT session's (un)measured
+  // context. The runner MUST project `contextTokens: undefined` explicitly
+  // (a conditional spread leaves session A's value in the merge).
+  const coordinator = new ContextMeasurementCoordinator()
+  const store = new StatusStore(emptyStatusSnapshot())
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { statusStore: store })
+  app.start()
+  const stats = (inputTokens: number): SessionStats => ({
+    turns: 5, steps: 9, llmMs: 100, firstTokenMsAvg: 50, tokensPerSec: 10, cacheHitPct: 0,
+    inputTokens, outputTokens: 200, cacheReadTokens: 0, cacheWriteTokens: 0, contextWindow: 128_000,
+  })
+  try {
+    const refreshCheap = (sessionId: string | undefined, sessionStats: SessionStats): void => {
+      const contextTokens = coordinator.valueFor(sessionId)
+      const usage = usageFromStats(sessionStats, contextTokens)
+      const current = store.snapshot()
+      const patch: { usage?: typeof usage } = {}
+      if (!plainSectionEqual(current.usage, usage)) patch.usage = usage
+      store.update(patch)
+      app.setStatus({ contextTokens, contextWindow: contextTokens === undefined ? undefined : sessionStats.contextWindow })
+    }
+    // Session A measured 110k/128k and projected.
+    coordinator.bind('session-a')
+    coordinator.measure('session-a', () => 110_000)
+    refreshCheap('session-a', stats(5_000))
+    assert.equal(store.snapshot().usage?.context?.usedTokens, 110_000, 'session A pressure is visible')
+
+    // Switch to B: the deferred measurement has NOT run yet — B's first
+    // cheap refresh must show B's own fallback, never A's 110k.
+    coordinator.bind('session-b')
+    refreshCheap('session-b', stats(3_000))
+    const afterSwitch = store.snapshot().usage?.context
+    assert.ok(afterSwitch !== undefined && afterSwitch.usedTokens !== 110_000, 'B must never show A context pressure')
+
+    // B's measurement FAILS (undefined, then throw): A's value must not
+    // revive — the cleared fields stay cleared, the fallback stays B's.
+    coordinator.measure('session-b', () => undefined)
+    refreshCheap('session-b', stats(3_000))
+    const afterUndefined = store.snapshot().usage?.context
+    assert.ok(afterUndefined !== undefined && afterUndefined.usedTokens !== 110_000, 'A context must not revive after an undefined measurement')
+    coordinator.markDirty()
+    coordinator.measure('session-b', () => { throw new Error('backend exploded') })
+    refreshCheap('session-b', stats(3_000))
+    const afterThrow = store.snapshot().usage?.context
+    assert.ok(afterThrow !== undefined && afterThrow.usedTokens !== 110_000, 'A context must not revive after a throwing measurement')
+
+    // B's later SUCCESS projects B's own value (the clear was per-session,
+    // not a permanent blank).
+    const later = coordinator.measure('session-b', () => 12_000)
+    assert.equal(later, 12_000)
+    refreshCheap('session-b', stats(3_000))
+    assert.equal(store.snapshot().usage?.context?.usedTokens, 12_000)
+  } finally {
+    app.stop()
+  }
+})
+
 test('D2 structural gate: the runner source keeps measurement out of cheap refreshes', () => {
   // The same source-audit style as test/rules.test.ts: a regression that
   // reintroduces a measuring reader (or the direct tokenMeter service)
@@ -297,4 +369,9 @@ test('D2 structural gate: the runner source keeps measurement out of cheap refre
   assert.ok(!cheapBlock.includes('tokenMeter'), 'the cheap refresh must never read the tokenMeter service')
   assert.ok(!stripped.includes("ctx.get('tokenMeter')"), 'the runner no longer reads tokenMeter directly (the Direct adapter owns it)')
   assert.ok(stripped.includes('backend.sessionReader.measureContext'), 'measurement goes through the SessionReader port')
+  // P1: the legacy context fields must be projected EXPLICITLY (undefined
+  // clears the TuiApp merge) — a conditional spread would leave the
+  // previous session's context on the new session's first frames.
+  assert.ok(cheapBlock.includes('contextTokens,'), 'setStatus must always carry the contextTokens field (undefined clears)')
+  assert.ok(cheapBlock.includes('contextWindow: contextTokens === undefined ? undefined :'), 'an unmeasured session must clear the window too')
 })

--- a/test/footer-command-runner.test.ts
+++ b/test/footer-command-runner.test.ts
@@ -67,6 +67,33 @@ test('a non-zero exit falls back', async () => {
   assert.equal(rows, undefined)
 })
 
+test('an instant-exit child cannot crash the runner with an unhandled stdin EPIPE (round-3 finding)', async () => {
+  // `true` via the shell exits BEFORE the JSON payload flushes: the async
+  // EPIPE on the parent's stdin stream used to be an unhandled 'error'
+  // event and crashed the whole process (the same class as the clipboard
+  // helper's round-3 finding — the try/catch around write() only catches
+  // SYNCHRONOUS throws). The runner must settle every run to the native
+  // fallback and survive the batch; with the bug, the process dies with
+  // an uncaughtException and this test fails.
+  for (let run = 0; run < 60; run += 1) {
+    const rows = await new Promise<string[] | undefined>((resolve) => {
+      const runner = new FooterCommandRunner({
+        config: { ...CONFIG, command: 'true', timeoutMs: 10000 },
+        snapshot: () => emptyStatusSnapshot(),
+        width: () => 100,
+        height: () => 30,
+        onOutput: (result) => {
+          runner.dispose()
+          resolve(result)
+        },
+        signal: new AbortController().signal,
+      })
+      runner.requestRefresh()
+    })
+    assert.equal(rows, undefined, `run ${run} must settle to the native fallback`)
+  }
+})
+
 test('a timeout kills the child and falls back', async () => {
   const rows = await runOnce({ ...CONFIG, timeoutMs: 100 }, 'setTimeout(() => process.stdout.write("late"), 5000)')
   assert.equal(rows, undefined)

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -18,7 +18,7 @@ import { color, currentPalette, darkColors, lightColors, setTheme } from '../src
 import { iconFor } from '../src/icons.ts'
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent, type TranscriptViewportAnchor } from '../src/tui-app.ts'
 import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
-import { searchTranscript, TranscriptFolder, type TurnActivity } from '../src/transcript.ts'
+import { TranscriptFolder, type TurnActivity } from '../src/transcript.ts'
 import { TranscriptWindowController } from '../src/transcript-window.ts'
 import { Text, visibleWidth, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
 import { VirtualTerminal } from './virtual-terminal.ts'
@@ -1386,13 +1386,12 @@ test('fullscreen Ctrl+F and Ctrl+Shift+F search the full folder and re-window to
     onSubmit: () => {},
     onExit: () => {},
     onSearchQuery: (query) => {
-      const matches = searchTranscript(folder, query)
+      const matches = folder.search(query)
       if (matches.length === 0) return
       const match = matches[0]
-      if (match === undefined || !('turn' in match)) return
-      const turn = match.turn
-      controller.anchorAt(turn)
-      hostMatches.push(turn)
+      if (match === undefined) return
+      controller.anchorAt(match.turn)
+      hostMatches.push(match.turn)
       renderWindow()
     },
     onSearchClose: () => {

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -16,6 +16,7 @@ import test from 'node:test'
 import { MessageId, ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { TranscriptFolder, transcriptSearchText, type TranscriptMessage, type TranscriptSearchMatch } from '../src/transcript.ts'
+import { refreshedSearchState } from '../src/index.ts'
 
 /** Build a minimal event envelope for tests. */
 function event<K extends SessionEvent['type']>(
@@ -656,6 +657,86 @@ test('live cross-turn append refreshes the WHOLE group (turn + shared text)', ()
   // The shared text is refreshed for ALL members: the merged args count is
   // searchable, and the superseded count is gone (strict legacy parity).
   assertCorpusParity(folder, ['gamma-only-needle', 'alpha content', 'beta content', '3 files', '2 files'])
+})
+
+test('stale search overlay: Next/Prev refreshes matches when the transcript changed underneath (P1)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    readToolCall(1, 'r1', 'src/a.ts', 0),
+    toolResult(2, 'r1', 'alpha payload'),
+    turnEnd(3, 0),
+    turnStart(4, 1),
+    readToolCall(5, 'r2', 'src/b.ts', 1),
+    toolResult(6, 'r2', 'beta payload'),
+    turnEnd(7, 1),
+  ])
+  // The overlay queried while the merged cross-turn card (turn 1) matched.
+  const initial = folder.search('payload')
+  assert.equal(initial.length, 1)
+  assert.equal(initial[0]!.turn, 1)
+  const state = { matches: initial, current: 0, query: 'payload', revision: folder.searchRevision(), folder }
+
+  // The agent keeps running: a turn-2 read joins the group — the card's
+  // turn moved to 2 and the projection revision changed. Next/Prev with
+  // the query untouched must refresh before jumping.
+  folder.apply([
+    turnStart(8, 2),
+    readToolCall(9, 'r3', 'src/c.ts', 2),
+    toolResult(10, 'r3', 'c-gamma payload'),
+    turnEnd(11, 2),
+  ])
+  const refreshed = refreshedSearchState(state, folder)
+  assert.equal(refreshed.changed, true, 'a moved revision must mark the overlay state stale')
+  assert.equal(refreshed.matches.length, 1)
+  assert.equal(refreshed.matches[0]!.turn, 2, 'the jump must use the NEW group turn, never the stale 1')
+  assert.equal(refreshed.matches[0]!.id, initial[0]!.id, 'the same logical card is recovered by stable id')
+  assert.equal(refreshed.current, 0)
+  assert.equal(refreshed.revision, folder.searchRevision(), 'the runner commits the new revision')
+
+  // Live NEW matches are visible to Next/Prev without a query change.
+  folder.apply([
+    turnStart(12, 3),
+    userMessage(13, 'three payload mentions', 3),
+    turnEnd(14, 3),
+  ])
+  const withNew = refreshedSearchState({ matches: refreshed.matches, current: refreshed.current, query: 'payload', revision: refreshed.revision, folder }, folder)
+  assert.equal(withNew.matches.length, 2, 'a live new match enters the candidate list')
+  assert.equal(withNew.current, 0, 'the previous current card stays current by id')
+
+  // An UNCHANGED revision is a no-op (query retyping path: onSearchQuery
+  // already committed the fresh revision).
+  const unchanged = refreshedSearchState({ matches: withNew.matches, current: 0, query: 'payload', revision: withNew.revision, folder }, folder)
+  assert.equal(unchanged.changed, false)
+
+  // A stale id that no longer matches clamps instead of crashing.
+  const clamped = refreshedSearchState({ matches: [{ id: 999, turn: 0 }], current: 0, query: 'payload', revision: 0, folder }, folder)
+  assert.equal(clamped.changed, true)
+  assert.ok(clamped.matches.length > 0 && clamped.current >= 0, 'the index clamps into the refreshed list')
+
+  // An empty-query overlay refreshes to nothing without searching.
+  const cleared = refreshedSearchState({ matches: initial, current: 0, query: '', revision: 0, folder }, folder)
+  assert.equal(cleared.matches.length, 0)
+  assert.equal(cleared.current, -1)
+})
+
+test('streaming lowercasing is whole-string — Greek sigma across chunk boundaries (P2)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'Ο' } }, 1),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 1, text: 'Σ' } }, 2),
+  ])
+  // Whole-string lowercase: 'ΟΣ' -> 'ος'. The chunk-split concatenation
+  // ('οσ') must NEVER be searchable, and 'ος' must match — legacy searched
+  // the final whole string.
+  assert.equal('ΟΣ'.toLowerCase(), 'ος', 'fixture sanity: sigma final-form lowercasing')
+  assertCorpusParity(folder, ['ος'])
+  assert.equal(folder.search('οσ').length, 0, 'the chunk-split lowercase must not leak into the corpus')
+  // The settled replacement restores the authoritative text either way.
+  folder.apply([assistantMessage(3, 0, 0, 'ΟΣ settled')])
+  assertCorpusParity(folder, ['ος settled', 'settled'])
+  assert.equal(folder.search('οσ').length, 0)
 })
 
 test('transcriptSearchText is the single corpus source (tool = name args result)', () => {

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -582,6 +582,49 @@ test('command/done and workflow cards are searchable exactly like legacy', () =>
   assert.equal(folder.resolveSearchMatch(workflow[0]!)?.kind, 'tool')
 })
 
+test('a settled assistant message created WITHOUT chunks stays searchable after replacement', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    assistantMessage(1, 0, 0, 'original settled text'),
+  ])
+  assertCorpusParity(folder, ['original settled'])
+  // A replay replacement (different authoritative text) mutates the entry
+  // in place: the search projection must follow (review finding — the
+  // entry created without a preceding streaming chunk used to miss its
+  // search-index registration).
+  folder.apply([assistantMessage(2, 0, 0, 'replaced authoritative text')])
+  assertCorpusParity(folder, ['replaced authoritative'])
+  assert.equal(folder.search('original settled').length, 0, 'the old text is gone from the corpus')
+  // A late text delta after the replacement also lands in the projection.
+  folder.apply([
+    ...assistantChunks(3, 0, 0, ['with a streamed tail']),
+  ])
+  assertCorpusParity(folder, ['replaced authoritative', 'streamed tail'])
+})
+
+test('interleaved reasoning and text deltas search their OWN entries (namespaced projection)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'reasoning-corpse marker' } }, 1),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'assistant-corpse marker' } }, 2),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 1, text: ' more reasoning deltas' } }, 3),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 1, text: ' more text deltas' } }, 4),
+  ])
+  assertCorpusParity(folder, ['reasoning-corpse', 'assistant-corpse', 'more reasoning', 'more text'])
+  // Parity catches the contamination vector: a reasoning-only needle must
+  // match ONLY the thinking card, never the assistant card (the shared
+  // step key used to route reasoning deltas into the assistant entry).
+  const reasoningMatches = folder.search('reasoning-corpse')
+  assert.equal(reasoningMatches.length, 1)
+  assert.equal(folder.resolveSearchMatch(reasoningMatches[0]!)?.kind, 'thinking')
+  const textMatches = folder.search('assistant-corpse')
+  assert.equal(textMatches.length, 1)
+  assert.equal(folder.resolveSearchMatch(textMatches[0]!)?.kind, 'assistant')
+  assert.equal(folder.search('marker').length, 2, 'both entries hit the shared word, each once')
+})
+
 test('transcriptSearchText is the single corpus source (tool = name args result)', () => {
   const folder = new TranscriptFolder()
   folder.apply([

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -625,6 +625,39 @@ test('interleaved reasoning and text deltas search their OWN entries (namespaced
   assert.equal(folder.search('marker').length, 2, 'both entries hit the shared word, each once')
 })
 
+test('live cross-turn append refreshes the WHOLE group (turn + shared text)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    readToolCall(1, 'r1', 'src/a.ts', 0),
+    toolResult(2, 'r1', 'alpha content'),
+    turnEnd(3, 0),
+    turnStart(4, 1),
+    readToolCall(5, 'r2', 'src/b.ts', 1),
+    toolResult(6, 'r2', 'beta content'),
+    turnEnd(7, 1),
+  ])
+  // a+b merged into one cross-turn card (turn = 1).
+  assert.equal(folder.search('alpha').length, 1)
+  // Live append: a turn-2 read joins the group; the group turn moves to 2.
+  folder.apply([
+    turnStart(8, 2),
+    readToolCall(9, 'r3', 'src/c.ts', 2),
+    toolResult(10, 'r3', 'gamma-only-needle content'),
+    turnEnd(11, 2),
+  ])
+  // The match for text present ONLY in the newest member must carry the
+  // NEW group turn (max), never the stale first-member turn (round-4
+  // finding: the tail-append refresh used to cover only the last two
+  // entries, leaving the earlier members' turn and text stale).
+  const matches = folder.search('gamma-only-needle')
+  assert.equal(matches.length, 1)
+  assert.equal(matches[0]!.turn, 2, 'the match must carry the NEW group turn')
+  // The shared text is refreshed for ALL members: the merged args count is
+  // searchable, and the superseded count is gone (strict legacy parity).
+  assertCorpusParity(folder, ['gamma-only-needle', 'alpha content', 'beta content', '3 files', '2 files'])
+})
+
 test('transcriptSearchText is the single corpus source (tool = name args result)', () => {
   const folder = new TranscriptFolder()
   folder.apply([

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -782,6 +782,25 @@ test('stale overlay edge: an EMPTIED result set clamps to -1 (the 0/0 counter) (
   assert.equal(next.matches.length, 0)
 })
 
+test('stale overlay edge: Next enters the fresh list at the FIRST match, Prev at the LAST (P2)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([turnStart(0, 0), userMessage(1, 'alpha only'), turnEnd(2, 0)])
+  const empty = folder.search('needle-new')
+  assert.equal(empty.length, 0)
+  const state = { matches: empty, current: -1, query: 'needle-new', revision: folder.searchRevision(), folder }
+  // TWO matching messages arrive while the overlay stays open.
+  folder.apply([
+    turnStart(3, 1), userMessage(4, 'one needle-new live message', 1), turnEnd(5, 1),
+    turnStart(6, 2), userMessage(7, 'two needle-new live messages', 2), turnEnd(8, 2),
+  ])
+  const next = steppedSearchOverlayState(state, folder, 1)
+  assert.equal(next.matches.length, 2)
+  assert.equal(next.current, 0, 'Next must enter the fresh list at the FIRST match, never skip it (round-12 finding)')
+  const prev = steppedSearchOverlayState(state, folder, -1)
+  assert.equal(prev.matches.length, 2)
+  assert.equal(prev.current, 1, 'Prev enters the fresh list at the LAST match')
+})
+
 test('transcriptSearchText is the single corpus source (tool = name args result)', () => {
   const folder = new TranscriptFolder()
   folder.apply([

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -16,7 +16,7 @@ import test from 'node:test'
 import { MessageId, ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { TranscriptFolder, transcriptSearchText, type TranscriptMessage, type TranscriptSearchMatch } from '../src/transcript.ts'
-import { refreshedSearchState, steppedSearchOverlayState } from '../src/index.ts'
+import { refreshedSearchState, steppedSearchOverlayState } from '../src/search-overlay.ts'
 
 /** Build a minimal event envelope for tests. */
 function event<K extends SessionEvent['type']>(

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -16,7 +16,7 @@ import test from 'node:test'
 import { MessageId, ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { TranscriptFolder, transcriptSearchText, type TranscriptMessage, type TranscriptSearchMatch } from '../src/transcript.ts'
-import { refreshedSearchState } from '../src/index.ts'
+import { refreshedSearchState, steppedSearchOverlayState } from '../src/index.ts'
 
 /** Build a minimal event envelope for tests. */
 function event<K extends SessionEvent['type']>(
@@ -748,10 +748,15 @@ test('stale overlay edge: Next/Prev discover a match that arrived AFTER an empty
   const state = { matches: empty, current: -1, query: 'needle-new', revision: folder.searchRevision(), folder }
   // ...and a matching message arrives while it stays open.
   folder.apply([turnStart(3, 1), userMessage(4, 'a needle-new live message', 1), turnEnd(5, 1)])
-  const refreshed = refreshedSearchState(state, folder)
-  assert.equal(refreshed.changed, true)
-  assert.equal(refreshed.matches.length, 1, 'Next/Prev must find the live new match')
-  assert.equal(refreshed.current, 0)
+  // The RUNNER's handler path (the production seam onSearchNext/Prev call):
+  // the empty candidate list must be refreshed BEFORE the emptiness check,
+  // or the live match is never discoverable.
+  const next = steppedSearchOverlayState(state, folder, 1)
+  assert.equal(next.matches.length, 1, 'Next must find the live new match')
+  assert.equal(next.current, 0, 'Next steps onto the newly arrived match')
+  const prev = steppedSearchOverlayState(state, folder, -1)
+  assert.equal(prev.matches.length, 1, 'Prev must find the live new match too')
+  assert.equal(prev.current, 0)
 })
 
 test('stale overlay edge: an EMPTIED result set clamps to -1 (the 0/0 counter) (P2)', () => {
@@ -771,6 +776,10 @@ test('stale overlay edge: an EMPTIED result set clamps to -1 (the 0/0 counter) (
   assert.equal(refreshed.changed, true)
   assert.equal(refreshed.matches.length, 0)
   assert.equal(refreshed.current, -1, 'an emptied result set must clamp to -1, never 0 (0/0 counter)')
+  // The runner's Next/Prev seam steps an emptied list to -1 as well.
+  const next = steppedSearchOverlayState(state, folder, 1)
+  assert.equal(next.current, -1)
+  assert.equal(next.matches.length, 0)
 })
 
 test('transcriptSearchText is the single corpus source (tool = name args result)', () => {

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -1,0 +1,594 @@
+/**
+ * Transcript search-index tests (PR D1): the incremental full-history search
+ * projection must be SEMANTICALLY IDENTICAL to the legacy full search
+ * (`folder.messages()` + filter + per-message lowercase) on the whole corpus
+ * — same count, same order, same turn, same resolved visible card — while
+ * the query path never materializes the grouped transcript and never
+ * re-lowercases history per query.
+ *
+ * The parity oracle (`legacySearchForTest`) exists ONLY in this test file —
+ * production keeps the single indexed implementation.
+ * @module @xmoon76/dsh-pi-tui/transcript-search-index.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { MessageId, ToolCallId } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { TranscriptFolder, transcriptSearchText, type TranscriptMessage, type TranscriptSearchMatch } from '../src/transcript.ts'
+
+/** Build a minimal event envelope for tests. */
+function event<K extends SessionEvent['type']>(
+  type: K,
+  data: SessionEvent<K>['data'],
+  seq: number,
+): SessionEvent {
+  return { type, seq, time: 1_700_000_000_000 + seq, data } as SessionEvent
+}
+
+/** Build a surface event carrying its surface metadata marker. */
+function surfaceEvent<K extends SessionEvent['type']>(
+  type: K,
+  data: SessionEvent<K>['data'],
+  seq: number,
+  surfaceOp: 'append' | { op: 'replace'; start: number; end: number },
+): SessionEvent {
+  return { type, seq, time: 1_700_000_000_000 + seq, data, surfaceOp } as SessionEvent
+}
+
+function userMessage(seq: number, text: string, turn = 0): SessionEvent {
+  return event('user/message', {
+    id: MessageId(`msg-${seq}`),
+    role: 'user',
+    content: [{ type: 'text', text }],
+    source: { kind: 'user' },
+  }, seq)
+}
+
+function assistantChunks(seq: number, turn: number, step: number, chunks: string[]): SessionEvent[] {
+  return chunks.map((text, index) => event('assistant/chunk', {
+    turn, step, chunk: { type: 'text-delta', index, text },
+  }, seq + index))
+}
+
+function assistantMessage(seq: number, turn: number, step: number, text: string): SessionEvent {
+  return event('assistant/message', {
+    turn, step,
+    message: { id: MessageId(`am-${seq}`), role: 'assistant', content: [{ type: 'text', text }], source: { kind: 'model', provider: 'test', model: 'test' } },
+  }, seq)
+}
+
+function turnStart(seq: number, turn: number): SessionEvent {
+  return event('turn/start', { turn }, seq)
+}
+
+function turnEnd(seq: number, turn: number, reason: SessionEvent<'turn/end'>['data']['reason'] = { kind: 'completed' }): SessionEvent {
+  return event('turn/end', { turn, reason }, seq)
+}
+
+/** One append-origin tool result for `callId`. */
+function toolResult(seq: number, callId: string, text: string, name = 'bash', turn = 0): SessionEvent {
+  return surfaceEvent('tool/result', {
+    turn, step: 0,
+    message: {
+      id: MessageId(`msg-${seq}`),
+      role: 'user',
+      content: [{
+        type: 'tool-result',
+        toolCallId: ToolCallId(callId),
+        content: [{ type: 'text', text }],
+      }],
+      source: { kind: 'tool', callId: ToolCallId(callId) },
+    },
+  }, seq, 'append')
+}
+
+function toolCall(seq: number, callId: string, name: string, args: unknown, turn = 0): SessionEvent {
+  return event('tool/call', {
+    turn, step: 0, callId: ToolCallId(callId), name,
+    arguments: typeof args === 'string' ? args : JSON.stringify(args),
+  }, seq)
+}
+
+function readToolCall(seq: number, callId: string, file: string, turn = 0): SessionEvent {
+  return toolCall(seq, callId, 'read', { file }, turn)
+}
+
+/** Build an event with loosely-typed data (plugin/extension event kinds). */
+function rawEvent(type: string, data: Record<string, unknown>, seq: number): SessionEvent {
+  return { type, seq, time: 1_700_000_000_000 + seq, data } as SessionEvent
+}
+
+function compactionEvent(type: 'compaction/start' | 'compaction/summary' | 'compaction/end', data: Record<string, unknown>, seq: number): SessionEvent {
+  return rawEvent(type, data, seq)
+}
+
+function cardText(message: TranscriptMessage | undefined): string {
+  if (message === undefined) return ''
+  if (message.kind === 'tool') return `${message.name} ${message.args} ${message.result}`
+  return message.text ?? ''
+}
+
+/**
+ * The legacy full-history search semantics — the PARITY ORACLE. This is the
+ * exact pre-D1 production path: every query materialized the grouped
+ * transcript and re-lowercased every message. Test-only; never production.
+ */
+function legacySearchForTest(folder: TranscriptFolder, query: string): TranscriptMessage[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return []
+  return folder.messages().filter(message => {
+    const text = message.kind === 'tool' ? `${message.name} ${message.args} ${message.result}` : message.text
+    return text.toLowerCase().includes(needle)
+  })
+}
+
+/**
+ * Semantic parity: same count, same order, same turn, and every indexed
+ * match resolves to the EXACT legacy card object (identity — a merged read
+ * group must resolve to the same card legacy emitted).
+ */
+function assertSearchParity(folder: TranscriptFolder, query: string, label = ''): void {
+  const legacy = legacySearchForTest(folder, query)
+  const indexed = folder.search(query)
+  assert.equal(indexed.length, legacy.length, `${label} count for ${JSON.stringify(query)} (indexed ${indexed.length} vs legacy ${legacy.length})`)
+  for (let i = 0; i < legacy.length; i += 1) {
+    const resolved = folder.resolveSearchMatch(indexed[i]!)
+    assert.equal(resolved, legacy[i], `${label} match ${i} for ${JSON.stringify(query)} must resolve to the legacy card`)
+    const legacyCard = legacy[i]!
+    const legacyTurn = 'turn' in legacyCard ? legacyCard.turn : undefined
+    assert.equal(indexed[i]!.turn, legacyTurn, `${label} match ${i} turn for ${JSON.stringify(query)}`)
+  }
+}
+
+/** Search corpus parity across a folder for a battery of queries. */
+function assertCorpusParity(folder: TranscriptFolder, queries: string[], label = ''): void {
+  for (const query of queries) assertSearchParity(folder, query, label)
+}
+
+test('parity: a plain user + assistant session (case-insensitive, empty query)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    userMessage(1, 'Hello Searchable World'),
+    ...assistantChunks(2, 0, 0, ['The ', 'quick brown ', 'fox.']),
+    assistantMessage(5, 0, 0, 'The quick brown fox.'),
+    turnEnd(6, 0),
+  ])
+  assertCorpusParity(folder, ['', 'hello', 'HELLO', 'searchable', 'brown', 'fox', 'missing', '   hello   '])
+  assert.deepEqual(folder.search(''), [], 'empty query yields no matches')
+  const first = folder.search('hello')
+  assert.equal(first.length, 1)
+  assert.equal(first[0]!.turn, 0)
+  const resolved = folder.resolveSearchMatch(first[0]!)
+  assert.equal(resolved?.kind, 'user')
+})
+
+test('parity: streaming text is searchable as it accumulates (running -> settled)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    ...assistantChunks(1, 0, 0, ['running ', 'needle', '-in-stream']),
+  ])
+  // Partial streamed text is searchable (legacy searched message.text too).
+  assertCorpusParity(folder, ['needle', 'running'])
+  folder.apply([assistantMessage(4, 0, 0, 'settled final answer')])
+  assertCorpusParity(folder, ['needle', 'settled', 'final'])
+})
+
+test('parity: tool cards search name + args + result; running args first', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    toolCall(1, 'c1', 'bash', { command: 'ls unusual-dir' }, 0),
+    toolResult(2, 'c1', 'file listing result content'),
+    turnEnd(3, 0),
+  ])
+  assertCorpusParity(folder, ['ls unusual-dir', 'file listing', 'result', 'bash', 'unusual-dir'])
+  // A still-running tool's ARGS are searchable before the result lands.
+  const runningFolder = new TranscriptFolder()
+  runningFolder.apply([
+    turnStart(0, 0),
+    toolCall(1, 'c2', 'bash', { command: 'grep live-needle' }, 0),
+  ])
+  assertCorpusParity(runningFolder, ['live-needle', 'grep'])
+  runningFolder.apply([toolResult(2, 'c2', 'the settled payload')])
+  assertCorpusParity(runningFolder, ['live-needle', 'settled payload', 'grep'])
+})
+
+test('parity: system cards, compaction summary and the image marker in user text', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    userMessage(1, 'Look at this 🖼️ screenshot.png content'),
+    rawEvent('llm/retry', { retry: 1, delayMs: 2000, failure: { code: 'E_RATE', message: 'too many requests' } }, 2),
+    compactionEvent('compaction/start', { compactionId: 'k1' }, 3),
+    compactionEvent('compaction/summary', { compactionId: 'k1', summary: [{ type: 'text', text: 'compressed earlier discussion about token budgets' }] }, 4),
+    compactionEvent('compaction/end', { compactionId: 'k1' }, 5),
+    turnEnd(6, 0),
+  ])
+  assertCorpusParity(folder, ['screenshot.png', '🖼️', 'E_RATE', 'too many requests', 'token budgets', 'compressed'])
+})
+
+test('case-insensitivity: Unicode lowercases exactly like the legacy path', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    userMessage(1, 'Ünïcödé Ärchiv Överflow'),
+  ])
+  assertCorpusParity(folder, ['ünïcödé', 'ÜNÏCÖDÉ', 'ärchiv', 'overflow'])
+})
+
+test('G1: same-turn adjacent reads merge into ONE visible match, parity kept', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    readToolCall(1, 'r1', 'src/a.ts', 0),
+    toolResult(2, 'r1', 'content of shared-keyword file A'),
+    readToolCall(3, 'r2', 'src/b.ts', 0),
+    toolResult(4, 'r2', 'content of shared-keyword file B'),
+    readToolCall(5, 'r3', 'src/c.ts', 0),
+    toolResult(6, 'r3', 'content of shared-keyword file C'),
+    turnEnd(7, 0),
+  ])
+  const messages = folder.messages()
+  const grouped = messages.filter(message => message.kind === 'tool' && message.name === 'read')
+  assert.equal(grouped.length, 1, 'the three reads merge into one card')
+  assertCorpusParity(folder, ['shared-keyword', 'file A', 'file B', 'file C', 'read'])
+  const matches = folder.search('shared-keyword')
+  assert.equal(matches.length, 1, 'one logical card -> one search result, never three')
+  assert.equal(matches[0]!.turn, 0)
+  // The legacy merged card searches "read N files <results>" — no member paths.
+  assert.equal(legacySearchForTest(folder, 'src/b.ts').length, 0)
+  assert.equal(folder.search('src/b.ts').length, 0, 'member paths are NOT searchable: strict legacy parity')
+})
+
+test('G2: cross-turn read grouping keeps one visible match with the max turn', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    readToolCall(1, 'r1', 'src/a.ts', 0),
+    toolResult(2, 'r1', 'cross-turn keyword part one'),
+    turnEnd(3, 0),
+    turnStart(4, 1),
+    readToolCall(5, 'r2', 'src/b.ts', 1),
+    toolResult(6, 'r2', 'cross-turn keyword part two'),
+    turnEnd(7, 1),
+  ])
+  const grouped = folder.messages().filter((message): message is Extract<TranscriptMessage, { turn: number }> => message.kind === 'tool' && message.name === 'read')
+  assert.equal(grouped.length, 1, 'the cross-turn reads merge into one card')
+  assert.equal(grouped[0]!.turn, 1, 'the merged card carries the max turn')
+  assertCorpusParity(folder, ['cross-turn', 'keyword', 'part one', 'part two'])
+  const matches = folder.search('cross-turn')
+  assert.equal(matches.length, 1)
+  assert.equal(matches[0]!.turn, 1)
+})
+
+test('G3: a late non-tail result reflows the run; search text updates, no duplicate', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    readToolCall(1, 'r1', 'src/a.ts', 0),
+    toolResult(2, 'r1', 'first file content'),
+    turnEnd(3, 0),
+    turnStart(4, 1),
+    userMessage(5, 'unrelated later turn'),
+    // The late result of an earlier call lands AFTER later items: the
+    // defensive reflow path must merge the run and refresh the projection.
+    toolResult(6, 'r1-again', 'late-second-file content'),
+    turnEnd(7, 1),
+  ])
+  // The orphan result appends a new read card AFTER the user message: no
+  // adjacency, so it stays a singleton — parity with the grouped output.
+  assertCorpusParity(folder, ['first file', 'late-second-file', 'unrelated'])
+  const before = folder.search('first file')
+  assert.equal(before.length, 1)
+  // A live late settle of an ADJACENT pending read (running -> settled in
+  // the middle of a run) must reflow and refresh.
+  const live = new TranscriptFolder()
+  live.hydrate([
+    turnStart(0, 0),
+    readToolCall(1, 'a', 'src/a.ts', 0),
+    toolResult(2, 'a', 'alpha payload'),
+    readToolCall(3, 'b', 'src/b.ts', 0),
+    readToolCall(4, 'c', 'src/c.ts', 0),
+    toolResult(5, 'c', 'gamma payload'),
+  ])
+  // b is still RUNNING: a and c are separate singletons; b searchable by args.
+  assertCorpusParity(live, ['alpha payload', 'gamma payload', 'src/b.ts'])
+  live.apply([toolResult(6, 'b', 'beta payload')])
+  // Now a+b+c merge into ONE card: one match for any member content.
+  const matches = live.search('payload')
+  assert.equal(matches.length, 1, 'late settlement merges the run into one visible match')
+  assertCorpusParity(live, ['alpha payload', 'beta payload', 'gamma payload', 'payload', 'src/b.ts'])
+})
+
+test('G4: running -> settled read args searchable, then merged group text', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    readToolCall(1, 'r1', 'src/alpha.ts', 0),
+    readToolCall(2, 'r2', 'src/beta.ts', 0),
+  ])
+  assertCorpusParity(folder, ['src/alpha.ts', 'src/beta.ts', 'read'])
+  folder.apply([toolResult(3, 'r1', 'alpha-result needle')])
+  // r1 settled; r2 still running: r1 alone is not groupable (needs a run).
+  assertCorpusParity(folder, ['alpha-result needle', 'src/beta.ts'])
+  folder.apply([toolResult(4, 'r2', 'beta-result needle')])
+  assertCorpusParity(folder, ['needle'])
+  const matches = folder.search('needle')
+  assert.equal(matches.length, 1, 'the merged read card is one match')
+})
+
+test('G5: error results and synthetic error cards keep legacy semantics', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    toolCall(1, 'e1', 'read', { file: 'src/missing.ts' }, 0),
+    surfaceEvent('tool/result', {
+      turn: 0, step: 0,
+      message: {
+        id: MessageId('msg-e1'), role: 'user',
+        content: [{ type: 'tool-result', toolCallId: ToolCallId('e1'), isError: true, content: [{ type: 'text', text: 'ENOENT: no such file' }] }],
+        source: { kind: 'tool', callId: ToolCallId('e1') },
+      },
+    }, 2, 'append'),
+    turnEnd(3, 0, { kind: 'error', error: { code: 'E_TURN', message: 'the turn failed loudly' } }),
+  ])
+  // The failed read stays a singleton (error results never group) and the
+  // synthetic error card is searchable exactly like legacy.
+  assertCorpusParity(folder, ['ENOENT', 'missing.ts', 'E_TURN', 'failed loudly'])
+  const errorCards = folder.search('E_TURN')
+  assert.equal(errorCards.length, 1)
+  assert.equal(folder.resolveSearchMatch(errorCards[0]!)?.kind, 'tool')
+})
+
+test('system reminder rows search their text (skill/context injection)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    rawEvent('user/message', {
+      id: 'ctx-1', role: 'user',
+      content: [{ type: 'text', text: '<system-reminder>follow the injected skill guidance</system-reminder>' }],
+      source: { kind: 'instruction', ref: 'skill-catalog' },
+    }, 1),
+    turnEnd(2, 0),
+  ])
+  assertCorpusParity(folder, ['injected skill', 'system-reminder'])
+})
+
+test('order: matches follow the logical transcript order across turns', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    userMessage(1, 'first needle'),
+    turnEnd(2, 0),
+    turnStart(3, 1),
+    userMessage(4, 'middle needle'),
+    turnEnd(5, 1),
+    turnStart(6, 2),
+    userMessage(7, 'last needle'),
+    turnEnd(8, 2),
+  ])
+  const matches = folder.search('needle')
+  assert.deepEqual(matches.map(match => match.turn), [0, 1, 2])
+  const resolved = matches.map(match => cardText(folder.resolveSearchMatch(match)))
+  assert.deepEqual(resolved, ['first needle', 'middle needle', 'last needle'])
+})
+
+test('stable ids survive settlement and group reflow (never object identity)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    readToolCall(1, 'r1', 'src/a.ts', 0),
+    toolResult(2, 'r1', 'result one'),
+    readToolCall(3, 'r2', 'src/b.ts', 0),
+    toolResult(4, 'r2', 'result two'),
+    turnEnd(5, 0),
+  ])
+  const matches = folder.search('result')
+  assert.equal(matches.length, 1, 'merged group -> one match')
+  const id = matches[0]!.id
+  // A later live append must not change the id namespace of earlier matches.
+  folder.apply([
+    turnStart(6, 1),
+    userMessage(7, 'result three in a new turn'),
+    turnEnd(8, 1),
+  ])
+  assert.equal(id, matches[0]!.id, 'the id stays stable across live appends')
+  const resolved = folder.resolveSearchMatch({ id, turn: 0 })
+  assert.equal(resolved?.kind, 'tool', 'the id still resolves to the merged card')
+  assert.ok(resolved!.result.includes('result one') && resolved!.result.includes('result two'))
+})
+
+test('query refinement: prefix typing narrows candidates only when the revision is unchanged', () => {
+  const folder = new TranscriptFolder()
+  const events: SessionEvent[] = []
+  let seq = 0
+  for (let turn = 0; turn < 50; turn += 1) {
+    events.push(turnStart(seq++, turn))
+    events.push(userMessage(seq++, `needle candidate ${turn}`, turn))
+    events.push(userMessage(seq++, `other filler ${turn}`, turn))
+    events.push(turnEnd(seq++, turn))
+  }
+  folder.hydrate(events)
+  const diagnosticsBefore = folder.searchDiagnosticsForTest()
+
+  let matches: TranscriptSearchMatch[] = folder.search('n')
+  let revision = folder.searchRevision()
+  assert.equal(matches.length, 50, 'every turn has a needle candidate')
+  assert.equal(folder.searchDiagnosticsForTest().fullScans, diagnosticsBefore.fullScans + 1)
+  const scansAtStart = folder.searchDiagnosticsForTest()
+
+  // Refined typing: n -> ne -> nee -> need -> needle.
+  for (const partial of ['ne', 'nee', 'need', 'needle']) {
+    matches = folder.search(partial, { previousQuery: partial.slice(0, -1), previousMatches: matches, revision })
+    revision = folder.searchRevision()
+  }
+  const diagnostics = folder.searchDiagnosticsForTest()
+  assert.equal(matches.length, 50)
+  assert.equal(diagnostics.fullScans, scansAtStart.fullScans, 'no full scan while refining')
+  assert.equal(diagnostics.refinedScans, scansAtStart.refinedScans + 4)
+  assert.deepEqual(matches.map(match => match.turn), Array.from({ length: 50 }, (_, index) => index), 'order preserved under refinement')
+
+  // A projection mutation between queries (live append) invalidates the
+  // refinement: the next query must full-scan.
+  folder.apply([userMessage(100, 'needle appended later', 50)])
+  const afterAppend = folder.search('needle', { previousQuery: 'needl', previousMatches: matches, revision })
+  assert.equal(afterAppend.length, 51, 'the new message is visible')
+  assert.equal(folder.searchDiagnosticsForTest().fullScans, scansAtStart.fullScans + 1, 'revision change forces a full lightweight scan')
+})
+
+test('live mutation while matches are held: no stale object, no crash, next query sees new content', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    userMessage(1, 'needle here'),
+    turnEnd(2, 0),
+  ])
+  const held = folder.search('needle')
+  assert.equal(held.length, 1)
+  // Stream a new message containing the needle while the old matches live.
+  folder.apply([
+    turnStart(3, 1),
+    ...assistantChunks(4, 1, 0, ['a brand new ', 'needle message']),
+  ])
+  const resolved = folder.resolveSearchMatch(held[0]!)
+  assert.equal(cardText(resolved), 'needle here', 'old match still resolves to its own card')
+  assert.equal(folder.search('needle').length, 2, 'a new query sees the streamed needle')
+})
+
+test('structural gate: search never materializes the transcript nor re-lowercases on query', () => {
+  const folder = new TranscriptFolder()
+  const events: SessionEvent[] = []
+  let seq = 0
+  for (let turn = 0; turn < 1000; turn += 1) {
+    events.push(turnStart(seq++, turn))
+    events.push(userMessage(seq++, `user prompt ${turn} with needle occasionally`, turn))
+    events.push(assistantMessage(seq++, turn, 0, `assistant answer ${turn}`))
+    events.push(toolCall(seq++, `t${turn}`, 'bash', { command: `echo needle ${turn}` }, turn))
+    events.push(toolResult(seq++, `t${turn}`, `output of tool ${turn}`))
+    events.push(turnEnd(seq++, turn))
+  }
+  folder.hydrate(events)
+  const diagnosticsAfterHydrate = folder.searchDiagnosticsForTest()
+  assert.equal(diagnosticsAfterHydrate.entries, folder.messages().length, 'one entry per visible logical card')
+
+  // Spy on messages(): the indexed query path must NEVER call it.
+  let messagesCalls = 0
+  const originalMessages = folder.messages.bind(folder)
+  Object.defineProperty(folder, 'messages', {
+    configurable: true,
+    value: (...args: unknown[]) => {
+      messagesCalls += 1
+      return (originalMessages as (...a: unknown[]) => TranscriptMessage[])(...args)
+    },
+  })
+  const miss = folder.search('unlikely-needle-not-present')
+  assert.equal(miss.length, 0)
+  const hits = folder.search('needle')
+  assert.ok(hits.length >= 1000, `every turn hits: ${hits.length}`)
+  assert.equal(messagesCalls, 0, 'the indexed query path never calls messages()')
+  const afterQueries = folder.searchDiagnosticsForTest()
+  assert.equal(afterQueries.normalizedRefreshes, diagnosticsAfterHydrate.normalizedRefreshes, 'queries never re-lowercase search text')
+  assert.equal(afterQueries.groupingRebuilds, diagnosticsAfterHydrate.groupingRebuilds, 'queries never rebuild grouping')
+})
+
+test('10k-turn structural complexity gate: lightweight scan + refinement, no projection', () => {
+  const folder = new TranscriptFolder()
+  const events: SessionEvent[] = []
+  let seq = 0
+  for (let turn = 0; turn < 10_000; turn += 1) {
+    events.push(turnStart(seq++, turn))
+    events.push(userMessage(seq++, `prompt ${turn}`, turn))
+    events.push(assistantMessage(seq++, turn, 0, `answer ${turn} with filler text`))
+    events.push(turnEnd(seq++, turn))
+  }
+  folder.hydrate(events)
+  const afterHydrate = folder.searchDiagnosticsForTest()
+  let messagesCalls = 0
+  const originalMessages = folder.messages.bind(folder)
+  Object.defineProperty(folder, 'messages', {
+    configurable: true,
+    value: (...args: unknown[]) => {
+      messagesCalls += 1
+      return (originalMessages as (...a: unknown[]) => TranscriptMessage[])(...args)
+    },
+  })
+  const matches = folder.search('answer')
+  assert.equal(matches.length, 10_000)
+  assert.equal(messagesCalls, 0, 'full history is never materialized on the query path')
+  assert.equal(folder.searchDiagnosticsForTest().normalizedRefreshes, afterHydrate.normalizedRefreshes, 'no re-lowercase on query')
+  // 'answer 999' hits turn 999 and every 999x turn (9990..9999).
+  const before: TranscriptSearchMatch[] = folder.search('answer 999')
+  assert.equal(before.length, 11)
+  const fullScans = folder.searchDiagnosticsForTest().fullScans
+  const after = folder.search('answer 9999', { previousQuery: 'answer 999', previousMatches: before, revision: folder.searchRevision() })
+  assert.equal(after.length, 1, 'refinement narrows candidates to the exact turn')
+  assert.equal(folder.searchDiagnosticsForTest().fullScans, fullScans, 'refinement avoids the full scan')
+  assert.equal(folder.searchDiagnosticsForTest().refinedScans, 1)
+})
+
+test('session/folder isolation: each folder owns its projection and matches', () => {
+  const folderA = new TranscriptFolder()
+  folderA.hydrate([turnStart(0, 0), userMessage(1, 'needle in session A'), turnEnd(2, 0)])
+  const folderB = new TranscriptFolder()
+  folderB.hydrate([turnStart(3, 0), userMessage(4, 'needle in session B'), turnEnd(5, 0)])
+  const a = folderA.search('needle')
+  const b = folderB.search('needle')
+  assert.equal(a.length, 1)
+  assert.equal(b.length, 1)
+  assert.equal(cardText(folderA.resolveSearchMatch(a[0]!)), 'needle in session A')
+  assert.equal(cardText(folderB.resolveSearchMatch(b[0]!)), 'needle in session B')
+  // Ids are namespace-local: identical ids resolve to different sessions.
+  assert.equal(a[0]!.id, b[0]!.id)
+})
+
+test('failed-read singleton never merges; its search text keeps the path', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    readToolCall(1, 'ok1', 'src/ok.ts', 0),
+    toolResult(2, 'ok1', 'ok result'),
+    readToolCall(3, 'bad1', 'src/missing.ts', 0),
+    surfaceEvent('tool/result', {
+      turn: 0, step: 0,
+      message: {
+        id: MessageId('bad'), role: 'user',
+        content: [{ type: 'tool-result', toolCallId: ToolCallId('bad1'), isError: true, content: [{ type: 'text', text: 'read failed' }] }],
+        source: { kind: 'tool', callId: ToolCallId('bad1') },
+      },
+    }, 4, 'append'),
+    turnEnd(5, 0),
+  ])
+  assertCorpusParity(folder, ['src/ok.ts', 'ok result', 'src/missing.ts', 'read failed'])
+  const reads = folder.messages().filter(message => message.kind === 'tool' && message.name === 'read')
+  assert.equal(reads.length, 2, 'ok run and failed singleton stay separate cards')
+})
+
+test('command/done and workflow cards are searchable exactly like legacy', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    rawEvent('command/run', { commandId: 'cmd1', name: 'theme', args: '' }, 1),
+    rawEvent('command/done', { commandId: 'cmd1', kind: 'success', text: 'theme set to dark' }, 2),
+    rawEvent('tool-workflow/run-start', { runId: 'run1', name: 'audit' }, 3),
+    rawEvent('tool-workflow/run-end', { runId: 'run1', stopReason: 'completed' }, 4),
+    turnEnd(5, 0),
+  ])
+  assertCorpusParity(folder, ['theme set to dark', '/theme', 'audit', 'stop: completed'])
+  const workflow = folder.search('stop: completed')
+  assert.equal(workflow.length, 1)
+  assert.equal(folder.resolveSearchMatch(workflow[0]!)?.kind, 'tool')
+})
+
+test('transcriptSearchText is the single corpus source (tool = name args result)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    toolCall(1, 'c1', 'bash', { command: 'echo hi' }, 0),
+  ])
+  const running = folder.messages()[0]!
+  assert.equal(transcriptSearchText(running), 'bash {"command":"echo hi"} ')
+  assert.ok(transcriptSearchText(running).toLowerCase().includes('echo hi'))
+})

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -739,6 +739,40 @@ test('streaming lowercasing is whole-string — Greek sigma across chunk boundar
   assert.equal(folder.search('οσ').length, 0)
 })
 
+test('stale overlay edge: Next/Prev discover a match that arrived AFTER an empty search (P1)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([turnStart(0, 0), userMessage(1, 'alpha only'), turnEnd(2, 0)])
+  // The overlay searched with zero matches...
+  const empty = folder.search('needle-new')
+  assert.equal(empty.length, 0)
+  const state = { matches: empty, current: -1, query: 'needle-new', revision: folder.searchRevision(), folder }
+  // ...and a matching message arrives while it stays open.
+  folder.apply([turnStart(3, 1), userMessage(4, 'a needle-new live message', 1), turnEnd(5, 1)])
+  const refreshed = refreshedSearchState(state, folder)
+  assert.equal(refreshed.changed, true)
+  assert.equal(refreshed.matches.length, 1, 'Next/Prev must find the live new match')
+  assert.equal(refreshed.current, 0)
+})
+
+test('stale overlay edge: an EMPTIED result set clamps to -1 (the 0/0 counter) (P2)', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    turnStart(0, 0),
+    assistantMessage(1, 0, 0, 'needle alpha'),
+  ])
+  const initial = folder.search('needle')
+  assert.equal(initial.length, 1)
+  const state = { matches: initial, current: 0, query: 'needle', revision: folder.searchRevision(), folder }
+  // The same step's authoritative text is REPLACED without the needle
+  // (replay semantics: the transcript entry mutates in place, the search
+  // projection follows) — every match disappears.
+  folder.apply([assistantMessage(2, 0, 0, 'no match here')])
+  const refreshed = refreshedSearchState(state, folder)
+  assert.equal(refreshed.changed, true)
+  assert.equal(refreshed.matches.length, 0)
+  assert.equal(refreshed.current, -1, 'an emptied result set must clamp to -1, never 0 (0/0 counter)')
+})
+
 test('transcriptSearchText is the single corpus source (tool = name args result)', () => {
   const folder = new TranscriptFolder()
   folder.apply([

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -801,6 +801,40 @@ test('stale overlay edge: Next enters the fresh list at the FIRST match, Prev at
   assert.equal(prev.current, 1, 'Prev enters the fresh list at the LAST match')
 })
 
+test('lazy normalization scans ONLY the dirty entries, never the history (P2)', () => {
+  const folder = new TranscriptFolder()
+  const events: SessionEvent[] = []
+  let seq = 0
+  for (let turn = 0; turn < 1000; turn += 1) {
+    events.push(turnStart(seq++, turn))
+    events.push(userMessage(seq++, `prompt ${turn}`, turn))
+    events.push(assistantMessage(seq++, turn, 0, `answer ${turn}`))
+    events.push(turnEnd(seq++, turn))
+  }
+  folder.hydrate(events)
+  // A query with NO mutations normalizes nothing and never scans history.
+  folder.search('answer')
+  assert.equal(folder.searchDiagnosticsForTest().dirtyScans, 0, 'no dirty entries -> zero normalization work')
+  // One streaming chunk marks ONE entry: the next query normalizes exactly it.
+  folder.apply([...assistantChunks(seq++, 1000, 0, [' tail-one'])])
+  folder.search('tail-one')
+  assert.equal(folder.searchDiagnosticsForTest().dirtyScans, 1)
+  // Ten more chunks on the SAME entry: the Set dedupes — still one scan.
+  folder.apply([...assistantChunks(seq++, 1000, 0, [' tail-two', ' tail-three', ' tail-four', ' tail-five', ' tail-six', ' tail-seven', ' tail-eight', ' tail-nine', ' tail-ten', ' tail-eleven'])])
+  folder.search('tail-eleven')
+  assert.equal(folder.searchDiagnosticsForTest().dirtyScans, 2, 'repeated marks on one entry dedupe to one scan')
+  // Five DISTINCT entries: five more scans.
+  folder.apply([
+    ...assistantChunks(seq++, 1001, 0, [' x1']),
+    ...assistantChunks(seq++, 1002, 0, [' x2']),
+    ...assistantChunks(seq++, 1003, 0, [' x3']),
+    ...assistantChunks(seq++, 1004, 0, [' x4']),
+    ...assistantChunks(seq++, 1005, 0, [' x5']),
+  ])
+  folder.search('x5')
+  assert.equal(folder.searchDiagnosticsForTest().dirtyScans, 7, 'five distinct entries -> five more scans')
+})
+
 test('transcriptSearchText is the single corpus source (tool = name args result)', () => {
   const folder = new TranscriptFolder()
   folder.apply([

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -10,7 +10,7 @@ import test from 'node:test'
 import { ToolCallId, MessageId } from '@deepseek-ai/dsh-llm'
 import { CommandId } from '@deepseek-ai/dsh-commands'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
-import { foldTranscript, searchTranscript, TranscriptFolder, windowMessages, type TranscriptMessage } from '../src/transcript.ts'
+import { foldTranscript, TranscriptFolder, windowMessages, type TranscriptMessage } from '../src/transcript.ts'
 import { TranscriptWindowController } from '../src/transcript-window.ts'
 
 /** Build a minimal event envelope for tests. */
@@ -565,10 +565,10 @@ test('non-monotonic raw turn indexes retain every turn for search navigation', (
 
   assert.deepEqual(folder.turns(), [1, 3, 2], 'the raw index must retain a lower turn discovered after monotonicity breaks')
   assert.deepEqual(folder.groupedTurns(), [1, 2, 3])
-  const match = searchTranscript(folder, 'turn 2')
+  const match = folder.search('turn 2')
   assert.equal(match.length, 1)
   const matchMessage = match[0]
-  assert.ok(matchMessage !== undefined && 'turn' in matchMessage)
+  assert.ok(matchMessage !== undefined)
   const controller = new TranscriptWindowController({ windowTurns: 1, stepTurns: 1, turns: folder.turns() })
   assert.equal(controller.anchorAt(matchMessage.turn), true, 'search must anchor a retained non-monotonic turn')
   assert.equal(controller.endTurn(), 2)


### PR DESCRIPTION
## PR D — long-session performance: full-history search index + context measurement decoupling

Implements the remaining PR D work from the long-session plan
(`temp/1.2-new/dsh-pi-tui-next-long-session-pr-d-remaining-plan.md`), as two semantic
commit groups (D1 → D2). PR A/B/C and the #56 live follow-state fix are untouched.

### D1 — Transcript full-history search index

**Before (each query change):** `folder.messages()` → materialize the full grouped
transcript → lowercase every message again → return `TranscriptMessage[]`.

**After:** the folder maintains an incremental searchable projection (one normalized
entry per raw item, index-aligned; merged read groups share ONE normalized string —
never N copies); queries scan lightweight `{id, turn}` matches with
group-representative dedupe (a merged read card is exactly ONE visible match, so
Next/Prev never loops on one card), plus prefix refinement gated on the projection
revision AND folder identity (child-viewer candidates can never leak into the parent
session or vice versa). `searchMatches` no longer holds `TranscriptMessage[]`; jumps
resolve stable ids to the CURRENT visible card (`resolveSearchMatch`) and fail soft on
reflow. The legacy `searchTranscript` is removed — indexed search is the single
implementation, kept honest by a test-only parity oracle.

**Complexity:**

```text
cold hydrate       : one-time O(history) projection build + seal
live append        : O(1) dirty marks (streaming chunks, read-group tail
                     appends, settlements) — NO per-chunk/per-member lowercase
query              : lazy whole-string re-normalization of ONLY the dirty
                     entries, then a lightweight scan of normalized strings —
                     no messages(), no grouping, no history re-lowercase
```

Live hot-path growth curves (bench section 9, the acceptance is the curve):
streaming 10/100/1000 KiB assistant in 1 KiB chunks → 0.04/0.23/1.75 ms
(x10 size ≈ x7.6 time); live read-group 10/100/1000 adjacent reads →
0.09/0.27/2.94 ms (x10 ≈ x11) — near-linear, never quadratic.

**Benchmark (100/1k/10k turns; legacy measured on base, indexed on this branch):**

| query class | legacy 10k p50/p95 | indexed 10k p50/p95 |
|---|---:|---:|
| miss | 9.01 / 15.01 ms | 1.47 / 1.59 ms |
| rare (1 hit) | ~9 ms (same full walk) | 2.23 / 2.34 ms |
| common (30k hits) | ~9–10 ms | 7.95 / 10.23 ms (match-object build dominates both) |

Incremental typing `n→ne→nee→need→needl→needle` (the plan §8.2 sequence, 6 queries,
10k turns): 37.4 ms p50 per sequence, 1 fresh 'n' full scan + 5 refined scans per
sample (bench counts full vs refined scans; earlier published numbers used a
sampling bug that made the sequence unrealistically cheap — corrected). Cold
hydrate+index build: 1.31 / 8.33 / 137.7 ms. Query-time normalized recomputes: **0**.
Structural counters (fullProjectionCount / normalizedRebuilds / groupingRebuilds):
300/400/1 · 3000/4000/1 · 30000/40000/1 — flat across queries by construction
(`searchDiagnosticsForTest()`).

PR C navigation baseline recorded in the same bench (moveOlder/moveNewer ×50 @
100/1k/10k: ≤0.05 ms p50) — unchanged.

### D2 — Context / status measurement decoupling

**Before:** every `refreshStatus()` call paid `tokenMeter.measure(liveAgent.session)`
directly — UI-only updates (theme, keybinding, permission, focus, resize, search,
credential/llm surfaces, knob events…) multiplied the measurement cost by the
unrelated-refresh count on long sessions.

**After:**

- `refreshStatusCheap()` — same projection, reads the CACHED context pressure;
  structurally cannot reach a measuring reader (hard gate, source-audit test).
- `refreshContextMeasurement(reason)` — the ONLY measuring path, through the existing
  semantic `SessionReader.measureContext()` port (`backend.sessionReader`); the runner
  no longer reads `ctx.get('tokenMeter')` (the Direct adapter owns that coupling).
- `ContextMeasurementCoordinator` — session-bound cache + dirty flag: model-visible
  events mark dirty and re-measure; a clean cache skips the reader (chain dedupe);
  failure/undefined keeps the last-good value and stays dirty for a retry; session
  identity change clears the old value; a foreign/stale session id is refused outright.
- Triggers: initial (deferred past first paint via setImmediate, fenced on
  sessionGeneration + session id, cancelled in cleanup), step/start, turn/end,
  matched compaction/end (fold-outcome path — a stale compaction/end never
  re-measures), session switches; `/status` keeps its existing explicit-port force
  path with unchanged semantics.
- Call-site classification audited one by one (16 sites); the runner surface's
  `refreshStatus` seam now points at the cheap implementation (UI-only by contract).
  `contextRefreshKind()` is the single classification seam the firehose routes
  through.

**Call-count evidence (tests, counting reader):**

```text
initial after paint        : 1
step/start                 : +1 (bounded)
turn/end                   : +1 (bounded, when dirty)
compaction/end (matched)   : +1
100 UI-only refreshes      : 0
clean cache, same chain    : 0 (skip)
session switch             : new session exactly 1; old value never leaks
stale deferred (switch)    : 0 commit
failure (undefined/throw)  : no crash, last-good kept, retry armed, recovery works
```

**Benchmark:** cheap refresh ×1000 (cached): p50 0.00 ms, `measureContextCalls 0`;
mixed loop (100 UI-only + 10 lifecycle): exactly 10 measures, never 110; explicit
measure context cost exposed separately.

### Key regression list

- Ctrl+F / Ctrl+Shift+F / host search: full-history search, jump re-windowing, close
  origin restore (latest vs history anchor) unchanged; fullscreen corpus/Next/Prev
  semantics unchanged (`rendering.test.ts` host-search test still green).
- Grouped read cards: same-turn + cross-turn + late-result reflow produce ONE visible
  match, strict legacy corpus parity (member paths are NOT newly searchable).
- Runner state: search results/refinement cleared on session swap, Ctrl+End, close.
- D2: first usable frame paints BEFORE any measurement; deferred measure cannot write
  to a new session; failure fallback (`usageFromStats` undefined path) intact.
- **PR C / #56:** no changes to `TranscriptWindowController`, window policy, viewport
  anchors, or `ScrollView.followingEnd`; navigation baseline recorded and unchanged.
- No new persistence/DSH private coupling (boundary gate: no new Host coupling);
  no alpha.3 `turnOutline`/`loadThrough` usage; no extension ABI change.

### Verification

- `pnpm typecheck` (fork + bundle) — clean
- `pnpm test` — fork 988, bundle 3494, docs 11 — all green (final run)
- `pnpm build` — clean
- `pnpm gate:boundary` (no new Host coupling), `pnpm gate:keybindings`,
  `pnpm gate:pi-surface-compat`, `node scripts/naming-gate.mjs`, `git diff --check`
- New suites: `test/transcript-search-index.test.ts` (25 tests incl. 10k-turn
  structural gate: `folder.messages()` spy proves the query path never materializes)
  and `test/context-measurement.test.ts` (14 tests incl. counting gates + first-paint
  ordering + source-audit hard gate)

### CI flake root cause (fixed)

The CI failure (`test/footer-command.test.ts` — "generated asynchronous activity
after the test ended ... write EPIPE") was NOT environmental: it exposed a real
production bug in the spawn-based `FooterCommandRunner`. The JSON payload is written
to the child's stdin inside a try/catch that only catches SYNCHRONOUS throws — a
command that exits before the payload flushes (e.g. `true` via the shell, or the PR D
runtime-arming test's `touch`) delivers the EPIPE asynchronously on the stdin
stream's 'error' event, and with no listener that is an uncaughtException that
crashes the whole TUI process. Fixed in `src/footer/command-runner.ts` (stdin
'error' swallow, matching the clipboard helper's round-3 pattern; stdout/stderr
'error' listeners added defensively) with a 60-instant-exit-run regression test
(verified failing without the fix: dies with `Error: write EPIPE`).

### Review chain

External holistic review (eleven rounds across two reviewers): round 1 found 2 P1
transcript-projection bugs (step-key namespace collision between thinking/assistant
entries; created-without-chunks entries missing index registration) + 2 P2 gaps
(bench counters; runner-level structural gating) — all fixed with regression tests;
round 2: accepted. Round 3 (after CI exposed the EPIPE crash): 1 P2 (stdout/stderr
'error' listeners) — fixed. Round 4: 1 P1 (live tail append refreshed only the last
two search entries of a merged read group) — fixed. Round 5: accepted. Round 6
(external review): 2 P1 + 2 P2 — stale search overlay on Next/Prev (live read-group
extension moved the card's turn past the stored match; refresh-before-jump via the
refreshedSearchState/steppedSearchOverlayState seams, stable-id recovery, clamp),
session context leak through the TuiApp status MERGE during the switch window
(explicit undefined clear + full-chain regression), streaming lowercasing not
chunk-splittable (Greek sigma; whole-string re-normalization of the active entry),
unrealistic bench sampling (per-sample fresh candidates) — all fixed with
failing-before regressions; follow-up findings (Next/Prev empty-guard ordering,
emptied-set clamp) fixed. Round 7: 3 P2 (handler-level regression coverage via the
production stepping seam; plan 'needl' bench step; honest fullProjectionEntries
counters) — fixed. Round 8: 1 P2 (/status bypassed the coordinator — force path)
— fixed. Round 9: 1 P1 + 1 P2 (?? fallback double-read; deferred re-measure) —
fixed. Round 10: 1 P1 (deferred guard before bind made the initial measure a
permanent no-op on cold resume/switch) — fixed. Round 11: accepted. The CI
tarball-smoke gate then found a public-ABI leak (the overlay seams exported
from the runner entry dragged the private transcript declaration into the
published .d.mts) — the seams moved to an internal module, pack:release +
tarball smoke verified green. Round 12: 1 P2 (Next entered a previously
empty overlay list at index 1, skipping the first newly discovered match)
— fixed. Round 13: accepted. A second external review then found 2 P1
LIVE hot-path performance regressions + 1 P2 benchmark gap — fixed in
one redesign: (1) streaming re-lowercased the whole accumulated message
per chunk (O(n²/chunk_size)) → O(1) dirty marks with query-time
whole-string lazy normalization; (2) read-group tail appends refreshed
every member per append (O(k²)) → the merged group's searchable text
lives only on the representative entry (O(1) per append, non-
representative members skipped at scan time, defensive reflows still
O(run) correctness-first); (3) bench gained the live streaming /
read-group growth-curve sections (10/100/1000 KiB and 10/100/1000 reads:
x10 size ≈ x7.6 / x11 time — near-linear). Round 14: accepted. A follow-up P2 optimization: lazy normalization
discovered dirty entries by scanning the whole searchEntries array on
every non-empty query (O(history) even with zero dirty entries) — the
dirty SET (Set<number>) is now the discovery structure: mutations add
O(1) idempotently, a query normalizes exactly the dirty entries
(O(#dirty)) and clears the set; a dirtyScans diagnostic + regression
prove the bound (0 scans with no mutations, 1 per distinct dirty entry,
dedupe on repeated marks). Round 15: **accepted, no findings** (full-diff
sweep).
