### PR TITLE
fix(footer): recent performance metrics + repeated item placements

### DIFF
--- a/docs/footer-customization.md
+++ b/docs/footer-customization.md
@@ -129,7 +129,12 @@ Common actions:
 
 The Add picker searches labels, ids, and descriptions.
 
-In addition to builtin and extension items, it contains:
+The picker lists the whole definition catalog. Adding a definition that is
+already placed appends an independent second placement — this is how the
+default Footer shows Performance twice (once as `latency`, once as `speed`):
+each placement keeps its own Style, Tone, Prefix/Suffix, and Importance.
+
+In addition to builtin and extension items, the picker contains:
 
 ```text
 + Create Custom Text
@@ -203,11 +208,25 @@ Common builtin Style sets include:
 | Working directory | `short`, `basename`, `full` |
 | Git branch | `plain`, `label` |
 | Context | `bar`, `percent`, `full` |
-| Token usage | `io`, `total`, `compact` |
-| Cache hit | `full`, `compact` |
+| Token usage | `pi`, `io`, `total`, `compact` |
+| Cache hit | `pi`, `full`, `compact` |
 | Performance | `full`, `speed`, `latency` |
 | Turns / steps | `both`, `turns`, `steps` |
 | Version | `tui`, `dsh`, `both` |
+
+The `default` preset's second row composes real semantic placements:
+
+```text
+token-usage:pi · cache-hit:pi · performance:latency · performance:speed
+```
+
+rendering as `↑114M ↓54k R520k W12k · CH93.9% · TTFB 8.1s · 51 tok/s`. The
+left group is session cumulative usage; the right group is recent model
+performance — the average time-to-first-token and the effective output
+throughput over the last five completed model requests (a model/provider
+switch resets that window). The session lifetime LLM wall time is still
+accumulated and available through `/stats`, but no longer part of the
+default Footer row.
 
 Omitting `format` keeps that item's default Style.
 

--- a/docs/footer-customization.md
+++ b/docs/footer-customization.md
@@ -225,8 +225,8 @@ left group is session cumulative usage; the right group is recent model
 performance — the average time-to-first-token and the effective output
 throughput over the last five completed model requests (a model/provider
 switch resets that window). The session lifetime LLM wall time is still
-accumulated and available through `/stats`, but no longer part of the
-default Footer row.
+accumulated and remains visible on the `/status` detail line, but it is no
+longer part of the default Footer row.
 
 Omitting `format` keeps that item's default Style.
 

--- a/src/footer/builtin-items.ts
+++ b/src/footer/builtin-items.ts
@@ -1,15 +1,18 @@
 /**
  * The builtin footer items (plan §7.1/§13.3): the semantic items the
- * default/compact presets compose. Every render callback is pure,
- * synchronous, I/O-free and reads only the StatusSnapshot + the host
- * surface context.
+ * default/compact presets and custom layouts compose. Every render
+ * callback is pure, synchronous, I/O-free and reads only the
+ * StatusSnapshot + the host surface context.
  *
- * M1 parity rules (plan §10.1/§13.6): the default preset reproduces the
- * legacy footer EXACTLY — including the viewer identity block (the legacy
- * viewer footer had no model/permission/plan/task/context/branch/extension
- * parts, so those items are view-conditional: they render only on the main
- * subject, and the data-source items (cwd/turns-steps/stats-line) follow
- * the display subject's section values).
+ * Default-preset composition: the status row is view-conditional — the
+ * main-only badges (model/permission/plan/task/context/branch/extension)
+ * render only on the main subject, while the data-source items
+ * (cwd/turns-steps and the stats-row placements: token-usage/cache-hit/
+ * performance) follow the display subject's section values. The default
+ * stats row composes semantic placements (token-usage:pi · cache-hit:pi ·
+ * performance:latency · performance:speed — the RECENT performance
+ * contract); `stats-line` stays registered as the legacy composite for
+ * existing custom layouts, never in the default preset.
  * @module @xmoon76/dsh-pi-tui/footer/builtin-items
  */
 

--- a/src/footer/builtin-items.ts
+++ b/src/footer/builtin-items.ts
@@ -18,6 +18,7 @@ import { visibleWidth } from '@xmoon76/pi-tui'
 import {
   formatCacheHit,
   formatCacheHitCompact,
+  formatCacheHitPi,
   formatContextFull,
   formatContextPercent,
   formatGitBranch,
@@ -25,7 +26,9 @@ import {
   formatPerformanceCompact,
   formatPerformanceFull,
   formatPerformanceLatency,
+  formatPerformanceLatencyCompact,
   formatPerformanceSpeed,
+  formatPerformanceSpeedCompact,
   formatPermissionPreset,
   formatPlanState,
   formatRunPhaseCompact,
@@ -34,6 +37,8 @@ import {
   formatStatsLineCompact,
   formatTokenUsageCompact,
   formatTokenUsageIo,
+  formatTokenUsagePi,
+  formatTokenUsagePiCompact,
   formatTokenUsageTotal,
   formatTurnsSteps,
   formatVersion,
@@ -250,11 +255,12 @@ const turnsStepsItem: FooterItemDefinition = {
 }
 
 /** The pi-vocabulary stats line (the legacy line-2), derived from the
- * STRUCTURED usage facts. */
+ * STRUCTURED usage facts. Kept registered for existing custom layouts;
+ * the default preset composes its stats row from real semantic items. */
 const statsLineItem: FooterItemDefinition = {
   id: 'stats-line',
   label: 'Stats line',
-  description: 'The pi-vocabulary usage line (tokens, cache, LLM timing, throughput).',
+  description: 'The pi-vocabulary usage line (tokens, cache, recent TTFB, throughput).',
   defaultZone: 'left',
   defaultImportance: 10,
   formats: ['pi'],
@@ -546,18 +552,27 @@ const todoItem: FooterItemDefinition = {
   },
 }
 
-/** The cache-hit share: full `C 91.9%` or compact `91.9%`. */
+/** The cache-hit share: pi `CH91.9%`, full `C 91.9%`, or compact `91.9%`.
+ * Absent cache facts (no billed input yet) render nothing — the composer
+ * eliminates the leftover separator. */
 const cacheHitItem: FooterItemDefinition = {
   id: 'cache-hit',
   label: 'Cache hit',
-  description: 'The cache-hit share of billed input tokens, full or compact.',
+  description: 'The cache-hit share of billed input tokens, pi, full, or compact.',
   defaultZone: 'left',
   defaultImportance: 55,
-  formats: ['full', 'compact'],
+  formats: ['pi', 'full', 'compact'],
   defaultFormat: 'full',
   render(snapshot: StatusSnapshot, ref, density) {
     const pct = snapshot.usage.cacheHitPct
     if (pct === undefined) return null
+    if (ref.format === 'pi') {
+      // The pi style's compact form drops the CH marker (the plan's
+      // shorter density); the user's own format choice is never written
+      // back.
+      const text = density === 'compact' ? formatCacheHitCompact(pct) : formatCacheHitPi(pct)
+      return { spans: [{ text, tone: 'success' }] }
+    }
     // Density compact reuses the persisted 'compact' style (`91.9%`);
     // the user's own format choice is never written back.
     const compact = density === 'compact' || ref.format === 'compact'
@@ -566,17 +581,27 @@ const cacheHitItem: FooterItemDefinition = {
   },
 }
 
-/** The token usage: input/output, all billed tokens, or compact total. */
+/** The token usage: pi vocabulary, input/output, all billed tokens, or
+ * compact total. */
 const tokenUsageItem: FooterItemDefinition = {
   id: 'token-usage',
   label: 'Token usage',
-  description: 'The input/output totals, billed total, or compact total.',
+  description: 'The pi input/output vocabulary, the io totals, billed total, or compact total.',
   defaultZone: 'left',
   defaultImportance: 50,
-  formats: ['io', 'total', 'compact'],
+  formats: ['pi', 'io', 'total', 'compact'],
   defaultFormat: 'io',
   render(snapshot: StatusSnapshot, ref, density) {
     const tokens = snapshot.usage.tokens
+    if (ref.format === 'pi') {
+      // The pi style keeps the cumulative input/output pair under width
+      // pressure and drops only the cache detail (`↑114M ↓54k`); the
+      // user's own format choice is never written back.
+      const text = density === 'compact'
+        ? formatTokenUsagePiCompact(tokens.input, tokens.output)
+        : formatTokenUsagePi(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
+      return { spans: [{ text, tone: 'success' }] }
+    }
     const preferred = ref.format === 'total'
       ? formatTokenUsageTotal(tokens.input, tokens.output, tokens.cacheRead, tokens.cacheWrite)
       : ref.format === 'compact'
@@ -593,32 +618,36 @@ const tokenUsageItem: FooterItemDefinition = {
   },
 }
 
-/** The performance styles: full `2.0s 40 tok/s`, speed-only, or
- * average time-to-first-token latency-only. */
+/** The recent model performance: full `TTFB 2.6s · 51 tok/s`, speed-only
+ * `51 tok/s`, or latency-only `TTFB 2.6s` — the RECENT average
+ * time-to-first-token and the RECENT effective output throughput. The
+ * definition may be PLACED TWICE (latency + speed) — the default preset
+ * does exactly that. */
 const performanceItem: FooterItemDefinition = {
   id: 'performance',
   label: 'Performance',
-  description: 'LLM wall time and output throughput, full, speed, or latency.',
+  description: 'Recent model performance: average TTFB and effective output throughput, full, speed, or latency.',
   defaultZone: 'left',
   defaultImportance: 40,
   formats: ['full', 'speed', 'latency'],
   defaultFormat: 'full',
   render(snapshot: StatusSnapshot, ref, density) {
     const performance = snapshot.usage.performance
-    const preferred = ref.format === 'speed'
-      ? formatPerformanceSpeed(performance.tokensPerSec)
-      : ref.format === 'latency'
-        ? formatPerformanceLatency(performance.firstTokenMs)
-        : formatPerformanceFull(performance.llmMs, performance.tokensPerSec)
-    if (density !== 'compact') return { spans: [{ text: preferred, tone: 'textMuted' }] }
-    // Density compact keeps BOTH facts with the shortened unit
-    // (`8.1s 40t/s`) — it never degrades to a speed-only or latency-only
-    // style (that would shift the composite item's semantic center).
-    // When the user's persisted style is ALREADY shorter (speed/latency),
-    // the compact form is the preferred form itself — a legitimate no-op,
-    // never a wider compact.
-    const compact = formatPerformanceCompact(performance.llmMs, performance.tokensPerSec)
-    const text = visibleWidth(compact) < visibleWidth(preferred) ? compact : preferred
+    if (ref.format === 'speed') {
+      const text = density === 'compact'
+        ? formatPerformanceSpeedCompact(performance.tokensPerSec)
+        : formatPerformanceSpeed(performance.tokensPerSec)
+      return { spans: [{ text, tone: 'textMuted' }] }
+    }
+    if (ref.format === 'latency') {
+      const text = density === 'compact'
+        ? formatPerformanceLatencyCompact(performance.firstTokenMs)
+        : formatPerformanceLatency(performance.firstTokenMs)
+      return { spans: [{ text, tone: 'textMuted' }] }
+    }
+    const text = density === 'compact'
+      ? formatPerformanceCompact(performance.firstTokenMs, performance.tokensPerSec)
+      : formatPerformanceFull(performance.firstTokenMs, performance.tokensPerSec)
     return { spans: [{ text, tone: 'textMuted' }] }
   },
 }

--- a/src/footer/configurator-model.ts
+++ b/src/footer/configurator-model.ts
@@ -511,15 +511,13 @@ export class FooterConfiguratorModel {
     }
   }
 
-  /** The registry ids NOT present in the draft layout (addable items —
-   * builtin and extension items alike). */
+  /** The registry's DEFINITION CATALOG (the Add picker's addable items —
+   * builtin and extension items alike). A definition may be PLACED any
+   * number of times: adding an already-placed id appends an independent
+   * placement (its own format/tone/prefix/suffix/importance), so the
+   * catalog is never filtered by what the draft layout already uses. */
   availableIds(): string[] {
-    const present = new Set<string>()
-    for (const row of this.draft.rows) {
-      for (const ref of row.left) present.add(ref.id)
-      for (const ref of row.right) present.add(ref.id)
-    }
-    return this.registry.ids().filter(id => !present.has(id))
+    return this.registry.ids()
   }
 
   /** Detached custom definitions in their persisted order. */
@@ -1306,8 +1304,9 @@ export class FooterConfiguratorModel {
     this.mode = 'row-move'
   }
 
-  /** Space (Edit Row page): remove the cursor's item (it returns to the
-   * Add picker's pool — Available is derived, never stored). */
+  /** Space (Edit Row page): remove the cursor's item placement (the
+   * picker's catalog is derived from the registry — the DEFINITION stays
+   * addable, and a second placement of the same id may remain placed). */
   removeActive(): void {
     if (this.mode !== 'row') return
     const at = this.refAt(this.cursor)
@@ -1336,9 +1335,11 @@ export class FooterConfiguratorModel {
   }
 
   /** Add one available item to a side of the edited row (appended at the
-   * end; the cursor lands on it). Returns false — with NO mutation —
-   * when the edited row is already at the parser's per-row item cap: a
-   * 33rd item would make every future save fail to parse. */
+   * end; the cursor lands on it). The same id may be added REPEATEDLY —
+   * each call appends an independent placement whose format/tone/prefix/
+   * suffix/importance later diverge freely. Returns false — with NO
+   * mutation — when the edited row is already at the parser's per-row
+   * item cap: a 33rd item would make every future save fail to parse. */
   addAvailable(id: string, zone: 'left' | 'right'): boolean {
     const row = this.editedRow()
     if (row.left.length + row.right.length >= MAX_ITEMS_PER_ROW) return false

--- a/src/footer/formatters.ts
+++ b/src/footer/formatters.ts
@@ -223,12 +223,14 @@ export function formatTurnsSteps(turns: number, steps: number, format = 'both'):
   }
 }
 
-/** The pi-vocabulary stats line (the legacy line-2 format), derived from
- * the STRUCTURED usage facts: `↑34k ↓8.1k R520k CH93.9% | TTFB 2.6s ·
+/** The pi-vocabulary FOOTER stats line (the legacy line-2 format), derived
+ * from the STRUCTURED usage facts: `↑34k ↓8.1k R520k CH93.9% | TTFB 2.6s ·
  * 51 tok/s`. The performance tail carries the RECENT metrics only — the
- * lifetime `LLM` wall left the line so a legacy composite never mixes
- * lifetime and recent windows. Mirrors formatStats exactly (guarded by a
- * source-consistency test). */
+ * lifetime `LLM` wall left the footer so a composite never mixes lifetime
+ * and recent windows. This is a SEPARATE presentation contract from
+ * formatStats (the /status detail line, which keeps the labeled lifetime
+ * `LLM ...` term beside the recent metrics) — footer chrome vs detail
+ * surface, never forced into string equality. */
 export function formatStatsLine(usage: UsageStatus): string {
   const piParts = [
     `↑${formatTokens(usage.tokens.input)}`,

--- a/src/footer/formatters.ts
+++ b/src/footer/formatters.ts
@@ -126,6 +126,11 @@ export function formatContextPercent(percent: number): string {
   return `ctx ${percent}%`
 }
 
+/** Cache-hit share, pi vocabulary: `CH93.9%`. */
+export function formatCacheHitPi(pct: number): string {
+  return `CH${pct.toFixed(1)}%`
+}
+
 /** Cache-hit share: `C 91.9%`. */
 export function formatCacheHit(pct: number): string {
   return `C ${pct.toFixed(1)}%`
@@ -141,6 +146,23 @@ export function formatTokenUsageIo(input: number, output: number): string {
   return `${input}/${output}`
 }
 
+/** Token usage, pi vocabulary: `↑34k ↓8.1k R520k W12k` — the session
+ * cumulative usage; the cache-read/write terms hide while zero. */
+export function formatTokenUsagePi(input: number, output: number, cacheRead: number, cacheWrite: number): string {
+  return [
+    `↑${formatTokens(input)}`,
+    `↓${formatTokens(output)}`,
+    cacheRead > 0 ? `R${formatTokens(cacheRead)}` : '',
+    cacheWrite > 0 ? `W${formatTokens(cacheWrite)}` : '',
+  ].filter(part => part !== '').join(' ')
+}
+
+/** Token usage, pi vocabulary under width pressure: `↑34k ↓8.1k` — the
+ * cumulative input/output pair survives, the cache detail drops. */
+export function formatTokenUsagePiCompact(input: number, output: number): string {
+  return `↑${formatTokens(input)} ↓${formatTokens(output)}`
+}
+
 /** Token usage, total form: `8.1k tokens` (all billed token classes). */
 export function formatTokenUsageTotal(input: number, output: number, cacheRead: number, cacheWrite: number): string {
   return `${formatTokens(input + output + cacheRead + cacheWrite)} tokens`
@@ -151,25 +173,40 @@ export function formatTokenUsageCompact(input: number, output: number, cacheRead
   return formatTokens(input + output + cacheRead + cacheWrite)
 }
 
-/** Performance, full form: `2.0s 40 tok/s`. */
-export function formatPerformanceFull(llmMs: number, tokensPerSec: number): string {
-  return `${formatSeconds(llmMs)} ${tokensPerSec} tok/s`
+/** Performance, full form: `TTFB 2.6s · 51 tok/s` — the RECENT average
+ * time-to-first-token and the RECENT effective throughput. The lifetime
+ * `LLM` wall is no longer a footer fact (it still accumulates in
+ * SessionStats.llmMs for /stats and session analysis). */
+export function formatPerformanceFull(firstTokenMs: number, tokensPerSec: number): string {
+  return `${formatPerformanceLatency(firstTokenMs)} · ${formatPerformanceSpeed(tokensPerSec)}`
 }
 
-/** Performance, compact pressure form: `2.0s 40t/s` — the full form's
- * `tok/s` unit shortened under width pressure (the composite item keeps
- * BOTH facts; it never degrades to a speed-only or latency-only style). */
-export function formatPerformanceCompact(llmMs: number, tokensPerSec: number): string {
-  return `${formatSeconds(llmMs)} ${tokensPerSec}t/s`
+/** Performance, compact pressure form: `2.6s 51t/s` — the full form's
+ * facts with the shortened units (the composite item keeps BOTH facts; it
+ * never degrades to a speed-only or latency-only style). */
+export function formatPerformanceCompact(firstTokenMs: number, tokensPerSec: number): string {
+  return `${formatPerformanceLatencyCompact(firstTokenMs)} ${formatPerformanceSpeedCompact(tokensPerSec)}`
 }
 
-/** Performance, speed-only form: `40 tok/s`. */
+/** Performance, speed-only form: `51 tok/s` — the recent effective
+ * throughput. */
 export function formatPerformanceSpeed(tokensPerSec: number): string {
   return `${tokensPerSec} tok/s`
 }
 
-/** Performance, average time-to-first-token form: `2.0s`. */
+/** Performance, speed-only compact form: `51t/s`. */
+export function formatPerformanceSpeedCompact(tokensPerSec: number): string {
+  return `${tokensPerSec}t/s`
+}
+
+/** Performance, latency-only form: `TTFB 2.6s` — the recent average
+ * time-to-first-token. */
 export function formatPerformanceLatency(firstTokenMs: number): string {
+  return `TTFB ${formatSeconds(firstTokenMs)}`
+}
+
+/** Performance, latency-only compact form: `2.6s`. */
+export function formatPerformanceLatencyCompact(firstTokenMs: number): string {
   return formatSeconds(firstTokenMs)
 }
 
@@ -187,8 +224,10 @@ export function formatTurnsSteps(turns: number, steps: number, format = 'both'):
 }
 
 /** The pi-vocabulary stats line (the legacy line-2 format), derived from
- * the STRUCTURED usage facts: `↑34k ↓8.1k R520k CH93.9% | LLM 138.8s ·
- * TTFB 2.6s · 659 tok/s`. Mirrors formatStats exactly (guarded by a
+ * the STRUCTURED usage facts: `↑34k ↓8.1k R520k CH93.9% | TTFB 2.6s ·
+ * 51 tok/s`. The performance tail carries the RECENT metrics only — the
+ * lifetime `LLM` wall left the line so a legacy composite never mixes
+ * lifetime and recent windows. Mirrors formatStats exactly (guarded by a
  * source-consistency test). */
 export function formatStatsLine(usage: UsageStatus): string {
   const piParts = [
@@ -199,7 +238,6 @@ export function formatStatsLine(usage: UsageStatus): string {
     usage.tokens.cacheRead > 0 || usage.tokens.cacheWrite > 0 ? `CH${(usage.cacheHitPct ?? 0).toFixed(1)}%` : '',
   ].filter(part => part !== '')
   const ownParts = [
-    `LLM ${formatSeconds(usage.performance.llmMs)}`,
     `TTFB ${formatSeconds(usage.performance.firstTokenMs)}`,
     `${usage.performance.tokensPerSec} tok/s`,
   ]
@@ -207,17 +245,17 @@ export function formatStatsLine(usage: UsageStatus): string {
 }
 
 /** The pi-vocabulary stats line, compact pressure form:
- * `↑34k ↓8.1k · LLM 138.8s · 659t/s` — input/output, ONE time indicator
- * and the throughput survive; the cache (R/W/CH) and TTFB facts are
- * omitted under width pressure. The structured UsageStatus is untouched
- * and the legacy formatStatsLine contract is unchanged. */
+ * `↑34k ↓8.1k · TTFB 2.6s · 659t/s` — input/output, ONE (recent) time
+ * indicator and the (recent) throughput survive; the cache (R/W/CH)
+ * facts are omitted under width pressure. The structured UsageStatus is
+ * untouched and the legacy formatStatsLine contract is unchanged. */
 export function formatStatsLineCompact(usage: UsageStatus): string {
   const piParts = [
     `↑${formatTokens(usage.tokens.input)}`,
     `↓${formatTokens(usage.tokens.output)}`,
   ]
   const ownParts = [
-    `LLM ${formatSeconds(usage.performance.llmMs)}`,
+    `TTFB ${formatSeconds(usage.performance.firstTokenMs)}`,
     `${usage.performance.tokensPerSec}t/s`,
   ]
   return `${piParts.join(' ')} · ${ownParts.join(' · ')}`

--- a/src/footer/presets.ts
+++ b/src/footer/presets.ts
@@ -7,23 +7,27 @@
  * @module @xmoon76/dsh-pi-tui/footer/presets
  */
 
-import type { FooterLayoutV1 } from './types.ts'
+import type { FooterItemRef, FooterLayoutV1 } from './types.ts'
 
-/** The default layout's first row: one status row. The view-scope item
- * leads: it renders nothing on the main subject and the viewer identity
- * block while viewing (the legacy viewer footer). */
-const STATUS_ROW_LEFT = [
-  { id: 'view-scope' },
-  { id: 'permission-preset' },
-  { id: 'plan-state' },
-  { id: 'model' },
-  { id: 'tasks' },
-  { id: 'cwd' },
-  { id: 'git-branch' },
-  { id: 'context' },
-  { id: 'turns-steps' },
-  { id: 'ext:*' },
-] as const
+/** Build the status row's placements, in order. The view-scope item leads:
+ * it renders nothing on the main subject and the viewer identity block
+ * while viewing (the legacy viewer footer). A FACTORY (never a shared
+ * object graph): each preset builds its own placement objects, so no
+ * consumer can mutate one preset's refs through another preset's alias. */
+function statusRowPlacements(): FooterItemRef[] {
+  return [
+    { id: 'view-scope' },
+    { id: 'permission-preset' },
+    { id: 'plan-state' },
+    { id: 'model' },
+    { id: 'tasks' },
+    { id: 'cwd' },
+    { id: 'git-branch' },
+    { id: 'context' },
+    { id: 'turns-steps' },
+    { id: 'ext:*' },
+  ]
+}
 
 /** The default layout's second row: semantic placements instead of the
  * legacy composite `stats-line`. Left group = session cumulative usage
@@ -38,7 +42,7 @@ export const DEFAULT_FOOTER_LAYOUT: FooterLayoutV1 = {
   schemaVersion: 1,
   rows: [
     {
-      left: [...STATUS_ROW_LEFT],
+      left: statusRowPlacements(),
       right: [],
     },
     {
@@ -59,7 +63,7 @@ export const COMPACT_FOOTER_LAYOUT: FooterLayoutV1 = {
   schemaVersion: 1,
   rows: [
     {
-      left: [...STATUS_ROW_LEFT],
+      left: statusRowPlacements(),
       right: [],
     },
   ],

--- a/src/footer/presets.ts
+++ b/src/footer/presets.ts
@@ -1,37 +1,55 @@
 /**
- * The builtin footer presets (plan §10): `default` reproduces the legacy
- * full footer EXACTLY (M1 parity — no beautification), `compact` drops the
- * stats row. The legacy `full` name maps to `default`; `custom` arrives in
- * M2.
+ * The builtin footer presets (plan §10): `default` composes the status
+ * row plus a stats row built from REAL semantic placements (session
+ * cumulative usage, cache hit, and the recent model performance as two
+ * `performance` placements — latency then speed), `compact` drops the
+ * stats row. The legacy `full` name maps to `default`.
  * @module @xmoon76/dsh-pi-tui/footer/presets
  */
 
 import type { FooterLayoutV1 } from './types.ts'
 
-/** The default (legacy full) layout: one status row + the stats row. The
- * view-scope item leads: it renders nothing on the main subject and the
- * viewer identity block while viewing (the legacy viewer footer). */
+/** The default layout's first row: one status row. The view-scope item
+ * leads: it renders nothing on the main subject and the viewer identity
+ * block while viewing (the legacy viewer footer). */
+const STATUS_ROW_LEFT = [
+  { id: 'view-scope' },
+  { id: 'permission-preset' },
+  { id: 'plan-state' },
+  { id: 'model' },
+  { id: 'tasks' },
+  { id: 'cwd' },
+  { id: 'git-branch' },
+  { id: 'context' },
+  { id: 'turns-steps' },
+  { id: 'ext:*' },
+] as const
+
+/** The default layout's second row: semantic placements instead of the
+ * legacy composite `stats-line`. Left group = session cumulative usage
+ * (tokens + cache), right = recent model performance (TTFB, effective
+ * throughput). The per-ref importance overrides define the narrow-width
+ * drop order (plan §3.3): cache-hit goes first, then the TTFB, then the
+ * throughput; the session usage pair survives longest — at least one
+ * usage signal and one speed signal outlive everything else on the row.
+ * The duplicated `performance` id is intentional: each placement carries
+ * its own format (FooterLayoutV1 allows repeated placements). */
 export const DEFAULT_FOOTER_LAYOUT: FooterLayoutV1 = {
   schemaVersion: 1,
   rows: [
     {
-      left: [
-        { id: 'view-scope' },
-        { id: 'permission-preset' },
-        { id: 'plan-state' },
-        { id: 'model' },
-        { id: 'tasks' },
-        { id: 'cwd' },
-        { id: 'git-branch' },
-        { id: 'context' },
-        { id: 'turns-steps' },
-        { id: 'ext:*' },
-      ],
+      left: [...STATUS_ROW_LEFT],
       right: [],
     },
     {
-      left: [{ id: 'stats-line' }],
+      left: [
+        { id: 'token-usage', format: 'pi', importance: 55 },
+        { id: 'cache-hit', format: 'pi', importance: 30 },
+        { id: 'performance', format: 'latency', importance: 40 },
+        { id: 'performance', format: 'speed', importance: 45 },
+      ],
       right: [],
+      separator: { text: ' · ' },
     },
   ],
 }
@@ -41,18 +59,7 @@ export const COMPACT_FOOTER_LAYOUT: FooterLayoutV1 = {
   schemaVersion: 1,
   rows: [
     {
-      left: [
-        { id: 'view-scope' },
-        { id: 'permission-preset' },
-        { id: 'plan-state' },
-        { id: 'model' },
-        { id: 'tasks' },
-        { id: 'cwd' },
-        { id: 'git-branch' },
-        { id: 'context' },
-        { id: 'turns-steps' },
-        { id: 'ext:*' },
-      ],
+      left: [...STATUS_ROW_LEFT],
       right: [],
     },
   ],

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -222,14 +222,16 @@ function latestSamples<T extends { ordinal: number }>(samples: readonly T[]): T[
   return [...samples].sort((a, b) => a.ordinal - b.ordinal).slice(-RECENT_PERFORMANCE_SAMPLE_LIMIT)
 }
 
-/** The performance route key of a settled message: provider + model. A
+/** The performance route key of a settled message: the (provider, model)
+ * TUPLE, encoded unambiguously — plain '/' concatenation would collide
+ * `("a/b", "c")` with `("a", "b/c")` and miss a real route change. A
  * message without a clear model-source identity yields undefined — the
  * window never resets on a missing key (fail-soft). */
 function routeKeyOf(message: { source?: unknown }): string | undefined {
   const source = (message as { source?: { kind?: unknown; provider?: unknown; model?: unknown } }).source
   if (source?.kind !== 'model') return undefined
   if (typeof source.provider !== 'string' || typeof source.model !== 'string') return undefined
-  return `${source.provider}/${source.model}`
+  return JSON.stringify([source.provider, source.model])
 }
 
 /** Advance the late-replay fence and clear the previous turn once. */

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,27 +1,32 @@
 /**
  * Session performance statistics folded from the event log, mirroring pi's
- * footer usage line: turns/steps, LLM wall time, first-token latency,
- * output tokens per second, cache hit rate, and token totals.
- * Pure and deterministic for headless tests.
+ * footer usage line: turns/steps, LLM wall time, recent first-token
+ * latency, recent effective output throughput, cache hit rate, and token
+ * totals. Pure and deterministic for headless tests.
  *
  * Accounting follows the Web's sessionStats/tokenUsage projections:
  * - the FIRST TOKEN is any non-empty token delta — text, reasoning, or a
- *   tool-call delta (the Web's isTokenDelta). Stamping only text-delta made
- *   the decode window start at the first VISIBLE token, which is much later
- *   than the first model token on reasoning models — tok/s came out
- *   systematically high and TTFB too. The whole step's timing (LLM wall,
- *   TTFT, decode window) settles at assistant/message, exactly like the
- *   projection; a step that never produced a message (cancelled/failed)
- *   contributes no timing at all;
+ *   tool-call delta (the Web's isTokenDelta). The whole step's timing (LLM
+ *   wall, TTFT) settles at assistant/message, exactly like the projection;
+ *   a step that never produced a message (cancelled/failed) contributes no
+ *   timing at all;
  * - usage is counted ONCE per step at step/end — the assistant/message
  *   usage replaces the streaming `usage` chunk (both carry the same
  *   assembler value; adding both would double the totals), and a step with
  *   only a usage chunk still counts (the projection's tokenUsage is
  *   step-keyed, not message-gated);
  * - turns/steps count at step/end (unique turns), like the projection;
- * - decode throughput samples only steps that carry BOTH a decode window
- *   (first token delta → assistant/message) and usage, so reasoning-only or
- *   tool-only steps never inflate the rate;
+ * - the STATUS performance metrics (firstTokenMsAvg / tokensPerSec) are
+ *   RECENT-window figures over the last {@link RECENT_PERFORMANCE_SAMPLE_LIMIT}
+ *   valid completed steps, not session-lifetime averages. A throughput
+ *   sample is Σ output / Σ FULL LLM wall (step/start → assistant/message),
+ *   so CPA burst tool-call delivery (hundreds of tokens delivered within
+ *   milliseconds after a multi-second request) counts as
+ *   `400 tokens / 10s whole request = 40 tok/s` instead of ratcheting a
+ *   lifetime "observable decode window" rate into the hundreds. A route
+ *   (provider + model) change clears both recent windows;
+ * - `llmMs` remains the session LIFETIME LLM wall — kept for debug,
+ *   /stats and session analysis, no longer shown in the default footer;
  * - billed input = uncached + cache-read + cache-write (the Web's
  *   billedInputTokens), and the cache-hit share divides by that sum.
  * @module @xmoon76/dsh-pi-tui/stats
@@ -36,11 +41,17 @@ export interface SessionStats {
   turns: number
   /** Model requests (steps). */
   steps: number
-  /** Total model wall time (step/start → assistant/message), ms. */
+  /** Total model wall time (step/start → assistant/message), ms — the
+   * session LIFETIME total (debug/stats surfaces; the default footer no
+   * longer shows it). */
   llmMs: number
-  /** Average time from step/start to the first text delta, ms. */
+  /** Average time from step/start to the first token over the RECENT
+   * window (the last {@link RECENT_PERFORMANCE_SAMPLE_LIMIT} completed
+   * first-token steps), ms. */
   firstTokenMsAvg: number
-  /** Output tokens per second over the sampled decode phases. */
+  /** Recent effective output throughput: Σ outputTokens / Σ full LLM wall
+   * over the RECENT window (the last {@link RECENT_PERFORMANCE_SAMPLE_LIMIT}
+   * valid completed steps), tok/s. */
   tokensPerSec: number
   /** Cache-read share of billed input tokens, 0–100. */
   cacheHitPct: number
@@ -69,6 +80,13 @@ const EMPTY: SessionStats = {
   cacheWriteTokens: 0,
 }
 
+/** The recent performance window's step count (plan §2.3): last-1 is too
+ * jittery across tool-call / reasoning / short-text steps; a session
+ * lifetime mixes in stale history; wall-clock windows go empty across
+ * long tool gaps. Five completed steps smooth the agent tool loop while
+ * staying responsive. */
+export const RECENT_PERFORMANCE_SAMPLE_LIMIT = 5
+
 /** Key identifying one step's model output (turn + step). */
 function stepKey(turn: number, step: number): string {
   return `${turn}/${step}`
@@ -81,7 +99,7 @@ function turnOfStepKey(key: string): number {
 }
 
 /** One step's timing accumulation, resolved at its boundaries. The usage
- * field feeds the decode-throughput sampling (settleStep); the token
+ * field feeds the recent performance sampling (settleStep); the token
  * ACCOUNTING itself lives in the shared {@link StepUsageAccumulator}, so
  * the footer and the Focus per-turn projection can never drift. */
 interface StepTiming {
@@ -91,9 +109,120 @@ interface StepTiming {
   usage?: UsageLike
   /** One step may have at most one timing settlement. */
   settled?: boolean
-  /** The already-accounted decode sample, when usage was available. */
-  sampledDuration?: number
-  sampledOutputTokens?: number
+  /** The completion's position in the recent window (assigned at the
+   * FIRST settlement; a late usage replacement reuses it). */
+  completionOrdinal?: number
+  /** The performance route the step's samples joined (provider + model)
+   * — a late replacement must not cross back into a reset window. */
+  routeKey?: string
+}
+
+/** One recent effective-throughput sample: the step's FULL LLM wall
+ * (step/start → assistant/message) against its authoritative output
+ * tokens — never a burst-delivery "observable decode window". */
+interface RecentThroughputSample {
+  key: string
+  ordinal: number
+  wallMs: number
+  outputTokens: number
+}
+
+/** One recent TTFT sample (step/start → first token delta). */
+interface RecentTtftSample {
+  key: string
+  ordinal: number
+  ttftMs: number
+}
+
+/**
+ * The bounded recent performance window shared by both folds (plan §6.1):
+ * the latest {@link RECENT_PERFORMANCE_SAMPLE_LIMIT} valid samples per
+ * metric, keyed by step, ordered by completion ordinal. A late
+ * authoritative usage replacement UPSERTS its step's sample (same
+ * ordinal) instead of appending a fake "newest" one. The window is
+ * route-scoped: the first settled message that clearly identifies a new
+ * provider + model clears both windows before its own samples join.
+ */
+class RecentPerformanceWindow {
+  /** The route (provider + model) the current window belongs to. */
+  routeKey: string | undefined
+  private nextOrdinal = 0
+  private throughput: RecentThroughputSample[] = []
+  private ttft: RecentTtftSample[] = []
+
+  /** Claim the next completion ordinal (exactly once per step, at its
+   * first settlement). */
+  claimOrdinal(): number {
+    return this.nextOrdinal++
+  }
+
+  /** Observe a settled message's route key. The FIRST observation adopts
+   * it; a CHANGE clears both windows so the new route's metrics start
+   * clean. A MISSING key never resets anything (fail-soft). Returns the
+   * window's route after the observation. */
+  observeRoute(routeKey: string | undefined): string | undefined {
+    if (routeKey !== undefined) {
+      if (this.routeKey === undefined) this.routeKey = routeKey
+      else if (this.routeKey !== routeKey) {
+        this.throughput = []
+        this.ttft = []
+        this.routeKey = routeKey
+      }
+    }
+    return this.routeKey
+  }
+
+  /** Upsert the step's TTFT sample (a replacement keeps its ordinal). */
+  upsertTtft(key: string, ordinal: number, ttftMs: number): void {
+    upsertSample(this.ttft, { key, ordinal, ttftMs })
+  }
+
+  /** Upsert the step's effective-throughput sample. */
+  upsertThroughput(key: string, ordinal: number, wallMs: number, outputTokens: number): void {
+    upsertSample(this.throughput, { key, ordinal, wallMs, outputTokens })
+  }
+
+  /** The derived recent metrics (the ONE helper both folds share — plan
+   * §6.4). No samples → 0, the established compat behavior. */
+  derive(): { firstTokenMsAvg: number; tokensPerSec: number } {
+    const ttft = latestSamples(this.ttft)
+    const firstTokenMsAvg = ttft.length > 0
+      ? ttft.reduce((sum, sample) => sum + sample.ttftMs, 0) / ttft.length
+      : 0
+    const throughput = latestSamples(this.throughput)
+    const wallMs = throughput.reduce((sum, sample) => sum + sample.wallMs, 0)
+    const outputTokens = throughput.reduce((sum, sample) => sum + sample.outputTokens, 0)
+    const tokensPerSec = wallMs > 0 ? Math.round((outputTokens * 1000) / wallMs) : 0
+    return { firstTokenMsAvg, tokensPerSec }
+  }
+}
+
+/** Insert-or-replace by step key, then trim to the LATEST ordinals (a
+ * late-valid old step joins at its ORIGINAL ordinal and may immediately
+ * fall out of the window again — it is an old step, not a newest one). */
+function upsertSample<T extends { key: string; ordinal: number }>(samples: T[], sample: T): void {
+  const index = samples.findIndex(existing => existing.key === sample.key)
+  if (index >= 0) samples[index] = sample
+  else samples.push(sample)
+  if (samples.length > RECENT_PERFORMANCE_SAMPLE_LIMIT) {
+    samples.sort((a, b) => a.ordinal - b.ordinal)
+    samples.splice(0, samples.length - RECENT_PERFORMANCE_SAMPLE_LIMIT)
+  }
+}
+
+/** The window's latest-N samples in completion order. */
+function latestSamples<T extends { ordinal: number }>(samples: readonly T[]): T[] {
+  return [...samples].sort((a, b) => a.ordinal - b.ordinal).slice(-RECENT_PERFORMANCE_SAMPLE_LIMIT)
+}
+
+/** The performance route key of a settled message: provider + model. A
+ * message without a clear model-source identity yields undefined — the
+ * window never resets on a missing key (fail-soft). */
+function routeKeyOf(message: { source?: unknown }): string | undefined {
+  const source = (message as { source?: { kind?: unknown; provider?: unknown; model?: unknown } }).source
+  if (source?.kind !== 'model') return undefined
+  if (typeof source.provider !== 'string' || typeof source.model !== 'string') return undefined
+  return `${source.provider}/${source.model}`
 }
 
 /** Advance the late-replay fence and clear the previous turn once. */
@@ -118,8 +247,8 @@ function advanceTimingTurn(
 /**
  * The Web's first-token predicate (dsh-llm `isTokenDelta`): any non-empty
  * text or reasoning delta, or a tool-call delta carrying content. The TUI
- * must stamp the SAME boundary or its decode window starts at the first
- * visible token and tok/s inflates on reasoning models.
+ * must stamp the SAME boundary or its TTFT starts at the first
+ * visible token and inflates on reasoning models.
  */
 function isTokenDelta(chunk: { type: string; text?: string; argumentsDelta?: string; name?: unknown }): boolean {
   switch (chunk.type) {
@@ -131,18 +260,6 @@ function isTokenDelta(chunk: { type: string; text?: string; argumentsDelta?: str
     default:
       return false
   }
-}
-
-/** Timing/throughput accumulators shared by the fold and the folder. */
-interface Throughput {
-  /** Total decode-window duration (ms) of sampled steps. */
-  outputMsTotal: number
-  /** Output tokens over the same sampled steps. */
-  decodeTokens: number
-  /** Summed TTFT over first-token steps. */
-  firstTokenTotal: number
-  /** Steps carrying a recorded first token. */
-  firstTokenCount: number
 }
 
 /**
@@ -160,7 +277,7 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
   // Step boundaries are idempotent within the active turn; older boundaries
   // are stale once the timing fence advances.
   const endedSteps = new Set<string>()
-  const throughput: Throughput = { outputMsTotal: 0, decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
+  const recent = new RecentPerformanceWindow()
   const usage = new StepUsageAccumulator()
   let completedTurnFence: number | undefined
   let lastTurn: number | undefined
@@ -254,7 +371,7 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
             timing.usage = chunk.usage
           }
         } else if (isTokenDelta(chunk)) {
-          // The FIRST token delta of the step stamps the decode-window start
+          // The FIRST token delta of the step stamps the TTFT start
           // (Web firstTokenTime). Reasoning and tool-call deltas count too.
           const timing = settledTurn === event.data.turn
             ? perStep.get(stepKey(event.data.turn, event.data.step))
@@ -272,19 +389,19 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
           ? perStep.get(key) ?? settledPerStep.get(key)
           : undefined
         if (timing !== undefined) {
-          // The message time is the step's decode end and its usage is the
+          // The message time is the step's LLM wall end and its usage is the
           // authoritative one; the whole step settles HERE (projection
           // semantics) — step/end only counts turns/steps and the usage.
           // A duplicate authoritative message may replace token usage, but it
-          // must never add a second wall-time or throughput sample.
+          // must never add a second wall-time or performance sample.
           if (timing.settled !== true) {
             timing.completed = event.time
             if (event.data.usage !== undefined) timing.usage = event.data.usage
-            settleStep(stats, timing, throughput)
+            settleStep(stats, key, timing, recent, routeKeyOf(event.data.message))
             timing.settled = true
           } else if (event.data.usage !== undefined) {
             timing.usage = event.data.usage
-            replaceSampledUsage(timing, event.data.usage, throughput)
+            replaceRecentThroughput(key, timing, event.data.usage, recent)
           }
         }
         usage.onAssistantMessage(event.data.turn, event.data.step, event.data.usage)
@@ -299,9 +416,7 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
     }
   }
 
-  if (throughput.firstTokenCount > 0) stats.firstTokenMsAvg = throughput.firstTokenTotal / throughput.firstTokenCount
-  const streamMs = throughput.outputMsTotal
-  if (streamMs > 0) stats.tokensPerSec = Math.round((throughput.decodeTokens * 1000) / streamMs)
+  applyDerivedPerformance(stats, recent)
   const totals = usage.sessionTotals()
   stats.inputTokens = totals.inputTokens
   stats.outputTokens = totals.outputTokens
@@ -312,42 +427,73 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
   return stats
 }
 
-/** Replace the output-token side of an already-accounted decode sample.
- * Assistant/message usage is authoritative and can replace an earlier value;
- * the decode window itself still belongs to the first settled message. */
-function replaceSampledUsage(timing: StepTiming, usage: UsageLike, throughput: Throughput): void {
-  const first = timing.firstDelta
-  const completed = timing.completed
-  if (timing.sampledDuration === undefined) {
-    if (first === undefined || completed === undefined) return
-    timing.sampledDuration = Math.max(0, completed - first)
-    throughput.outputMsTotal += timing.sampledDuration
-  } else {
-    throughput.decodeTokens -= timing.sampledOutputTokens ?? 0
-  }
-  throughput.decodeTokens += usage.outputTokens
-  timing.sampledOutputTokens = usage.outputTokens
+/** Write the recent window's derived metrics onto the stats (the ONE
+ * shared derive path for both folds — plan §6.4). */
+function applyDerivedPerformance(stats: SessionStats, recent: RecentPerformanceWindow): void {
+  const derived = recent.derive()
+  stats.firstTokenMsAvg = derived.firstTokenMsAvg
+  stats.tokensPerSec = derived.tokensPerSec
 }
 
-/** Settle one step's TIMING at its assistant/message boundary. A step with
- * no message (cancelled/failed) never reaches here — the projection counts
- * no timing for it. Usage is NOT settled here; step/end adds it once. */
-function settleStep(stats: SessionStats, timing: StepTiming, throughput: Throughput): void {
+/** Settle one step's TIMING at its assistant/message boundary: the
+ * lifetime LLM wall, its completion ordinal, the route observation, and
+ * the recent TTFB / effective-throughput samples. A step with no message
+ * (cancelled/failed) never reaches here. Usage is NOT settled here;
+ * step/end adds it once. */
+function settleStep(
+  stats: SessionStats,
+  key: string,
+  timing: StepTiming,
+  recent: RecentPerformanceWindow,
+  routeKey: string | undefined,
+): void {
   const completed = timing.completed
   if (completed === undefined) return
   const start = timing.start
   if (start !== undefined) stats.llmMs += Math.max(0, completed - start)
+  // One completion ordinal per step; the route check runs BEFORE the
+  // samples join, so a model/provider switch starts a clean window.
+  const ordinal = recent.claimOrdinal()
+  timing.completionOrdinal = ordinal
+  timing.routeKey = recent.observeRoute(routeKey)
   const first = timing.firstDelta
-  if (first !== undefined) {
-    // TTFT: step/start → first token (the projection's ttftMs).
-    throughput.firstTokenTotal += Math.max(0, first - (start ?? completed))
-    throughput.firstTokenCount += 1
-    // Sampled throughput: the decode window enters the denominator only when
-    // the step also reported usage, and vice versa (projection sampled
-    // semantics) — a reasoning-only or usage-less step skews neither side.
-    const usage = timing.usage
-    if (usage !== undefined) replaceSampledUsage(timing, usage, throughput)
+  if (first !== undefined && start !== undefined) {
+    // TTFT: step/start → first token (the projection's ttftMs). A latency
+    // sample — never token-weighted.
+    recent.upsertTtft(key, ordinal, Math.max(0, first - start))
   }
+  const usage = timing.usage
+  if (usage !== undefined && start !== undefined) {
+    // Effective throughput: Σ output / Σ FULL LLM wall. The sample
+    // conditions (valid usage, a wall to divide by) need no multi-delta
+    // streaming — a burst-delivered tool-call step samples on its whole
+    // request wall (plan §2.2).
+    const wallMs = Math.max(0, completed - start)
+    if (usage.outputTokens > 0 && wallMs > 0) {
+      recent.upsertThroughput(key, ordinal, wallMs, usage.outputTokens)
+    }
+  }
+}
+
+/** Replace the throughput sample of an already-settled step from a late
+ * authoritative usage (assistant/message duplicate). The sample keeps its
+ * original completion ordinal — it replaces, never appends; llmMs and
+ * TTFB are never re-added; and a message belonging to a route the window
+ * has moved past must not resurrect its sample into the current window. */
+function replaceRecentThroughput(
+  key: string,
+  timing: StepTiming,
+  usage: UsageLike,
+  recent: RecentPerformanceWindow,
+): void {
+  if (timing.routeKey !== undefined && recent.routeKey !== undefined && timing.routeKey !== recent.routeKey) return
+  if (timing.completionOrdinal === undefined) return
+  const start = timing.start
+  const completed = timing.completed
+  if (start === undefined || completed === undefined) return
+  const wallMs = Math.max(0, completed - start)
+  if (usage.outputTokens <= 0 || wallMs <= 0) return
+  recent.upsertThroughput(key, timing.completionOrdinal, wallMs, usage.outputTokens)
 }
 
 /** Token totals from one usage record (cache fields counted separately). */
@@ -373,7 +519,7 @@ export class StatsFolder {
   // are stale once the timing fence advances.
   private readonly endedSteps = new Set<string>()
   private settledTurn: number | undefined
-  private readonly throughput: Throughput = { outputMsTotal: 0, decodeTokens: 0, firstTokenTotal: 0, firstTokenCount: 0 }
+  private readonly recent = new RecentPerformanceWindow()
   /** The shared per-step usage accounting (same class as the Focus fold). */
   private readonly usage = new StepUsageAccumulator()
   /** Highest turn finalized by turn/end; older events are replay artifacts.
@@ -401,9 +547,7 @@ export class StatsFolder {
   /** The derived stats as of the last applied event. */
   snapshot(): SessionStats {
     const derived: SessionStats = { ...this.stats }
-    if (this.throughput.firstTokenCount > 0) derived.firstTokenMsAvg = this.throughput.firstTokenTotal / this.throughput.firstTokenCount
-    const streamMs = this.throughput.outputMsTotal
-    if (streamMs > 0) derived.tokensPerSec = Math.round((this.throughput.decodeTokens * 1000) / streamMs)
+    applyDerivedPerformance(derived, this.recent)
     const totals = this.usage.sessionTotals()
     derived.inputTokens = totals.inputTokens
     derived.outputTokens = totals.outputTokens
@@ -514,17 +658,18 @@ export class StatsFolder {
           ? this.perStep.get(key) ?? this.settledPerStep.get(key)
           : undefined
         if (timing !== undefined) {
-          // Keep timing and throughput idempotent if a malformed/replayed log
-          // carries the same authoritative message more than once. The shared
-          // usage accumulator still applies replacement semantics below.
+          // Keep timing and performance sampling idempotent if a
+          // malformed/replayed log carries the same authoritative message
+          // more than once. The shared usage accumulator still applies
+          // replacement semantics below.
           if (timing.settled !== true) {
             timing.completed = event.time
             if (event.data.usage !== undefined) timing.usage = event.data.usage
-            settleStep(this.stats, timing, this.throughput)
+            settleStep(this.stats, key, timing, this.recent, routeKeyOf(event.data.message))
             timing.settled = true
           } else if (event.data.usage !== undefined) {
             timing.usage = event.data.usage
-            replaceSampledUsage(timing, event.data.usage, this.throughput)
+            replaceRecentThroughput(key, timing, event.data.usage, this.recent)
           }
         }
         this.usage.onAssistantMessage(event.data.turn, event.data.step, event.data.usage)
@@ -553,8 +698,12 @@ function formatSeconds(ms: number): string {
 
 /**
  * Render the stats line in pi abbreviation vocabulary:
- * `↑34k ↓8.1k R520k CH93.9% | LLM 138.8s · TTFB 2.6s · 659 tok/s`
+ * `↑34k ↓8.1k R520k CH93.9% | TTFB 2.6s · 51 tok/s`
  * Cost (`$0.164`) is omitted: dsh's TokenUsage carries no price data.
+ * The performance tail carries the RECENT metrics only — the lifetime
+ * `LLM ...` wall left the line (it still accumulates in
+ * {@link SessionStats.llmMs} for /stats and session analysis), so a
+ * legacy composite never mixes lifetime and recent windows.
  * Context pressure lives in the footer's first line (progress bar), so it
  * is not repeated here. Turn/step counters live there too.
  * @param stats - the folded statistics.
@@ -569,7 +718,6 @@ export function formatStats(stats: SessionStats): string {
     stats.cacheReadTokens > 0 || stats.cacheWriteTokens > 0 ? `CH${stats.cacheHitPct.toFixed(1)}%` : '',
   ].filter(part => part !== '')
   const ownParts = [
-    `LLM ${formatSeconds(stats.llmMs)}`,
     `TTFB ${formatSeconds(stats.firstTokenMsAvg)}`,
     `${stats.tokensPerSec} tok/s`,
   ]

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -182,6 +182,13 @@ class RecentPerformanceWindow {
     upsertSample(this.throughput, { key, ordinal, wallMs, outputTokens })
   }
 
+  /** Drop the step's throughput sample (an authoritative replacement that
+   * invalidates the sample — e.g. outputTokens corrected to 0 — must not
+   * leave the superseded value in the window). No-op when absent. */
+  removeThroughput(key: string): void {
+    this.throughput = this.throughput.filter(sample => sample.key !== key)
+  }
+
   /** The derived recent metrics (the ONE helper both folds share — plan
    * §6.4). No samples → 0, the established compat behavior. */
   derive(): { firstTokenMsAvg: number; tokensPerSec: number } {
@@ -479,7 +486,10 @@ function settleStep(
  * authoritative usage (assistant/message duplicate). The sample keeps its
  * original completion ordinal — it replaces, never appends; llmMs and
  * TTFB are never re-added; and a message belonging to a route the window
- * has moved past must not resurrect its sample into the current window. */
+ * has moved past must not resurrect its sample into the current window.
+ * A replacement that turns the sample INVALID (outputTokens corrected to
+ * 0) removes it: the superseded tokens must not keep feeding the recent
+ * rate. */
 function replaceRecentThroughput(
   key: string,
   timing: StepTiming,
@@ -492,7 +502,10 @@ function replaceRecentThroughput(
   const completed = timing.completed
   if (start === undefined || completed === undefined) return
   const wallMs = Math.max(0, completed - start)
-  if (usage.outputTokens <= 0 || wallMs <= 0) return
+  if (usage.outputTokens <= 0 || wallMs <= 0) {
+    recent.removeThroughput(key)
+    return
+  }
   recent.upsertThroughput(key, timing.completionOrdinal, wallMs, usage.outputTokens)
 }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -87,6 +87,19 @@ const EMPTY: SessionStats = {
  * staying responsive. */
 export const RECENT_PERFORMANCE_SAMPLE_LIMIT = 5
 
+/** How many throughput CANDIDATES the window physically retains (the
+ * derived metric still pools only {@link RECENT_PERFORMANCE_SAMPLE_LIMIT}
+ * of them — derive takes the latest five VALID samples). The extra
+ * candidates exist so an authoritative invalidation of one of the latest
+ * five BACKFILLS correctly: the window's contract is "the latest 5 valid
+ * samples", and a sample invalidated by a late duplicate stops being
+ * valid, letting the next-older retained candidate rejoin. Twice the
+ * window covers the worst case of every derived sample being
+ * invalidated; a duplicate older than the candidate buffer is a replay
+ * artifact beyond the recent contract. TTFT needs no candidates — its
+ * samples have no invalidation path. */
+const RECENT_PERFORMANCE_CANDIDATE_LIMIT = RECENT_PERFORMANCE_SAMPLE_LIMIT * 2
+
 /** Key identifying one step's model output (turn + step). */
 function stepKey(turn: number, step: number): string {
   return `${turn}/${step}`
@@ -115,6 +128,11 @@ interface StepTiming {
   /** The performance route the step's samples joined (provider + model)
    * — a late replacement must not cross back into a reset window. */
   routeKey?: string
+  /** The route LIFECYCLE epoch at settlement. The route STRING alone
+   * cannot gate a late replacement: A → B → A returns to an equal string
+   * while the window's samples belong to the SECOND A lifecycle — only
+   * an epoch match proves the same route generation. */
+  routeEpoch?: number
 }
 
 /** One recent effective-throughput sample: the step's FULL LLM wall
@@ -136,16 +154,24 @@ interface RecentTtftSample {
 
 /**
  * The bounded recent performance window shared by both folds (plan §6.1):
- * the latest {@link RECENT_PERFORMANCE_SAMPLE_LIMIT} valid samples per
- * metric, keyed by step, ordered by completion ordinal. A late
- * authoritative usage replacement UPSERTS its step's sample (same
- * ordinal) instead of appending a fake "newest" one. The window is
- * route-scoped: the first settled message that clearly identifies a new
- * provider + model clears both windows before its own samples join.
+ * the latest {@link RECENT_PERFORMANCE_SAMPLE_LIMIT} VALID samples per
+ * metric, keyed by step, ordered by completion ordinal (throughput keeps
+ * {@link RECENT_PERFORMANCE_CANDIDATE_LIMIT} candidates so an
+ * invalidation backfills). A late authoritative usage replacement UPSERTS
+ * its step's sample (same ordinal) instead of appending a fake "newest"
+ * one — or REMOVES it when the replacement invalidates the sample. The
+ * window is route-scoped: the first settled message that clearly
+ * identifies a new provider + model clears both windows (bumping the
+ * route epoch) before its own samples join.
  */
 class RecentPerformanceWindow {
   /** The route (provider + model) the current window belongs to. */
   routeKey: string | undefined
+  /** The current route LIFECYCLE generation — bumped on every REAL route
+   * change (A → B → A bumps twice). Samples and settled steps carry the
+   * epoch they joined, so a late replacement can only mutate the window
+   * of its own generation, never a later one with an equal route string. */
+  routeEpoch = 0
   private nextOrdinal = 0
   private throughput: RecentThroughputSample[] = []
   private ttft: RecentTtftSample[] = []
@@ -157,29 +183,29 @@ class RecentPerformanceWindow {
   }
 
   /** Observe a settled message's route key. The FIRST observation adopts
-   * it; a CHANGE clears both windows so the new route's metrics start
-   * clean. A MISSING key never resets anything (fail-soft). Returns the
-   * window's route after the observation. */
-  observeRoute(routeKey: string | undefined): string | undefined {
+   * it; a CHANGE clears both windows (and bumps the route epoch) so the
+   * new route's metrics start clean. A MISSING key never resets anything
+   * (fail-soft). */
+  observeRoute(routeKey: string | undefined): void {
     if (routeKey !== undefined) {
       if (this.routeKey === undefined) this.routeKey = routeKey
       else if (this.routeKey !== routeKey) {
         this.throughput = []
         this.ttft = []
         this.routeKey = routeKey
+        this.routeEpoch += 1
       }
     }
-    return this.routeKey
   }
 
   /** Upsert the step's TTFT sample (a replacement keeps its ordinal). */
   upsertTtft(key: string, ordinal: number, ttftMs: number): void {
-    upsertSample(this.ttft, { key, ordinal, ttftMs })
+    upsertSample(this.ttft, { key, ordinal, ttftMs }, RECENT_PERFORMANCE_SAMPLE_LIMIT)
   }
 
   /** Upsert the step's effective-throughput sample. */
   upsertThroughput(key: string, ordinal: number, wallMs: number, outputTokens: number): void {
-    upsertSample(this.throughput, { key, ordinal, wallMs, outputTokens })
+    upsertSample(this.throughput, { key, ordinal, wallMs, outputTokens }, RECENT_PERFORMANCE_CANDIDATE_LIMIT)
   }
 
   /** Drop the step's throughput sample (an authoritative replacement that
@@ -204,16 +230,17 @@ class RecentPerformanceWindow {
   }
 }
 
-/** Insert-or-replace by step key, then trim to the LATEST ordinals (a
- * late-valid old step joins at its ORIGINAL ordinal and may immediately
- * fall out of the window again — it is an old step, not a newest one). */
-function upsertSample<T extends { key: string; ordinal: number }>(samples: T[], sample: T): void {
+/** Insert-or-replace by step key, then trim to the LATEST ordinals within
+ * the caller's retention limit (a late-valid old step joins at its
+ * ORIGINAL ordinal and may immediately fall out of the derived window —
+ * it is an old step, not a newest one). */
+function upsertSample<T extends { key: string; ordinal: number }>(samples: T[], sample: T, limit: number): void {
   const index = samples.findIndex(existing => existing.key === sample.key)
   if (index >= 0) samples[index] = sample
   else samples.push(sample)
-  if (samples.length > RECENT_PERFORMANCE_SAMPLE_LIMIT) {
+  if (samples.length > limit) {
     samples.sort((a, b) => a.ordinal - b.ordinal)
-    samples.splice(0, samples.length - RECENT_PERFORMANCE_SAMPLE_LIMIT)
+    samples.splice(0, samples.length - limit)
   }
 }
 
@@ -464,7 +491,9 @@ function settleStep(
   // samples join, so a model/provider switch starts a clean window.
   const ordinal = recent.claimOrdinal()
   timing.completionOrdinal = ordinal
-  timing.routeKey = recent.observeRoute(routeKey)
+  recent.observeRoute(routeKey)
+  timing.routeKey = recent.routeKey
+  timing.routeEpoch = recent.routeEpoch
   const first = timing.firstDelta
   if (first !== undefined && start !== undefined) {
     // TTFT: step/start → first token (the projection's ttftMs). A latency
@@ -489,6 +518,9 @@ function settleStep(
  * original completion ordinal — it replaces, never appends; llmMs and
  * TTFB are never re-added; and a message belonging to a route the window
  * has moved past must not resurrect its sample into the current window.
+ * The EPOCH is the authoritative gate: A → B → A returns to an equal
+ * route STRING while the window belongs to the second A lifecycle, so
+ * only `timing.routeEpoch === recent.routeEpoch` admits the replacement.
  * A replacement that turns the sample INVALID (outputTokens corrected to
  * 0) removes it: the superseded tokens must not keep feeding the recent
  * rate. */
@@ -499,6 +531,7 @@ function replaceRecentThroughput(
   recent: RecentPerformanceWindow,
 ): void {
   if (timing.routeKey !== undefined && recent.routeKey !== undefined && timing.routeKey !== recent.routeKey) return
+  if (timing.routeEpoch !== undefined && timing.routeEpoch !== recent.routeEpoch) return
   if (timing.completionOrdinal === undefined) return
   const start = timing.start
   const completed = timing.completed
@@ -711,14 +744,28 @@ function formatSeconds(ms: number): string {
   return `${trimDecimal(ms / 1000)}s`
 }
 
+/** Format a DURATION for the detail stats surface: `8.1s` under a minute,
+ * `27m54s` under an hour, `1h06m05s` beyond — the lifetime LLM wall grows
+ * into minutes and hours, where plain seconds stop being readable. */
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  if (totalSeconds < 60) return formatSeconds(ms)
+  const seconds = totalSeconds % 60
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  if (totalMinutes < 60) return `${totalMinutes}m${String(seconds).padStart(2, '0')}s`
+  const minutes = totalMinutes % 60
+  const hours = Math.floor(totalMinutes / 60)
+  return `${hours}h${String(minutes).padStart(2, '0')}m${String(seconds).padStart(2, '0')}s`
+}
+
 /**
- * Render the stats line in pi abbreviation vocabulary:
- * `↑34k ↓8.1k R520k CH93.9% | TTFB 2.6s · 51 tok/s`
+ * Render the DETAILED stats line (the /status Stats row and the
+ * statusLine payload) in pi abbreviation vocabulary:
+ * `↑34k ↓8.1k R520k CH93.9% | LLM 27m54s · TTFB 2.6s · 51 tok/s`
  * Cost (`$0.164`) is omitted: dsh's TokenUsage carries no price data.
- * The performance tail carries the RECENT metrics only — the lifetime
- * `LLM ...` wall left the line (it still accumulates in
- * {@link SessionStats.llmMs} for /stats and session analysis), so a
- * legacy composite never mixes lifetime and recent windows.
+ * The performance tail keeps BOTH windows, each labeled: the LIFETIME
+ * `LLM ...` wall (this is the detail surface that still shows it — the
+ * footer's stats row dropped it) beside the RECENT TTFB and throughput.
  * Context pressure lives in the footer's first line (progress bar), so it
  * is not repeated here. Turn/step counters live there too.
  * @param stats - the folded statistics.
@@ -733,6 +780,7 @@ export function formatStats(stats: SessionStats): string {
     stats.cacheReadTokens > 0 || stats.cacheWriteTokens > 0 ? `CH${stats.cacheHitPct.toFixed(1)}%` : '',
   ].filter(part => part !== '')
   const ownParts = [
+    `LLM ${formatDuration(stats.llmMs)}`,
     `TTFB ${formatSeconds(stats.firstTokenMsAvg)}`,
     `${stats.tokensPerSec} tok/s`,
   ]

--- a/src/status/derive-usage.ts
+++ b/src/status/derive-usage.ts
@@ -33,6 +33,8 @@ export function usageFromStats(stats: SessionStats, contextTokens?: number): Usa
     },
     ...stats.cacheReadTokens > 0 || stats.cacheWriteTokens > 0 ? { cacheHitPct: stats.cacheHitPct } : {},
     performance: {
+      // llmMs stays the session LIFETIME wall; the two status performance
+      // metrics are the RECENT (last-5) averages folded by StatsFolder.
       llmMs: stats.llmMs,
       firstTokenMs: stats.firstTokenMsAvg,
       tokensPerSec: stats.tokensPerSec,

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -118,6 +118,12 @@ export interface UsageStatus {
     readonly cacheWrite: number
   }
   readonly cacheHitPct?: number
+  /** Model performance facts. Field names are frozen for the status
+   * contract; the SEMANTICS are: `llmMs` = the session LIFETIME LLM wall
+   * (kept for /stats and analysis, not shown in the default footer),
+   * `firstTokenMs` = the RECENT (last 5) average time-to-first-token,
+   * `tokensPerSec` = the RECENT (last 5) effective output throughput
+   * (Σ output / Σ full LLM wall). */
   readonly performance: {
     readonly llmMs: number
     readonly firstTokenMs: number

--- a/test/experience.test.ts
+++ b/test/experience.test.ts
@@ -37,7 +37,7 @@ test('footer shows model, cwd, branch, counters, context bar, and stats', async 
     // facts (the legacy statsLine string is no longer a footer input).
     usage: {
       tokens: { input: 1200, output: 3400, cacheRead: 0, cacheWrite: 0 },
-      performance: { llmMs: 8100, firstTokenMs: 0, tokensPerSec: 0 },
+      performance: { llmMs: 8100, firstTokenMs: 8_100, tokensPerSec: 0 },
       turns: 2,
       steps: 5,
     },
@@ -49,7 +49,7 @@ test('footer shows model, cwd, branch, counters, context bar, and stats', async 
   assert.ok(view.includes(' main '), `branch missing:\n${view}`)
   assert.ok(view.includes('t2/s5'), `counters missing:\n${view}`)
   assert.ok(view.includes('] 25%'), `context bar missing:\n${view}`)
-  assert.ok(view.includes('↑1.2k ↓3.4k | LLM 8.1s'), `stats line missing:\n${view}`)
+  assert.ok(view.includes('↑1.2k ↓3.4k · TTFB 8.1s · 0 tok/s'), `stats line missing:\n${view}`)
 })
 
 test('plan mode shows badges in header and footer and tints the editor border', async () => {

--- a/test/extension-footer-item.test.ts
+++ b/test/extension-footer-item.test.ts
@@ -247,7 +247,7 @@ test('the configurator lists extension items in the Available section and can ad
     const layout = model.preview()
     const added = layout.rows.some(row => [...row.left, ...row.right].some(ref => ref.id.startsWith('ext:')))
     assert.ok(added, 'the extension item must be added to the draft')
-    assert.ok(!model.addMatches().some(id => id.startsWith('ext:')), 'the added item leaves the pool')
+    assert.ok(model.addMatches().some(id => id.startsWith('ext:')), 'the definition stays addable for another placement')
     view = vt.getViewport().join('\n')
     assert.ok(view.includes('kube:prod'), `the added item must render in the preview:\n${view}`)
     app.stop()

--- a/test/footer-composer-compat.test.ts
+++ b/test/footer-composer-compat.test.ts
@@ -71,37 +71,53 @@ function legacyLine1(snap: StatusSnapshot, editorEmpty: boolean, extensionText: 
   ].filter(part => part !== '')
 }
 
-/** The LEGACY stats line (formatStats of the structured usage). */
-function legacyStatsLine(snap: StatusSnapshot): string {
+/** The token-count formatter (mirrors formatTokens). */
+function fmt(count: number): string {
+  if (count < 1000) return String(count)
+  if (count < 10000) return `${(count / 1000).toFixed(1)}k`
+  if (count < 1_000_000) return `${Math.round(count / 1000)}k`
+  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`
+  return `${Math.round(count / 1_000_000)}M`
+}
+
+/** The seconds formatter (mirrors formatSeconds). */
+function sec(ms: number): string {
+  const text = (ms / 1000).toFixed(1)
+  return `${text.endsWith('.0') ? text.slice(0, -2) : text}s`
+}
+
+/** The NEW default stats row: real semantic placements (token-usage:pi,
+ * cache-hit:pi, performance:latency, performance:speed) joined by the
+ * row separator ' · '. Items whose fact is absent (no cache activity →
+ * no cacheHitPct) drop WITH their separator — mirrored here, including
+ * the semantic span tones (success = usage/cache, muted = performance). */
+function defaultStatsRow(snap: StatusSnapshot): string {
   const t = snap.usage.tokens
   const p = snap.usage.performance
-  const fmt = (count: number): string => {
-    if (count < 1000) return String(count)
-    if (count < 10000) return `${(count / 1000).toFixed(1)}k`
-    if (count < 1_000_000) return `${Math.round(count / 1000)}k`
-    if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`
-    return `${Math.round(count / 1_000_000)}M`
-  }
-  const sec = (ms: number): string => {
-    const text = (ms / 1000).toFixed(1)
-    return `${text.endsWith('.0') ? text.slice(0, -2) : text}s`
-  }
-  const piParts = [
+  const usage = [
     `↑${fmt(t.input)}`,
     `↓${fmt(t.output)}`,
     t.cacheRead > 0 ? `R${fmt(t.cacheRead)}` : '',
     t.cacheWrite > 0 ? `W${fmt(t.cacheWrite)}` : '',
-    t.cacheRead > 0 || t.cacheWrite > 0 ? `CH${(snap.usage.cacheHitPct ?? 0).toFixed(1)}%` : '',
-  ].filter(part => part !== '')
-  return `${piParts.join(' ')} | LLM ${sec(p.llmMs)} · TTFB ${sec(p.firstTokenMs)} · ${p.tokensPerSec} tok/s`
+  ].filter(part => part !== '').join(' ')
+  const spans: Array<{ text: string; tone: 'success' | 'textMuted' }> = [
+    { text: usage, tone: 'success' },
+  ]
+  if (snap.usage.cacheHitPct !== undefined) {
+    spans.push({ text: `CH${snap.usage.cacheHitPct.toFixed(1)}%`, tone: 'success' })
+  }
+  spans.push({ text: `TTFB ${sec(p.firstTokenMs)}`, tone: 'textMuted' })
+  spans.push({ text: `${p.tokensPerSec} tok/s`, tone: 'textMuted' })
+  return spans
+    .map(span => span.tone === 'success' ? color.success(span.text) : color.textMuted(span.text))
+    .join(' · ')
 }
 
 /** The REFERENCE footer rows (plan 2026-08-31 §6.2): the first row wraps
  * into 1..2 physical lines (its cap boundary cut with '…'); the tail line
  * row's allowance is the LEFTOVER capacity (up to two lines at generous
- * widths — a 42-cell stats line wraps into two FULL rows at 40 columns
- * instead of truncating), ANSI-safely truncated to the allowance when it
- * still overflows. The composer's
+ * widths), ANSI-safely truncated to the allowance when it still
+ * overflows. The composer's
  * item-level fitting can only DROP more than this reference (semantic
  * importance), never render wider or taller. */
 function referenceFooter(line1: string[], line2: string, width: number): string {
@@ -142,14 +158,14 @@ const CONTEXT = { taskBrowserAvailable: true, extensionFooterText: '' }
 
 test('default preset output is byte-equivalent to the reference footer (wide)', () => {
   const snap = mainSnapshot()
-  const expected = referenceFooter(legacyLine1(snap, true, ''), legacyStatsLine(snap), 100)
+  const expected = referenceFooter(legacyLine1(snap, true, ''), defaultStatsRow(snap), 100)
   const actual = composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
   assert.equal(actual, expected)
 })
 
 test('default preset output is byte-equivalent to the reference footer (narrow, wrapped)', () => {
   const snap = mainSnapshot()
-  const expected = referenceFooter(legacyLine1(snap, true, ''), legacyStatsLine(snap), 40)
+  const expected = referenceFooter(legacyLine1(snap, true, ''), defaultStatsRow(snap), 40)
   const actual = composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 40, context: CONTEXT })
   assert.equal(actual, expected)
 })
@@ -167,7 +183,7 @@ test('the Ctrl+C instruction appends as an INDEPENDENT line (the stats row survi
   // render beside it, position-independent.
   const snap = mainSnapshot()
   const expected = [
-    referenceFooter(legacyLine1(snap, true, ''), legacyStatsLine(snap), 100),
+    referenceFooter(legacyLine1(snap, true, ''), defaultStatsRow(snap), 100),
     color.textDim('Press Ctrl+C again to exit'),
   ].join('\n')
   const actual = composer.render({
@@ -189,7 +205,7 @@ test('permission/plan/task variants stay byte-equivalent', () => {
       collaboration: { plan: { effective: true } },
       activity: { ...snap.activity, taskCount: 1, childAgentCount: 2 },
     }
-    const expected = referenceFooter(legacyLine1(variant, true, ''), legacyStatsLine(variant), 100)
+    const expected = referenceFooter(legacyLine1(variant, true, ''), defaultStatsRow(variant), 100)
     const actual = composer.render({ snapshot: variant, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
     assert.equal(actual, expected, `permission ${permission}`)
   }
@@ -197,7 +213,7 @@ test('permission/plan/task variants stay byte-equivalent', () => {
 
 test('extension segments merge at the reference position', () => {
   const snap = mainSnapshot()
-  const expected = referenceFooter(legacyLine1(snap, true, '[EXT-SEG]'), legacyStatsLine(snap), 100)
+  const expected = referenceFooter(legacyLine1(snap, true, '[EXT-SEG]'), defaultStatsRow(snap), 100)
   const actual = composer.render({
     snapshot: snap,
     layout: DEFAULT_FOOTER_LAYOUT,
@@ -322,16 +338,16 @@ test('independent golden vectors lock the composed output (wide/narrow/compact)'
   assert.equal(
     composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
       .replace(/\x1b\[[0-9;]*m/g, ''),
-    '[workspace-write]  [deepseek/flash]  x/proj  main  [███░░░░░░░░░] 25%  t2/s5\n↑1.2k ↓3.4k | LLM 8.1s · TTFB 0s · 0 tok/s',
+    // The stats row is the semantic placements joined by ' · '; with no
+    // cache activity the cache-hit placement drops WITH its separator.
+    '[workspace-write]  [deepseek/flash]  x/proj  main  [███░░░░░░░░░] 25%  t2/s5\n↑1.2k ↓3.4k · TTFB 0s · 0 tok/s',
   )
   assert.equal(
     composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 40, context: CONTEXT })
       .replace(/\x1b\[[0-9;]*m/g, ''),
-    // 40 columns: the status row fills its 2-line allowance exactly (75
-    // cells → 2 rows) and the stats row keeps its own 1-line allowance,
-    // The capacity of 4 lets the stats row take the remaining
-    // allowance of 2 — it WRAPS into two full rows (42 ≤ 2×40 cells).
-    '[workspace-write]  [deepseek/flash]\nx/proj  main  [███░░░░░░░░░] 25%  t2/s5\n↑1.2k ↓3.4k | LLM 8.1s · TTFB 0s · 0\ntok/s',
+    // 40 columns: the status row fills its 2-line allowance (75 cells →
+    // 2 rows) and the 29-cell stats row keeps a single line.
+    '[workspace-write]  [deepseek/flash]\nx/proj  main  [███░░░░░░░░░] 25%  t2/s5\n↑1.2k ↓3.4k · TTFB 0s · 0 tok/s',
   )
   assert.equal(
     composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 20, context: CONTEXT })
@@ -340,8 +356,9 @@ test('independent golden vectors lock the composed output (wide/narrow/compact)'
     // 2×20-cell row budget — the responsive compact pass shortens the
     // items FIRST (ww/flash/proj/ctx 25%), and only what still does not
     // fit drops by importance; never a slice of the wrapped lines (plan
-    // §6.2). The stats row compacts to its pressure form too.
-    'ww  flash  proj\nmain  ctx 25%  t2/s5\n↑1.2k ↓3.4k · LLM\n8.1s · 0t/s',
+    // §6.2). The stats row's preferred form (31 cells) fits its 2-line
+    // allowance by WRAPPING — no compaction, no drop.
+    'ww  flash  proj\nmain  ctx 25%  t2/s5\n↑1.2k ↓3.4k · TTFB\n0s · 0 tok/s',
   )
   assert.equal(
     composer.render({ snapshot: snap, layout: COMPACT_FOOTER_LAYOUT, width: 100, context: CONTEXT })

--- a/test/footer-configurator-model.test.ts
+++ b/test/footer-configurator-model.test.ts
@@ -123,7 +123,7 @@ test('Space removes the active item; it returns to the Add pool', () => {
   assert.equal(idAtCursor(m), 'turns-steps')
 })
 
-test('the Add picker: search, add, the item leaves the pool, Esc clears then back', () => {
+test('the Add picker: search, add, the definition remains addable, Esc clears then back', () => {
   const m = model()
   m.activate()
   m.startAdd()
@@ -132,31 +132,74 @@ test('the Add picker: search, add, the item leaves the pool, Esc clears then bac
   // Label hit, case-insensitive.
   m.text('AGENT PRESET')
   assert.deepEqual(m.addMatches(), ['agent-preset'])
-  // id hit.
+  // id hit. The catalog lists EVERY definition now, so the description
+  // substring 'cache' also matches the placed stats-line — search with the
+  // label instead.
   for (let i = 0; i < 12; i += 1) m.backspace()
   assert.equal(m.state().addQuery, '')
-  m.text('cache')
+  m.text('cache hit')
   assert.deepEqual(m.addMatches(), ['cache-hit'])
   m.activate()
-  // The item joined the layout (the picker's side) and left the pool; a
-  // SUCCESSFUL add closes the picker (ccstatusline parity — the cursor
-  // lands on the added item).
+  // The placement joined the layout (the picker's side); the DEFINITION
+  // stays addable for another placement; a SUCCESSFUL add closes the
+  // picker (ccstatusline parity — the cursor lands on the added item).
   assert.ok(m.state().layout.rows[0]!.left.some(ref => ref.id === 'cache-hit'))
-  assert.ok(!m.addMatches().includes('cache-hit'))
+  assert.ok(m.addMatches().includes('cache-hit'))
   assert.equal(m.state().mode, 'row')
   assert.equal(idAtCursor(m), 'cache-hit', 'the cursor lands on the added item')
-  // Description hit ("wall time" matches the Performance description) —
-  // the picker reopens with a FRESH query.
+  // Description hit ("throughput" matches Performance AND the placed
+  // stats-line — the catalog is unfiltered) — the picker reopens with a
+  // FRESH query.
   m.startAdd()
   assert.equal(m.state().addQuery, '')
-  m.text('wall time')
-  assert.deepEqual(m.addMatches(), ['performance'])
+  m.text('throughput')
+  assert.deepEqual(m.addMatches(), ['stats-line', 'performance'])
   // Esc: clear the search first, then return to the row.
   assert.ok(m.cancel())
   assert.equal(m.state().addQuery, '')
   assert.equal(m.state().mode, 'add')
   m.cancel()
   assert.equal(m.state().mode, 'row')
+})
+
+test('duplicate placements: the same id appends independent, separately styled refs', () => {
+  const m = model()
+  m.activate()
+  m.startAdd()
+  m.text('performance')
+  assert.deepEqual(m.addMatches(), ['performance'])
+  m.activate() // first performance placement (the cursor lands on it)
+  assert.equal(m.state().mode, 'row')
+  // Second Add: the picker still offers performance.
+  m.startAdd()
+  m.text('performance')
+  assert.ok(m.addMatches().includes('performance'), 'a placed definition remains addable')
+  m.activate() // second performance placement (the cursor lands on it)
+  const refs = () => m.state().layout.rows[0]!.left.filter(ref => ref.id === 'performance')
+  assert.equal(refs().length, 2, 'two performance placements exist')
+  // The cursor sits on the second placement: style it Speed (full → speed).
+  m.cycleFormat()
+  assert.equal(refs()[1]!.format, 'speed', 'the second placement styles Speed')
+  // Walk back onto the first placement and style it Latency (full → speed
+  // → latency; a third cycle would return to the default and drop the
+  // override again).
+  while (m.state().cursor !== m.state().layout.rows[0]!.left.indexOf(refs()[0]!)) m.moveUp()
+  m.cycleFormat()
+  m.cycleFormat()
+  assert.equal(refs()[0]!.format, 'latency', 'the first placement styles Latency')
+  // One placement's style never leaks into the other.
+  assert.equal(refs()[1]!.format, 'speed')
+  // A third placement can live in the other zone (the first moves right).
+  m.moveZone('right')
+  const rightRefs = () => m.state().layout.rows[0]!.right.filter(ref => ref.id === 'performance')
+  assert.equal(rightRefs().length, 1, 'the moved placement lives in the right zone')
+  assert.equal(rightRefs()[0]!.format, 'latency', 'the moved placement keeps its own style')
+  assert.equal(refs().length, 1, 'one placement remains on the left')
+  assert.equal(refs()[0]!.format, 'speed', 'the left placement keeps its own style')
+  // The 32-item row cap is unchanged (independent of duplicate ids).
+  const padded = Array.from({ length: 32 }, (_, index) => ({ id: `pad-${index}` }))
+  const m2 = new FooterConfiguratorModel({ schemaVersion: 1, rows: [{ left: padded, right: [] }] }, registry)
+  assert.equal(m2.addAvailable('performance', 'left'), false, 'the row cap still refuses the 33rd placement')
 })
 
 test('the add side follows the cursor item (right zone)', () => {
@@ -166,9 +209,12 @@ test('the add side follows the cursor item (right zone)', () => {
   m.moveZone('right')
   m.startAdd()
   assert.equal(m.state().addSide, 'right')
-  m.activate() // add the first match (agent-preset)
-  assert.ok(m.state().layout.rows[0]!.right.some(ref => ref.id === 'agent-preset'))
-  assert.ok(!m.state().layout.rows[0]!.left.some(ref => ref.id === 'agent-preset'))
+  // The unfiltered query's first match is permission-preset — ALREADY
+  // placed in the left zone, so this is a live second placement.
+  m.activate()
+  assert.ok(m.state().layout.rows[0]!.right.some(ref => ref.id === 'permission-preset'))
+  assert.ok(m.state().layout.rows[0]!.left.some(ref => ref.id === 'permission-preset')
+    , 'the left placement is untouched')
 })
 
 test('Move Mode: M enters, ↑↓ reorder within the zone, Enter/Esc exits', () => {
@@ -739,6 +785,51 @@ test('PR E: rename and delete of a custom definition count as dirty', () => {
   m.activate() // confirm
   assert.equal(m.state().mode, 'row', 'delete returns to the row page')
   assert.equal(m.isDirty(), true, 'delete is dirty')
+})
+
+test('a custom definition placed MULTIPLE times: rename and delete update every ref', () => {
+  const { m, catalog } = customModel()
+  m.activate() // → row
+  m.startAdd()
+  m.text('env')
+  assert.ok(m.addMatches().includes('user:env'), 'a placed custom definition remains addable')
+  m.activate() // second placement — the cursor lands on it
+  const refs = () => [
+    ...m.state().layout.rows[0]!.left,
+    ...m.state().layout.rows[0]!.right,
+  ].filter(ref => ref.id.startsWith('user:'))
+  assert.equal(refs().length, 2, 'two placements of the same custom definition')
+
+  // Give the SECOND placement (the cursor is on it) its own tone override.
+  m.activate() // → item editor (menu: 0 Text, 1 Default tone, 2 Tone…)
+  m.moveDown()
+  m.moveDown()
+  m.activate() // tone picker
+  m.moveDown() // Primary
+  m.activate() // applies to THIS placement only
+  m.cancel() // → row
+  assert.ok(refs().some(ref => ref.tone === 'primary'), 'one placement is toned')
+  assert.ok(refs().some(ref => ref.tone === undefined), 'the other placement stays default')
+
+  // Rename the definition: every duplicate ref follows the new id and the
+  // per-placement overrides survive.
+  m.activate() // item editor (still on the second placement)
+  for (let i = 0; i < 4; i += 1) m.moveDown() // 4 Rename definition
+  m.activate() // custom-name
+  m.text('2')
+  m.activate() // commit user:env → user:env2
+  assert.equal(catalog.get('user:env2')?.kind, 'text')
+  assert.equal(catalog.has('user:env'), false)
+  assert.deepEqual(refs().map(ref => ref.id), ['user:env2', 'user:env2'], 'every duplicate ref renames')
+  assert.ok(refs().some(ref => ref.tone === 'primary'), 'the toned placement keeps its override')
+  assert.ok(refs().some(ref => ref.tone === undefined), 'the default placement keeps its absence')
+
+  // Delete the definition: every duplicate ref goes in one action.
+  m.moveDown() // 5 Delete definition
+  m.activate() // delete page
+  m.activate() // confirm
+  assert.equal(refs().length, 0, 'no dangling duplicate refs survive the delete')
+  assert.equal(catalog.has('user:env2'), false, 'the definition itself is gone')
 })
 
 test('PR E: the home selection covers rows plus the Save action', () => {

--- a/test/footer-configurator-model.test.ts
+++ b/test/footer-configurator-model.test.ts
@@ -72,8 +72,12 @@ test('the Row Selector moves between rows; Enter enters the highlighted row', ()
   assert.equal(m.state().mode, 'row')
   assert.equal(m.state().rowIndex, 1)
   assert.equal(m.state().cursor, 0)
-  // The default layout's second row has one item (stats-line).
-  assert.equal(m.state().layout.rows[1]!.left[0]!.id, 'stats-line')
+  // The default layout's second row is the semantic stats row: the usage
+  // pair leads, then cache hit, then the two performance placements.
+  assert.deepEqual(
+    m.state().layout.rows[1]!.left.map(ref => ref.id),
+    ['token-usage', 'cache-hit', 'performance', 'performance'],
+  )
 })
 
 test('Available is reachable ONLY through the Add picker (no cursor section)', () => {

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -228,6 +228,37 @@ test('A opens the Add picker; typing filters; Enter adds and closes', async () =
   app.stop()
 })
 
+test('the Row Editor distinguishes the default row\'s two Performance placements by style', async () => {
+  const { vt, app } = startApp()
+  app.setStatus({
+    model: 'deepseek/flash',
+    cwd: '/home/x/proj',
+    usage: {
+      tokens: { input: 1200, output: 3400, cacheRead: 0, cacheWrite: 0 },
+      performance: { llmMs: 8100, firstTokenMs: 2_600, tokensPerSec: 40 },
+      turns: 2,
+      steps: 5,
+    },
+  })
+  const model = openDefault(app)
+  await vt.waitForRender()
+  // Enter the DEFAULT stats row (Row 2): its duplicate performance
+  // placements must be distinguishable through the existing style column
+  // — same label, different Style (Latency vs Speed).
+  vt.sendInput('\x1b[B') // Row 2
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  const rowEditor = view.split('\n').filter(line => line.includes('Performance'))
+  assert.equal(rowEditor.length, 2, `two Performance placements must be listed:\n${view}`)
+  assert.ok(rowEditor.some(line => line.includes('Latency')), `the latency placement must show its style:\n${view}`)
+  assert.ok(rowEditor.some(line => line.includes('Speed')), `the speed placement must show its style:\n${view}`)
+  // The draft kept both placements (the duplicate id is legal data).
+  assert.equal(model.preview().rows[1]!.left.filter(ref => ref.id === 'performance').length, 2)
+  app.stop()
+})
+
 test('the Item Editor edits style/tone; the picker renders live examples', async () => {
   const { vt, app } = startApp()
   app.setStatus({ model: 'deepseek/flash', cwd: '/home/x/proj' })

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -191,8 +191,10 @@ test('A opens the Add picker; typing filters; Enter adds and closes', async () =
   let view = vt.getViewport().join('\n')
   assert.ok(view.includes('Add Item → Row 1 · Left'), `picker title missing (the add side is shown):\n${view}`)
   assert.ok(view.includes('Search:'), `search line missing:\n${view}`)
-  // Type to filter (one chunk — the paste-burst path).
-  vt.sendInput('cache')
+  // Type to filter (one chunk — the paste-burst path). The label 'cache
+  // hit' pins the match: the unfiltered catalog also carries stats-line,
+  // whose description contains 'cache'.
+  vt.sendInput('cache hit')
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('Cache hit'), `the search must filter to the match:\n${view}`)
@@ -205,14 +207,16 @@ test('A opens the Add picker; typing filters; Enter adds and closes', async () =
   assert.equal(model.state().mode, 'row', 'a successful add closes the picker')
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('Edit Row 1'), `the picker must close back into the row editor:\n${view}`)
-  // Reopen: the query is FRESH, and the added item has left the pool.
+  // Reopen: the query is FRESH, and the added definition is STILL offered
+  // (a definition may be placed repeatedly — another Add appends an
+  // independent placement).
   vt.sendInput('a')
   await vt.waitForRender()
   assert.equal(model.state().addQuery, '')
-  vt.sendInput('cache')
+  vt.sendInput('cache hit')
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
-  assert.ok(view.includes('(no matching items)'), `the pool must drop the added item:\n${view}`)
+  assert.ok(view.includes('Cache hit'), `the placed definition stays addable:\n${view}`)
   // Esc clears the search first, then returns to the row editor.
   vt.sendInput('\x1b')
   await vt.waitForRender()
@@ -416,8 +420,8 @@ test('bracketed paste split across terminal chunks buffers until the end marker'
   vt.sendInput('a')
   await vt.waitForRender()
   // Start/content/end split across chunks (slow terminals deliver paste
-  // in pieces). 'cach' filters to Cache hit (context is already IN the
-  // default layout, so the pool wouldn't list it).
+  // in pieces). 'cach' filters to Cache hit (the definition catalog lists
+  // every item; the substring still isolates the match).
   vt.sendInput('\x1b[200~c')
   await vt.waitForRender()
   vt.sendInput('ac')

--- a/test/footer-density.test.ts
+++ b/test/footer-density.test.ts
@@ -95,17 +95,19 @@ const ROW2_LAYOUT = {
 
 test('Row2 = stats-line + turns-steps compacts BEFORE dropping at moderate narrow widths', () => {
   const snap = richSnapshot()
-  // Moderate narrow (30): the full stats line cannot fit the 2-line row
+  // Moderate narrow (28): the full stats line cannot fit the 2-line row
   // budget, but the COMPACT stats line + the counters can. The pre-fix
   // behavior dropped stats-line here because its compact render was a
   // no-op — the row collapsed to `t4/s191`.
-  const text = composer.render({ snapshot: snap, layout: ROW2_LAYOUT, width: 30, context: CONTEXT })
+  const text = composer.render({ snapshot: snap, layout: ROW2_LAYOUT, width: 28, context: CONTEXT })
   const lines = plain(text).split('\n')
   assert.ok(lines.some(line => line.includes('↑34k')), `compact stats must survive:\n${plain(text)}`)
   assert.ok(lines.some(line => line.includes('t4/s191')), `the counters must survive:\n${plain(text)}`)
-  assert.ok(!plain(text).includes('TTFB'), `the full stats form must not survive at this width:\n${plain(text)}`)
+  // The compact form carries the recent TTFB; the FULL form's '|' group
+  // separator is what must not survive at this width.
+  assert.ok(!plain(text).includes('|'), `the full stats form must not survive at this width:\n${plain(text)}`)
   assert.ok(lines.length <= 4, `the whole footer stays inside the hard capacity:\n${plain(text)}`)
-  for (const line of lines) assert.ok(visibleWidth(line) <= 30, `overflow:\n${plain(text)}`)
+  for (const line of lines) assert.ok(visibleWidth(line) <= 28, `overflow:\n${plain(text)}`)
   // Extreme narrow (15): importance drop still wins (stats-line 10 <
   // turns-steps 45) — compact is a space-saving step, never a priority
   // redefinition.
@@ -148,24 +150,20 @@ test('responsive items: compact is never wider than preferred (every declared fo
   }
 })
 
-test('performance compact never exceeds a shorter persisted style (speed/latency)', () => {
+test('performance compact shortens EVERY persisted style (full/speed/latency)', () => {
   const snap = richSnapshot()
-  // The latency style is already minimal: the compact both-facts form
-  // (`138.8s 659t/s`) is WIDER, so the item must fall back to the
-  // preferred form — a legitimate no-op, never a wider compact.
+  // Latency: the TTFB marker drops under pressure (`TTFB 2.6s` → `2.6s`).
   const latencyRef: FooterItemRef = { id: 'performance', format: 'latency' }
-  assert.equal(renderDensity('performance', snap, latencyRef, 'preferred'), '2.6s')
-  assert.equal(renderDensity('performance', snap, latencyRef, 'compact'),
-    renderDensity('performance', snap, latencyRef, 'preferred'),
-    'latency compact must be a no-op (the style is already shorter)')
-  // Same for the speed style.
+  assert.equal(renderDensity('performance', snap, latencyRef, 'preferred'), 'TTFB 2.6s')
+  assert.equal(renderDensity('performance', snap, latencyRef, 'compact'), '2.6s')
+  // Speed: the tok/s unit shortens (`659 tok/s` → `659t/s`).
   const speedRef: FooterItemRef = { id: 'performance', format: 'speed' }
   assert.equal(renderDensity('performance', snap, speedRef, 'preferred'), '659 tok/s')
-  assert.equal(renderDensity('performance', snap, speedRef, 'compact'),
-    renderDensity('performance', snap, speedRef, 'preferred'),
-    'speed compact must be a no-op (the style is already shorter)')
-  // The full style still gets the strictly shorter both-facts compact.
-  assert.equal(renderDensity('performance', snap, { id: 'performance', format: 'full' }, 'compact'), '138.8s 659t/s')
+  assert.equal(renderDensity('performance', snap, speedRef, 'compact'), '659t/s')
+  // The full style keeps BOTH facts with the shortened units — it never
+  // degrades to a single-fact style.
+  assert.equal(renderDensity('performance', snap, { id: 'performance', format: 'full' }, 'preferred'), 'TTFB 2.6s · 659 tok/s')
+  assert.equal(renderDensity('performance', snap, { id: 'performance', format: 'full' }, 'compact'), '2.6s 659t/s')
 })
 
 test('token-usage compact never exceeds a shorter persisted io style (cache-heavy)', () => {
@@ -196,8 +194,8 @@ test('B-class compact presentations match the agreed golden strings', () => {
     ['queue', 'q3'],
     ['agents', 'a2'],
     ['todo', 'td3'],
-    ['performance', '138.8s 659t/s'],
-    ['stats-line', '↑34k ↓8.1k · LLM 138.8s · 659t/s'],
+    ['performance', '2.6s 659t/s'],
+    ['stats-line', '↑34k ↓8.1k · TTFB 2.6s · 659t/s'],
   ]
   for (const [id, expected] of cases) {
     assert.equal(renderDensity(id, snap, { id }, 'compact'), expected, `${id} compact golden`)
@@ -267,13 +265,15 @@ test('the width matrix locks preferred → compact → importance-drop → trunc
   const snap = richSnapshot()
   const at = (width: number): string =>
     plain(composer.render({ snapshot: snap, layout: ROW2_LAYOUT, width, context: CONTEXT }))
-  // Wide: the full stats line renders (preferred).
+  // Wide: the full stats line renders (preferred) — recent TTFB and the
+  // effective throughput, no lifetime LLM wall.
   const wide = at(120)
-  assert.ok(wide.includes('LLM 138.8s') && wide.includes('tok/s'), `wide must keep the full stats:\n${wide}`)
+  assert.ok(wide.includes('TTFB 2.6s') && wide.includes('tok/s'), `wide must keep the full stats:\n${wide}`)
+  assert.ok(!wide.includes('LLM'), `the lifetime LLM wall never renders:\n${wide}`)
   // Moderate narrow: compact stats + counters (never a straight drop).
-  const moderate = at(30)
+  const moderate = at(28)
   assert.ok(moderate.includes('↑34k') && moderate.includes('t4/s191'), `moderate must compact first:\n${moderate}`)
-  assert.ok(!moderate.includes('TTFB'), `moderate must not keep the full stats:\n${moderate}`)
+  assert.ok(!moderate.includes('|'), `moderate must not keep the full stats:\n${moderate}`)
   // Narrower: importance drop (stats-line 10 < turns-steps 45).
   const narrow = at(15)
   assert.ok(narrow.includes('t4/s191') && !narrow.includes('↑'), `narrow must drop by importance:\n${narrow}`)

--- a/test/footer-fullscreen-narrow.test.ts
+++ b/test/footer-fullscreen-narrow.test.ts
@@ -35,7 +35,7 @@ const RICH_STATUS: StatusData = {
   contextWindow: 10000,
   usage: {
     tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    performance: { llmMs: 12300, firstTokenMs: 0, tokensPerSec: 0 },
+    performance: { llmMs: 12300, firstTokenMs: 12_300, tokensPerSec: 0 },
     turns: 3,
     steps: 7,
   },
@@ -169,7 +169,7 @@ test('the armed Ctrl+C instruction never pushes the footer out of a narrow fulls
     const view = lines.join('\n')
     assert.ok(view.includes('Press Ctrl+C again to exit'), `the exit hint must stay visible:\n${view}`)
     assert.ok(view.includes('workspace-write') || view.includes('ww'), `the status row must survive beside the hint:\n${view}`)
-    assert.ok(view.includes('LLM 12.3s'), `the stats row must survive beside the hint:\n${view}`)
+    assert.ok(view.includes('TTFB 12.3s'), `the stats row must survive beside the hint:\n${view}`)
     const footerLines = [...app.footerRenderRowsForTest()]
     assert.equal(footerLines.length, 3, `the footer with its instruction must stay inside the effective budget:\n${view}`)
     assert.ok(footerLines[footerLines.length - 1]!.includes('Press Ctrl+C again'), `the hint must be the footer's last line:\n${view}`)

--- a/test/footer-items.test.ts
+++ b/test/footer-items.test.ts
@@ -171,7 +171,10 @@ test('stats-line renders the pi vocabulary from the structured usage', () => {
     snap.usage.tokens = { input: 1200, output: 3400, cacheRead: 0, cacheWrite: 0 }
     snap.usage.performance = { llmMs: 8100, firstTokenMs: 0, tokensPerSec: 0 }
   }))
-  assert.equal(text, '↑1.2k ↓3.4k | LLM 8.1s · TTFB 0s · 0 tok/s')
+  // The performance tail is recent-only — the lifetime LLM wall never
+  // appears in the display line.
+  assert.equal(text, '↑1.2k ↓3.4k | TTFB 0s · 0 tok/s')
+  assert.ok(!text.includes('LLM'))
 })
 
 test('view-scope renders the legacy viewer identity block', () => {
@@ -257,15 +260,24 @@ test('builtin styles render meaningful golden variants without changing defaults
     },
     {
       id: 'token-usage',
-      formats: [['io', '1200/3400'], ['total', '6.7k tokens'], ['compact', '6.7k']],
+      formats: [
+        ['pi', '↑1.2k ↓3.4k R2.0k W100'],
+        ['io', '1200/3400'],
+        ['total', '6.7k tokens'],
+        ['compact', '6.7k'],
+      ],
     },
     {
       id: 'cache-hit',
-      formats: [['full', 'C 91.9%'], ['compact', '91.9%']],
+      formats: [['pi', 'CH91.9%'], ['full', 'C 91.9%'], ['compact', '91.9%']],
     },
     {
       id: 'performance',
-      formats: [['full', '1104s 40 tok/s'], ['speed', '40 tok/s'], ['latency', '1.8s']],
+      formats: [
+        ['full', 'TTFB 1.8s · 40 tok/s'],
+        ['speed', '40 tok/s'],
+        ['latency', 'TTFB 1.8s'],
+      ],
     },
     {
       id: 'turns-steps',
@@ -307,7 +319,7 @@ test('builtin styles render meaningful golden variants without changing defaults
   assert.equal(render('context', snap), '[███░░░░░░░░░] 25%')
   assert.equal(render('token-usage', snap), '1200/3400')
   assert.equal(render('cache-hit', snap), 'C 91.9%')
-  assert.equal(render('performance', snap), '1104s 40 tok/s')
+  assert.equal(render('performance', snap), 'TTFB 1.8s · 40 tok/s')
   assert.equal(render('turns-steps', snap), 't3/s7')
 })
 
@@ -335,14 +347,15 @@ test('new builtin styles fall back to the unchanged default formatter', () => {
   assert.equal(render('turns-steps', snap, { id: 'turns-steps', format: 'unknown' }), 't0/s0')
   assert.equal(render('cache-hit', snap, { id: 'cache-hit', format: 'unknown' }), 'C 50.0%')
   assert.equal(render('token-usage', snap, { id: 'token-usage', format: 'unknown' }), '1200/3400')
-  assert.equal(render('performance', snap, { id: 'performance', format: 'unknown' }), '8.1s 40 tok/s')
+  assert.equal(render('performance', snap, { id: 'performance', format: 'unknown' }), 'TTFB 0s · 40 tok/s')
   assert.equal(render('version', snap, { id: 'version', format: 'unknown' }), 'v0.0.0')
   // `plain` (turns) and `compact` (performance) appeared in older custom
   // documents even though they were never declared meaningful styles. They
   // still degrade to the same effective legacy defaults instead of changing
-  // old layouts on load.
+  // old layouts on load (performance's legacy 'compact' fallback is the
+  // full style — now the recent TTFB + throughput pair).
   assert.equal(render('turns-steps', snap, { id: 'turns-steps', format: 'plain' }), 't0/s0')
-  assert.equal(render('performance', snap, { id: 'performance', format: 'compact' }), '8.1s 40 tok/s')
+  assert.equal(render('performance', snap, { id: 'performance', format: 'compact' }), 'TTFB 0s · 40 tok/s')
 })
 
 test('unknown persisted formats survive parsing and fail soft in the real composer', () => {
@@ -373,7 +386,8 @@ test('unknown persisted formats survive parsing and fail soft in the real compos
     assert.ok(visibleWidth(row) <= 40, `composer output overflows: ${JSON.stringify(row)}`)
   }
   const text = plain(output)
-  assert.ok(text.includes('8.1s 40 tok/s'), `performance must use its default: ${text}`)
+  assert.ok(text.includes('TTFB 0s · 40 tok/s'), `performance must use its default: ${text}`)
+  assert.ok(!text.includes('LLM'), `no lifetime LLM wall in the performance tail: ${text}`)
   assert.ok(text.includes('C 50.0%'), `cache hit must use its default: ${text}`)
   assert.ok(text.includes('1200/3400'), `token usage must use its default: ${text}`)
 })
@@ -398,6 +412,53 @@ test('an unknown format string degrades to the item default, never throws', () =
     snap.usage.context = { usedTokens: 25000, windowTokens: 100000, percent: 25 }
   }), { id: 'x', format: 'zzz' })
   assert.equal(context, '[███░░░░░░░░░] 25%', 'the unknown context format must fall back to the default bar')
+})
+
+test('the split performance styles render distinct preferred/compact forms', () => {
+  const snap = snapshotWith(snap => {
+    snap.usage.performance = { llmMs: 138_800, firstTokenMs: 2_600, tokensPerSec: 659 }
+  })
+  const def = registry.get('performance')!
+  const renderAt = (format: string, density: 'preferred' | 'compact'): string => {
+    const segment = def.render(snap, { id: 'performance', format }, density, CONTEXT)
+    return segment === null ? '' : plain(renderSpans(segment.spans))
+  }
+  // preferred: latency carries the TTFB marker, speed the tok/s unit.
+  assert.equal(renderAt('latency', 'preferred'), 'TTFB 2.6s')
+  assert.equal(renderAt('speed', 'preferred'), '659 tok/s')
+  assert.equal(renderAt('full', 'preferred'), 'TTFB 2.6s · 659 tok/s')
+  // compact: shortened forms (the Row Editor's two placements still read
+  // distinctly through their style column).
+  assert.equal(renderAt('latency', 'compact'), '2.6s')
+  assert.equal(renderAt('speed', 'compact'), '659t/s')
+  assert.equal(renderAt('full', 'compact'), '2.6s 659t/s')
+  // The lifetime LLM wall is gone from every form.
+  for (const format of ['full', 'speed', 'latency']) {
+    for (const density of ['preferred', 'compact'] as const) {
+      assert.ok(!renderAt(format, density).includes('138.8'), `${format}/${density} must not show llmMs`)
+    }
+  }
+})
+
+test('token-usage:pi and cache-hit:pi render the pi vocabulary with compact pressure forms', () => {
+  const snap = snapshotWith(snap => {
+    snap.usage.tokens = { input: 114_000_000, output: 54_000, cacheRead: 520_000, cacheWrite: 12_000 }
+    snap.usage.cacheHitPct = 93.9
+  })
+  // Zero-valued cache terms hide (the plan's preferred example).
+  const noCache = snapshotWith(snap => {
+    snap.usage.tokens = { input: 114_000_000, output: 54_000, cacheRead: 0, cacheWrite: 0 }
+  })
+  assert.equal(render('token-usage', noCache, { id: 'token-usage', format: 'pi' }), '↑114M ↓54k')
+  assert.equal(render('token-usage', snap, { id: 'token-usage', format: 'pi' }), '↑114M ↓54k R520k W12k')
+  assert.equal(render('cache-hit', snap, { id: 'cache-hit', format: 'pi' }), 'CH93.9%')
+  // Compact pressure keeps the io pair and drops the cache detail.
+  const def = registry.get('token-usage')!
+  const segment = def.render(snap, { id: 'token-usage', format: 'pi' }, 'compact', CONTEXT)
+  assert.equal(segment === null ? '' : plain(renderSpans(segment.spans)), '↑114M ↓54k')
+  const cacheDef = registry.get('cache-hit')!
+  const cacheSegment = cacheDef.render(snap, { id: 'cache-hit', format: 'pi' }, 'compact', CONTEXT)
+  assert.equal(cacheSegment === null ? '' : plain(renderSpans(cacheSegment.spans)), '93.9%')
 })
 
 test('formatStatsLine is source-consistent with the legacy formatStats (guarded)', async () => {

--- a/test/footer-items.test.ts
+++ b/test/footer-items.test.ts
@@ -461,26 +461,35 @@ test('token-usage:pi and cache-hit:pi render the pi vocabulary with compact pres
   assert.equal(cacheSegment === null ? '' : plain(renderSpans(cacheSegment.spans)), '93.9%')
 })
 
-test('formatStatsLine is source-consistent with the legacy formatStats (guarded)', async () => {
-  // The formatter's doc comment claims a source-consistency guard — make
-  // it real: the structured stats line must equal the legacy pi-vocabulary
-  // line for the same stats.
+test('the footer stats line and the /status detail line are SEPARATE contracts', async () => {
+  // The footer's stats-line is chrome: recent metrics only, no lifetime
+  // LLM wall. formatStats is the /status DETAIL line: it keeps the labeled
+  // lifetime wall beside the recent metrics. They share the pi token
+  // vocabulary but must never be forced into string equality — the old
+  // source-consistency guard pinned them together and would have dragged
+  // the LLM wall back into every footer.
   const { formatStatsLine } = await import('../src/footer/formatters.ts')
   const { formatStats } = await import('../src/stats.ts')
   const { usageFromStats } = await import('../src/status/derive-usage.ts')
   const stats = {
     turns: 12,
     steps: 38,
-    llmMs: 120000,
-    firstTokenMsAvg: 2000,
+    llmMs: 120_000,
+    firstTokenMsAvg: 2_000,
     tokensPerSec: 40,
     cacheHitPct: 91.9,
-    inputTokens: 2579,
-    outputTokens: 5507,
+    inputTokens: 2_579,
+    outputTokens: 5_507,
     contextWindow: 1_000_000,
-    cacheReadTokens: 20000,
+    cacheReadTokens: 20_000,
     cacheWriteTokens: 0,
   }
-  assert.equal(formatStatsLine(usageFromStats(stats as never)), formatStats(stats as never),
-    'formatStatsLine must mirror formatStats exactly')
+  const footerLine = formatStatsLine(usageFromStats(stats as never))
+  const detailLine = formatStats(stats as never)
+  assert.ok(!footerLine.includes('LLM'), `the footer line carries no lifetime wall:\n${footerLine}`)
+  assert.ok(footerLine.includes('TTFB 2s') && footerLine.includes('40 tok/s'), `recent metrics on the footer line:\n${footerLine}`)
+  assert.ok(detailLine.includes('LLM 2m00s'), `the detail line keeps the lifetime wall:\n${detailLine}`)
+  assert.ok(detailLine.includes('TTFB 2s') && detailLine.includes('40 tok/s'), `recent metrics on the detail line:\n${detailLine}`)
+  // The token/cache prefix stays IDENTICAL between the two surfaces.
+  assert.ok(footerLine.split(' | ')[0] === detailLine.split(' | ')[0], `shared pi vocabulary:\n${footerLine}\n${detailLine}`)
 })

--- a/test/footer-layout-settings.test.ts
+++ b/test/footer-layout-settings.test.ts
@@ -126,13 +126,16 @@ test('the custom layout renders the screenshot-like acceptance fixture', async (
   // The plan's screenshot-like line: model │ cwd │ context │ cache │
   // tokens │ performance │ version ... focus. The M2 items render the
   // structured facts (the plan's exact token spellings are formatter
-  // choices — the pi vocabulary applies, so 2000ms renders `2s`).
+  // choices — the pi vocabulary applies, so 2000ms renders `2s`). The
+  // row is width-pressured at 100 columns, so the low-importance
+  // performance item renders its compact form (`2s 40t/s`) — both recent
+  // facts (TTFB + throughput) survive.
   assert.ok(view.includes('deepseek-v4-flash'), `model missing:\n${view}`)
   assert.ok(view.includes('space4'), `project cwd missing:\n${view}`)
   assert.ok(view.includes('160k/1.0M (16%)'), `context missing:\n${view}`)
   assert.ok(view.includes('C 91.9%'), `cache-hit missing:\n${view}`)
   assert.ok(view.includes('2579/5507'), `token-usage missing:\n${view}`)
-  assert.ok(view.includes('2s 40 tok/s'), `performance missing:\n${view}`)
+  assert.ok(view.includes('2s 40t/s'), `performance missing:\n${view}`)
   assert.ok(view.includes('v0.3.3'), `version missing:\n${view}`)
   assert.ok(view.includes('focus'), `focus-mode missing:\n${view}`)
   app.stop()

--- a/test/footer-layout.test.ts
+++ b/test/footer-layout.test.ts
@@ -8,11 +8,21 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { isFooterLayout, parseFooterLayout, resolveCommandFooterFallback, stripControlChars } from '../src/footer/layout.ts'
-import { DEFAULT_FOOTER_LAYOUT } from '../src/footer/presets.ts'
+import { COMPACT_FOOTER_LAYOUT, DEFAULT_FOOTER_LAYOUT } from '../src/footer/presets.ts'
 
 test('the builtin default layout parses as valid', () => {
   const parsed = parseFooterLayout(DEFAULT_FOOTER_LAYOUT)
   assert.ok(isFooterLayout(parsed), `default layout must parse: ${JSON.stringify(parsed)}`)
+})
+
+test('the presets never share placement objects (no cross-preset aliasing)', () => {
+  // The status-row placements come from a FACTORY: mutating one preset's
+  // refs (a runtime consumer ignoring the readonly types) must never
+  // reach the other preset.
+  const defaultRef = DEFAULT_FOOTER_LAYOUT.rows[0]!.left[0]!
+  const compactRef = COMPACT_FOOTER_LAYOUT.rows[0]!.left[0]!
+  assert.notEqual(defaultRef, compactRef, 'each preset owns its placement objects')
+  assert.deepEqual(defaultRef, compactRef, 'the placement content is identical')
 })
 
 test('a custom layout with zones, separator, formats and tones parses', () => {

--- a/test/footer-layout.test.ts
+++ b/test/footer-layout.test.ts
@@ -36,6 +36,32 @@ test('a custom layout with zones, separator, formats and tones parses', () => {
   assert.equal(layout.rows[0]!.separator?.text, ' │ ')
 })
 
+test('DUPLICATE item ids parse in order with every ref intact (repeated placements)', () => {
+  // The ordered array IS the placement identity (rowIndex + zone + index):
+  // the same definition may be placed repeatedly with independent
+  // overrides — no instance id, no schema change (schemaVersion stays 1).
+  const parsed = parseFooterLayout({
+    schemaVersion: 1,
+    rows: [{
+      left: [
+        { id: 'performance', format: 'latency' },
+        { id: 'performance', format: 'speed' },
+        { id: 'user:env', tone: 'primary' },
+        { id: 'user:env', importance: 10 },
+      ],
+      right: [{ id: 'performance' }],
+    }],
+  })
+  assert.ok(isFooterLayout(parsed), `duplicate placements must parse: ${JSON.stringify(parsed)}`)
+  const layout = parsed as Exclude<typeof parsed, { kind: 'error' }>
+  const left = layout.rows[0]!.left
+  assert.deepEqual(left.map(ref => ref.id), ['performance', 'performance', 'user:env', 'user:env'])
+  assert.deepEqual(left.map(ref => ref.format), ['latency', 'speed', undefined, undefined])
+  assert.equal(left[2]!.tone, 'primary')
+  assert.equal(left[3]!.importance, 10)
+  assert.deepEqual(layout.rows[0]!.right.map(ref => ref.id), ['performance'])
+})
+
 test('invalid documents fail soft with a message', () => {
   const cases: Array<[unknown, RegExp]> = [
     [null, /must be an object/],

--- a/test/footer-responsive.test.ts
+++ b/test/footer-responsive.test.ts
@@ -11,6 +11,7 @@ import test from 'node:test'
 import { visibleWidth } from '@xmoon76/pi-tui'
 import { FooterComposer } from '../src/footer/composer.ts'
 import { createBuiltinFooterRegistry } from '../src/footer/builtin-items.ts'
+import { DEFAULT_FOOTER_LAYOUT } from '../src/footer/presets.ts'
 import { emptyStatusSnapshot, type StatusSnapshot } from '../src/status/types.ts'
 
 const composer = new FooterComposer(createBuiltinFooterRegistry())
@@ -217,6 +218,63 @@ test('extreme narrow widths never crash and never produce negative padding', () 
     assert.equal(typeof text, 'string')
     for (const row of text.split('\n')) {
       assert.ok(visibleWidth(row) <= Math.max(1, width), `row overflows at ${width}`)
+    }
+  }
+})
+
+test('the default stats row drops cache-hit, then TTFB, then speed — usage survives longest', () => {
+  // The default row-2 per-ref importance overrides define the drop order
+  // (plan §3.3): cache-hit(30) → performance:latency(40) →
+  // performance:speed(45) → token-usage(55). At moderate widths the row
+  // WRAPS first (the preferred form fits 1..2 physical lines); the
+  // compact → drop cascade engages below that.
+  const snap = emptyStatusSnapshot() as DeepMutable<StatusSnapshot>
+  snap.usage = {
+    tokens: { input: 34_000, output: 8_100, cacheRead: 520_000, cacheWrite: 12_000 },
+    cacheHitPct: 93.9,
+    performance: { llmMs: 138_800, firstTokenMs: 2_600, tokensPerSec: 659 },
+    turns: 4,
+    steps: 191,
+  }
+  const at = (width: number): string => composer
+    .render({ snapshot: snap as StatusSnapshot, layout: DEFAULT_FOOTER_LAYOUT, width, context: CONTEXT })
+    .replace(/\x1b\[[0-9;]*m/g, '')
+
+  // Wide: the full preferred row renders every placement.
+  const wide = at(60)
+  assert.ok(wide.includes('↑34k ↓8.1k R520k W12k'), `usage preferred:\n${wide}`)
+  assert.ok(wide.includes('CH93.9%') && wide.includes('TTFB 2.6s') && wide.includes('659 tok/s'), `full row:\n${wide}`)
+
+  // Moderate: the compact pass shortens cache-hit FIRST (CH93.9% → 93.9%)
+  // — the lowest-importance placement is always the first victim.
+  const moderate = at(30)
+  assert.ok(!moderate.includes('CH'), `cache-hit compacts first:\n${moderate}`)
+  assert.ok(moderate.includes('93.9%'), `the compact cache form survives:\n${moderate}`)
+
+  // Narrower: the compact cascade reaches the TTFB marker (TTFB 2.6s →
+  // 2.6s) and the io pair drops its cache detail (↑34k ↓8.1k).
+  const narrow = at(22)
+  assert.ok(!narrow.includes('TTFB'), `latency compacts next:\n${narrow}`)
+  assert.ok(narrow.includes('2.6s'), `the compact latency value survives:\n${narrow}`)
+
+  // Extreme: the DROPS start — cache-hit goes first (93.9% gone), TTFB
+  // second (2.6s gone); the session usage + the speed signal are the last
+  // meaningful pair on the row.
+  const extreme = at(12)
+  assert.ok(!extreme.includes('93.9%'), `cache-hit drops first:\n${extreme}`)
+  assert.ok(!extreme.includes('2.6s'), `the TTFB placement drops second:\n${extreme}`)
+  assert.ok(extreme.includes('↑34k'), `session usage survives:\n${extreme}`)
+  assert.ok(extreme.includes('659t/s'), `a recent speed signal survives:\n${extreme}`)
+
+  // Degenerate: only the usage pair remains — it outlives the speed
+  // signal (usage is the highest-importance placement on the row).
+  const degenerate = at(8)
+  assert.ok(degenerate.includes('↑34k'), `usage is the last survivor:\n${degenerate}`)
+  assert.ok(!degenerate.includes('659'), `speed drops before usage:\n${degenerate}`)
+  for (const width of [60, 40, 30, 22, 14, 12, 8]) {
+    const text = composer.render({ snapshot: snap as StatusSnapshot, layout: DEFAULT_FOOTER_LAYOUT, width, context: CONTEXT })
+    for (const line of text.split('\n')) {
+      assert.ok(visibleWidth(line) <= Math.max(1, width), `overflow at ${width}: ${JSON.stringify(line)}`)
     }
   }
 })

--- a/test/footer-row-budget.test.ts
+++ b/test/footer-row-budget.test.ts
@@ -88,10 +88,10 @@ test('every logical row of the default layout stays inside the 1..2-line row con
     // The stats row keeps at least one visible line within its allowance —
     // with the hard capacity of 4 it may even wrap INTO two when the
     // surface has the room (its demand is lower in layout order). At
-    // degenerate widths the truncated stats line may no longer carry its
-    // 'LLM' text, only its leading '↑' counter.
+    // degenerate widths the truncated stats row may no longer carry its
+    // 'tok/s' text, only its leading '↑' counter.
     if (width > 4) {
-      const stats = lines.find(line => line.includes('LLM') || line.includes('↑'))
+      const stats = lines.find(line => line.includes('tok/s') || line.includes('↑'))
       assert.ok(stats !== undefined && visibleWidth(stats) <= Math.max(1, width), `stats row lost at ${width}:\n${JSON.stringify(lines)}`)
     }
   }
@@ -164,7 +164,7 @@ test('the Host instruction reserves its line; capacity 4 gives status 2 + stats 
   assert.equal(lines.length, 4, `2 + 1 + hint inside the capacity of 4:\n${JSON.stringify(lines)}`)
   assert.ok(lines[lines.length - 1]!.includes('Press Ctrl+C again to exit'), `the hint must be its own line:\n${JSON.stringify(lines)}`)
   assert.ok(lines.some(line => line.includes('yolo')), `the status row must survive:\n${JSON.stringify(lines)}`)
-  assert.ok(lines.some(line => line.includes('LLM')), `the stats row must survive (not be replaced):\n${JSON.stringify(lines)}`)
+  assert.ok(lines.some(line => line.includes('tok/s')), `the stats row must survive (not be replaced):\n${JSON.stringify(lines)}`)
 })
 
 test('a 3-row layout under the DEFAULT budget fits beside the instruction', () => {
@@ -197,7 +197,7 @@ test('a DYNAMIC total of 2 still keeps the instruction and drops the stats tail'
   assert.equal(lines.length, 2, `exactly the surface budget, hint included:\n${JSON.stringify(lines)}`)
   assert.ok(lines[lines.length - 1]!.includes('Press Ctrl+C again to exit'), `the hint must be last:\n${JSON.stringify(lines)}`)
   assert.ok(lines.some(line => line.includes('yolo')), `the highest-importance row must survive:\n${JSON.stringify(lines)}`)
-  assert.ok(!lines.some(line => line.includes('LLM')), `the stats tail must drop under height pressure:\n${JSON.stringify(lines)}`)
+  assert.ok(!lines.some(line => line.includes('tok/s')), `the stats tail must drop under height pressure:\n${JSON.stringify(lines)}`)
 })
 
 test('a capacity of 4 lets BOTH rows wrap (2 + 2) when no instruction competes', () => {

--- a/test/footer-view-subject.test.ts
+++ b/test/footer-view-subject.test.ts
@@ -48,7 +48,7 @@ function enterViewer(snap: StatusSnapshot, mode: 'one-shot' | 'continuable', act
   mutable.workspace = { cwd: '/child/ws', project: 'ws' }
   mutable.usage = {
     tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    performance: { llmMs: 12300, firstTokenMs: 0, tokensPerSec: 0 },
+    performance: { llmMs: 12300, firstTokenMs: 12_300, tokensPerSec: 0 },
     turns: 3,
     steps: 5,
   }
@@ -63,7 +63,7 @@ test('the viewer footer composes the SAME preset with the child data (one-shot)'
   assert.ok(text.includes('inactive'), `activity missing:\n${text}`)
   assert.ok(text.includes('ws'), `child cwd missing:\n${text}`)
   assert.ok(text.includes('t3/s5'), `child counters missing:\n${text}`)
-  assert.ok(text.includes('LLM 12.3s'), `child stats line missing:\n${text}`)
+  assert.ok(text.includes('TTFB 12.3s'), `child stats line missing:\n${text}`)
   // The parent's main-only facts never leak in.
   assert.ok(!text.includes('parent'), `the parent model must not leak:\n${text}`)
   assert.ok(!text.includes('[yolo]'), `the parent permission must not leak:\n${text}`)
@@ -86,7 +86,7 @@ test('the compact preset drops the child stats row while viewing', () => {
   enterViewer(snap, 'one-shot', 'inactive')
   const text = composer.render({ snapshot: snap, layout: COMPACT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
   assert.ok(text.includes('[subagent · one-shot]'), `viewer badge missing:\n${text}`)
-  assert.ok(!text.includes('LLM 12.3s'), `compact must drop the stats line:\n${text}`)
+  assert.ok(!text.includes('TTFB 12.3s'), `compact must drop the stats line:\n${text}`)
 })
 
 test('returning to the main subject restores the parent footer', () => {

--- a/test/footer-wrap.test.ts
+++ b/test/footer-wrap.test.ts
@@ -47,7 +47,7 @@ const SHORT_STATUS: StatusData = {
   // M1: the footer composes the stats line from the STRUCTURED usage.
   usage: {
     tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    performance: { llmMs: 12300, firstTokenMs: 0, tokensPerSec: 0 },
+    performance: { llmMs: 12300, firstTokenMs: 12_300, tokensPerSec: 0 },
     turns: 3,
     steps: 7,
   },

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -1207,20 +1207,20 @@ test('footer preset hides the stats line in compact mode', async () => {
     // M1: the stats line composes from the structured usage facts.
     usage: {
       tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      performance: { llmMs: 8100, firstTokenMs: 0, tokensPerSec: 0 },
+      performance: { llmMs: 8100, firstTokenMs: 8_100, tokensPerSec: 0 },
       turns: 0,
       steps: 0,
     },
   })
   let view = await viewport(vt)
-  assert.ok(view.includes('LLM 8.1s'), `stats line missing in full mode:\n${view}`)
+  assert.ok(view.includes('TTFB 8.1s'), `stats line missing in full mode:\n${view}`)
   app.setFooterPreset('compact')
   view = await viewport(vt)
-  assert.ok(!view.includes('LLM 8.1s'), `stats line visible in compact mode:\n${view}`)
+  assert.ok(!view.includes('TTFB 8.1s'), `stats line visible in compact mode:\n${view}`)
   assert.ok(view.includes('[m]'), `line 1 missing:\n${view}`)
   app.setFooterPreset('full')
   view = await viewport(vt)
-  assert.ok(view.includes('LLM 8.1s'), `stats line not restored:\n${view}`)
+  assert.ok(view.includes('TTFB 8.1s'), `stats line not restored:\n${view}`)
 })
 
 test('autoDetectTheme resolves without changing the theme when the terminal is silent', async () => {

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -132,8 +132,9 @@ test('first-token semantics match the Web isTokenDelta: reasoning deltas start t
     event('step/end', { turn: 1, step: 0 }, 8, t + 8_000),
   ]
   const stats = computeStats(log)
-  // Step 0: 450 tokens / 4500 ms = 100 tok/s. Step 1: 50 / 500 ms = 100.
-  assert.equal(stats.tokensPerSec, 100, `decode window must start at the first reasoning delta:\n${JSON.stringify(stats)}`)
+  // Step 0: 450 tokens / 5000 ms full wall = 90 tok/s. Step 1: 50 / 600 ms.
+  // The effective throughput pools BOTH steps: 500 tokens / 5600 ms.
+  assert.equal(stats.tokensPerSec, Math.round((500 * 1000) / 5_600), `effective throughput uses the full LLM wall:\n${JSON.stringify(stats)}`)
   // TTFT averages both steps: 500 ms (step 0: start → first reasoning
   // delta) and 100 ms (step 1: start → first tool-call delta).
   assert.equal(stats.firstTokenMsAvg, 300)
@@ -246,52 +247,37 @@ test('higher turn/end advances the shared usage fence before older turn/end', ()
   assert.equal(computeStats(prefix).outputTokens, 20)
 })
 
-test('StatsFolder stores sampled decode duration as a scalar', () => {
+test('StatsFolder keeps the recent throughput window bounded', () => {
   const t = 1_700_000_000_000
   const folder = new StatsFolder()
-  folder.apply([
-    event('step/start', { turn: 0, step: 0 }, 0, t),
-    event('assistant/chunk', {
-      turn: 0,
-      step: 0,
-      chunk: { type: 'text-delta', index: 0, text: 'answer' },
-    }, 1, t + 100),
-    event('assistant/message', {
-      turn: 0,
-      step: 0,
-      message: {
-        id: MessageId('m-scalar'),
-        role: 'assistant',
-        content: [{ type: 'text', text: 'answer' }],
-        source: { kind: 'model', provider: 'p', model: 'm' },
-      },
-      usage: { inputTokens: 10, outputTokens: 100 },
-    }, 2, t + 1_100),
-    event('step/end', { turn: 0, step: 0 }, 3, t + 1_200),
-    event('step/start', { turn: 0, step: 1 }, 4, t + 2_000),
-    event('assistant/chunk', {
-      turn: 0,
-      step: 1,
-      chunk: { type: 'text-delta', index: 0, text: 'more' },
-    }, 5, t + 2_100),
-    event('assistant/message', {
-      turn: 0,
-      step: 1,
-      message: {
-        id: MessageId('m-scalar-2'),
-        role: 'assistant',
-        content: [{ type: 'text', text: 'more' }],
-        source: { kind: 'model', provider: 'p', model: 'm' },
-      },
-      usage: { inputTokens: 5, outputTokens: 50 },
-    }, 6, t + 2_600),
-    event('step/end', { turn: 0, step: 1 }, 7, t + 2_700),
-  ])
-  const throughput = (folder as unknown as { throughput: { outputMsTotal: number; outputMs?: unknown } }).throughput
-  assert.equal(throughput.outputMsTotal, 1_500)
-  assert.equal(throughput.outputMs, undefined, 'a long session must not retain every decode sample')
-  assert.equal(folder.snapshot().tokensPerSec, 100)
-  assert.equal(folder.snapshot().outputTokens, 150)
+  // 12 completed steps: the window must hold only the LATEST 5 samples.
+  for (let step = 0; step < 12; step += 1) {
+    folder.apply([
+      event('step/start', { turn: 0, step }, step * 10, t + step * 1_000),
+      event('assistant/chunk', {
+        turn: 0,
+        step,
+        chunk: { type: 'text-delta', index: 0, text: 'answer' },
+      }, step * 10 + 1, t + step * 1_000 + 100),
+      event('assistant/message', {
+        turn: 0,
+        step,
+        message: {
+          id: MessageId(`m-bounded-${step}`),
+          role: 'assistant',
+          content: [{ type: 'text', text: 'answer' }],
+          source: { kind: 'model', provider: 'p', model: 'm' },
+        },
+        usage: { inputTokens: 10, outputTokens: 100 },
+      }, step * 10 + 2, t + step * 1_000 + 500),
+      event('step/end', { turn: 0, step }, step * 10 + 3, t + step * 1_000 + 600),
+    ])
+  }
+  const internals = folder as unknown as { recent: { throughput: unknown[]; ttft: unknown[] } }
+  assert.equal(internals.recent.throughput.length, 5, 'a long session must not retain every throughput sample')
+  assert.equal(internals.recent.ttft.length, 5, 'a long session must not retain every TTFT sample')
+  assert.equal(folder.snapshot().tokensPerSec, 200)
+  assert.equal(folder.snapshot().outputTokens, 1_200)
 })
 
 test('duplicate assistant messages settle timing only once', () => {
@@ -325,7 +311,9 @@ test('duplicate assistant messages settle timing only once', () => {
   folder.apply(log)
   assert.equal(oneShot.llmMs, 1_000)
   assert.equal(oneShot.firstTokenMsAvg, 100)
-  assert.equal(oneShot.tokensPerSec, 222)
+  // The duplicate replaced the sample in place: 200 tokens over the SAME
+  // 1000 ms wall (one sample, never two).
+  assert.equal(oneShot.tokensPerSec, 200)
   assert.equal(oneShot.outputTokens, 200)
   assert.deepEqual(folder.snapshot(), oneShot)
 })
@@ -397,7 +385,10 @@ test('settled timing ignores a late token delta before a duplicate message', () 
   folder.apply(log)
   assert.equal(oneShot.llmMs, 100)
   assert.equal(oneShot.firstTokenMsAvg, 0)
-  assert.equal(oneShot.tokensPerSec, 0)
+  // The burst-delivered step (no token delta before settle) samples on its
+  // FULL 100 ms wall, and the late replacement swaps the sample in place:
+  // 200 tokens over the same wall → 2000 tok/s, never a second sample.
+  assert.equal(oneShot.tokensPerSec, 2_000)
   assert.equal(oneShot.outputTokens, 200)
   assert.deepEqual(folder.snapshot(), oneShot)
 })
@@ -435,7 +426,7 @@ test('older duplicate messages cannot mutate timing after a higher turn starts',
   // The late duplicate is stale for both folds: the original sample and
   // output-token total remain authoritative.
   assert.equal(oneShot.llmMs, 200)
-  assert.equal(oneShot.tokensPerSec, 1_000)
+  assert.equal(oneShot.tokensPerSec, 500)
   assert.equal(oneShot.outputTokens, 100)
   assert.deepEqual(folder.snapshot(), oneShot)
 })
@@ -515,7 +506,9 @@ test('duplicate step/start preserves settled timing and a duplicate end is idemp
   assert.equal(oneShot.steps, 1)
   assert.equal(oneShot.llmMs, 100)
   assert.equal(oneShot.firstTokenMsAvg, 10)
-  assert.equal(oneShot.tokensPerSec, Math.round((300 * 1000) / 90))
+  // The replacement settled the same step in place: 300 tokens over the
+  // SAME 100 ms wall — one sample, never two.
+  assert.equal(oneShot.tokensPerSec, 3_000)
   assert.equal(oneShot.outputTokens, 300)
   assert.deepEqual(folder.snapshot(), oneShot)
 })
@@ -567,11 +560,11 @@ test('late assistant usage after step/end replaces the sampled throughput token 
   const oneShot = computeStats([...prefix, ...suffix])
   const folder = new StatsFolder()
   folder.apply(prefix)
-  assert.equal(folder.snapshot().tokensPerSec, 111)
+  assert.equal(folder.snapshot().tokensPerSec, 100)
   assert.equal((folder as unknown as { perStep: Map<unknown, unknown> }).perStep.size, 0)
   folder.apply(suffix)
   assert.equal(folder.snapshot().outputTokens, 200)
-  assert.equal(folder.snapshot().tokensPerSec, 222)
+  assert.equal(folder.snapshot().tokensPerSec, 200)
   assert.deepEqual(folder.snapshot(), oneShot)
   assert.equal((folder as unknown as { settledPerStep: Map<unknown, unknown> }).settledPerStep.size, 0)
 })
@@ -594,7 +587,9 @@ test('formats the stats line in pi abbreviation vocabulary', () => {
   assert.ok(line.includes('↓216k'), line)
   assert.ok(line.includes('R86M'), line)
   assert.ok(line.includes('CH93.9%'), line)
-  assert.ok(line.includes('LLM 8.1s'), line)
+  // The lifetime LLM wall left the display line (it still accumulates in
+  // SessionStats.llmMs); the tail is recent TTFB + recent throughput only.
+  assert.ok(!line.includes('LLM'), line)
   assert.ok(line.includes('TTFB 1.1s'), line)
   assert.ok(line.includes('118 tok/s'), line)
 })
@@ -624,18 +619,31 @@ test('usage is counted once per step despite chunk and message both carrying it'
   assert.equal(stats.cacheHitPct, 10)
 })
 
-test('tok/s samples only steps carrying both a decode window and usage', () => {
+test('tok/s samples every completed step with valid usage on its FULL LLM wall', () => {
   const t = 1_700_000_000_000
-  // Step 0: reasoning only — usage but no text delta (must not inflate tok/s).
-  // Step 1: decode + usage — the only sampled pair.
-  // Step 2: decode but no usage (must not enter the denominator alone).
+  // Step 0: burst delivery — a single late tool-call delta, usage, and a
+  // completed message. The effective throughput divides by the WHOLE
+  // request wall (10 s), never the 1 ms observable delta window.
+  // Step 1: streaming text with usage — also sampled on its full wall.
+  // Step 2: a step that never completed (no assistant/message) — no sample.
   const log = [
     event('step/start', { turn: 0, step: 0 }, 0, t),
     event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'usage', usage: { inputTokens: 10, outputTokens: 10_000, cacheReadTokens: 0 } } }, 1, t + 500),
-    event('step/end', { turn: 0, step: 0 }, 2, t + 5_000),
-    event('step/start', { turn: 0, step: 1 }, 3, t + 6_000),
-    event('assistant/chunk', { turn: 0, step: 1, chunk: { type: 'text-delta', index: 0, text: 'a' } }, 4, t + 6_100),
-    event('assistant/chunk', { turn: 0, step: 1, chunk: { type: 'text-delta', index: 0, text: 'b' } }, 5, t + 6_200),
+    event('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'tool-call-delta', index: 0, id: 'tc-0' as ToolCallId, name: 'bash', argumentsDelta: '{"command":"ls"}' } }, 2, t + 10_000),
+    event('assistant/message', {
+      turn: 0, step: 0,
+      message: {
+        id: MessageId('m-1'),
+        role: 'assistant',
+        content: [{ type: 'tool-call', id: 'tc-0' as ToolCallId, name: 'bash', arguments: '{"command":"ls"}' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 10, outputTokens: 400, cacheReadTokens: 0 },
+    }, 3, t + 10_001),
+    event('step/end', { turn: 0, step: 0 }, 4, t + 11_000),
+    event('step/start', { turn: 0, step: 1 }, 5, t + 12_000),
+    event('assistant/chunk', { turn: 0, step: 1, chunk: { type: 'text-delta', index: 0, text: 'a' } }, 6, t + 12_100),
+    event('assistant/chunk', { turn: 0, step: 1, chunk: { type: 'text-delta', index: 0, text: 'b' } }, 7, t + 12_200),
     event('assistant/message', {
       turn: 0, step: 1,
       message: {
@@ -645,20 +653,18 @@ test('tok/s samples only steps carrying both a decode window and usage', () => {
         source: { kind: 'model', provider: 'p', model: 'm' },
       },
       usage: { inputTokens: 10, outputTokens: 500, cacheReadTokens: 0 },
-    }, 6, t + 7_000),
-    event('step/end', { turn: 0, step: 1 }, 7, t + 8_000),
-    event('step/start', { turn: 0, step: 2 }, 8, t + 9_000),
-    event('assistant/chunk', { turn: 0, step: 2, chunk: { type: 'text-delta', index: 0, text: 'x' } }, 9, t + 9_100),
-    event('assistant/chunk', { turn: 0, step: 2, chunk: { type: 'text-delta', index: 0, text: 'y' } }, 10, t + 9_200),
-    event('step/end', { turn: 0, step: 2 }, 11, t + 10_000),
+    }, 8, t + 13_000),
+    event('step/end', { turn: 0, step: 1 }, 9, t + 14_000),
+    event('step/start', { turn: 0, step: 2 }, 10, t + 15_000),
+    event('assistant/chunk', { turn: 0, step: 2, chunk: { type: 'text-delta', index: 0, text: 'x' } }, 11, t + 15_100),
+    event('step/end', { turn: 0, step: 2 }, 12, t + 16_000),
   ]
   const stats = computeStats(log)
-  // Step 1: 500 tokens over (7000 - 6100) = 900 ms → 555 tok/s.
-  assert.equal(stats.tokensPerSec, Math.round(500 / 0.9))
-  // Total output includes the reasoning-only step (10_000 + 500).
-  assert.equal(stats.outputTokens, 10_500)
-  // The decode end uses the assistant/message time, not the last delta
-  // (6100→7000 window above proves it: last delta was at 6200).
+  // Pooled recent window: (400 + 500) tokens / (10.001 s + 1 s) full wall
+  // — the burst step contributes ~40 tok/s, not 400 000.
+  assert.equal(stats.tokensPerSec, Math.round((900 * 1000) / 11_001))
+  // Total output includes the burst step's authoritative tokens.
+  assert.equal(stats.outputTokens, 900)
 })
 
 test('turn/start advances the accumulator: a delayed prior-turn usage fact is stale', () => {
@@ -817,4 +823,299 @@ test('llmMs spans step/start to assistant/message, not to step/end', () => {
     event('step/end', { turn: 0, step: 0 }, 2, t + 9_000),
   ])
   assert.equal(stats.llmMs, 2_000)
+})
+
+// ── Recent performance contract (recent-5 effective throughput / TTFB) ───
+
+/** One completed step with a model-source identity and usage. */
+function completedStep(
+  turn: number,
+  step: number,
+  startSeq: number,
+  startTime: number,
+  options: {
+    provider?: string
+    model?: string
+    outputTokens?: number
+    wallMs?: number
+    firstDeltaMs?: number
+  } = {},
+): SessionEvent[] {
+  const wallMs = options.wallMs ?? 1_000
+  const firstDeltaMs = options.firstDeltaMs
+  const events: SessionEvent[] = [
+    event('step/start', { turn, step }, startSeq, startTime),
+  ]
+  let seq = startSeq
+  if (firstDeltaMs !== undefined) {
+    seq += 1
+    events.push(event('assistant/chunk', {
+      turn,
+      step,
+      chunk: { type: 'text-delta', index: 0, text: 'answer' },
+    }, seq, startTime + firstDeltaMs))
+  }
+  seq += 1
+  events.push(event('assistant/message', {
+    turn,
+    step,
+    message: {
+      id: MessageId(`m-recent-${turn}-${step}-${startSeq}`),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: options.provider ?? 'p', model: options.model ?? 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens: options.outputTokens ?? 100 },
+  }, seq, startTime + wallMs))
+  seq += 1
+  events.push(event('step/end', { turn, step }, seq, startTime + wallMs + 100))
+  return events
+}
+
+test('recent-5 throughput pools the latest five steps and evicts the first (Σoutput / Σwall)', () => {
+  const t = 1_700_000_000_000
+  // Six 1-token-per-second steps: the 6th completes → the 1st leaves the
+  // window; TPS = Σ(step2..step6 output) / Σ(step2..step6 wall).
+  const log: SessionEvent[] = []
+  let seq = 0
+  for (let step = 0; step < 6; step += 1) {
+    const events = completedStep(0, step, seq, t + step * 10_000, { outputTokens: 1_000, wallMs: 1_000 })
+    log.push(...events)
+    seq += events.length
+  }
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  // Five steps × 1000 tokens over five 1s walls = 1000 tok/s.
+  assert.equal(oneShot.tokensPerSec, 1_000)
+  assert.deepEqual(folder.snapshot(), oneShot)
+  // Hard gate: cold and incremental folds agree at EVERY suffix boundary.
+  const probe = new StatsFolder()
+  for (let index = 0; index < log.length; index += 1) {
+    probe.apply([log[index]!])
+    assert.deepEqual(probe.snapshot(), computeStats(log.slice(0, index + 1)), `parity after event ${index}`)
+  }
+})
+
+test('an early burst never ratchets the session TPS (recent window, not lifetime)', () => {
+  const t = 1_700_000_000_000
+  // Twenty burst tool-call steps (400 tokens over a 2 s request each),
+  // then one long reasoning step (500 tokens over 25 s). The lifetime
+  // decode-window ratchet would spike then "fall back"; the recent-5
+  // effective rate simply describes the last five requests.
+  const log: SessionEvent[] = []
+  let seq = 0
+  const burst = (step: number, startTime: number): SessionEvent[] => [
+    event('step/start', { turn: 0, step }, seq++, startTime),
+    event('assistant/chunk', {
+      turn: 0,
+      step,
+      chunk: { type: 'tool-call-delta', index: 0, id: `tc-${step}` as ToolCallId, name: 'bash', argumentsDelta: '{"command":"ls"}' },
+    }, seq++, startTime + 1_900),
+    event('assistant/message', {
+      turn: 0,
+      step,
+      message: {
+        id: MessageId(`m-burst-${step}`),
+        role: 'assistant',
+        content: [{ type: 'tool-call', id: `tc-${step}` as ToolCallId, name: 'bash', arguments: '{"command":"ls"}' }],
+        source: { kind: 'model', provider: 'p', model: 'm' },
+      },
+      usage: { inputTokens: 10, outputTokens: 400 },
+    }, seq++, startTime + 2_000),
+    event('step/end', { turn: 0, step }, seq++, startTime + 2_100),
+  ]
+  for (let step = 0; step < 20; step += 1) log.push(...burst(step, t + step * 5_000))
+  const afterBurst = computeStats(log)
+  assert.equal(afterBurst.tokensPerSec, 200, 'burst steps sample on their full request wall (400/2s)')
+  const longStep = completedStep(0, 20, seq, t + 100_000, { outputTokens: 500, wallMs: 25_000, firstDeltaMs: 1_000 })
+  log.push(...longStep)
+  const afterLong = computeStats(log)
+  // The long step is 1 of 5 window samples: 4×400 tokens/2s + 500/25s →
+  // pooled (2100 tokens / 33 s) — no lifetime ratchet, no crash back.
+  assert.equal(afterLong.tokensPerSec, Math.round((2_100 * 1000) / 33_000))
+})
+
+test('recent TTFB averages the latest five first-token steps', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  for (let step = 0; step < 6; step += 1) {
+    const events = completedStep(0, step, seq, t + step * 10_000, {
+      outputTokens: 10,
+      wallMs: 500,
+      firstDeltaMs: 100 * (step + 1),
+    })
+    log.push(...events)
+    seq += events.length
+  }
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  // Latest five first-token deltas: 200..600 ms → mean 400 ms.
+  assert.equal(oneShot.firstTokenMsAvg, 400)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('a model/provider route change resets the recent performance window', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  for (let step = 0; step < 5; step += 1) {
+    const events = completedStep(0, step, seq, t + step * 10_000, {
+      provider: 'a', model: 'slow', outputTokens: 1_000, wallMs: 5_000, firstDeltaMs: 4_000,
+    })
+    log.push(...events)
+    seq += events.length
+  }
+  const switchEvents = completedStep(0, 5, seq, t + 50_000, {
+    provider: 'b', model: 'fast', outputTokens: 100, wallMs: 1_000, firstDeltaMs: 100,
+  })
+  log.push(...switchEvents)
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log.slice(0, log.length - switchEvents.length))
+  assert.equal(folder.snapshot().tokensPerSec, 200, 'before the switch the window is route A')
+  assert.equal(folder.snapshot().firstTokenMsAvg, 4_000)
+  folder.apply(switchEvents)
+  // After B's first completed response the window holds ONLY B's sample.
+  assert.deepEqual(folder.snapshot(), oneShot)
+  assert.equal(folder.snapshot().tokensPerSec, 100)
+  assert.equal(folder.snapshot().firstTokenMsAvg, 100)
+  // The lifetime LLM wall and the usage totals keep accumulating.
+  assert.equal(folder.snapshot().llmMs, 5 * 5_000 + 1_000)
+  assert.equal(folder.snapshot().outputTokens, 5_100)
+})
+
+test('a late usage replacement cannot resurrect a sample after a route reset', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  const stepA = completedStep(0, 0, seq, t, { provider: 'a', model: 'm', outputTokens: 100, wallMs: 1_000 })
+  log.push(...stepA)
+  seq += stepA.length
+  // Route B settles → the window clears A's sample.
+  const stepB = completedStep(0, 1, seq, t + 10_000, { provider: 'b', model: 'm', outputTokens: 100, wallMs: 1_000 })
+  log.push(...stepB)
+  seq += stepB.length
+  // A late duplicate of the OLD-route step must not re-insert its sample.
+  const late = event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId('m-late-old-route'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'a', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens: 9_999 },
+  }, seq++, t + 20_000)
+  log.push(late)
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(oneShot.tokensPerSec, 100, 'only route B\'s sample remains')
+  assert.equal(oneShot.outputTokens, 10_099, 'the token ACCOUNTING still applies the authoritative replacement')
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('a usage-less step that becomes valid via a late authoritative message joins at its original ordinal', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  for (let step = 0; step < 2; step += 1) {
+    // Steps 0-1 settle WITHOUT usage (no sample yet).
+    const events: SessionEvent[] = [
+      event('step/start', { turn: 0, step }, seq++, t + step * 10_000),
+      event('assistant/message', {
+        turn: 0,
+        step,
+        message: {
+          id: MessageId(`m-nousage-${step}`),
+          role: 'assistant',
+          content: [{ type: 'text', text: 'answer' }],
+          source: { kind: 'model', provider: 'p', model: 'm' },
+        },
+      }, seq++, t + step * 10_000 + 1_000),
+      event('step/end', { turn: 0, step }, seq++, t + step * 10_000 + 1_100),
+    ]
+    log.push(...events)
+  }
+  // Step 2 settles WITH usage (a real sample, ordinal 2).
+  const step2 = completedStep(0, 2, seq, t + 20_000, { outputTokens: 300, wallMs: 1_000 })
+  log.push(...step2)
+  seq += step2.length
+  // A late authoritative duplicate gives step 1 its usage: it must join
+  // the window at its ORIGINAL completion ordinal, not as the newest.
+  const late = event('assistant/message', {
+    turn: 0,
+    step: 1,
+    message: {
+      id: MessageId('m-nousage-1-late'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens: 900 },
+  }, seq++, t + 30_000)
+  log.push(late)
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log.slice(0, -1))
+  // Before the late message: one sample (step 2: 300 tokens / 1 s).
+  assert.equal(folder.snapshot().tokensPerSec, 300)
+  folder.apply([late])
+  assert.deepEqual(folder.snapshot(), oneShot)
+  // Samples: step1 (900 tokens over 1 s wall, ordinal 1) + step2 →
+  // pooled 1200 tokens / 2 s = 600 tok/s — the old step joined mid-window.
+  assert.equal(oneShot.tokensPerSec, 600)
+})
+
+test('a burst route keeps token totals identical to the pre-recent accounting', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  for (let step = 0; step < 8; step += 1) {
+    const events = completedStep(0, step, seq, t + step * 10_000, { outputTokens: 400, wallMs: 100 })
+    log.push(...events)
+    seq += events.length
+  }
+  const stats = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  // Effective throughput may exceed 1 tok/ms on burst routes — that is the
+  // honest full-wall rate; nothing clamps it (plan §2.2: no TPS clamps).
+  assert.equal(stats.tokensPerSec, 4_000)
+  // Usage accounting is untouched by the performance window.
+  assert.equal(stats.outputTokens, 3_200)
+  assert.equal(stats.steps, 8)
+  assert.deepEqual(folder.snapshot(), stats)
+})
+
+test('cancelled and failed steps contribute no recent performance samples', () => {
+  const t = 1_700_000_000_000
+  const prefix: SessionEvent[] = []
+  let seq = 0
+  for (let step = 0; step < 3; step += 1) {
+    const events = completedStep(0, step, seq, t + step * 10_000, { outputTokens: 100, wallMs: 1_000 })
+    prefix.push(...events)
+    seq += events.length
+  }
+  // A cancelled step: start, a delta, step/end — never a message.
+  const cancelled: SessionEvent[] = [
+    event('step/start', { turn: 0, step: 3 }, seq++, t + 30_000),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 3,
+      chunk: { type: 'text-delta', index: 0, text: 'partial' },
+    }, seq++, t + 30_100),
+    event('step/end', { turn: 0, step: 3 }, seq++, t + 35_000),
+  ]
+  const log = [...prefix, ...cancelled]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(oneShot.tokensPerSec, 100)
+  assert.equal(oneShot.firstTokenMsAvg, 0)
+  assert.deepEqual(folder.snapshot(), oneShot)
 })

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -1159,4 +1159,25 @@ test('an authoritative duplicate that invalidates the sample REMOVES it (no stal
   assert.equal(folder.snapshot().firstTokenMsAvg, 100)
   // The usage accounting applied the authoritative replacement.
   assert.equal(folder.snapshot().outputTokens, 0)
+
+  // The stale-denominator repro: a SECOND valid step after the
+  // invalidation must pool over its own wall only. Keeping A's wall
+  // (the lifetime-style subtract-only variant → 300 tokens / 2 s = 150)
+  // or keeping A's sample whole (the unremoved variant → 400 tokens /
+  // 2 s = 200) both miss; the correct removal yields 300 tok/s.
+  const stepB = completedStep(0, 1, 5, t + 10_000, { outputTokens: 300, wallMs: 1_000 })
+  const withB = [...prefix, invalidating, ...stepB]
+  const oneShotWithB = computeStats(withB)
+  const folderB = new StatsFolder()
+  folderB.apply(prefix)
+  folderB.apply([invalidating, ...stepB])
+  assert.equal(folderB.snapshot().tokensPerSec, 300, `the invalidated wall must not ride the window:\n${JSON.stringify(folderB.snapshot())}`)
+  assert.deepEqual(folderB.snapshot(), oneShotWithB)
+
+  // A LATER VALID duplicate of the invalidated step re-inserts its sample
+  // at the ORIGINAL completion ordinal (0 → 500: pooled with B = 400).
+  const revalid = message(9, t + 20_000, 500)
+  folderB.apply([revalid])
+  assert.deepEqual(folderB.snapshot(), computeStats([...withB, revalid]))
+  assert.equal(folderB.snapshot().tokensPerSec, 400, 'the re-validated step rejoins the pooled window')
 })

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -987,6 +987,23 @@ test('a model/provider route change resets the recent performance window', () =>
   assert.equal(folder.snapshot().outputTokens, 5_100)
 })
 
+test('route keys are delimiter-safe (provider/model containing "/" never collide)', () => {
+  const t = 1_700_000_000_000
+  // ("a/b", "c") vs ("a", "b/c"): a naive `provider + '/' + model`
+  // concatenation collapses BOTH routes to "a/b/c" and the switch goes
+  // undetected — the window would pool both steps (1100 tokens / 6 s ≈
+  // 183 tok/s, TTFB mean 2050). The tuple-encoded key must reset.
+  const stepA = completedStep(0, 0, 0, t, { provider: 'a/b', model: 'c', outputTokens: 1_000, wallMs: 5_000, firstDeltaMs: 4_000 })
+  const stepB = completedStep(0, 1, stepA.length, t + 10_000, { provider: 'a', model: 'b/c', outputTokens: 100, wallMs: 1_000, firstDeltaMs: 100 })
+  const log = [...stepA, ...stepB]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(folder.snapshot().tokensPerSec, 100, 'the delimiter-ambiguous switch must still reset the window')
+  assert.equal(folder.snapshot().firstTokenMsAvg, 100)
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
 test('a late usage replacement cannot resurrect a sample after a route reset', () => {
   const t = 1_700_000_000_000
   const log: SessionEvent[] = []

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -274,9 +274,9 @@ test('StatsFolder keeps the recent throughput window bounded', () => {
     ])
   }
   const internals = folder as unknown as { recent: { throughput: unknown[]; ttft: unknown[] } }
-  assert.equal(internals.recent.throughput.length, 5, 'a long session must not retain every throughput sample')
+  assert.equal(internals.recent.throughput.length, 10, 'throughput keeps only the bounded candidate buffer (2x the window)')
   assert.equal(internals.recent.ttft.length, 5, 'a long session must not retain every TTFT sample')
-  assert.equal(folder.snapshot().tokensPerSec, 200)
+  assert.equal(folder.snapshot().tokensPerSec, 200, 'derive still pools the latest FIVE valid samples')
   assert.equal(folder.snapshot().outputTokens, 1_200)
 })
 
@@ -569,7 +569,7 @@ test('late assistant usage after step/end replaces the sampled throughput token 
   assert.equal((folder as unknown as { settledPerStep: Map<unknown, unknown> }).settledPerStep.size, 0)
 })
 
-test('formats the stats line in pi abbreviation vocabulary', () => {
+test('formats the DETAILED stats line: lifetime LLM beside the recent metrics', () => {
   const line = formatStats({
     turns: 2,
     steps: 2,
@@ -587,11 +587,22 @@ test('formats the stats line in pi abbreviation vocabulary', () => {
   assert.ok(line.includes('↓216k'), line)
   assert.ok(line.includes('R86M'), line)
   assert.ok(line.includes('CH93.9%'), line)
-  // The lifetime LLM wall left the display line (it still accumulates in
-  // SessionStats.llmMs); the tail is recent TTFB + recent throughput only.
-  assert.ok(!line.includes('LLM'), line)
+  // The /status detail line KEEPS the labeled lifetime wall beside the
+  // recent TTFB + throughput (the footer line dropped it — that split is
+  // asserted on the footer side).
+  assert.ok(line.includes('LLM 8.1s'), line)
   assert.ok(line.includes('TTFB 1.1s'), line)
   assert.ok(line.includes('118 tok/s'), line)
+})
+
+test('formats the lifetime LLM wall as a readable duration at scale', () => {
+  const at = (llmMs: number): string => formatStats({
+    turns: 1, steps: 1, llmMs, firstTokenMsAvg: 0, tokensPerSec: 0,
+    cacheHitPct: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
+  })
+  assert.ok(at(8_100).includes('LLM 8.1s'), 'under a minute keeps the decimal seconds')
+  assert.ok(at(1_674_000).includes('LLM 27m54s'), 'minutes render as MmSSs')
+  assert.ok(at(3_965_000).includes('LLM 1h06m05s'), 'hours render as HhMMmSSs')
 })
 
 test('usage is counted once per step despite chunk and message both carrying it', () => {
@@ -1197,4 +1208,81 @@ test('an authoritative duplicate that invalidates the sample REMOVES it (no stal
   folderB.apply([revalid])
   assert.deepEqual(folderB.snapshot(), computeStats([...withB, revalid]))
   assert.equal(folderB.snapshot().tokensPerSec, 400, 'the re-validated step rejoins the pooled window')
+})
+
+test('a route STRING match is not enough: A → B → A cannot resurrect the first A\'s sample', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  const push = (events: SessionEvent[]): void => {
+    log.push(...events)
+    seq += events.length
+  }
+  // Epoch 0: route A settles a big sample.
+  push(completedStep(0, 0, seq, t, { provider: 'p', model: 'a', outputTokens: 1_000, wallMs: 1_000 }))
+  // Epoch 1: route B resets the window.
+  push(completedStep(0, 1, seq, t + 10_000, { provider: 'p', model: 'b', outputTokens: 100, wallMs: 1_000 }))
+  // Epoch 2: route A AGAIN — the route string equals epoch 0's, but this
+  // is a NEW route lifecycle with a fresh window.
+  push(completedStep(0, 2, seq, t + 20_000, { provider: 'p', model: 'a', outputTokens: 200, wallMs: 1_000 }))
+  // A late authoritative duplicate of the OLD A step: its route string
+  // matches the current window's — only the epoch gate must keep it out.
+  const late = event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId('m-old-a-epoch'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'a' },
+    },
+    usage: { inputTokens: 10, outputTokens: 9_999 },
+  }, seq, t + 30_000)
+  log.push(late)
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(log)
+  // Only the SECOND A lifecycle's sample rides the window: 200 tok/s.
+  assert.equal(oneShot.tokensPerSec, 200, `the epoch gate must hold:\n${JSON.stringify(oneShot)}`)
+  assert.deepEqual(folder.snapshot(), oneShot)
+  // The token ACCOUNTING still applies the authoritative replacement.
+  assert.equal(oneShot.outputTokens, 10_299)
+})
+
+test('invalidating one of the latest five BACKFILLS the next-older candidate', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  const push = (events: SessionEvent[]): void => {
+    log.push(...events)
+    seq += events.length
+  }
+  // Six same-route valid samples: 0 = 1000 tok / 1s, 1..5 = 100 tok / 1s.
+  push(completedStep(0, 0, seq, t, { outputTokens: 1_000, wallMs: 1_000 }))
+  for (let step = 1; step <= 5; step += 1) {
+    push(completedStep(0, step, seq, t + step * 10_000, { outputTokens: 100, wallMs: 1_000 }))
+  }
+  const folder = new StatsFolder()
+  folder.apply(log)
+  assert.equal(folder.snapshot().tokensPerSec, 100, 'the sixth completion evicts sample 0 from the derived window')
+  // An authoritative duplicate invalidates the NEWEST sample (ordinal 5):
+  // the window's contract is "latest 5 VALID samples", so ordinal 0 —
+  // still retained as a candidate — must BACKFILL: (1000 + 4x100) / 5 s.
+  const invalidating = event('assistant/message', {
+    turn: 0,
+    step: 5,
+    message: {
+      id: MessageId('m-backfill-invalidate'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 10, outputTokens: 0 },
+  }, seq++, t + 100_000)
+  log.push(invalidating)
+  const oneShot = computeStats(log)
+  folder.apply([invalidating])
+  assert.equal(folder.snapshot().tokensPerSec, 280, `the evicted candidate must backfill:\n${JSON.stringify(folder.snapshot())}`)
+  assert.deepEqual(folder.snapshot(), oneShot)
+  assert.equal(folder.snapshot().outputTokens, 1_400, 'the accounting applies the authoritative zero')
 })

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -1119,3 +1119,44 @@ test('cancelled and failed steps contribute no recent performance samples', () =
   assert.equal(oneShot.firstTokenMsAvg, 0)
   assert.deepEqual(folder.snapshot(), oneShot)
 })
+
+test('an authoritative duplicate that invalidates the sample REMOVES it (no stale throughput)', () => {
+  const t = 1_700_000_000_000
+  const message = (seq: number, time: number, outputTokens: number | undefined): SessionEvent => event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId(`m-invalidate-${seq}`),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    ...(outputTokens === undefined ? {} : { usage: { inputTokens: 10, outputTokens } }),
+  }, seq, time)
+  const prefix = [
+    event('step/start', { turn: 0, step: 0 }, 0, t),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'text-delta', index: 0, text: 'answer' },
+    }, 1, t + 100),
+    message(2, t + 1_000, 100),
+    event('step/end', { turn: 0, step: 0 }, 3, t + 1_100),
+  ]
+  // The authoritative duplicate corrects outputTokens to 0: the step's
+  // sample is no longer valid and must not keep feeding the recent rate.
+  const invalidating = message(4, t + 2_000, 0)
+  const log = [...prefix, invalidating]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  folder.apply(prefix)
+  assert.equal(folder.snapshot().tokensPerSec, 100, 'the valid sample rides the window first')
+  folder.apply([invalidating])
+  assert.deepEqual(folder.snapshot(), oneShot)
+  assert.equal(folder.snapshot().tokensPerSec, 0, 'the invalidated sample leaves the window')
+  // Timing facts survive the correction untouched.
+  assert.equal(folder.snapshot().llmMs, 1_000)
+  assert.equal(folder.snapshot().firstTokenMsAvg, 100)
+  // The usage accounting applied the authoritative replacement.
+  assert.equal(folder.snapshot().outputTokens, 0)
+})

--- a/test/subagent-viewer-interactive.test.ts
+++ b/test/subagent-viewer-interactive.test.ts
@@ -518,7 +518,7 @@ test('the footer switches to the viewed child\u2019s identity and back on exit',
     // usage facts.
     usage: {
       tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      performance: { llmMs: 12300, firstTokenMs: 0, tokensPerSec: 0 },
+      performance: { llmMs: 12300, firstTokenMs: 12_300, tokensPerSec: 0 },
       turns: 3,
       steps: 5,
     },
@@ -528,7 +528,7 @@ test('the footer switches to the viewed child\u2019s identity and back on exit',
   assert.ok(view.includes('[subagent · continuable]'), `subagent footer badge missing:\n${view}`)
   assert.ok(view.includes('research'), `child label missing from the footer:\n${view}`)
   assert.ok(view.includes('t3/s5'), `child turn/step counters missing:\n${view}`)
-  assert.ok(view.includes('LLM 12.3s'), `child stats line missing:\n${view}`)
+  assert.ok(view.includes('TTFB 12.3s'), `child stats line missing:\n${view}`)
   assert.ok(!view.includes('parent-model'), `the parent model must not leak into the viewer footer:\n${view}`)
   // Clearing restores the parent footer (the runner's exitView calls BOTH
   // setters — the view subject and the footer payload return together).
@@ -558,7 +558,7 @@ test('the one-shot viewer footer carries the one-shot badge and no stats line un
     statsLine: 'child stats',
     usage: {
       tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      performance: { llmMs: 12300, firstTokenMs: 0, tokensPerSec: 0 },
+      performance: { llmMs: 12300, firstTokenMs: 12_300, tokensPerSec: 0 },
       turns: 1,
       steps: 2,
     },
@@ -566,7 +566,7 @@ test('the one-shot viewer footer carries the one-shot badge and no stats line un
   await vt.waitForRender()
   const view = vt.getViewport().join('\n')
   assert.ok(view.includes('[subagent · one-shot]'), `one-shot badge missing:\n${view}`)
-  assert.ok(!view.includes('LLM 12.3s'), `compact preset must drop the stats line:\n${view}`)
+  assert.ok(!view.includes('TTFB 12.3s'), `compact preset must drop the stats line:\n${view}`)
   app.setViewerFooter(undefined)
   app.setViewerMode(undefined)
   app.stop()
@@ -594,7 +594,7 @@ test('the viewer footer never shows the parent\u2019s Ctrl+C exit hint (round-1 
     statsLine: 'child stats line',
     usage: {
       tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      performance: { llmMs: 12300, firstTokenMs: 0, tokensPerSec: 0 },
+      performance: { llmMs: 12300, firstTokenMs: 12_300, tokensPerSec: 0 },
       turns: 1,
       steps: 1,
     },
@@ -602,7 +602,7 @@ test('the viewer footer never shows the parent\u2019s Ctrl+C exit hint (round-1 
   await vt.waitForRender()
   const view = vt.getViewport().join('\n')
   assert.ok(!view.includes('Press Ctrl+C again'), `the parent exit hint must never leak into the viewer footer:\n${view}`)
-  assert.ok(view.includes('LLM 12.3s'), `the child stats line must show instead:\n${view}`)
+  assert.ok(view.includes('TTFB 12.3s'), `the child stats line must show instead:\n${view}`)
   app.setViewerFooter(undefined)
   app.setViewerMode(undefined)
   app.stop()


### PR DESCRIPTION
## Summary

Implements the `next` footer plan (recent performance + repeated placements) in three logical commits, hardened by a 4-round external review loop (final verdict: **accepted**, findings: none).

### 1. `refactor(footer): allow repeated item placements`
- The Add picker offers the registry's full definition catalog; adding an already-placed id appends an independent placement (its own format/tone/prefix/suffix/importance).
- FooterLayoutV1 stays schemaVersion 1 — no instance ids. Custom definition rename/delete update/remove every duplicate ref; 32-item row cap unchanged.

### 2. `fix(stats): use recent effective LLM throughput`
- `tok/s` = recent-5 `Σ outputTokens / Σ full LLM wall` (step/start → assistant/message): CPA burst tool-call delivery now counts as `400 tokens / 10s request = 40 tok/s` instead of ratcheting a lifetime decode-window rate.
- TTFB = recent-5 mean; provider+model route change resets both windows (missing model-source keys never reset — fail-soft).
- Late authoritative usage replaces its step's sample at the ORIGINAL completion ordinal (never re-adds llmMs/TTFB; old-route duplicates cannot resurrect samples; an invalidating replacement removes the sample — review round 1).
- Route keys are delimiter-safe (`JSON.stringify([provider, model])` — review round 3).
- `llmMs` keeps accumulating (lifetime) for `/stats`; it left every display line.

### 3. `refactor(footer): compose default performance row from items`
- Default second row: `token-usage:pi · cache-hit:pi · performance:latency · performance:speed` → `↑114M ↓54k R520k W12k · CH93.9% · TTFB 8.1s · 51 tok/s`.
- Per-ref importance overrides fix the narrow-width drop order: cache-hit → TTFB → speed; session usage survives longest.
- `stats-line` stays registered for legacy custom layouts with the new recent-only tail (never mixes lifetime LLM with recent metrics; intentional display contract change, no settings migration per plan §4).
- New `pi` styles for token-usage/cache-hit; performance latency carries the `TTFB` marker.

## Review loop

4 rounds (`gpt-5.6-luna` reviewer, fresh-context, read-only, full-diff sweep each round): needs-fixes ×3 → **accepted**. 5 findings fixed directly (stale-sample invalidation P1, preset object aliasing, stale module comment, weak regression repro, delimiter-ambiguous route key); every regression test was verified to fail on the pre-fix code.

## Validation

- Focused footer/stats suites: 251/251
- `pnpm test:product`: 3359/3359; full `pnpm test`: 4522/4522 (fork 988 + product 3359 + tooling 164 + tmux 11)
- `pnpm typecheck` / `pnpm build` / `git diff --check` / `pnpm verify:prepush`: all green

Plan: `temp/1.2-new/dsh-pi-tui-next-footer-recent-performance-and-repeat-placement-plan.md`
