### PR TITLE
fix: post-re-vendor audit follow-ups (X037–X045, 4x P1 + 10x P2)

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Post-re-vendor follow-up audit fixes (X037–X045; 4x P1, 10x P2, several P3; review-round hardening included)
+
+A full sweep after PR #68 (the Earendil v0.84.4 rebase) merged,
+cross-checked against the original kimi fork, the upstream 0.84.4 tarball,
+and the pre-rebase snapshot; the audit record lives at
+`temp/1.2-new/dsh-pi-tui-revendor-0.84.4-followup-audit-and-fixes.md`.
+
+- **P1 fixes**:
+  - **PasteBurst restored (X038)** — an editor-internal terminal-input
+    bugfix wrongly removed as "no host consumer" (when a terminal loses
+    bracketed-paste markers, the Enter trailing a rapid character stream
+    must insert a newline instead of submitting a half-pasted draft).
+    Restored in the full kimi form (including the `disablePasteBurst`
+    escape hatch); the lesson is recorded in the ledger: "no host
+    consumer" is only a valid removal criterion for Host-API patches.
+  - **SelectList filter state split (X041)** — `setFilter()` narrowed
+    `filteredItems` while `getFilter()`/`setItems()` kept reading the
+    search box, silently dropping programmatic filters on the next
+    keystroke/refresh; the filter query is now one canonical source of
+    truth.
+  - **Large paste + Ctrl+G external editor lost content** — `$EDITOR`
+    saw only the `[paste #N …]` marker and the registry was cleared on
+    restore; the seat abstraction gains optional `getExpandedText?()`
+    (an upstream-native API the host never used); the external-editor
+    round-trip and subagent draft mirroring use the expanded text.
+  - **Outbound draft paths expand paste markers everywhere (round-2
+    review)** — steer / submit / queue / getDraft / viewer submission and
+    seat handoffs previously still used getText() (literal markers on the
+    wire); centralized through expandedSeatWireDraft() plus the new fork
+    seam getExpandedCursor() (X045 — handoff cursors map through the
+    expansion), the Windows `cmd /c start` URL launch quotes the URL as a
+    single token (cmd metacharacter injection guard), and the
+    external-editor suspend failure path gained a best-effort rollback.
+  - **Editor submit remap polluted every vendored Input (X037)** — new
+    dedicated binding `tui.editor.submit` (Editor-only);
+    `tui.input.submit` always keeps its default Enter, so question
+    free-text and search boxes no longer submit on `submit: ctrl+x`-style
+    configs.
+- **P2 fixes**: X007 dispose contract completed (Box/SettingsList/overlay
+  hide via opt-in `disposeOnHide`, remountable leases exempt, host-side
+  redundant compensations removed); Ctrl+G now suspends through
+  `suspendForExternalEditor()/resumeFromExternalEditor()` (fullscreen and
+  the surface generation survive, using upstream-native `preserveScreen`);
+  IME Focusable propagation (X042 + the host's FocusForwardingFrame);
+  fullscreen Ctrl+Up/Down owned by host turn navigation (the fork's OSC133
+  scan is a permanent no-op on DSH transcripts); fullscreen OSC 8 link
+  clicks and the Windows right-click paste wired (`open-url.ts` +
+  `readClipboardText`, both upstream-native seams); X023 paste-registry
+  prune; the autocomplete seam promoted to protected (X044, replacing
+  private casts); `Input.setValue` cursor semantics (X040 — typing after
+  a prefill appends instead of prepending); fullscreen raw-input
+  precedence (X043 — deferred viewport-listener registration plus a mouse
+  pass-through in the host key ladder).
+- **P3/records**: `WIDTH_CACHE_SIZE` back to 4096 (X039); LaTeX rendering
+  off everywhere (the kimi choice, `HOST_MARKDOWN_OPTIONS`); native
+  prebuild docs state the real degrade impact and supported surface; X028
+  records `canScroll`; fullscreen ScrollView `basis: 0`; the
+  `REMOVED_UNUSED` list rewritten with per-category criteria.
+- **Verification**: fork suite 1017 tests (+39; round 5 adds the stale-submenu-callback guard), the full bundle suite,
+  pi-surface-compat 8/8, typecheck, and build all green.
 ### Development temp-file hygiene (/tmp hygiene)
 
 - **Test-fixture temp directories now have a test-owned lifecycle**:

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -65,7 +65,7 @@ and the pre-rebase snapshot; the audit record lives at
   prebuild docs state the real degrade impact and supported surface; X028
   records `canScroll`; fullscreen ScrollView `basis: 0`; the
   `REMOVED_UNUSED` list rewritten with per-category criteria.
-- **Verification**: fork suite 1017 tests (+39; round 5 adds the stale-submenu-callback guard), the full bundle suite,
+- **Verification**: fork suite 1019 tests (+41; the independent review round adds Box.dispose and the synchronous-done guard), the full bundle suite,
   pi-surface-compat 8/8, typecheck, and build all green.
 ### Development temp-file hygiene (/tmp hygiene)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@
 
 ## [Unreleased]
 
+### Re-vendor 后续审计修复（X037–X045，P1×4 + P2×10 + P3 若干；含 review 轮加固）
+
+对 PR #68（Earendil v0.84.4 重定基）合并后的全面复扫，交叉对照 kimi
+原始 fork、上游 0.84.4 tarball 与重定基前快照；审计记录见
+`temp/1.2-new/dsh-pi-tui-revendor-0.84.4-followup-audit-and-fixes.md`。
+
+- **P1 修复**：
+  - **PasteBurst 恢复（X038）**——重定基时以"无宿主消费者"为由误删的
+    editor 内部 terminal-input bugfix（iTerm2/tmux 丢 bracketed-paste
+    marker 时，快速字符流后的 Enter 应换行而非提交半截 paste）。按 kimi
+    完整形态恢复（含 `disablePasteBurst` 逃生开关）；教训已写入 ledger：
+    "no host consumer" 只对 Host-API patch 有效。
+  - **SelectList filter 状态分裂（X041）**——`setFilter()` 只改
+    `filteredItems`，`getFilter()`/`setItems()` 读搜索框，程序化过滤器
+    会被下一次按键/刷新静默丢弃；改为 canonical `filterQuery` 单一事实源。
+  - **大 paste → Ctrl+G 外部编辑器丢内容**——`$EDITOR` 只见
+    `[paste #N …]` marker 且返回后 registry 被清；seat 抽象新增
+    `getExpandedText?()`（上游原生 API，宿主此前未用），外部编辑器与
+    subagent 草稿镜像改用展开文本。
+  - **出站草稿路径全面展开 paste marker（round-2 review）**——steer /
+    submit / queue / getDraft / viewer 提交与 seat handoff 此前仍走
+    `getText()`（字面 marker 泄漏到 wire）；集中经 `expandedSeatWireDraft()`
+    + 新 fork seam `getExpandedCursor()`（X045，handoff 光标随扩展映射），
+    `cmd /c start` 打开 URL 改为引号包裹单 token（防 cmd 元字符注入），
+    external editor 的 suspend 失败路径增加 best-effort 回滚。
+  - **editor submit remap 污染全部 vendored Input（X037)**——新增独立
+    binding `tui.editor.submit`（仅 Editor 消费）；`tui.input.submit` 永远
+    保持默认 Enter，question/搜索框不再被 `submit: ctrl+x` 之类配置误提交。
+- **P2 修复**：X007 dispose 契约补齐（Box/SettingsList/overlay hide 经
+  opt-in `disposeOnHide`，remountable 租约豁免，宿主冗余补偿清理）；
+  Ctrl+G 改经 `suspendForExternalEditor()/resumeFromExternalEditor()`
+  挂起（fullscreen 与 surface generation 得以保留，上游原生
+  `preserveScreen`）；IME Focusable 下传（X042 + 宿主
+  FocusForwardingFrame）；fullscreen Ctrl+Up/Down 由宿主 turn 导航接管
+  （fork 的 OSC133 扫描在 DSH transcript 上是永久 no-op）；fullscreen
+  OSC8 链接点击与 Windows 右键 paste 接线（`open-url.ts` +
+  `readClipboardText`，均上游原生 seam）；X023 paste registry prune；
+  autocomplete seam 提升 protected（X044，替代 private cast）；
+  `Input.setValue` 光标语义（X040，预填后续输入不再前插）；fullscreen
+  raw-input precedence（X043，viewport listener 延迟注册 + mouse 直通）。
+- **P3/记录**：`WIDTH_CACHE_SIZE` 恢复 4096（X039）；LaTeX 渲染全站关闭
+  （kimi 方案，`HOST_MARKDOWN_OPTIONS`）；native prebuild 文档如实写明
+  降级影响与支持面；X028 补记 `canScroll`；fullscreen ScrollView
+  `basis: 0`；`REMOVED_UNUSED` 清单按四类标准重写理由。
+- **验证**：fork 套件 1017 项（+39，round-5 补 stale-callback 守卫）、bundle 全量、pi-surface-compat 8/8、
+  typecheck、build 全绿。
 ### 开发环境临时文件卫生（/tmp hygiene）
 
 - **单测 fixture 临时目录改为 test-owned 生命周期**：新增

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
   （kimi 方案，`HOST_MARKDOWN_OPTIONS`）；native prebuild 文档如实写明
   降级影响与支持面；X028 补记 `canScroll`；fullscreen ScrollView
   `basis: 0`；`REMOVED_UNUSED` 清单按四类标准重写理由。
-- **验证**：fork 套件 1017 项（+39，round-5 补 stale-callback 守卫）、bundle 全量、pi-surface-compat 8/8、
+- **验证**：fork 套件 1019 项（+41，独立复核轮补 Box.dispose/同步 done 守卫）、bundle 全量、pi-surface-compat 8/8、
   typecheck、build 全绿。
 ### 开发环境临时文件卫生（/tmp hygiene）
 

--- a/docs/tmux-testing.md
+++ b/docs/tmux-testing.md
@@ -43,7 +43,7 @@ sleep 5                                            # wait for startup
 tmux capture-pane -t demo -p > /tmp/pane.txt
 tmux capture-pane -t demo -e -p > /tmp/pane.ansi
 
-# send a command: same two-step rhythm (see the batched-Enter trap)
+# send a command: same two-step rhythm (see the PasteBurst trap)
 tmux send-keys -t demo -l "/settings"
 sleep 0.4
 tmux send-keys -t demo Enter
@@ -141,14 +141,13 @@ tasks-browser.ts.
 
 ## Trap list (every item hit in real testing)
 
-1. **Batched text+Enter used to lose the Enter**: `send-keys 'text' Enter`
-   delivers text and Enter in one input batch. The fork's old PasteBurst
-   heuristic (≥8 plain chars within 8ms → treated as a paste, Enter
-   suppressed 120ms) made this actively drop the Enter; it was removed with
-   the kimi baseline in the Earendil re-vendor (DIVERGENCES.md removed
-   list), so a batch Enter submits normally again. Keep the two-step
-   rhythm anyway — it is the deterministic way to drive the editor from
-   tmux: `send-keys -l 'text'` → `sleep 0.3+` → `send-keys Enter`.
+1. **PasteBurst turns a batched Enter into a newline**: `send-keys 'text'
+   Enter` delivers the text fast enough for the editor's lost-marker paste
+   heuristic (X038: ≥8 plain chars within 8ms → the trailing Enter inserts
+   a newline instead of submitting, 120ms window) to treat it as a paste.
+   Restored with the kimi baseline after the Earendil re-vendor briefly
+   dropped it (DIVERGENCES.md X038). Always drive the editor in two steps:
+   `send-keys -l 'text'` → `sleep 0.3+` → `send-keys Enter`.
 2. **zsh treats `;` as a command separator**: `COLORFGBG=15;0 dsh …` runs
    `0`. Quote the env value (`COLORFGBG='15;0' dsh …`) and mind nested quotes
    in scripts (wrap the whole thing in double quotes).

--- a/packages/pi-tui/AGENTS.md
+++ b/packages/pi-tui/AGENTS.md
@@ -25,7 +25,12 @@ matches upstream; the only remaining divergences are listed in
 - **Package shell contract:** name stays `@xmoon76/pi-tui`, `private: true`,
   tsdown build producing `dist/index.mjs` + `dist/index.d.mts`. Do not
   switch to the upstream tsgo contract. Native prebuilds are deliberately NOT
-  vendored; loading degrades gracefully without them.
+  vendored (supported surface: Linux/WSL/SSH into Linux). "Degrade" is
+  input-capability loss, not a crash: without the prebuilds Shift+Tab is
+  indistinguishable from Tab and the Windows/Apple Terminal Shift+Enter
+  modifier fallback is unavailable — `terminal.ts` falls back to sequence
+  heuristics only. If Windows/macOS become supported platforms, vendor the
+  matching `native/` prebuilds from the pinned upstream tarball.
 - **When an upstream file conflicts with a local divergence, the Earendil
   file is the base** — re-apply the necessary patch on top. Never go the
   other direction (local file as base, cherry-picking upstream code back).

--- a/packages/pi-tui/DIVERGENCES.md
+++ b/packages/pi-tui/DIVERGENCES.md
@@ -43,6 +43,8 @@ each re-vendor (see `UPSTREAM.json` for the pinned baseline).
   PageUp/PageDown page navigation, and substring search over
   value+label+description. `setFilter` is redefined to the same
   case-insensitive substring filter (upstream prefix-matched value only).
+  The filter query's canonical single-source-of-truth (getFilter/setItems
+  stay in sync with setFilter) is X041 — re-apply both together.
   Upstream 0.84.4 still has none of these.
 - Consumer: host `/sessions` picker, model picker, category picker,
   autocomplete compact picker, dynamic title enrichment.
@@ -151,11 +153,29 @@ each re-vendor (see `UPSTREAM.json` for the pinned baseline).
 ### X007 — Component `dispose()` lifecycle (was #7)
 
 - Category: `HARD_HOST_API` / `PUBLIC_COMPONENT_CONTRACT`
-- Files: `src/tui.ts`, `src/components/scroll-view.ts`, `src/components/text.ts`, `src/components/loader.ts`
+- Files: `src/tui.ts`, `src/components/scroll-view.ts`, `src/components/text.ts`, `src/components/loader.ts`, `src/components/box.ts`, `src/components/settings-list.ts`
 - Reason: `Component` gains an optional `dispose()`; `Container.removeChild`/
   `clear`/`dispose` release child resources; `ScrollView` disposes its hide
   timer and render callback; `Text` gets a no-op `dispose()`; `Loader`
   disposes its animation timer. Upstream 0.84.4 has no `dispose` anywhere.
+  COMPLETED in the 2026-09 follow-up audit so the contract covers EVERY
+  ownership path, not just Container/ScrollView:
+  - `Box.removeChild`/`clear` dispose removed children (Box had its own
+    override that silently skipped dispose);
+  - `SettingsList` owns its submenu slot — `closeSubmenu`, submenu
+    replacement and `dispose()` release the component (dispose bypasses the
+    navigateAfterClose resurrection);
+  - `OverlayHandle.hide()`/`hideOverlay()` dispose the removed component
+    ONLY with the new opt-in `OverlayOptions.disposeOnHide` — default false
+    (upstream behavior) because hide()+re-mount is a legitimate screen-
+    migration pattern; the host opts IN for every overlay entry it owns
+    (panels behind an owning FocusForwardingFrame) and opts OUT for the
+    remountable extension/advanced/unstable leases.
+- Ownership map after the completion: Container removal → dispose;
+  Stack removal → dispose; ScrollView disposal → child dispose;
+  Box removal → dispose; SettingsList submenu slot → dispose;
+  Overlay hide (disposeOnHide) → dispose; overlay hide (default) → caller
+  owns.
 - Consumer: host pi-surface-compat gate (`test/pi-component-compat.test.ts`:
   close idempotent, dispose exactly once, surface disposal invalidates old
   leases, fullscreen migration keeps one live adapter) and the extension
@@ -379,6 +399,10 @@ each re-vendor (see `UPSTREAM.json` for the pinned baseline).
   endings/tabs, replaces the document and cursor without firing `onChange`,
   cancelling autocomplete, leaving history browsing, pushing undo, or
   clearing the paste registry. Upstream 0.84.4 has no such method.
+  TIGHTENED in the 2026-09 follow-up audit: the paste registry is PRUNED to
+  the markers that survive in the staged text (neither "keep all" — a
+  replaced document orphaned multi-hundred-KB entries — nor "clear all" —
+  surviving markers must keep expanding).
 - Consumer: host `editor-seat-holder` declined-key replacement fallback.
 - Upstream status: absent.
 - Tests: public staging/normalization tests in `test/editor.test.ts` and the
@@ -457,12 +481,20 @@ each re-vendor (see `UPSTREAM.json` for the pinned baseline).
 ### X028 — Fullscreen viewport boundary, pre-input, and search-reset seams (was #28)
 
 - Category: `HARD_HOST_API`
-- Files: `src/tui-alt-screen.ts`
+- Files: `src/tui-alt-screen.ts`, `src/components/scroll-view.ts`
 - Reason: `onScrollBoundary` reports final unconsumed wheel/page/primary-
   scrollbar edge attempts, `onBeforeViewportInput` lets a host claim semantic
   viewport keys before built-in Home/End/Page handling, and `clearSearch()`
   lets a host reset the built-in fullscreen transcript search. Upstream
-  0.84.4 has none of these.
+  0.84.4 has none of these. ALSO PART OF THIS ENTRY (2026-09 audit): the
+  `ScrollView.canScroll` getter — it drives the navigation fall-through (a
+  non-scrollable primary viewport must let PageUp/Home/End fall through to
+  the focused component instead of consuming them). `canScroll` lives in
+  scroll-view.ts; losing it on a future re-vendor would silently consume
+  navigation keys on short transcripts. The HOST additionally claims the
+  fork's `previousPrompt`/`nextPrompt` keys (Ctrl+Up/Ctrl+Down) through
+  `onBeforeViewportInput` for its own turn navigation — the fork's built-in
+  OSC 133 scan finds nothing in DSH transcripts (permanent no-op).
 - Consumer: host virtual transcript (page older/newer), Home/End ownership,
   host search (`app.transcript.jumpLatest`, `app.transcript.search`),
   `clearSearch` on jump-latest.
@@ -640,6 +672,189 @@ each re-vendor (see `UPSTREAM.json` for the pinned baseline).
 - Migration action: re-apply (passthrough AFTER the FOCUS_OUT selection
   cleanup; keep the cleanup).
 
+### X037 — Editor-owned submit binding `tui.editor.submit` (2026-09 follow-up audit)
+
+- Category: `HARD_HOST_API` / `PUBLIC_COMPONENT_CONTRACT`
+- Files: `src/keybindings.ts`, `src/components/editor.ts`
+- Reason: the editor's submit check consults a DEDICATED `tui.editor.submit`
+  binding (default `enter`) instead of `tui.input.submit`. Keybindings are
+  process-global: the host remaps the editor's submission by writing the
+  binding, and sharing it with `tui.input.submit` leaked the remap into
+  every plain `Input` (question free-text, task/history search, picker
+  search boxes) — a `submit: ctrl+x` config made plain Inputs submit on
+  ctrl+x. `tui.input.submit` stays the plain-Input binding (always `enter`
+  at the host) and is never remapped. `shouldSubmitOnBackslashEnter` reads
+  the editor binding too.
+- Consumer: host `onEditorSubmitSync` (keybindings/manager.ts), the
+  dispose-time default restore, the `editorAccepts` inventory
+  (src/tui-app.ts).
+- Upstream status: absent (upstream has only `tui.input.submit`).
+- Tests: "editor submit binding split (X037)" in `test/editor.test.ts`;
+  bundle: the anti-pollution tests in `test/keybinding-integration.test.ts`.
+- Migration action: re-apply BOTH halves — the binding definition AND the
+  two editor.ts call sites — or the split silently reverts.
+
+### X038 — PasteBurst non-bracketed paste fallback RESTORED (was wrongly REMOVED_UNUSED)
+
+- Category: `BUGFIX_MISSING_UPSTREAM`
+- Files: `src/paste-burst.ts`, `src/components/editor.ts`
+- Reason: terminals that lose bracketed-paste markers (iTerm2/tmux) deliver
+  pastes as rapid plain-character streams; the trailing Enter must insert a
+  newline instead of submitting a half-pasted draft. The 2026-09 re-vendor
+  deleted it as "no host consumer" — a WRONG criterion for an
+  editor-internal terminal-input bugfix (it needs no host consumer by
+  design). Restored in the kimi form: `PasteBurst` class (≥8 chars at ≤8ms
+  intervals, 30ms active window, 120ms Enter-suppress window),
+  `disablePasteBurst` constructor option + `setDisablePasteBurst()` (tests
+  and integrations opting out), kimi-exact SINGLE-char tracking — a
+  multi-char chunk RESETS the burst (multi-char reads are typed-ahead text
+  or whole-line injections, not a terminal dribbling a paste; this also
+  keeps synchronous whole-string test input submitting normally).
+- Consumer: host editor paste path (every remap/SSH/tmux session without
+  bracketed paste).
+- Upstream status: absent.
+- Tests: "paste-burst fallback (X038)" describes in `test/editor.test.ts`.
+- Migration action: re-apply `paste-burst.ts` verbatim + the editor
+  integration (tracking block after the bracketed-paste section, the
+  submit-branch check, the two insert-point feeds, the option/setter).
+  LESSON: "no host consumer" is only a valid removal criterion for
+  Host-API patches — internal bugfixes, perf contracts and product
+  behaviors need their own criteria (see the removed-code section below).
+
+### X039 — `WIDTH_CACHE_SIZE` 4096 restored (kimi-era perf contract)
+
+- Category: `PERF_HOST_DEPENDENT`
+- Files: `src/utils.ts`
+- Reason: the non-ASCII width cache holds 4096 entries (upstream 512). The
+  host renders CJK-heavy transcripts; width changes, theme invalidations
+  and cold renders re-measure many non-ASCII lines and a 512-entry FIFO
+  thrashes. X035 bounds the STEADY frame; this bounds the burst paths.
+  Deliberately restored after the re-vendor briefly took upstream's 512
+  (the old ledger had listed 4096 as removable "kimi tweak" — the removal
+  criterion for a perf contract is the measured benefit, not host imports).
+- Consumer: every `visibleWidth` caller.
+- Upstream status: absent (upstream 512).
+- Tests: covered by the wrap/layout suites (no dedicated test — a size
+  constant).
+- Migration action: keep 4096 unless a benchmark says otherwise.
+
+### X040 — `Input.setValue` cursor placement
+
+- Category: `PUBLIC_COMPONENT_CONTRACT`
+- Files: `src/components/input.ts`
+- Reason: `setValue(value, { cursor })` places the cursor at the END of the
+  new value by default — every caller pre-fills a query/draft the user
+  continues typing, and the historical clamp left a fresh Input's cursor at
+  0, so `setValue("foo")` + typing "x" produced "xfoo" (SelectList
+  initialQuery, task/history panels, question draft restore).
+  `{ cursor: "preserve" }` keeps the clamped-cursor behavior for mid-edit
+  replacements.
+- Consumer: host pickers/panels via X001 `initialQuery`; question flow
+  draft restore.
+- Upstream status: absent (upstream and the kimi snapshot clamp only).
+- Tests: "setValue cursor semantics (X040)" in `test/input.test.ts`.
+- Migration action: re-apply with X041 (setFilter depends on it).
+
+### X041 — SelectList canonical filter query
+
+- Category: `HARD_HOST_API` (extends X001/X002)
+- Files: `src/components/select-list.ts`
+- Reason: the filter query has ONE source of truth (`filterQuery`, written
+  by every `applyFilter` call). Previously `setFilter()` narrowed
+  `filteredItems` while `getFilter()`/`setItems()` kept reading the search
+  box — a programmatic filter (`/sessions <query>`) desynced from the
+  rendered box, was silently DROPPED by the next keystroke, lost across
+  category switches and `setItems` refreshes, and `getFilter()` lied (empty)
+  with search disabled. `setFilter()` now syncs the search box (cursor at
+  the end via X040) before applying; `getFilter()` returns the canonical
+  query; `setItems()` re-applies it.
+- Consumer: host `/sessions` picker prefill, categorized picker Tab cycle,
+  MarqueeFilterAdapter, dynamic row enrichment.
+- Upstream status: absent (upstream has no search).
+- Tests: "canonical filter state (X041)" in `test/select-list.test.ts`.
+- Migration action: re-apply together with X001/X002 (same file, same
+  feature).
+
+### X042 — Focusable propagation on Input-owning lists
+
+- Category: `PUBLIC_COMPONENT_CONTRACT`
+- Files: `src/components/select-list.ts`, `src/components/settings-list.ts`
+- Reason: `SelectList`/`SettingsList` implement `Focusable`: the focused
+  flag propagates to the input the user actually types into (SelectList's
+  search Input; SettingsList's search Input AND the open submenu
+  component). Without it a focused list never emitted the hardware
+  `CURSOR_MARKER` and the IME candidate window mispositioned — the kimi
+  package README states the wrapper contract ("every wrapper owning an
+  Input/Editor must implement Focusable") but the kimi list components
+  themselves did not implement it either; the host compensates with its
+  FocusForwardingFrame for the Frame layer.
+- Consumer: host pickers/settings overlays (mounted behind frames).
+- Upstream status: absent.
+- Tests: fork lifecycle/X041 suites assert the focused flag shape; the
+  host-side wiring is covered by the bundle suites.
+- Migration action: re-apply (getter/setter pair + SettingsList
+  propagateFocus on submenu open).
+
+### X043 — Deferred viewport input listener registration (alt screen)
+
+- Category: `HARD_HOST_API`
+- Files: `src/tui-alt-screen.ts`
+- Reason: `TuiAltScreenOptions.deferViewportListener` skips the constructor
+  registration of the viewport input listener; `installViewportListener()`
+  (idempotent) registers it later. Input listeners dispatch in REGISTRATION
+  order, and the constructor registered the viewport listener FIRST — every
+  host listener installed afterwards (the app's single router, the
+  unstable raw-capture stage) only saw a chunk AFTER the viewport had
+  already consumed wheel/mouse events and semantic scroll keys, breaking
+  the host's "a raw capture sees/consumes/rewrites ANY chunk" contract in
+  fullscreen and diverging from the main screen's routing. The host
+  installs its router first, then the viewport listener.
+- Consumer: host `setFullscreen` (src/tui-app.ts) — router first, viewport
+  second; `onBeforeViewportInput` (X028) still runs inside the viewport
+  listener before its built-in keys.
+- Upstream status: absent (upstream always registers in the constructor).
+- Tests: "viewport listener registration order (X043)" in
+  `test/tui-alt-screen.test.ts`.
+- Migration action: re-apply the option + method pair; the default
+  (constructor registration) preserves upstream behavior.
+
+### X045 — Editor expanded-cursor mapping `getExpandedCursor()` (round-2 review)
+
+- Category: `HARD_HOST_API`
+- Files: `src/components/editor.ts`
+- Reason: `getExpandedCursor()` maps the cursor offset into
+  `getExpandedText()`'s coordinate space (every paste marker before the
+  cursor grows the offset by its content length; the editor's start-snap
+  keeps inside-marker cursors at the marker's start). getExpandedText is
+  upstream-native but gives no cursor pairing — draft HANDOFFS (seat
+  transfers via wireCursorOf) need both the text and the cursor to
+  survive marker expansion, or the transferred cursor lands at the wrong
+  visual position.
+- Consumer: host `src/editor-seat-holder.ts` (wireCursorOf),
+  HostEditorAdapter/SeatEditor optional `getExpandedCursor?()`.
+- Upstream status: absent.
+- Tests: "expanded cursor mapping (X045)" in `test/editor.test.ts`.
+- Migration action: re-apply together with the host's expanded-draft
+  wiring (round-2 P1: steer/submit/getDraft/viewer wires and seat
+  handoffs all carry expanded text).
+
+### X044 — Protected autocomplete seam
+
+- Category: `HARD_HOST_API`
+- Files: `src/components/editor.ts`
+- Reason: `requestAutocomplete`/`cancelAutocomplete` are `protected` (were
+  private): the host's TuiEditor subclass drives explicit/context-gated
+  completion and stale-dropdown cancellation through them. A private method
+  forced the host into `as unknown as` casts that keep COMPILING through
+  upstream signature changes and explode at runtime — exactly the class of
+  silent breakage the re-vendor gates exist to prevent.
+- Consumer: host `src/tui-editor.ts` (six former cast sites).
+- Upstream status: absent (upstream keeps them private).
+- Tests: "protected autocomplete seam (X044)" in `test/editor.test.ts`
+  (subclass compilation + no-throw with no provider).
+- Migration action: visibility change only; re-apply if upstream reverts
+  it.
+
 ## Host-side relocation audit (2026-09)
 
 Which divergences could move into the host bundle (`src/`) instead of
@@ -683,25 +898,61 @@ consumer actually changes.
 
 ## Removed kimi-only code (do NOT re-apply)
 
-These were part of the kimi-code snapshot but have no host consumer and are
-not in the upstream baseline. They are intentionally dropped by the Earendil
-re-vendor:
+These were part of the kimi-code snapshot and are not in the upstream
+baseline. REMOVAL CRITERIA (2026-09 audit lesson, from the PasteBurst
+regression): "no host consumer" is only valid for Host-API patches.
+Editor-internal bugfixes need terminal-environment coverage arguments, perf
+contracts need measurements, product behaviors need explicit product
+decisions. Each removal below names its criterion:
 
-- `PasteBurst` + `disablePasteBurst`/`setDisablePasteBurst` (editor) — no host consumer.
-- `inlineSlashTrigger` + inline-slash helpers (editor) — no host consumer.
-- `setHistoryFilter` (editor) — no host consumer.
-- `setText(text, { preservePasteRegistry })` (editor) — no host consumer.
-- `AutocompleteProvider` `additionalBasePaths` + multi-root fan-out — no host consumer.
-- `data?.["inlineSkill"]` Enter-non-submit carve-out (editor) — no host consumer.
-- `getLayoutRoot()` (alt screen) — no consumer.
-- `WIDTH_CACHE_SIZE = 4096` (utils) — kimi tweak; upstream 512 is retained.
-  With X035's reuse fast path the cold-path width measurements are bounded
-  to changed lines, so the larger FIFO is not needed.
+- ~~`PasteBurst`~~ — REMOVED as "no host consumer", RE-APPLIED as X038:
+  the criterion was wrong for an editor-internal terminal-input bugfix.
+- `inlineSlashTrigger` + inline-slash helpers (editor) — PRODUCT DECISION:
+  the host chose explicit, context-gated Tab completion over kimi's
+  opt-in inline `/` dropdown (default-off in kimi too).
+- `setHistoryFilter` (editor) — PRODUCT DECISION (parity enhancement):
+  kimi's shell-mode ↑ filters history by mode; DSH recall is mode-agnostic
+  by design. Revisit only as an explicit parity feature.
+- `setText(text, { preservePasteRegistry })` (editor) — SUPERSEDED: X023's
+  `setTextAndCursor` prune keeps surviving markers' entries and releases
+  vanished ones — a strictly better contract than the manual opt-in flag.
+- `AutocompleteProvider` `additionalBasePaths` + multi-root fan-out —
+  HOST API with no consumer (verified): the host's MentionProvider owns
+  multi-root fan-out itself.
+- `data?.["inlineSkill"]` Enter-non-submit carve-out (editor) — PRODUCT
+  DECISION: DSH has no mid-prompt inline-skill token concept; slash
+  commands submit on Enter by design (same as kimi's non-inlineSkill
+  path).
+- `getLayoutRoot()` (alt screen) — no consumer (verified).
+- ~~`WIDTH_CACHE_SIZE = 4096` (utils)~~ — REMOVED as a "kimi tweak", then
+  RESTORED as X039 (PERF_HOST_DEPENDENT): a perf contract's removal
+  criterion is the measured benefit, not the absence of host imports;
+  CJK-heavy burst re-measurement thrashes a 512-entry FIFO.
 - Negative-width `repeat()` guards (text/truncated-text/markdown/editor) —
   upstream baseline retained; X032's clamp protects the entry point. The
   one `Math.max(0, end - start)` padding guard in `layout.ts`
   (`targetText`) is also a local defensive keep alongside X032 (upstream
   0.84.4 pads without the clamp).
+
+## Final status after the 2026-09 follow-up audit (post-PR-#68 sweep)
+
+- NEW divergences: X037 (editor submit split), X038 (PasteBurst restored),
+  X039 (width cache 4096 restored), X040 (setValue cursor), X041 (canonical
+  filter query), X042 (Focusable lists), X043 (deferred viewport listener),
+  X044 (protected autocomplete seam), X045 (expanded-cursor mapping,
+  round-2 review).
+- UPDATED: X007 (dispose completed across Box/SettingsList/overlay hide via
+  opt-in disposeOnHide), X023 (paste registry prune), X028 (canScroll +
+  host prompt-nav claim), X001/X002 (see X041).
+- Host-side fixes that need NO fork divergence (upstream-native seams the
+  host failed to use): `getExpandedText` for the external-editor round-trip
+  and draft snapshots; `TuiStopOptions.preserveScreen` for the
+  external-editor suspend/resume (fullscreen preserved);
+  `openUrl`/`onRightClickPaste` fullscreen wiring; `renderLatex: false`
+  (product decision, kimi parity); `basis: 0` on the fullscreen scroll
+  entry.
+- REMOVAL CRITERIA recorded in the removed-code section: "no host consumer"
+  applies to Host-API patches only.
 
 ## Acceptance after syncing from upstream
 
@@ -712,7 +963,9 @@ re-vendor:
 
 ## Final status after the v0.84.4 re-vendor (2026-09)
 
-- `KEEP` (re-applied on the Earendil v0.84.4 base): X001, X002,
+- `KEEP` (re-applied on the Earendil v0.84.4 base; the 2026-09
+  follow-up audit ADDS X037–X045 — see its own status section above):
+  X001, X002,
   X004A, X004B, X005, X006, X007, X008, X009, X010, X011, X012,
   X014 (measurement cache ONLY — the scrollbar thumb clamp is already in
   upstream 0.84.4, see the entry's scope note), X016, X018, X019, X020,
@@ -728,11 +981,15 @@ re-vendor:
 - `PACKAGING_ONLY`: X025 (tsdown config — XMoon shell kept).
 - `REMOVED_UNUSED` (no host consumer; X003 is a code-unit/grapheme
   mismatch defect and X013 is unconsumed — see their entries): X003,
-  X013, PasteBurst,
-  inlineSlashTrigger, setHistoryFilter, preservePasteRegistry,
-  additionalBasePaths, inlineSkill data, getLayoutRoot,
-  WIDTH_CACHE_SIZE 4096. (Defensive negative-width `repeat()` guards are
-  dropped in text/truncated-text/markdown/editor; `layout.ts` retains one
-  local `Math.max(0, end - start)` `targetText` padding guard alongside
+  X013, inlineSlashTrigger, setHistoryFilter, preservePasteRegistry,
+  additionalBasePaths, inlineSkill data, getLayoutRoot. NOTE
+  (2026-09 follow-up audit): PasteBurst and `WIDTH_CACHE_SIZE = 4096`
+  were initially listed here and are NO LONGER REMOVED — PasteBurst is
+  restored as X038 and the width cache as X039 (the "no host consumer"
+  criterion was wrong for an internal bugfix and a perf contract; see the
+  removed-code section above for the per-category criteria). (Defensive
+  negative-width `repeat()` guards are dropped in
+  text/truncated-text/markdown/editor; `layout.ts` retains one local
+  `Math.max(0, end - start)` `targetText` padding guard alongside
   X032's entry-point clamp — the scrollbar thumb clamp itself is upstream
   baseline.)

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -56,5 +56,5 @@
 	"engines": {
 		"node": ">=22.19.0"
 	},
-	"//native": "native/ (darwin/win32 modifier-key prebuilds) is deliberately not vendored; loading degrades gracefully without it. See AGENTS.md."
+	"//native": "native/ (darwin/win32 modifier-key prebuilds) is deliberately not vendored. Without it the TUI still runs, but platform input degrades: on Windows/Apple Terminal Shift+Tab is indistinguishable from Tab and the native Shift+Enter modifier fallback is unavailable (terminal.ts falls back to sequence heuristics). Supported surface: Linux/WSL/SSH into Linux. See AGENTS.md."
 }

--- a/packages/pi-tui/src/components/box.ts
+++ b/packages/pi-tui/src/components/box.ts
@@ -36,10 +36,14 @@ export class Box implements Component {
 		if (index !== -1) {
 			this.children.splice(index, 1);
 			this.invalidateCache();
+			// Removal ends ownership: release the child's resources, exactly
+			// like Container.removeChild (dsh-pi-tui divergence X007).
+			component.dispose?.();
 		}
 	}
 
 	clear(): void {
+		for (const child of this.children) child.dispose?.();
 		this.children = [];
 		this.invalidateCache();
 	}

--- a/packages/pi-tui/src/components/box.ts
+++ b/packages/pi-tui/src/components/box.ts
@@ -48,6 +48,16 @@ export class Box implements Component {
 		this.invalidateCache();
 	}
 
+	/**
+	 * Release every child (dsh-pi-tui divergence X007): a Box nested under
+	 * a Container/overlay must forward disposal — without this, only
+	 * box.removeChild/clear released children and a parent-owned Box
+	 * leaked its resource-owning subtree.
+	 */
+	dispose(): void {
+		this.clear();
+	}
+
 	setBgFn(bgFn?: (text: string) => string): void {
 		this.bgFn = bgFn;
 		// Don't invalidate here - we'll detect bgFn changes by sampling output

--- a/packages/pi-tui/src/components/editor.ts
+++ b/packages/pi-tui/src/components/editor.ts
@@ -2,6 +2,7 @@ import type { AutocompleteProvider, AutocompleteSuggestions } from "../autocompl
 import { getKeybindings } from "../keybindings.ts";
 import { decodePrintableKey, matchesKey } from "../keys.ts";
 import { KillRing } from "../kill-ring.ts";
+import { PasteBurst } from "../paste-burst.ts";
 import { type Component, CURSOR_MARKER, type Focusable, type TUI } from "../tui.ts";
 import { UndoStack } from "../undo-stack.ts";
 import {
@@ -254,6 +255,16 @@ export interface EditorTheme {
 export interface EditorOptions {
 	paddingX?: number;
 	autocompleteMaxVisible?: number;
+	/**
+	 * Disable the non-bracketed paste-burst fallback (dsh-pi-tui divergence
+	 * X038). Default false (the fallback is ON): terminals that lose
+	 * bracketed-paste markers (iTerm2/tmux) deliver pastes as rapid plain
+	 * character streams, and the trailing Enter must insert a newline
+	 * instead of submitting the half-pasted draft. Exposed as an option so
+	 * tests and integrations that legitimately type fast sequences followed
+	 * by Enter can opt out.
+	 */
+	disablePasteBurst?: boolean;
 }
 
 const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
@@ -378,14 +389,28 @@ export class Editor implements Component, Focusable {
 	// Undo support
 	private undoStack = new UndoStack<EditorSnapshot>();
 
+	// Non-bracketed paste-burst fallback (dsh-pi-tui divergence X038)
+	private pasteBurst = new PasteBurst();
+	private disablePasteBurst = false;
+
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
 	public disableSubmit: boolean = false;
+
+	/**
+	 * Toggle the non-bracketed paste-burst fallback at runtime
+	 * (dsh-pi-tui divergence X038). Default: enabled.
+	 */
+	setDisablePasteBurst(disabled: boolean): void {
+		this.disablePasteBurst = disabled;
+		if (disabled) this.pasteBurst.reset();
+	}
 
 	constructor(tui: TUI, theme: EditorTheme, options: EditorOptions = {}) {
 		this.tui = tui;
 		this.theme = theme;
 		this.borderColor = theme.borderColor;
+		this.disablePasteBurst = options.disablePasteBurst ?? false;
 		const paddingX = options.paddingX ?? 0;
 		this.paddingX = Number.isFinite(paddingX) ? Math.max(0, Math.floor(paddingX)) : 0;
 		const maxVisible = options.autocompleteMaxVisible ?? 5;
@@ -728,6 +753,22 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
+		// Non-bracketed paste-burst tracking (dsh-pi-tui divergence X038,
+		// kimi-exact semantics): a rapid stream of SINGLE plain characters
+		// followed by Enter is treated as a lost-marker paste. Enter itself
+		// keeps the burst alive; a single printable character feeds it; any
+		// other input (multi-char chunks, arrows, chords, escapes) breaks
+		// it — multi-char reads are ordinary typed-ahead text or an explicit
+		// whole-line injection, not a terminal dribbling a paste one
+		// character at a time. Disabled integrations skip the tracking
+		// entirely.
+		const isEnterKey = data !== "\n" && kb.matches(data, "tui.editor.submit");
+		const burstChar = decodePrintableKey(data)
+			?? (data.length === 1 && data.charCodeAt(0) >= 32 && data.charCodeAt(0) !== 0x7f ? data : undefined);
+		if (!this.disablePasteBurst && !isEnterKey && burstChar === undefined) {
+			this.pasteBurst.reset();
+		}
+
 		// Ctrl+C - let parent handle (exit/clear)
 		if (kb.matches(data, "tui.input.copy")) {
 			return;
@@ -890,8 +931,10 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
-		// Submit (Enter)
-		if (kb.matches(data, "tui.input.submit")) {
+		// Submit (Enter) — the editor consults its OWN submit binding
+		// (tui.editor.submit, X037): a host remap of the editor's
+		// submission must not change what every plain Input submits on.
+		if (kb.matches(data, "tui.editor.submit")) {
 			if (this.disableSubmit) return;
 
 			// Workaround for terminals without Shift+Enter support:
@@ -900,6 +943,17 @@ export class Editor implements Component, Focusable {
 			if (this.state.cursorCol > 0 && currentLine[this.state.cursorCol - 1] === "\\") {
 				this.handleBackspace();
 				this.addNewLine();
+				return;
+			}
+
+			// Paste-burst fallback (dsh-pi-tui divergence X038): this Enter
+			// directly follows a rapid plain-character stream — a lost-marker
+			// paste's trailing Enter. Insert a newline instead of submitting
+			// the half-pasted draft (and keep the window open: a multi-line
+			// paste ends with several Enter-delimited lines).
+			if (!this.disablePasteBurst && this.pasteBurst.shouldInsertNewlineInsteadOfSubmit(Date.now())) {
+				this.addNewLine();
+				this.pasteBurst.extendWindow(Date.now());
 				return;
 			}
 
@@ -970,12 +1024,14 @@ export class Editor implements Component, Focusable {
 
 		const printable = decodePrintableKey(data);
 		if (printable !== undefined) {
+			if (!this.disablePasteBurst) this.pasteBurst.onPlainChar(Date.now());
 			this.insertCharacter(printable);
 			return;
 		}
 
 		// Regular characters
 		if (data.charCodeAt(0) >= 32) {
+			if (!this.disablePasteBurst) this.pasteBurst.onPlainChar(Date.now());
 			this.insertCharacter(data);
 		}
 	}
@@ -1089,6 +1145,42 @@ export class Editor implements Component, Focusable {
 		return this.expandPasteMarkers(this.state.lines.join("\n"));
 	}
 
+	/**
+	 * The cursor offset mapped into getExpandedText()'s coordinate space
+	 * (dsh-pi-tui divergence X045): every paste marker before the cursor
+	 * grows the offset by its content length; a cursor inside an atomic
+	 * marker snaps to that marker's end first. Pairs with
+	 * getExpandedText() for draft HANDOFFS (seat transfers), where both
+	 * the text and the cursor must survive marker expansion.
+	 */
+	getExpandedCursor(): number {
+		let rawCursor = 0;
+		for (let line = 0; line < this.state.cursorLine; line++) {
+			rawCursor += (this.state.lines[line] ?? "").length + 1;
+		}
+		rawCursor += this.state.cursorCol;
+		let delta = 0;
+		let lineStart = 0;
+		for (const text of this.state.lines) {
+			for (const match of (text ?? "").matchAll(PASTE_MARKER_REGEX)) {
+				const content = this.pastes.get(Number.parseInt(match[1]!, 10));
+				if (content === undefined) continue;
+				const markerStart = lineStart + match.index!;
+				const markerEnd = markerStart + match[0].length;
+				if (rawCursor >= markerEnd) {
+					delta += content.length - match[0].length;
+				} else if (rawCursor > markerStart) {
+					// The cursor sits inside an atomic marker: snap to its
+					// end, then account for the expansion.
+					rawCursor = markerEnd;
+					delta += content.length - match[0].length;
+				}
+			}
+			lineStart += (text ?? "").length + 1;
+		}
+		return rawCursor + delta;
+	}
+
 	getLines(): string[] {
 		return [...this.state.lines];
 	}
@@ -1164,6 +1256,20 @@ export class Editor implements Component, Focusable {
 		this.state.cursorLine = line;
 		this.setCursorCol(col);
 		this.scrollOffset = 0;
+		// The whole document is replaced: PRUNE the paste registry to the
+		// markers that actually survive in the new text. Staged replacement
+		// text (a plugin editor's document) otherwise leaves orphaned
+		// multi-hundred-KB paste entries that can never be expanded again
+		// (dsh-pi-tui divergence X023 tightening — neither "keep all" nor
+		// "clear all": surviving markers keep their content, vanished ones
+		// release theirs).
+		const survivingPasteIds = new Set<number>();
+		for (const match of normalized.matchAll(PASTE_MARKER_REGEX)) {
+			survivingPasteIds.add(Number.parseInt(match[1]!, 10));
+		}
+		for (const pasteId of this.pastes.keys()) {
+			if (!survivingPasteIds.has(pasteId)) this.pastes.delete(pasteId);
+		}
 		this.tui.requestRender();
 	}
 
@@ -1404,7 +1510,7 @@ export class Editor implements Component, Focusable {
 	private shouldSubmitOnBackslashEnter(data: string, kb: ReturnType<typeof getKeybindings>): boolean {
 		if (this.disableSubmit) return false;
 		if (!matchesKey(data, "enter")) return false;
-		const submitKeys = kb.getKeys("tui.input.submit");
+		const submitKeys = kb.getKeys("tui.editor.submit");
 		const hasShiftEnter = submitKeys.includes("shift+enter") || submitKeys.includes("shift+return");
 		if (!hasShiftEnter) return false;
 
@@ -2336,7 +2442,14 @@ export class Editor implements Component, Focusable {
 		this.requestAutocomplete({ force: true, explicitTab });
 	}
 
-	private requestAutocomplete(options: { force: boolean; explicitTab: boolean }): void {
+	/**
+	 * Request an autocomplete round. PROTECTED (dsh-pi-tui divergence X044):
+	 * a subclass (the host's TuiEditor) drives explicit/context-gated
+	 * completion triggers through this seam — a private method forced the
+	 * host into `as unknown as` casts that survive upstream signature
+	 * changes at runtime instead of failing to compile.
+	 */
+	protected requestAutocomplete(options: { force: boolean; explicitTab: boolean }): void {
 		if (!this.autocompleteProvider) return;
 
 		if (options.force) {
@@ -2526,7 +2639,14 @@ export class Editor implements Component, Focusable {
 		this.autocompletePrefix = "";
 	}
 
-	private cancelAutocomplete(): void {
+	/**
+	 * Close any open autocomplete UI and abort the pending request.
+	 * PROTECTED (dsh-pi-tui divergence X044): a subclass (the host's
+	 * TuiEditor) cancels stale dropdowns on mode switches and Esc; same
+	 * rationale as requestAutocomplete — the host must not reach internals
+	 * through casts.
+	 */
+	protected cancelAutocomplete(): void {
 		this.cancelAutocompleteRequest();
 		this.clearAutocompleteUi();
 	}

--- a/packages/pi-tui/src/components/input.ts
+++ b/packages/pi-tui/src/components/input.ts
@@ -13,6 +13,16 @@ interface InputState {
 	cursor: number;
 }
 
+/** Cursor placement options for {@link Input.setValue}. */
+export interface InputSetValueOptions {
+	/**
+	 * Where the cursor lands after the value is replaced. Defaults to
+	 * `"end"` (prefill semantics — the next keystroke appends); `"preserve"`
+	 * keeps the historical clamped-cursor behavior.
+	 */
+	cursor?: "end" | "preserve";
+}
+
 /**
  * Input component - single-line text input with horizontal scrolling
  */
@@ -40,9 +50,18 @@ export class Input implements Component, Focusable {
 		return this.value;
 	}
 
-	setValue(value: string): void {
+	setValue(value: string, options?: InputSetValueOptions): void {
 		this.value = value;
-		this.cursor = Math.min(this.cursor, value.length);
+		// Prefill cursor semantics (dsh-pi-tui divergence X040; upstream and
+		// the kimi snapshot only clamp): the cursor lands at the END of the new
+		// value so the next typed character APPENDS. Every existing caller
+		// pre-fills a query/draft the user continues typing; a fresh Input's
+		// cursor 0 made `setValue("foo")` + "x" produce "xfoo". Pass
+		// { cursor: "preserve" } for the historical clamped-cursor behavior
+		// (mid-edit value replacement).
+		this.cursor = options?.cursor === "preserve"
+			? Math.min(this.cursor, value.length)
+			: value.length;
 	}
 
 	handleInput(data: string): void {

--- a/packages/pi-tui/src/components/select-list.ts
+++ b/packages/pi-tui/src/components/select-list.ts
@@ -1,5 +1,5 @@
 import { getKeybindings } from "../keybindings.ts";
-import type { Component } from "../tui.ts";
+import type { Component, Focusable } from "../tui.ts";
 import { truncateToWidth, visibleWidth } from "../utils.ts";
 import { Input } from "./input.ts";
 
@@ -77,9 +77,19 @@ export interface SelectListOptions {
 	initialQuery?: string;
 }
 
-export class SelectList implements Component {
+export class SelectList implements Component, Focusable {
 	private items: SelectItem[] = [];
 	private filteredItems: SelectItem[] = [];
+	/**
+	 * The CANONICAL filter query. One source of truth for getFilter(),
+	 * setItems() re-application and the rendered search box: a programmatic
+	 * setFilter(), a setItems() refresh and user typing all write through
+	 * applyFilter(), so they can never drift apart (a setFilter that only
+	 * narrowed filteredItems left getFilter() reading a stale search box and
+	 * the next keystroke silently dropping the programmatic query).
+	 * (dsh-pi-tui divergence X041; upstream has no search at all.)
+	 */
+	private filterQuery = "";
 	/** Lowercased value+label+description per item, rebuilt on setItems. */
 	private searchTexts = new Map<SelectItem, string>();
 	private selectedIndex: number = 0;
@@ -93,6 +103,22 @@ export class SelectList implements Component {
 	public onSelect?: (item: SelectItem) => void;
 	public onCancel?: () => void;
 	public onSelectionChange?: (item: SelectItem) => void;
+
+	/**
+	 * Focusable (dsh-pi-tui divergence X042): the focused flag propagates to
+	 * the search Input so it emits the hardware CURSOR_MARKER for IME
+	 * candidate-window positioning. The wrapper contract: every component
+	 * owning an Input/Editor must forward focus; a plain Component swallows
+	 * the flag and the IME misplaces its candidate window.
+	 */
+	private _focused = false;
+	get focused(): boolean {
+		return this._focused;
+	}
+	set focused(value: boolean) {
+		this._focused = value;
+		if (this.searchInput !== undefined) this.searchInput.focused = value;
+	}
 
 	constructor(
 		items: SelectItem[],
@@ -129,15 +155,24 @@ export class SelectList implements Component {
 	setItems(items: SelectItem[]): void {
 		this.items = items;
 		this.searchTexts = this.buildSearchTexts(items);
-		this.applyFilter(this.searchInput?.getValue() ?? "", true);
+		// Re-apply the CANONICAL query (not the search box's value): a
+		// programmatic setFilter() must survive an async row refresh.
+		this.applyFilter(this.filterQuery, true);
 	}
 
 	/** The current search query (empty when search is disabled). */
 	getFilter(): string {
-		return this.searchInput?.getValue() ?? "";
+		return this.filterQuery;
 	}
 
 	setFilter(filter: string): void {
+		// Sync the search box so the box, the filter and getFilter() can
+		// never diverge; the setValue cursor lands at the end so the user's
+		// next keystroke APPENDS to the programmatic query instead of
+		// prepending in front of it.
+		if (this.searchEnabled && this.searchInput !== undefined && this.searchInput.getValue() !== filter) {
+			this.searchInput.setValue(filter);
+		}
 		this.applyFilter(filter);
 	}
 
@@ -274,6 +309,7 @@ export class SelectList implements Component {
 	 * survives the filter — used by setItems, where the query did not change
 	 * and snapping back to the top would fight the user's cursor. */
 	private applyFilter(query: string, preserveSelection = false): void {
+		this.filterQuery = query;
 		const previousValue = preserveSelection ? this.filteredItems[this.selectedIndex]?.value : undefined;
 		if (query === "") {
 			this.filteredItems = this.items;

--- a/packages/pi-tui/src/components/settings-list.ts
+++ b/packages/pi-tui/src/components/settings-list.ts
@@ -268,7 +268,7 @@ export class SettingsList implements Component, Focusable {
 			// X007 — the submenu slot owns the component's lifecycle).
 			this.submenuComponent?.dispose?.();
 			const generation = ++this.submenuGeneration;
-			this.submenuComponent = item.submenu(
+			const component = item.submenu(
 				item.currentValue,
 				(selectedValue?: string, options?: { navigateTo?: string }) => {
 					// A callback from a CLOSED/REPLACED/DISPOSED submenu is
@@ -284,6 +284,17 @@ export class SettingsList implements Component, Focusable {
 					this.closeSubmenu();
 				},
 			);
+			// The factory may call done() SYNCHRONOUSLY before returning
+			// (round-7 review P2): the callback passed its own generation
+			// check, closeSubmenu() ran, and the outer assignment would
+			// otherwise RESURRECT the closed submenu (or overwrite a
+			// follow-up submenu opened by navigateAfterClose). Re-check the
+			// generation AFTER the factory returns and release the orphan.
+			if (generation !== this.submenuGeneration) {
+				component.dispose?.();
+				return;
+			}
+			this.submenuComponent = component;
 			// The freshly opened submenu becomes the input the user types
 			// into: forward the current focus state so its CURSOR_MARKER
 			// (IME positioning) matches the list's focus (dsh-pi-tui

--- a/packages/pi-tui/src/components/settings-list.ts
+++ b/packages/pi-tui/src/components/settings-list.ts
@@ -1,6 +1,6 @@
 import { fuzzyFilter } from "../fuzzy.ts";
 import { getKeybindings } from "../keybindings.ts";
-import type { Component } from "../tui.ts";
+import type { Component, Focusable } from "../tui.ts";
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "../utils.ts";
 import { Input } from "./input.ts";
 
@@ -35,7 +35,7 @@ export interface SettingsListOptions {
 	enableSearch?: boolean;
 }
 
-export class SettingsList implements Component {
+export class SettingsList implements Component, Focusable {
 	private items: SettingItem[];
 	private filteredItems: SettingItem[];
 	private theme: SettingsListTheme;
@@ -50,6 +50,40 @@ export class SettingsList implements Component {
 	private submenuComponent: Component | null = null;
 	private submenuItemIndex: number | null = null;
 	private navigateAfterClose: string | null = null;
+	/**
+	 * Submenu generation token (round-5 review P2): every submenu factory
+	 * callback captures the generation at OPEN time; a callback that fires
+	 * after the submenu was closed, REPLACED or the list disposed is stale
+	 * and must be a no-op — otherwise a delayed `done()` could resurrect
+	 * navigation on a disposed list.
+	 */
+	private submenuGeneration = 0;
+
+	/**
+	 * Focusable (dsh-pi-tui divergence X042): the focused flag propagates to
+	 * the input the user is actually typing into — the search Input on the
+	 * main list, the open submenu component while it is active — so it
+	 * emits the hardware CURSOR_MARKER for IME candidate-window positioning.
+	 * The wrapper contract: every component owning an Input/Editor must
+	 * forward focus; a plain Component swallows the flag and the IME
+	 * misplaces its candidate window.
+	 */
+	private _focused = false;
+	get focused(): boolean {
+		return this._focused;
+	}
+	set focused(value: boolean) {
+		this._focused = value;
+		this.propagateFocus();
+	}
+
+	private propagateFocus(): void {
+		if (this.searchInput !== undefined) this.searchInput.focused = this._focused;
+		const submenu = this.submenuComponent;
+		if (submenu !== null && "focused" in submenu) {
+			(submenu as Focusable).focused = this._focused;
+		}
+	}
 
 	constructor(
 		items: SettingItem[],
@@ -90,6 +124,19 @@ export class SettingsList implements Component {
 
 	invalidate(): void {
 		this.submenuComponent?.invalidate?.();
+	}
+
+	/**
+	 * Release owned resources: the open submenu component (its slot owns
+	 * the lifecycle). Raw release — deliberately NOT closeSubmenu(), whose
+	 * navigateAfterClose handling would resurrect a FOLLOW-UP submenu
+	 * during disposal. Idempotent. (dsh-pi-tui divergence X007.)
+	 */
+	dispose(): void {
+		this.navigateAfterClose = null;
+		this.submenuGeneration++;
+		this.submenuComponent?.dispose?.();
+		this.submenuComponent = null;
 	}
 
 	render(width: number): string[] {
@@ -216,9 +263,17 @@ export class SettingsList implements Component {
 		if (item.submenu) {
 			// Open submenu, passing current value so it can pre-select correctly
 			this.submenuItemIndex = this.selectedIndex;
+			// Replacing an open submenu ends its ownership: dispose the old
+			// component before the new one takes over (dsh-pi-tui divergence
+			// X007 — the submenu slot owns the component's lifecycle).
+			this.submenuComponent?.dispose?.();
+			const generation = ++this.submenuGeneration;
 			this.submenuComponent = item.submenu(
 				item.currentValue,
 				(selectedValue?: string, options?: { navigateTo?: string }) => {
+					// A callback from a CLOSED/REPLACED/DISPOSED submenu is
+					// stale: it must never resurrect navigation (round-5 P2).
+					if (generation !== this.submenuGeneration) return;
 					if (selectedValue !== undefined) {
 						item.currentValue = selectedValue;
 						this.onChange(item.id, selectedValue);
@@ -229,6 +284,11 @@ export class SettingsList implements Component {
 					this.closeSubmenu();
 				},
 			);
+			// The freshly opened submenu becomes the input the user types
+			// into: forward the current focus state so its CURSOR_MARKER
+			// (IME positioning) matches the list's focus (dsh-pi-tui
+			// divergence).
+			this.propagateFocus();
 		} else if (item.values && item.values.length > 0) {
 			// Cycle through values
 			const currentIndex = item.values.indexOf(item.currentValue);
@@ -240,6 +300,11 @@ export class SettingsList implements Component {
 	}
 
 	private closeSubmenu(): void {
+		// Closing the submenu ends its ownership: release the component's
+		// resources (dsh-pi-tui divergence X007) and invalidate every
+		// outstanding submenu callback (round-5 P2).
+		this.submenuGeneration++;
+		this.submenuComponent?.dispose?.();
 		this.submenuComponent = null;
 		if (this.navigateAfterClose !== null) {
 			const id = this.navigateAfterClose;

--- a/packages/pi-tui/src/keybindings.ts
+++ b/packages/pi-tui/src/keybindings.ts
@@ -34,6 +34,8 @@ export interface Keybindings {
 	"tui.input.submit": true;
 	"tui.input.tab": true;
 	"tui.input.copy": true;
+	// Editor-owned submit (split from tui.input.submit — see X037)
+	"tui.editor.submit": true;
 	// Generic selection actions
 	"tui.select.up": true;
 	"tui.select.down": true;
@@ -142,6 +144,15 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.undo": { defaultKeys: "ctrl+-", description: "Undo" },
 	"tui.input.newLine": { defaultKeys: ["shift+enter", "ctrl+j"], description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
+	/**
+	 * The EDITOR's submit key, deliberately separate from
+	 * `tui.input.submit` (dsh-pi-tui divergence X037): keybindings are
+	 * process-global, so a host remapping the editor's submission must not
+	 * leak into every plain `Input` (search boxes, question free-text,
+	 * pickers). The editor consults only this binding; `Input` keeps
+	 * `tui.input.submit`.
+	 */
+	"tui.editor.submit": { defaultKeys: "enter", description: "Submit the editor draft" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },
 	"tui.input.copy": { defaultKeys: "ctrl+c", description: "Copy selection" },
 	"tui.select.up": { defaultKeys: "up", description: "Move selection up" },

--- a/packages/pi-tui/src/paste-burst.ts
+++ b/packages/pi-tui/src/paste-burst.ts
@@ -1,0 +1,61 @@
+const PASTE_BURST_MIN_CHARS = 8;
+const PASTE_BURST_CHAR_INTERVAL_MS = 8;
+const PASTE_BURST_ACTIVE_IDLE_TIMEOUT_MS = 30;
+const PASTE_ENTER_SUPPRESS_WINDOW_MS = 120;
+
+/**
+ * Detects non-bracketed paste bursts: a rapid stream of plain characters
+ * followed by Enter, where a bare Enter would otherwise submit the draft.
+ *
+ * This is a heuristic fallback for terminals that do not surface bracketed
+ * paste markers. It intentionally does not buffer characters; the editor still
+ * inserts typed text normally, and this class only decides whether an imminent
+ * Enter should insert a newline instead of submitting.
+ */
+export class PasteBurst {
+  private lastPlainCharAt?: number;
+  private consecutivePlainChars = 0;
+  private activeUntil = 0;
+  private enterSuppressUntil = 0;
+
+  onPlainChar(now: number): void {
+    if (
+      this.lastPlainCharAt !== undefined &&
+      now - this.lastPlainCharAt <= PASTE_BURST_CHAR_INTERVAL_MS
+    ) {
+      this.consecutivePlainChars++;
+    } else {
+      this.consecutivePlainChars = 1;
+    }
+
+    this.lastPlainCharAt = now;
+
+    if (this.consecutivePlainChars >= PASTE_BURST_MIN_CHARS) {
+      this.extendWindow(now);
+    }
+  }
+
+  shouldInsertNewlineInsteadOfSubmit(now: number): boolean {
+    if (now <= this.activeUntil || now <= this.enterSuppressUntil) {
+      return true;
+    }
+
+    return (
+      this.lastPlainCharAt !== undefined &&
+      this.consecutivePlainChars >= PASTE_BURST_MIN_CHARS &&
+      now - this.lastPlainCharAt <= PASTE_BURST_CHAR_INTERVAL_MS
+    );
+  }
+
+  extendWindow(now: number): void {
+    this.activeUntil = now + PASTE_BURST_ACTIVE_IDLE_TIMEOUT_MS;
+    this.enterSuppressUntil = now + PASTE_ENTER_SUPPRESS_WINDOW_MS;
+  }
+
+  reset(): void {
+    this.lastPlainCharAt = undefined;
+    this.consecutivePlainChars = 0;
+    this.activeUntil = 0;
+    this.enterSuppressUntil = 0;
+  }
+}

--- a/packages/pi-tui/src/tui-alt-screen.ts
+++ b/packages/pi-tui/src/tui-alt-screen.ts
@@ -189,6 +189,17 @@ export interface TuiAltScreenOptions {
 	 * divergence X018.)
 	 */
 	onCellClick?: (x: number, y: number) => void;
+	/**
+	 * Defer the viewport input listener's registration out of the
+	 * constructor (dsh-pi-tui divergence X043). Input listeners run in
+	 * REGISTRATION order, and the constructor registers the viewport
+	 * listener FIRST — so every later host listener (the app's single
+	 * router, raw-capture stages) sees a chunk only AFTER the viewport has
+	 * already consumed wheel/mouse events and semantic scroll keys. With
+	 * this option the host installs its own listeners first, then calls
+	 * {@link TuiAltScreen.installViewportListener} exactly once.
+	 */
+	deferViewportListener?: boolean;
 }
 
 /** Alternate-screen TUI with a scrollable, application-owned viewport. */
@@ -261,8 +272,26 @@ export class TuiAltScreen extends TuiBase implements ViewportTUI {
 		this.onCellClick = options.onCellClick;
 		this.onScrollBoundary = options.onScrollBoundary;
 		this.onBeforeViewportInput = options.onBeforeViewportInput;
+		if (options.deferViewportListener !== true) {
+			this.viewportListenerInstalled = true;
+			this.addInputListener((data) => this.handleViewportInput(data));
+		}
+	}
+
+	/**
+	 * Register the viewport input listener explicitly — only valid with the
+	 * {@link TuiAltScreenOptions.deferViewportListener} constructor option,
+	 * idempotent afterwards (subsequent calls are no-ops). Registration
+	 * order IS dispatch order: call this AFTER every host listener that
+	 * must see raw chunks first. (dsh-pi-tui divergence X043.)
+	 */
+	installViewportListener(): void {
+		if (this.viewportListenerInstalled) return;
+		this.viewportListenerInstalled = true;
 		this.addInputListener((data) => this.handleViewportInput(data));
 	}
+
+	private viewportListenerInstalled = false;
 
 	get viewportTop(): number {
 		return this.getPrimaryScrollView().scrollTop;

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -166,6 +166,15 @@ export interface OverlayOptions {
 	visible?: (termWidth: number, termHeight: number) => boolean;
 	/** If true, don't capture keyboard focus when shown */
 	nonCapturing?: boolean;
+	/**
+	 * Dispose the component when the overlay is permanently removed
+	 * (hide() / hideOverlay()) — ownership ends with the removal
+	 * (dsh-pi-tui divergence X007). DEFAULT FALSE (upstream behavior):
+	 * hide() only unregisters, so an integrator that re-mounts the SAME
+	 * component elsewhere (fullscreen screen migration) keeps it alive.
+	 * Set true when this overlay's entry is the component's sole owner.
+	 */
+	disposeOnHide?: boolean;
 }
 
 /** Options for {@link OverlayHandle.unfocus}. */
@@ -587,6 +596,12 @@ export abstract class TuiBase extends Container implements TUI {
 					this.clearOverlayFocusRestoreFor(entry);
 					this.retargetOverlayPreFocus(entry);
 					this.overlayStack.splice(index, 1);
+					// Opt-in ownership end (dsh-pi-tui divergence X007): with
+					// disposeOnHide the removal releases the component's
+					// resources. The stack-guard makes this run exactly once
+					// per removal; the default (no flag) keeps upstream
+					// behavior so re-mountable integrations stay alive.
+					if (options?.disposeOnHide === true) component.dispose?.();
 					// Restore focus if this overlay had focus
 					if (this.focusedComponent === component) {
 						const topVisible = this.getTopmostVisibleOverlay();
@@ -665,6 +680,9 @@ export abstract class TuiBase extends Container implements TUI {
 		this.clearOverlayFocusRestoreFor(overlay);
 		this.retargetOverlayPreFocus(overlay);
 		this.overlayStack.pop();
+		// Opt-in ownership end (dsh-pi-tui divergence X007, same contract
+		// as OverlayHandle.hide's disposeOnHide).
+		if (overlay.options?.disposeOnHide === true) overlay.component.dispose?.();
 		if (this.focusedComponent === overlay.component) {
 			// Find topmost visible overlay, or fall back to preFocus
 			const topVisible = this.getTopmostVisibleOverlay();

--- a/packages/pi-tui/src/utils.ts
+++ b/packages/pi-tui/src/utils.ts
@@ -47,8 +47,12 @@ const terminalSpacingMarkRegex =
 	/^(?:[\p{Spacing_Mark}--[\u1734\u302E\u302F]]|[\u065F\u0F7F\u102B\u102C\u1031\u1033-\u1035\u1038\u103A-\u103E])+$/v;
 const rgiEmojiRegex = /^\p{RGI_Emoji}$/v;
 
-// Cache for non-ASCII strings
-const WIDTH_CACHE_SIZE = 512;
+// Cache for non-ASCII strings. 4096 (dsh-pi-tui divergence X039, kimi-era
+// value): the host renders CJK-heavy transcripts where a 512-entry FIFO
+// thrashes on width changes / theme invalidations / cold renders that
+// re-measure many non-ASCII lines; the entry cost is a short string key.
+// (Upstream 0.84.4 uses 512.)
+const WIDTH_CACHE_SIZE = 4096;
 const widthCache = new Map<string, number>();
 
 export const cjkBreakRegex =

--- a/packages/pi-tui/test/dispose-lifecycle.test.ts
+++ b/packages/pi-tui/test/dispose-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { Box } from "../src/components/box.ts";
+import { Container } from "../src/tui.ts";
 import { SettingsList } from "../src/components/settings-list.ts";
 import { Text } from "../src/components/text.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
@@ -108,6 +109,27 @@ describe("Component dispose lifecycle completeness (X007)", () => {
 			box.clear();
 			assert.equal(first.disposeCount, 1);
 			assert.equal(second.disposeCount, 1);
+		});
+
+		it("a parent-owned Box forwards disposal to its children (nested ownership)", () => {
+			// Container -> Box -> resource-owning child: removing the Box
+			// from the Container must dispose the child exactly once.
+			const container = new Container();
+			const box = new Box(1, 1);
+			const child = new DisposeCounter();
+			box.addChild(child.toComponent());
+			container.addChild(box);
+
+			container.removeChild(box);
+			assert.equal(child.disposeCount, 1, "Box.dispose must cascade to its children");
+
+			// And a second removal path (Container.dispose) stays idempotent.
+			const box2 = new Box(1, 1);
+			const child2 = new DisposeCounter();
+			box2.addChild(child2.toComponent());
+			container.addChild(box2);
+			container.dispose();
+			assert.equal(child2.disposeCount, 1);
 		});
 	});
 
@@ -259,6 +281,33 @@ describe("Component dispose lifecycle completeness (X007)", () => {
 		// navigate anywhere (its generation is stale).
 		closeFirst!(undefined, { navigateTo: "a" });
 		assert.equal(second.disposeCount, 0, "a stale callback must not close the CURRENT submenu");
+	});
+
+	it("a SYNCHRONOUS done() inside the factory cannot resurrect the submenu (round-7 P2)", () => {
+		const counter = new DisposeCounter();
+		const followUp = new DisposeCounter();
+		const items = [
+			{
+				id: "nav",
+				label: "Nav",
+				currentValue: "",
+				submenu: (_c: string, done: (v?: string, o?: { navigateTo?: string }) => void) => {
+					// The factory closes itself BEFORE returning its component.
+					done(undefined, { navigateTo: "other" });
+					return counter.toComponent();
+				},
+			},
+			{ id: "other", label: "Other", currentValue: "", submenu: () => followUp.toComponent() },
+		];
+		const list = new SettingsList(items, 5, listTheme, () => {}, () => {});
+		list.selectItem("nav");
+		list.handleInput("\r");
+
+		// The synchronous done() closed "nav" and opened the follow-up
+		// "other"; the factory's returned component must NOT resurrect
+		// "nav" over it.
+		assert.equal(counter.disposeCount, 1, "the orphaned factory component is disposed");
+		assert.equal(followUp.disposeCount, 0, "the follow-up submenu stays mounted");
 	});
 
 	it("Text.dispose() stays a harmless no-op inside disposed containers", () => {

--- a/packages/pi-tui/test/dispose-lifecycle.test.ts
+++ b/packages/pi-tui/test/dispose-lifecycle.test.ts
@@ -1,0 +1,270 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { Box } from "../src/components/box.ts";
+import { SettingsList } from "../src/components/settings-list.ts";
+import { Text } from "../src/components/text.ts";
+import { TuiMainScreen } from "../src/tui-main-screen.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+class DisposeCounter {
+	disposeCount = 0;
+	disposed = false;
+
+	toComponent(): import("../src/tui.ts").Component {
+		return {
+			render: () => ["counter"],
+			invalidate: () => {},
+			dispose: () => {
+				this.disposeCount += 1;
+				this.disposed = true;
+			},
+		};
+	}
+}
+
+const listTheme = {
+	label: (text: string) => text,
+	value: (text: string) => text,
+	cursor: "→",
+	hint: (text: string) => text,
+};
+
+function createTestTui(): TuiMainScreen {
+	return new TuiMainScreen(new VirtualTerminal(80, 24));
+}
+
+describe("Component dispose lifecycle completeness (X007)", () => {
+	describe("OverlayHandle.hide()", () => {
+		it("disposes the overlay component exactly once (opt-in disposeOnHide)", () => {
+			const tui = createTestTui();
+			const counter = new DisposeCounter();
+			const handle = tui.showOverlay(counter.toComponent(), { disposeOnHide: true });
+
+			handle.hide();
+			assert.equal(counter.disposeCount, 1, "hide must dispose the removed overlay component");
+
+			handle.hide(); // second hide is a no-op
+			assert.equal(counter.disposeCount, 1, "a repeated hide must not dispose again");
+		});
+
+		it("hide keeps the component alive by default (remount-friendly upstream behavior)", () => {
+			const tui = createTestTui();
+			const counter = new DisposeCounter();
+			const handle = tui.showOverlay(counter.toComponent());
+
+			handle.hide();
+			assert.equal(counter.disposeCount, 0, "without disposeOnHide the removal must NOT dispose (screen-migration re-mount pattern)");
+		});
+
+		it("hideOverlay() disposes the popped overlay component (opt-in disposeOnHide)", () => {
+			const tui = createTestTui();
+			const counter = new DisposeCounter();
+			tui.showOverlay(counter.toComponent(), { disposeOnHide: true });
+
+			tui.hideOverlay();
+			assert.equal(counter.disposeCount, 1, "hideOverlay must dispose the removed overlay");
+		});
+
+		it("hideOverlay keeps the component alive by default", () => {
+			const tui = createTestTui();
+			const counter = new DisposeCounter();
+			tui.showOverlay(counter.toComponent());
+
+			tui.hideOverlay();
+			assert.equal(counter.disposeCount, 0);
+		});
+
+		it("setHidden(true) does NOT dispose (temporary hide)", () => {
+			const tui = createTestTui();
+			const counter = new DisposeCounter();
+			const handle = tui.showOverlay(counter.toComponent(), { disposeOnHide: true });
+
+			handle.setHidden(true);
+			assert.equal(counter.disposeCount, 0, "a temporary hide must keep the component alive");
+
+			handle.hide();
+			assert.equal(counter.disposeCount, 1);
+		});
+	});
+
+	describe("Box", () => {
+		it("removeChild disposes the removed child", () => {
+			const box = new Box(1, 1);
+			const counter = new DisposeCounter();
+			const component = counter.toComponent();
+			box.addChild(component);
+
+			box.removeChild(component);
+			assert.equal(counter.disposeCount, 1);
+		});
+
+		it("clear disposes every child", () => {
+			const box = new Box(1, 1);
+			const first = new DisposeCounter();
+			const second = new DisposeCounter();
+			box.addChild(first.toComponent());
+			box.addChild(second.toComponent());
+
+			box.clear();
+			assert.equal(first.disposeCount, 1);
+			assert.equal(second.disposeCount, 1);
+		});
+	});
+
+	describe("SettingsList submenu slot", () => {
+		it("closing the submenu disposes it", () => {
+			const counter = new DisposeCounter();
+			let done: ((value?: string, options?: { navigateTo?: string }) => void) | undefined;
+			const items = [
+				{
+					id: "theme",
+					label: "Theme",
+					currentValue: "dark",
+					submenu: (
+						_current: string,
+						close: (value?: string, options?: { navigateTo?: string }) => void,
+					) => {
+						done = close;
+						return counter.toComponent();
+					},
+				},
+			];
+			const list = new SettingsList(items, 5, listTheme, () => {}, () => {});
+			list.handleInput("\r"); // activate -> opens submenu
+			assert.ok(counter.disposed === false, "the open submenu is alive");
+			assert.ok(done !== undefined, "the submenu factory received the done callback");
+
+			done!(); // the submenu's own close path (onCancel -> done)
+			assert.equal(counter.disposeCount, 1, "closeSubmenu must dispose the submenu component");
+		});
+
+		it("replacing an open submenu disposes the previous one", () => {
+			const first = new DisposeCounter();
+			const second = new DisposeCounter();
+			let closeFirst: (() => void) | undefined;
+			let closeSecond: (() => void) | undefined;
+			const items = [
+				{
+					id: "a",
+					label: "A",
+					currentValue: "",
+					submenu: (_c: string, close: () => void) => {
+						closeFirst = close;
+						return first.toComponent();
+					},
+				},
+				{
+					id: "b",
+					label: "B",
+					currentValue: "",
+					submenu: (_c: string, close: () => void) => {
+						closeSecond = close;
+						return second.toComponent();
+					},
+				},
+			];
+			const list = new SettingsList(items, 5, listTheme, () => {}, () => {});
+
+			list.selectItem("a");
+			list.handleInput("\r"); // open A's submenu
+			closeFirst!();
+			assert.equal(first.disposeCount, 1, "closing A's submenu disposes it");
+
+			list.selectItem("b");
+			list.handleInput("\r"); // open B's submenu
+			closeSecond!();
+			assert.equal(second.disposeCount, 1, "closing B's submenu disposes it");
+		});
+
+		it("dispose() releases the open submenu without resurrecting navigation", () => {
+			const counter = new DisposeCounter();
+			const followUp = new DisposeCounter();
+			const items = [
+				{
+					id: "nav",
+					label: "Nav",
+					currentValue: "",
+					submenu: (_c: string, close: (v?: string, o?: { navigateTo?: string }) => void) => {
+						// A LATER close with navigateTo must not resurrect a submenu
+						// after the list itself was disposed.
+						setTimeout(() => close(undefined, { navigateTo: "other" }), 0);
+						return counter.toComponent();
+					},
+				},
+				{ id: "other", label: "Other", currentValue: "", submenu: () => followUp.toComponent() },
+			];
+			const list = new SettingsList(items, 5, listTheme, () => {}, () => {});
+			list.selectItem("nav");
+			list.handleInput("\r");
+
+			list.dispose();
+			assert.equal(counter.disposeCount, 1, "dispose must release the open submenu");
+		});
+	});
+
+	it("a stale submenu callback after dispose() never resurrects navigation (round-5 P2)", () => {
+		const counter = new DisposeCounter();
+		const followUp = new DisposeCounter();
+		let done: ((v?: string, o?: { navigateTo?: string }) => void) | undefined;
+		const items = [
+			{
+				id: "nav",
+				label: "Nav",
+				currentValue: "",
+				submenu: (_c: string, close: (v?: string, o?: { navigateTo?: string }) => void) => {
+					done = close;
+					return counter.toComponent();
+				},
+			},
+			{ id: "other", label: "Other", currentValue: "", submenu: () => followUp.toComponent() },
+		];
+		const list = new SettingsList(items, 5, listTheme, () => {}, () => {});
+		list.selectItem("nav");
+		list.handleInput("\r");
+		list.dispose();
+		assert.equal(counter.disposeCount, 1);
+
+		// The submenu's own close callback fires LATE (after disposal) with a
+		// navigateTo — it must be a no-op, never re-open "other".
+		done!(undefined, { navigateTo: "other" });
+		assert.equal(followUp.disposeCount, 0, "a stale callback must not resurrect a follow-up submenu");
+	});
+
+	it("a stale callback from a REPLACED submenu is a no-op (round-5 P2)", () => {
+		const first = new DisposeCounter();
+		const second = new DisposeCounter();
+		let closeFirst: ((v?: string, o?: { navigateTo?: string }) => void) | undefined;
+		const items = [
+			{
+				id: "a",
+				label: "A",
+				currentValue: "",
+				submenu: (_c: string, close: (v?: string, o?: { navigateTo?: string }) => void) => {
+					closeFirst = close;
+					return first.toComponent();
+				},
+			},
+			{ id: "b", label: "B", currentValue: "", submenu: () => second.toComponent() },
+		];
+		const list = new SettingsList(items, 5, listTheme, () => {}, () => {});
+		list.selectItem("a");
+		list.handleInput("\r");
+		// A's own close drives the navigateAfterClose replacement: A is
+		// disposed and B opens in its place.
+		closeFirst!(undefined, { navigateTo: "b" });
+		assert.equal(first.disposeCount, 1, "the replaced submenu is disposed");
+		assert.equal(second.disposeCount, 0, "B is open");
+
+		// A's close callback fires AGAIN, late: it must not close B or
+		// navigate anywhere (its generation is stale).
+		closeFirst!(undefined, { navigateTo: "a" });
+		assert.equal(second.disposeCount, 0, "a stale callback must not close the CURRENT submenu");
+	});
+
+	it("Text.dispose() stays a harmless no-op inside disposed containers", () => {
+		const box = new Box(1, 1);
+		box.addChild(new Text("hello", 1, 0));
+		box.clear(); // must not throw
+		assert.ok(true);
+	});
+});

--- a/packages/pi-tui/test/editor.test.ts
+++ b/packages/pi-tui/test/editor.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { stripVTControlCharacters } from "node:util";
 import { type AutocompleteProvider, CombinedAutocompleteProvider } from "../src/autocomplete.ts";
 import { Editor, wordWrapLine } from "../src/components/editor.ts";
+import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings.ts";
 import type { TUI } from "../src/tui.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
 import { visibleWidth } from "../src/utils.ts";
@@ -4514,5 +4515,248 @@ describe("Oversized paste and undo snapshot isolation", () => {
 		assert.strictEqual(editor.getText(), "a\nx\n");
 		editor.handleInput("\x1f");
 		assert.strictEqual(editor.getText(), "a\nx");
+	});
+});
+
+describe("paste-burst fallback (X038)", () => {
+	it("inserts a newline instead of submitting when Enter follows a rapid character stream", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		let submitted: string | undefined;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+
+		for (const ch of "hello world pasted") editor.handleInput(ch);
+		editor.handleInput("\r");
+
+		assert.strictEqual(submitted, undefined, "the trailing Enter of a lost-marker paste must not submit");
+		assert.strictEqual(editor.getText(), "hello world pasted\n");
+	});
+
+	it("keeps converting Enter to newline across consecutive paste lines", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		let submitted: string | undefined;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+
+		for (const ch of "first line!!") editor.handleInput(ch);
+		editor.handleInput("\r"); // paste line 1 end -> newline
+		for (const ch of "second") editor.handleInput(ch); // paste dribbles one char per chunk
+		editor.handleInput("\r"); // still inside the paste window -> newline
+
+		assert.strictEqual(submitted, undefined);
+		assert.strictEqual(editor.getText(), "first line!!\nsecond\n");
+	});
+
+	it("submits normally when the input is slow (not a burst)", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		let submitted: string | undefined;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+
+		// Fewer than the 8-char burst minimum
+		editor.handleInput("h");
+		editor.handleInput("i");
+		editor.handleInput("\r");
+
+		assert.strictEqual(submitted, "hi");
+	});
+
+	it("resets the burst on a non-printable key between chars and Enter", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		let submitted: string | undefined;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+
+		for (const ch of "hello world pasted") editor.handleInput(ch);
+		editor.handleInput("\x1b[D"); // Left arrow breaks the burst
+		editor.handleInput("\x1b[C"); // Right arrow restores the cursor
+		editor.handleInput("\r");
+
+		assert.strictEqual(submitted, "hello world pasted", "an intervening navigation key must end the burst");
+	});
+
+	it("a multi-char chunk resets the burst (kimi-exact semantics)", () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			let submitted: string | undefined;
+			editor.onSubmit = (text) => {
+				submitted = text;
+			};
+
+			for (const ch of "hello world pasted") editor.handleInput(ch);
+			editor.handleInput("tail"); // one multi-char read: typed-ahead text, not a dribbled paste
+			editor.handleInput("\r");
+
+			assert.strictEqual(submitted, "hello world pastedtail");
+		});
+
+		it("disablePasteBurst option opts out (submits the burst)", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme, { disablePasteBurst: true });
+		let submitted: string | undefined;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+
+		for (const ch of "hello world pasted") editor.handleInput(ch);
+		editor.handleInput("\r");
+
+		assert.strictEqual(submitted, "hello world pasted");
+	});
+
+	it("setDisablePasteBurst toggles the fallback at runtime", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		let submitted: string | undefined;
+		editor.onSubmit = (text) => {
+			submitted = text;
+		};
+
+		editor.setDisablePasteBurst(true);
+		for (const ch of "hello world pasted") editor.handleInput(ch);
+		editor.handleInput("\r");
+		assert.strictEqual(submitted, "hello world pasted");
+
+		submitted = undefined;
+		editor.setDisablePasteBurst(false);
+		for (const ch of "again a burst") editor.handleInput(ch);
+		editor.handleInput("\r");
+		assert.strictEqual(submitted, undefined, "re-enabling must restore the fallback");
+	});
+});
+
+describe("editor submit binding split (X037)", () => {
+	it("the editor submits on tui.editor.submit, not tui.input.submit", () => {
+		setKeybindings(
+			new KeybindingsManager(TUI_KEYBINDINGS, {
+				"tui.input.submit": "ctrl+x",
+				"tui.editor.submit": [],
+			}),
+		);
+		try {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			let submitted: string | undefined;
+			editor.onSubmit = (text) => {
+				submitted = text;
+			};
+
+			editor.handleInput("h");
+			editor.handleInput("\r"); // plain Enter: tui.editor.submit is empty -> newline path? no: \r is not \n, not submit -> nothing
+			assert.strictEqual(submitted, undefined, "an emptied editor binding must not submit");
+
+			setKeybindings(
+				new KeybindingsManager(TUI_KEYBINDINGS, {
+					"tui.input.submit": "ctrl+x",
+					"tui.editor.submit": "ctrl+enter",
+				}),
+			);
+			editor.handleInput("\x1b[13;5u"); // ctrl+enter
+			assert.strictEqual(submitted, "h", "the editor follows its own binding");
+		} finally {
+			setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS));
+		}
+	});
+});
+
+describe("setTextAndCursor paste registry prune (X023 tightening)", () => {
+	it("prunes registry entries whose markers vanished from the staged text", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		// Two large bracketed pastes -> two markers stored in the registry
+		const bigA = Array.from({ length: 12 }, (_, i) => `A-line-${i}`).join("\n");
+		const bigB = Array.from({ length: 12 }, (_, i) => `B-line-${i}`).join("\n");
+		editor.handleInput("\x1b[200~" + bigA + "\x1b[201~");
+		editor.handleInput("\x1b[200~" + bigB + "\x1b[201~");
+
+		const pastes = (editor as unknown as { pastes: Map<number, string> }).pastes;
+		assert.ok(pastes.size >= 2, "both pastes must be registered");
+
+		// Stage a replacement document that keeps ONLY the first marker
+		const markerA = editor.getText().match(/\[paste #\d+[^\]]*\]/g)![0]!;
+		editor.setTextAndCursor("kept " + markerA, { line: 0, col: 0 });
+
+		assert.strictEqual(pastes.size, 1, "vanished paste entries must be pruned");
+		assert.ok(editor.getExpandedText().includes(bigA), "surviving marker must still expand");
+		assert.ok(!editor.getExpandedText().includes(bigB));
+	});
+
+	it("keeps the registry intact when every marker survives", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const big = Array.from({ length: 12 }, (_, i) => `C-line-${i}`).join("\n");
+		editor.handleInput("\x1b[200~" + big + "\x1b[201~");
+		const marker = editor.getText().match(/\[paste #\d+[^\]]*\]/g)![0]!;
+		const pastes = (editor as unknown as { pastes: Map<number, string> }).pastes;
+		const before = pastes.size;
+
+		editor.setTextAndCursor("x " + marker + " y", { line: 0, col: 0 });
+
+		assert.strictEqual(pastes.size, before, "surviving markers keep their entries");
+	});
+});
+
+describe("expanded cursor mapping (X045)", () => {
+	function pasteLarge(editor: Editor): string {
+		const pasted = Array.from({ length: 12 }, (_, i) => `L${i}`).join("\n");
+		editor.handleInput(`\x1b[200~${pasted}\x1b[201~`);
+		return pasted;
+	}
+
+	it("maps a cursor AFTER a marker through the expansion", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const pasted = pasteLarge(editor);
+		editor.handleInput("x"); // cursor after the marker
+		const expanded = editor.getExpandedText();
+		const cursor = editor.getExpandedCursor();
+		assert.strictEqual(expanded.slice(0, cursor), pasted + "x", "the expanded cursor must point after the expanded content");
+	});
+
+	it("maps a cursor BEFORE any marker unchanged", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		editor.handleInput("a");
+		editor.handleInput("b");
+		const pasted = pasteLarge(editor);
+		// The paste moved the cursor after the marker; stage it back at 2
+		// (before the marker) explicitly.
+		editor.setTextAndCursor(editor.getText(), { line: 0, col: 2 });
+		assert.strictEqual(editor.getExpandedCursor(), 2, "a cursor before every marker keeps its offset");
+		assert.ok(editor.getExpandedText().startsWith("ab" + pasted));
+	});
+
+	it("maps the editor's start-snapped cursor to the expansion start", () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		const pasted = pasteLarge(editor);
+		const marker = editor.getText().match(/\[paste #\d+[^\]]*\]/g)![0]!;
+		const markerStart = editor.getText().indexOf(marker);
+		// The EDITOR snaps a cursor staged inside an atomic marker to the
+		// marker's START (snappedFromCursorCol); the mapping must place it
+		// at the same offset in expanded space — right before the content.
+		editor.setTextAndCursor(editor.getText(), { line: 0, col: markerStart + 3 });
+		assert.strictEqual(editor.getCursor().col, markerStart, "precondition: the editor start-snapped the cursor");
+		assert.strictEqual(
+			editor.getExpandedCursor(),
+			markerStart,
+			"a start-snapped cursor maps to the expansion's start",
+		);
+		assert.ok(editor.getExpandedText().startsWith(editor.getText().slice(0, markerStart) + pasted));
+	});
+});
+
+describe("protected autocomplete seam (X044)", () => {
+	it("a subclass can cancel and request autocomplete through the protected seam", async () => {
+		const editor = new Editor(createTestTUI(), defaultEditorTheme);
+		class SubEditor extends Editor {
+			exposedCancel(): void {
+				this.cancelAutocomplete();
+			}
+			exposedRequest(): void {
+				this.requestAutocomplete({ force: true, explicitTab: true });
+			}
+		}
+		const sub = new SubEditor(createTestTUI(), defaultEditorTheme);
+		// No provider: request must be a safe no-op, cancel must not throw
+		sub.exposedRequest();
+		sub.exposedCancel();
+		assert.strictEqual(sub.isShowingAutocomplete(), false);
+		assert.ok(editor instanceof Editor);
 	});
 });

--- a/packages/pi-tui/test/input.test.ts
+++ b/packages/pi-tui/test/input.test.ts
@@ -644,4 +644,32 @@ describe("Input component", () => {
 			assert.strictEqual(input.getValue(), "");
 		});
 	});
+	describe("setValue cursor semantics (X040)", () => {
+		it("places the cursor at the END of the prefilled value by default", () => {
+			const input = new Input();
+			input.setValue("foo");
+			input.handleInput("x");
+
+			assert.strictEqual(input.getValue(), "foox", "typing after a prefill must append");
+		});
+
+		it("keeps the clamped-cursor behavior with cursor: 'preserve'", () => {
+			const input = new Input();
+			input.setValue("foo", { cursor: "preserve" });
+			input.handleInput("x");
+
+			assert.strictEqual(input.getValue(), "xfoo", "preserve keeps the historical cursor-0 semantics");
+		});
+
+		it("preserve clamps a mid-edit cursor to the new length", () => {
+			const input = new Input();
+			input.handleInput("a");
+			input.handleInput("b");
+			input.handleInput("c"); // cursor at 3
+			input.setValue("ab", { cursor: "preserve" });
+
+			input.handleInput("!");
+			assert.strictEqual(input.getValue(), "ab!", "cursor clamps to the shorter value's end");
+		});
+	});
 });

--- a/packages/pi-tui/test/keybindings.test.ts
+++ b/packages/pi-tui/test/keybindings.test.ts
@@ -79,3 +79,17 @@ describe("KeybindingsManager", () => {
 		assert.deepStrictEqual(keybindings.getKeys("tui.editor.cursorLeft"), ["left", "ctrl+b"]);
 	});
 });
+
+describe("editor submit binding split (X037)", () => {
+	it("tui.editor.submit defaults to Enter, independent of tui.input.submit", () => {
+		const kb = new KeybindingsManager(TUI_KEYBINDINGS);
+		assert.deepStrictEqual(kb.getKeys("tui.editor.submit"), ["enter"]);
+		assert.deepStrictEqual(kb.getKeys("tui.input.submit"), ["enter"]);
+
+		kb.setUserBindings({ "tui.input.submit": "ctrl+x" });
+		assert.deepStrictEqual(kb.getKeys("tui.editor.submit"), ["enter"], "input remap must not move the editor binding");
+
+		kb.setUserBindings({ "tui.editor.submit": ["ctrl+enter"] });
+		assert.deepStrictEqual(kb.getKeys("tui.editor.submit"), ["ctrl+enter"]);
+	});
+});

--- a/packages/pi-tui/test/select-list.test.ts
+++ b/packages/pi-tui/test/select-list.test.ts
@@ -319,4 +319,56 @@ describe("SelectList", () => {
 			assert.equal(list.getSelectedItem()?.value, "7");
 		});
 	});
+	describe("canonical filter state (X041)", () => {
+		const items = [
+			{ value: "session-a", label: "alpha", description: "first" },
+			{ value: "session-b", label: "zulu", description: "second" },
+			{ value: "session-c", label: "mike", description: "third" },
+		];
+
+		it("setFilter updates getFilter() and the rendered search box", () => {
+			const list = new SelectList(items, 5, testTheme, {}, { enableSearch: true });
+			list.setFilter("al");
+
+			assert.equal(list.getFilter(), "al", "getFilter must reflect the programmatic filter");
+			const rendered = list.render(80);
+			assert.ok(rendered.some((line) => line.includes("al")), "search box must show the programmatic query");
+			assert.equal(list.getSelectedItem()?.value, "session-a");
+		});
+
+		it("user typing APPENDS to a programmatic filter instead of replacing it", () => {
+			const list = new SelectList(items, 5, testTheme, {}, { enableSearch: true });
+			list.setFilter("alp");
+			list.handleInput("h");
+
+			assert.equal(list.getFilter(), "alph", "the typed char must extend the programmatic query");
+			assert.equal(list.getSelectedItem()?.value, "session-a");
+		});
+
+		it("a programmatic filter survives setItems() refreshes", () => {
+			const list = new SelectList(items, 5, testTheme, {}, { enableSearch: true });
+			list.setFilter("zu");
+			list.setItems(items.map((item) => ({ ...item, description: "refreshed" })));
+
+			assert.equal(list.getFilter(), "zu", "setItems must re-apply the canonical query");
+			assert.equal(list.getSelectedItem()?.value, "session-b");
+		});
+
+		it("getFilter() reports the programmatic query with search disabled too", () => {
+			const list = new SelectList(items, 5, testTheme);
+			list.setFilter("mi");
+
+			assert.equal(list.getFilter(), "mi");
+			assert.equal(list.getSelectedItem()?.value, "session-c");
+		});
+
+		it("initialQuery prefill leaves the cursor at the end (typing appends)", () => {
+			const list = new SelectList(items, 5, testTheme, {}, { enableSearch: true, initialQuery: "al" });
+			assert.equal(list.getFilter(), "al");
+			list.handleInput("p");
+
+			assert.equal(list.getFilter(), "alp", "the first keystroke must append, not prepend");
+			assert.equal(list.getSelectedItem()?.value, "session-a");
+		});
+	});
 });

--- a/packages/pi-tui/test/tui-alt-screen.test.ts
+++ b/packages/pi-tui/test/tui-alt-screen.test.ts
@@ -1780,3 +1780,63 @@ describe("TuiAltScreen", () => {
 		tui.stop();
 
 });
+
+describe("TuiAltScreen viewport listener registration order (X043)", () => {
+	it("registers the viewport listener in the constructor by default (host listeners see consumed scroll keys last)", async () => {
+		const terminal = new VirtualTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal);
+		const seen: string[] = [];
+		tui.addInputListener((data) => {
+			seen.push(data);
+			return undefined;
+		});
+		const text = new Text(Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n"), 0, 0);
+		tui.setLayoutRoot(new VStack([{ component: new ScrollView(text, { follow: "end", primary: true }), basis: 0, grow: 1 }]));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<64;1;1M"); // wheel up — the viewport consumes it
+		await terminal.waitForRender();
+		assert.strictEqual(seen.length, 0, "with the default order the viewport listener consumes wheel events before later host listeners");
+		assert.ok(tui.viewportTop < 6, "the viewport actually scrolled");
+		tui.stop();
+	});
+
+	it("deferViewportListener lets the host install its router FIRST", async () => {
+		const terminal = new VirtualTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal, undefined, undefined, { deferViewportListener: true });
+		const seen: string[] = [];
+		tui.addInputListener((data) => {
+			seen.push(data);
+			return undefined;
+		});
+		tui.installViewportListener();
+		const text = new Text(Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n"), 0, 0);
+		tui.setLayoutRoot(new VStack([{ component: new ScrollView(text, { follow: "end", primary: true }), basis: 0, grow: 1 }]));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<64;1;1M"); // wheel up — the host listener now sees it first
+		await terminal.waitForRender();
+		assert.deepStrictEqual(seen, ["\x1b[<64;1;1M"], "the host router must see raw chunks before the viewport consumes them");
+		assert.ok(tui.viewportTop < 6, "the unconsumed chunk still reaches the viewport and scrolls");
+		tui.stop();
+	});
+
+	it("installViewportListener is idempotent", async () => {
+		const terminal = new VirtualTerminal(20, 4);
+		const tui = new TuiAltScreen(terminal, undefined, undefined, { deferViewportListener: true });
+		tui.installViewportListener();
+		tui.installViewportListener();
+		const text = new Text(Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n"), 0, 0);
+		tui.setLayoutRoot(new VStack([{ component: new ScrollView(text, { follow: "end", primary: true }), basis: 0, grow: 1 }]));
+		tui.start();
+		await terminal.waitForRender();
+
+		terminal.sendInput("\x1b[<64;1;1M");
+		await terminal.waitForRender();
+		// A duplicated viewport listener would scroll TWICE per wheel event.
+		assert.strictEqual(tui.viewportTop, 5, "one wheel event must scroll exactly one line-step (no double listener)");
+		tui.stop();
+	});
+});

--- a/src/editor-seat-holder.ts
+++ b/src/editor-seat-holder.ts
@@ -50,6 +50,22 @@ interface ChangeSubscription {
 export interface SeatEditor {
   readonly id: 'host' | string
   getText(): string
+  /**
+   * The draft with fork paste markers (`[paste #N ...]`) EXPANDED to their
+   * real content (the fork Editor's registry lookup; X004A). Use this
+   * whenever draft text LEAVES the editor's own context — the external
+   * editor round-trip, draft snapshots — or the registry can be cleared
+   * before the marker is expanded again and the real content is lost.
+   * Absent on editors without a paste registry: fall back to getText().
+   */
+  getExpandedText?(): string
+  /**
+   * The cursor offset mapped into the expanded text's coordinates
+   * (X045): pairs with getExpandedText() for seat HANDOFFS, where the
+   * cursor must survive marker expansion too. Absent together with
+   * getExpandedText on editors without a paste registry.
+   */
+  getExpandedCursor?(): number
   setText(text: string): void
   getCursor(): number
   setCursor(offset: number): void
@@ -92,6 +108,10 @@ export interface SeatEditor {
 /** A host-editor adapter (the fork Editor + history/autocomplete). */
 export interface HostEditorAdapter {
   getText(): string
+  /** The draft with paste markers expanded (external-editor round-trip). */
+  getExpandedText?(): string
+  /** The cursor offset in the expanded text's coordinates (X045). */
+  getExpandedCursor?(): number
   setText(text: string): void
   /** Whether the host editor's autocomplete dropdown is open. */
   isShowingAutocomplete?(): boolean
@@ -250,6 +270,12 @@ export class EditorSeatHolder {
     const seat: SeatEditor = {
       id: 'host',
       getText: () => editor.getText(),
+      getExpandedText: editor.getExpandedText === undefined
+        ? undefined
+        : () => editor.getExpandedText!(),
+      getExpandedCursor: editor.getExpandedCursor === undefined
+        ? undefined
+        : () => editor.getExpandedCursor!(),
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete?.() ?? false,
       getInputMode: () => editor.getInputMode?.() ?? 'prompt',
@@ -300,13 +326,23 @@ export class EditorSeatHolder {
    */
   private wireCursorOf(seat: SeatEditor): { wireText: string; wireCursor: number } {
     const mode = seat.getInputMode?.() ?? 'prompt'
+    // Round-2 review P1: expand paste markers for the handoff — the
+    // target editor holds no share in THIS editor's paste registry, so
+    // literal `[paste #N …]` markers would orphan the moment any restore
+    // clears the registry. The cursor maps through the same expansion
+    // (X045) so it lands at the same visual position in the new document.
+    const rawText = seat.getText()
+    const expandedText = seat.getExpandedText?.()
+    const expanded = expandedText !== undefined && expandedText !== rawText
+    const text = expanded ? expandedText! : rawText
+    const cursor = expanded ? seat.getExpandedCursor?.() ?? seat.getCursor() : seat.getCursor()
     if (mode !== 'prompt') {
       return {
-        wireText: serializeEditorInput(mode, seat.getText()),
-        wireCursor: seat.getCursor() + shellPrefixForMode(mode).length,
+        wireText: serializeEditorInput(mode, text),
+        wireCursor: cursor + shellPrefixForMode(mode).length,
       }
     }
-    return { wireText: seat.getText(), wireCursor: seat.getCursor() }
+    return { wireText: text, wireCursor: cursor }
   }
 
   /** The current seat snapshot (Phase 2: the ADVANCED editor controls

--- a/src/extension/internal/component-compiler.ts
+++ b/src/extension/internal/component-compiler.ts
@@ -21,7 +21,7 @@
 
 import { Container, HStack, Markdown, Spacer, VStack, type Component } from '@xmoon76/pi-tui'
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@xmoon76/pi-tui'
-import { color, markdownTheme } from '../../theme.ts'
+import { color, HOST_MARKDOWN_OPTIONS, markdownTheme } from '../../theme.ts'
 import type { ExtensionView, StyledSpan, TextView } from '../public-types.ts'
 import { renderSpans, sanitizeSpanText } from './slot-outlet.ts'
 
@@ -138,7 +138,7 @@ class CompiledMarkdown implements Component {
     this.cachedWidth = width
     // Zero padding: the host pads widget rows; the fork's default 1-cell
     // padding would double it.
-    this.cached = new Markdown(this.markdown, 0, 0, markdownTheme).render(width)
+    this.cached = new Markdown(this.markdown, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS).render(width)
     return this.cached
   }
 }

--- a/src/image/clipboard.ts
+++ b/src/image/clipboard.ts
@@ -281,6 +281,50 @@ async function powershellProbe(run: RunCommand, wsl: boolean): Promise<Clipboard
  * failures throw {@link ClipboardImageError} (a clipboard that DOES carry
  * an image but cannot be read must be distinguished from no image).
  */
+/**
+ * Read the system clipboard as PLAIN TEXT (the fullscreen right-click
+ * paste — native Windows terminals lose their right-click paste under the
+ * alt screen's mouse capture, so the host reads the clipboard itself and
+ * feeds a bracketed paste). Returns undefined when no backend is
+ * available; best-effort, never throws.
+ */
+export async function readClipboardText(run: RunCommand, env: ClipboardEnvironment): Promise<string | undefined> {
+  const platformCommand = (): { command: string; args: string[]; syntheticTrailingNewline: boolean } | undefined => {
+    if (isTermux(env)) return { command: 'termux-clipboard-get', args: [], syntheticTrailingNewline: false }
+    if (env.platform === 'darwin') return { command: 'pbpaste', args: [], syntheticTrailingNewline: false }
+    if (env.platform === 'win32' || isWsl(env)) {
+      // Get-Clipboard SYNTHESIZES a trailing CRLF that is NOT part of the
+      // copied text; every other backend returns the clipboard verbatim
+      // (a real trailing newline belongs to the content and must survive).
+      return {
+        command: isWsl(env) ? 'powershell.exe' : 'powershell',
+        args: ['-NoProfile', '-Command', 'Get-Clipboard'],
+        syntheticTrailingNewline: true,
+      }
+    }
+    if (env.env.WAYLAND_DISPLAY !== undefined && env.exists('wl-paste')) {
+      // NO --no-newline: wl-paste would strip a REAL trailing newline from
+      // the copied content — only PowerShell's synthetic CRLF is removed.
+      return { command: 'wl-paste', args: [], syntheticTrailingNewline: false }
+    }
+    if (env.env.DISPLAY !== undefined && env.exists('xclip')) {
+      return { command: 'xclip', args: ['-selection', 'clipboard', '-o'], syntheticTrailingNewline: false }
+    }
+    return undefined
+  }
+  const target = platformCommand()
+  if (target === undefined) return undefined
+  try {
+    const result = await run(target.command, target.args, { timeoutMs: 2000 })
+    if (result.code !== 0) return undefined
+    const text = result.stdout.toString('utf8')
+    if (!target.syntheticTrailingNewline) return text
+    return text.replace(/\r\n$/, '').replace(/\n$/, '')
+  } catch {
+    return undefined
+  }
+}
+
 export async function readClipboardImage(run: RunCommand, env: ClipboardEnvironment): Promise<ClipboardReadResult> {
   if (isTermux(env)) return { kind: 'unsupported' }
   if (env.platform === 'darwin') return macosProbe(run)

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,8 @@ import { FileHistorySearchSource } from './history-search.ts'
 import { safeErrorMessage } from './error-boundary.ts'
 import { DraftImageStore } from './image/draft-store.ts'
 import { ImageInputError } from './image/errors.ts'
-import { clipboardBackendOf, commandOnPath, createClipboardRunner, readClipboardImage, type ClipboardEnvironment } from './image/clipboard.ts'
+import { clipboardBackendOf, commandOnPath, createClipboardRunner, readClipboardImage, readClipboardText, type ClipboardEnvironment } from './image/clipboard.ts'
+import { openExternalUrl } from './open-url.ts'
 import { buildOsc52Sequence, copyToClipboard, type CopyEnvironment, type CopyExecutor } from './clipboard.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
 import { wheelScrollLinesOf } from './wheel-scroll.ts'
@@ -5013,6 +5014,25 @@ export function apply(ctx: Context, config: Config): void {
         else app.restoreTranscriptViewportAnchor(anchor, 'top')
         return true
       },
+      // Ctrl+Up / Ctrl+Down in fullscreen: single-turn prompt navigation
+      // over the virtual window (the fork's OSC 133 scan finds nothing in
+      // DSH transcripts — the semantic turn list lives HERE).
+      onTranscriptTurnOlder: () => {
+        if (!app.isFullscreen()) return false
+        const controller = activeWindow()
+        if (!controller.turnOlder()) return false
+        repaint(app, activeFolder(), controller)
+        app.scrollToBottom({ disableFollow: true })
+        return true
+      },
+      onTranscriptTurnNewer: () => {
+        if (!app.isFullscreen()) return false
+        const controller = activeWindow()
+        if (!controller.turnNewer()) return false
+        repaint(app, activeFolder(), controller)
+        app.scrollToBottom({ disableFollow: true })
+        return true
+      },
       onTranscriptMoveNewer: () => {
         const anchor = app.captureTranscriptViewportAnchor()
         const controller = activeWindow()
@@ -5316,6 +5336,12 @@ export function apply(ctx: Context, config: Config): void {
       // shared policy as /copy (tmux → platform helper → OSC 52) — a bare
       // OSC 52 write is a silent lie under tmux `set-clipboard external`.
       copySelection: (text) => copyToClipboard(text, runCopyCommand, copyEnv),
+      // Fullscreen OSC 8 link clicks + the Windows right-click paste: the
+      // alt screen's mouse capture swallows both native behaviors, so the
+      // host opens http/https links itself and reads the clipboard through
+      // the same platform-aware policy as the image paste probe.
+      openExternalUrl: (url) => openExternalUrl(url),
+      readClipboardText: () => readClipboardText(runClipboardCommand, clipboardEnv),
       // M7: the transcript/tool renderer registry. Renderer failures are
       // isolated per contribution (the registry catches throws and the
       // host falls back); the health sink records them for /status.

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -35,7 +35,7 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
     // The submit key stays with the FORK editor's submit path
     // (backslash-newline semantics live there — plan §8 resolver
     // priority 5); the host ladder NEVER consumes it. A user remap /
-    // `false` is synced into the fork editor's `tui.input.submit` binding
+    // `false` is synced into the fork editor's `tui.editor.submit` binding (X037)
     // by the runner (onEditorSubmitSync), so Enter REALLY moves / gets
     // disabled — not just the hints (PR review finding).
     hostResolved: false,

--- a/src/keybindings/manager.ts
+++ b/src/keybindings/manager.ts
@@ -64,7 +64,7 @@ export interface HostKeybindingManagerOptions {
   /**
    * Called after every rebuild with the EFFECTIVE submit keys of
    * `app.input.submit` (an empty array = the action is disabled). The
-   * app syncs them into the fork editor's `tui.input.submit` binding so
+   * app syncs them into the fork editor's `tui.editor.submit` binding (X037) so
    * a user remap/disable of submit REALLY moves/removes the editor's
    * Enter submission (review finding — the editor path was previously
    * physical-only and ignored user config).
@@ -115,7 +115,7 @@ export class HostKeybindingManager {
     this.keymap = this.buildKeymap()
     // Sync the BUILTIN submit keys immediately: the fork's keybindings
     // are PROCESS-GLOBAL, so a fresh manager must restore the default
-    // `tui.input.submit` — otherwise a previous TUI instance's remap/
+    // `tui.editor.submit` — otherwise a previous TUI instance's remap/
     // disable leaks into this one (PR review finding: remap → stop →
     // new default app kept the old ctrl+x/disabled submit).
     this.onEditorSubmitSync(this.editorSubmitKeysFor())
@@ -242,7 +242,7 @@ export class HostKeybindingManager {
     const leaderKey = effectiveLeaderConfig?.key
     // Collision with BOTH the host keymap's active keys AND the
     // EDITOR-OWNED submit keys (hostResolved:false actions — the fork
-    // editor's tui.input.submit owns them; the keymap does not list them,
+    // editor's tui.editor.submit owns them (X037); the keymap does not list them,
     // so e.g. `leader: enter` would silently swallow Enter — PR review
     // finding) AND the live PLUGIN keys (the leader machine feeds before
     // the plugin stage — round-12 finding).
@@ -295,14 +295,14 @@ export class HostKeybindingManager {
     // Sync the effective submit keys into the fork editor's binding
     // (review finding): a user remap or `false` of app.input.submit must
     // REALLY move/remove the editor's submission — the fork editor routes
-    // Enter (or the remapped key) through tui.input.submit. Empty = the
+    // Enter (or the remapped key) through tui.editor.submit (X037). Empty = the
     // action is disabled (no key submits).
     this.onEditorSubmitSync(this.editorSubmitKeysFor())
     this.onInvalidate()
   }
 
   /** The effective submit keys of `app.input.submit` as the fork editor's
-   * `tui.input.submit` should carry them: the action's effective direct
+   * `tui.editor.submit` should carry them: the action's effective direct
    * keys, or an EMPTY array when disabled (`false`) or safe mode dropped
    * them. `app.input.submit` is hostResolved:false — the host ladder
    * NEVER consumes these keys; the editor owns them, so the sync is the
@@ -478,7 +478,7 @@ export class HostKeybindingManager {
    * the action's context predicate, convergence §4.7). */
   canActivate(action: AppKeybindingId, context: KeybindingContext): boolean {
     // Editor-owned submit: active whenever it has an EFFECTIVE editor
-    // trigger (the fork editor's tui.input.submit or a live leader
+    // trigger (the fork editor's tui.editor.submit or a live leader
     // sequence) — a leader submit completion must activate iff submit
     // itself is available (convergence §4.7).
     if (action === 'app.input.submit') {

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -126,7 +126,7 @@ export interface AppKeybindingDefinition {
    * user direct bindings BOTH compile into the effective model as
    * owner=editor rules, participate in conflict/shadow/winner selection,
    * but execution is deferred to the fork editor (the effective keys
-   * sync into its `tui.input.submit` via onEditorSubmitSync), preserving
+   * sync into its `tui.editor.submit` via onEditorSubmitSync — X037), preserving
    * backslash-newline semantics. */
   readonly hostResolved?: boolean
 }

--- a/src/open-url.ts
+++ b/src/open-url.ts
@@ -1,0 +1,51 @@
+import { spawn } from 'node:child_process'
+
+/**
+ * Open one external URL with the platform opener (fullscreen OSC 8 link
+ * clicks — the alt screen's mouse capture swallows the terminal's native
+ * click-to-open, so the host owns link activation; the fork reports the
+ * URL through its `openUrl` seam).
+ *
+ * SECURITY: only http/https URLs ever reach an opener — the OSC 8 href
+ * comes from rendered transcript content, and `file:`/custom schemes
+ * would hand attacker-controlled strings to a shell helper. Fire-and-
+ * forget: opener failures are best-effort (a link click must never
+ * disturb the TUI).
+ */
+export function openExternalUrl(rawUrl: string): void {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return
+
+  const { command, args } = openerFor(url.href, process.platform)
+  try {
+    const child = spawn(command, args, { stdio: 'ignore', detached: true })
+    child.on('error', () => {})
+    child.unref()
+  } catch {
+    // Best-effort: an unavailable opener must never crash the surface.
+  }
+}
+
+/**
+ * The platform opener command line. WINDOWS INJECTION SAFETY (round-2
+ * review P1): `cmd /c start` re-parses its command line with shell
+ * metacharacter rules, so a transcript-controlled `&` in a query string
+ * would split into a second COMMAND. The URL is therefore wrapped in
+ * literal double quotes — the WHATWG URL serializer never emits a raw
+ * quote/space/control character in href, so the quoted token cannot be
+ * escaped — and cmd treats everything inside double quotes as literal.
+ */
+export function openerFor(href: string, platform: string = process.platform): { command: string; args: string[] } {
+  if (platform === 'win32') {
+    return { command: 'cmd', args: ['/c', 'start', '', `"${href}"`] }
+  }
+  if (platform === 'darwin') {
+    return { command: 'open', args: [href] }
+  }
+  return { command: 'xdg-open', args: [href] }
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -383,6 +383,18 @@ export const editorTheme: EditorTheme = {
   selectList: selectListTheme,
 }
 
+/**
+ * Markdown rendering options shared by EVERY host transcript renderer
+ * (assistant cards, thinking blocks, plugin component compilation).
+ * LaTeX-to-Unicode rendering is deliberately OFF (the kimi-host parity
+ * choice): the Earendil 0.84.4 re-vendor introduced `renderLatex`
+ * defaulting to true, which silently changed how `$...$`/`$$...$$`
+ * segments in assistant output render. Keep the pre-re-vendor rendering;
+ * revisit as an explicit setting if LaTeX output ever becomes a product
+ * requirement.
+ */
+export const HOST_MARKDOWN_OPTIONS = { renderLatex: false } as const
+
 /** Markdown palette for assistant messages. */
 export const markdownTheme: MarkdownTheme = {
   heading: (text: string) => chalk.bold.hex(currentPalette.textStrong)(text),

--- a/src/transcript-window.ts
+++ b/src/transcript-window.ts
@@ -167,6 +167,41 @@ export class TranscriptWindowController {
     return true
   }
 
+  /**
+   * Move exactly ONE turn toward older (Ctrl+Up prompt navigation — a
+   * single-turn variant of {@link moveOlder}'s page step). From live-tail
+   * this anchors history at the previous turn's end.
+   */
+  turnOlder(): boolean {
+    this.refreshTurnOrder()
+    if (this.turns.length === 0) return false
+    const latestIndex = this.turns.length - 1
+    const currentIndex = this.current.mode === 'latest'
+      ? latestIndex
+      : this.turnIndex(this.current.endTurn ?? this.turns[latestIndex]!)
+    if (currentIndex <= 0) return false
+    const endTurn = this.turns[currentIndex - 1]
+    if (endTurn === undefined) return false
+    this.current = { mode: 'history', endTurn }
+    return true
+  }
+
+  /**
+   * Move exactly ONE turn toward newer, resuming live-tail at the newest
+   * (Ctrl+Down prompt navigation — single-turn variant of {@link moveNewer}).
+   */
+  turnNewer(): boolean {
+    this.refreshTurnOrder()
+    if (this.current.mode !== 'history' || this.turns.length === 0) return false
+    const currentIndex = this.turnIndex(this.current.endTurn ?? this.turns[0]!)
+    if (currentIndex < 0) return false
+    if (currentIndex >= this.turns.length - 1) return this.latest()
+    const endTurn = this.turns[currentIndex + 1]
+    if (endTurn === undefined) return false
+    this.current = { mode: 'history', endTurn }
+    return true
+  }
+
   /** Move one overlapping page toward newer turns, resuming live-tail at end. */
   moveNewer(): boolean {
     this.refreshTurnOrder()

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2700,6 +2700,16 @@ export class TuiApp {
   private rightClickPasteFromClipboard(): void {
     const read = this.readClipboardText
     if (read === undefined) return
+    // Capture the paste TARGET at right-click time (round-2 review P2):
+    // the clipboard read is async, and focus may move while it runs (a
+    // question closes, the user clicks the editor) — pasting into the
+    // CURRENT focus owner would drop the content into the wrong input.
+    // The screen identity is fenced too: a fullscreen toggle during the
+    // read swaps the active screen entirely.
+    const screen = this.activeScreen
+    const target = screen.getFocusedComponent()
+    const handleInput = target?.handleInput
+    if (handleInput === undefined) return
     // Fire-and-forget through the owned-task entry (AGENTS.md hard rule —
     // never a bare `void promise`): a clipboard-read failure is classified
     // and logged, never an unhandled rejection; success feeds the paste.
@@ -2711,8 +2721,11 @@ export class TuiApp {
         return // best-effort: no backend / helper failure is user-invisible
       }
       if (text === undefined || text === '') return
-      this.activeScreen.getFocusedComponent()?.handleInput?.(`\x1b[200~${text}\x1b[201~`)
-      this.activeScreen.requestRender()
+      // The right-click target must still be the focused component on the
+      // SAME screen — otherwise the paste is dropped (never misdirected).
+      if (this.disposed || this.activeScreen !== screen || screen.getFocusedComponent() !== target) return
+      handleInput(`\x1b[200~${text}\x1b[201~`)
+      screen.requestRender()
     }, { onCancel: () => {}, onError: () => {} })
   }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2708,8 +2708,7 @@ export class TuiApp {
     // read swaps the active screen entirely.
     const screen = this.activeScreen
     const target = screen.getFocusedComponent()
-    const handleInput = target?.handleInput
-    if (handleInput === undefined) return
+    if (target === null || target === undefined || target.handleInput === undefined) return
     // Fire-and-forget through the owned-task entry (AGENTS.md hard rule —
     // never a bare `void promise`): a clipboard-read failure is classified
     // and logged, never an unhandled rejection; success feeds the paste.
@@ -2724,7 +2723,13 @@ export class TuiApp {
       // The right-click target must still be the focused component on the
       // SAME screen — otherwise the paste is dropped (never misdirected).
       if (this.disposed || this.activeScreen !== screen || screen.getFocusedComponent() !== target) return
-      handleInput(`\x1b[200~${text}\x1b[201~`)
+      // Call THROUGH the target — never cache the method: handleInput is a
+      // prototype method (TuiEditor/Input/FocusForwardingFrame) that reads
+      // `this`; a bare extracted call would run with this === undefined in
+      // strict mode and throw on the first access. The `!` is safe: the
+      // guard above plus the focus-identity re-check guarantee the method
+      // exists on the still-focused component.
+      target.handleInput!(`\x1b[200~${text}\x1b[201~`)
       screen.requestRender()
     }, { onCancel: () => {}, onError: () => {} })
   }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -41,6 +41,7 @@ import {
   wrapTextWithAnsi,
   type Component,
   type Focusable,
+  isFocusable,
   type OverlayHandle,
   type OverlayOptions,
   type SelectListTruncatePrimaryContext,
@@ -55,6 +56,7 @@ import {
   detectThemeFromBackground,
   detectThemeFromColorFgBg,
   editorTheme,
+  HOST_MARKDOWN_OPTIONS,
   markdownTheme,
   selectListTheme,
   settingsListTheme,
@@ -393,6 +395,50 @@ class QuestionFrame extends Frame implements Focusable {
   private lastTermColumns = 0
 }
 
+/**
+ * A Frame that forwards the focused flag to its child (fork X042 / the
+ * IME cursor-marker contract): the fork sets `focused` only on the
+ * component it focuses directly — a plain Frame SWALLOWS the flag, so an
+ * Input-owning child behind it (HistoryPanel, SelectList's search box,
+ * SettingsList, TaskBrowserPanel) never emits the hardware CURSOR_MARKER
+ * and the IME candidate window misplaces itself. Forwarding is a no-op
+ * for non-Focusable children (plain dialogs).
+ */
+class FocusForwardingFrame extends Frame implements Focusable {
+  private readonly focusedChild: Component & Focusable | undefined
+  /** The RAW child: the frame OWNS it regardless of Focusable-ness (round-5
+   * review P2 — a non-Focusable panel behind the frame must still be
+   * disposed on overlay removal). */
+  private readonly ownedChild: Component
+  private disposed = false
+
+  constructor(child: Component, fillWidth = false) {
+    super(child, fillWidth)
+    this.ownedChild = child
+    this.focusedChild = isFocusable(child) ? (child as Component & Focusable) : undefined
+  }
+
+  get focused(): boolean {
+    return this.focusedChild?.focused ?? false
+  }
+
+  set focused(value: boolean) {
+    if (this.focusedChild !== undefined) this.focusedChild.focused = value
+  }
+
+  /**
+   * OWNING, idempotent dispose (X007): overlay removal (disposeOnHide)
+   * releases the panel behind the frame — the frame is the overlay entry,
+   * so the fork calls THIS, not the child. Idempotent so a close path
+   * that already disposed the child can never double-fire.
+   */
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.ownedChild.dispose?.()
+  }
+}
+
 /** The session head card: identity facts, wrapped to the available width so
  * nothing is truncated, framed with a box whose width matches the editor's
  * border below it (a fixed-width rule looked misaligned next to the frame). */
@@ -488,13 +534,25 @@ class Spacer implements Component {
  * it), and resets the marquee. Zero fork divergence: the SelectList
  * itself is untouched, this wraps it on the consumer side.
  */
-class MarqueeFilterAdapter implements Component {
+class MarqueeFilterAdapter implements Component, Focusable {
   private readonly list: SelectList
   private readonly onFilterChange: () => void
+  private _focused = false
 
   constructor(list: SelectList, onFilterChange: () => void) {
     this.list = list
     this.onFilterChange = onFilterChange
+  }
+
+  /** Focusable (X042): forward to the wrapped SelectList so its search
+   * Input emits the hardware CURSOR_MARKER (IME positioning). */
+  get focused(): boolean {
+    return this._focused
+  }
+
+  set focused(value: boolean) {
+    this._focused = value
+    this.list.focused = value
   }
 
   invalidate(): void {
@@ -517,6 +575,9 @@ class MarqueeFilterAdapter implements Component {
     return this.list.render(width)
   }
 }
+
+/** SGR mouse reports (press/drag/release/wheel) — the alt screen owns them. */
+const MOUSE_SEQUENCE = /^\x1b\[<\d+;\d+;\d+[Mm]$/
 
 /**
  * The transcript surface's RIGHT GUTTER (the transcript right-gutter width contract):
@@ -1067,6 +1128,16 @@ export interface TuiAppEventsBase {
   onTranscriptMoveOlder?: (source: 'wheel' | 'page' | 'scrollbar') => boolean
   /** A fullscreen viewport reached the newer edge. */
   onTranscriptMoveNewer?: (source: 'wheel' | 'page' | 'scrollbar') => boolean
+  /**
+   * Prompt-turn navigation (fullscreen Ctrl+Up / Ctrl+Down): move the
+   * virtual transcript window exactly one turn older / newer. The host
+   * claims the fork's `previousPrompt`/`nextPrompt` keys BEFORE the fork's
+   * built-in OSC 133 scan (the DSH transcript emits no OSC 133 markers, so
+   * the fork scan is a permanent no-op — host wiring over X028's seam).
+   */
+  onTranscriptTurnOlder?: () => boolean
+  /** @see onTranscriptTurnOlder */
+  onTranscriptTurnNewer?: () => boolean
   /** Reset the active transcript window to the live tail. */
   onTranscriptJumpLatest?: () => boolean
   /**
@@ -1482,6 +1553,20 @@ export interface TuiAppOptions {
    * flash. Optional — absent keeps the vendor's OSC 52 fallback.
    */
   copySelection?: (text: string) => Promise<boolean>
+  /**
+   * Host-owned link activation for fullscreen OSC 8 clicks: the alt
+   * screen's mouse capture swallows the terminal's native click-to-open,
+   * so the host opens http/https URLs itself (src/open-url.ts). Optional
+   * — absent leaves fullscreen link clicks inert.
+   */
+  openExternalUrl?: (url: string) => void
+  /**
+   * Host-owned clipboard READ for the fullscreen right-click paste
+   * (native Windows terminals lose their right-click paste under mouse
+   * capture). Returns the clipboard text, or undefined when no backend
+   * exists. Optional — absent keeps right-click inert.
+   */
+  readClipboardText?: () => Promise<string | undefined>
   /**
    * The empty-editor double-Ctrl+C exit window in ms (issue #8);
    * injectable so headless tests never wait the real 1.5s. The footer
@@ -2004,6 +2089,8 @@ export class TuiApp {
    * selection (tmux → platform helper → OSC 52); undefined keeps the
    * vendor's raw OSC 52 write. */
   private readonly copySelection: ((text: string) => Promise<boolean>) | undefined
+  private readonly openExternalUrl: ((url: string) => void) | undefined
+  private readonly readClipboardText: (() => Promise<string | undefined>) | undefined
   /**
    * P1-1: the renderer registry revision observed by the LAST render pass.
    * When the registry revision moves (a renderer registered/unloaded —
@@ -2312,15 +2399,19 @@ export class TuiApp {
       },
       // A user remap/disable of app.input.submit must REALLY move/remove
       // the editor's submission: the fork editor routes the submit key
-      // through its OWN tui.input.submit binding, so we sync the
-      // effective keys there (review finding — the editor path was
-      // previously physical-only and ignored user config). Empty = the
-      // action is disabled (no key submits; plain Enter becomes inert).
+      // through its OWN tui.editor.submit binding (X037 — deliberately NOT
+      // tui.input.submit: keybindings are process-global and a remap there
+      // would leak into every plain Input — search boxes, question
+      // free-text, pickers), so we sync the effective keys there. Empty =
+      // the action is disabled (no key submits; plain Enter becomes inert).
+      // tui.input.submit is reset to its builtin default in the same write:
+      // a pre-X037 instance (or test) may have left a remap behind.
       onEditorSubmitSync: (keys) => {
         const kb = getKeybindings()
         kb.setUserBindings({
           ...kb.getUserBindings(),
-          'tui.input.submit': keys.length === 0 ? [] : keys.length === 1 ? keys[0]! : [...keys],
+          'tui.input.submit': 'enter',
+          'tui.editor.submit': keys.length === 0 ? [] : keys.length === 1 ? keys[0]! : [...keys],
         })
       },
     })
@@ -2328,6 +2419,8 @@ export class TuiApp {
     this.renderers = options.renderers
     this.editorRegistry = options.editorRegistry
     this.copySelection = options.copySelection
+    this.openExternalUrl = options.openExternalUrl
+    this.readClipboardText = options.readClipboardText
     this.overlayBroker = new OverlayBroker({
       question: () => this.activeQuestions,
       setFocusSeat: (seat) => this.setFocusSeat(seat),
@@ -2421,7 +2514,14 @@ export class TuiApp {
       // shell-mode draft round-trips through the viewer with its mode.
       const viewer = this.viewerMode
       if (viewer !== undefined && isViewerAccessInteractive(resolveViewerAccess(viewer.mode, viewer.access))) {
-        this.subagentDrafts.set(viewer.childSessionId, this.serializeSeatDraft(this.seatEditor().getText()))
+        // Paste markers must not outlive the live registry: a submit
+        // between mirror and restore clears it, orphaning the marker text
+        // (same class as the external-editor round-trip).
+        const draftSeat = this.seatEditor()
+        this.subagentDrafts.set(
+          viewer.childSessionId,
+          this.serializeSeatDraft(draftSeat.getExpandedText?.() ?? draftSeat.getText()),
+        )
       }
       // P1-11: every HOST-driven editor mutation notifies the seat
       // holder's subscribers (the fork Editor's own typing/editing flows
@@ -2463,27 +2563,26 @@ export class TuiApp {
         // safety.
         switch (action) {
           case 'submit': {
-            const text = this.seatEditor().getText()
-            // Emptiness is judged on the SERIALIZED wire form: a bare `!`
-            // / `!!` shell mode has an empty BODY but a non-empty wire
-            // form, and must reach the existing protocol like the literal
-            // prefix did before the mode feature.
-            if (!serializedDraftHasPayload(this.serializeSeatDraft(text))) return false
+            // Emptiness is judged on the SERIALIZED (marker-expanded) wire
+            // form: a bare `!` / `!!` shell mode has an empty BODY but a
+            // non-empty wire form, and must reach the existing protocol
+            // like the literal prefix did before the mode feature.
+            if (!serializedDraftHasPayload(this.expandedSeatWireDraft())) return false
             this.submitDraft(false)
             return true
           }
           case 'queue-submit': {
-            const text = this.seatEditor().getText()
-            if (!serializedDraftHasPayload(this.serializeSeatDraft(text))) return false
+            if (!serializedDraftHasPayload(this.expandedSeatWireDraft())) return false
             this.submitDraft(true)
             return true
           }
           case 'steer': {
-            const text = this.seatEditor().getText()
             // The shell-editor-mode boundary, like the Ctrl+S path: the
             // wire form leaves the app (identity for a plugin editor,
             // whose document IS the wire form; defensive for a host seat).
-            const serialized = this.serializeSeatDraft(text)
+            // Paste markers are EXPANDED — the steer wire never carries
+            // registry-bound marker text.
+            const serialized = this.expandedSeatWireDraft()
             this.seatEditor().setText('')
             this.editorSeatHolder.notifyChanged()
             this.resetEditorMode()
@@ -2590,6 +2689,76 @@ export class TuiApp {
     this.tui.start()
   }
 
+  /**
+   * The fullscreen right-click paste: read the clipboard through the
+   * host's platform policy, then feed the text to the FOCUSED component
+   * as a bracketed paste (both the fork Editor and plain Input understand
+   * the markers; their paste paths clean newlines). The feed bypasses
+   * routeInput deliberately — a synthetic paste is not user input, and
+   * the host ladder must not get a chance to consume it as a shortcut.
+   */
+  private rightClickPasteFromClipboard(): void {
+    const read = this.readClipboardText
+    if (read === undefined) return
+    // Fire-and-forget through the owned-task entry (AGENTS.md hard rule —
+    // never a bare `void promise`): a clipboard-read failure is classified
+    // and logged, never an unhandled rejection; success feeds the paste.
+    this.events.runOwned?.('clipboard paste', async () => {
+      let text: string | undefined
+      try {
+        text = await read()
+      } catch {
+        return // best-effort: no backend / helper failure is user-invisible
+      }
+      if (text === undefined || text === '') return
+      this.activeScreen.getFocusedComponent()?.handleInput?.(`\x1b[200~${text}\x1b[201~`)
+      this.activeScreen.requestRender()
+    }, { onCancel: () => {}, onError: () => {} })
+  }
+
+  /**
+   * MINIMAL suspend for the external-editor round-trip (Ctrl+G): stops
+   * ONLY the active screen — a fullscreen surface is stopped with
+   * `preserveScreen` (exit the alt buffer WITHOUT replaying the transcript
+   * into the main buffer; $EDITOR takes the terminal over) and its
+   * renderer INSTANCE survives, so {@link resumeFromExternalEditor} can
+   * re-enter the SAME fullscreen surface. This deliberately replaces the
+   * old `stop()/start()` pair, which dropped `this.fullscreen` entirely:
+   * returning from $EDITOR always landed on the regular screen (P2
+   * lifecycle violation — the external-editor round-trip is documented as
+   * a temporary transition INSIDE one surface generation). Questions,
+   * approvals, the busy indicator and extension registrations all survive
+   * the round-trip (they die only with dispose()).
+   */
+  private suspendForExternalEditor(): void {
+    this.keybindings.cancelLeader()
+    this.clearCtrlCExit()
+    this.lastEscapeAt = undefined
+    if (this.fullscreen !== undefined) {
+      this.fullscreen.stop({ preserveScreen: true })
+    } else {
+      this.tui.stop()
+    }
+  }
+
+  /**
+   * Re-enter the surface {@link suspendForExternalEditor} stopped. Focus
+   * is deliberately NOT reassigned: TuiBase keeps its focusedComponent
+   * across stop/start on the same instance, so whatever owned focus before
+   * the suspend (the seat editor, an active question's QuestionFrame, an
+   * approval overlay) still owns it — forcing the seat editor here would
+   * break a live question's modal focus and IME anchor.
+   */
+  private resumeFromExternalEditor(): void {
+    if (this.fullscreen !== undefined) {
+      this.fullscreen.start()
+      this.fullscreen.requestRender(true)
+    } else {
+      this.tui.start()
+      this.tui.requestRender(true)
+    }
+  }
+
   /** Leave raw mode and stop rendering. */
   stop(): void {
     this.clearNotify()
@@ -2631,15 +2800,16 @@ export class TuiApp {
     // keymap and schedule rendering — the disposed manager makes those
     // rebuilds inert (PR review finding).
     this.keybindings.dispose()
-    // Restore the fork's global submit binding to the builtin default:
+    // Restore the fork's global submit bindings to the builtin defaults:
     // the fork keybindings are PROCESS-GLOBAL, and a disposed surface
     // must not leak its remap/disable into a LATER TuiApp instance (PR
     // review finding — remap → stop → new app inherited ctrl+x/inert
     // Enter). The manager's constructor re-syncs the builtin default for
-    // a fresh instance too; this covers the no-new-instance case.
+    // a fresh instance too; this covers the no-new-instance case. Both
+    // the editor binding (X037) and the plain-Input default are restored.
     try {
       const kb = getKeybindings()
-      kb.setUserBindings({ ...kb.getUserBindings(), 'tui.input.submit': 'enter' })
+      kb.setUserBindings({ ...kb.getUserBindings(), 'tui.input.submit': 'enter', 'tui.editor.submit': 'enter' })
     } catch {
       // Best effort: the global keybindings may already be torn down.
     }
@@ -2903,6 +3073,17 @@ export class TuiApp {
   /** The host's own input precedence ladder (the raw stage has already
    * run — see {@link handleInput}). */
   private handleInputCore(data: string): TuiInputListenerResult {
+    // MOUSE chunks bypass the host KEY ladder (X043): with the viewport
+    // listener now registered AFTER this router, the ladder sees mouse
+    // sequences first — and a question/approval handler consumes EVERY
+    // key, which would starve the alt screen's selection/click handling
+    // (fullscreen question clicks route through onCellClick, not keys).
+    // Fall through so the viewport listener owns the mouse, exactly as it
+    // did when it was registered first. (Unstable raw captures already ran
+    // BEFORE this point and still see every chunk.)
+    if (MOUSE_SEQUENCE.test(data) || (data.length === 6 && data.startsWith('\x1b[M'))) {
+      return undefined
+    }
     // Kitty-protocol terminals report press, repeat, and release events as
     // separate sequences; the app must act on the PRESS only. A release of
     // Ctrl+O would otherwise double-toggle the fold (press expands, release
@@ -3111,7 +3292,7 @@ export class TuiApp {
       // - 'host' → the Host dispatcher (the only owner that may run the
       //   Host-private app.* actions);
       // - 'editor' → the FORK EDITOR executes (hostResolved: false — the
-      //   editor's tui.input.submit was synced by onEditorSubmitSync, so
+      //   editor's tui.editor.submit was synced by onEditorSubmitSync, so
       //   the key really submits there with backslash-newline semantics);
       // - 'plugin' → NEVER the AppActionDispatcher: a Stable plugin may
       //   only trigger the PUBLIC TuiAction set, and those execute
@@ -3227,7 +3408,7 @@ export class TuiApp {
     }
     if (action === 'app.input.submit' && data !== '') {
       // The fork editor OWNS the direct submit keys (backslash-newline
-      // semantics live in its tui.input.submit — the
+      // semantics live in its tui.editor.submit — X037; the
       // effective keys are synced there by onEditorSubmitSync). The host
       // ladder never consumes a DIRECT submit key: resolving it here would
       // bypass the editor's full submit logic (PR review finding — a
@@ -3435,7 +3616,7 @@ export class TuiApp {
           // `!` / `!!` shell mode has an empty BODY but a non-empty wire
           // form, and must reach the queue protocol like the literal
           // prefix did before the mode feature.
-          if (!serializedDraftHasPayload(this.serializeSeatDraft(this.seatEditor().getText()))) return true
+          if (!serializedDraftHasPayload(this.expandedSeatWireDraft())) return true
         }
         this.submitDraft(forceQueue)
         return true
@@ -3449,8 +3630,7 @@ export class TuiApp {
         // editor buffer holds the bare command body, so the wire form is
         // re-serialized here (serializeSeatDraft) and the mode reset with
         // the draft.
-        const draft = this.seatEditor().getText()
-        const serialized = this.serializeSeatDraft(draft)
+        const serialized = this.expandedSeatWireDraft()
         this.seatEditor().setText('')
         this.editorSeatHolder.notifyChanged()
         this.resetEditorMode()
@@ -3664,7 +3844,7 @@ export class TuiApp {
           'tui.editor.deleteWordBackward', 'tui.editor.deleteWordForward',
           'tui.editor.deleteToLineStart', 'tui.editor.deleteToLineEnd',
           'tui.editor.yank', 'tui.editor.yankPop', 'tui.editor.undo',
-          'tui.input.newLine', 'tui.input.submit', 'tui.input.tab', 'tui.input.copy',
+          'tui.input.newLine', 'tui.editor.submit', 'tui.input.tab', 'tui.input.copy',
           'tui.select.up', 'tui.select.down', 'tui.select.pageUp', 'tui.select.pageDown',
           'tui.select.confirm', 'tui.select.cancel',
         ].some(binding => kb.matches(data, binding as never))
@@ -3702,7 +3882,11 @@ export class TuiApp {
    * @param options - overlay sizing/positioning.
    * @returns the handle; hide() also forgets the handle.
    */
-  private showOverlayOnHost(component: Component, options: OverlayOptions): OverlayHandle {
+  private showOverlayOnHost(
+    component: Component,
+    options: OverlayOptions,
+    ownership: { remountable?: boolean } = {},
+  ): OverlayHandle {
     // P1-09: never mount on a finally-disposed surface (the plugin lease
     // path guards earlier; this is the last-chance guard for every other
     // caller — a stopped screen's showOverlay would otherwise revive a
@@ -3713,7 +3897,16 @@ export class TuiApp {
     // M6: an overlay owns the focused component now — any pending leader
     // sequence is cancelled (focus-transition cancellation).
     this.keybindings.cancelLeader()
-    const handle = this.activeScreen.showOverlay(component, options)
+    // X007 ownership: by default an overlay entry OWNS its component —
+    // removal (hide) disposes it (panels stop their timers exactly once,
+    // via the owning frame or the component itself). REMOUNTABLE overlays
+    // (extension/advanced/unstable leases, re-mounted across fullscreen
+    // screen switches) opt out: their component must survive the screen's
+    // teardown; their lease owns the lifecycle instead.
+    const merged: OverlayOptions = ownership.remountable === true
+      ? { ...options, disposeOnHide: false }
+      : { disposeOnHide: true, ...options }
+    const handle = this.activeScreen.showOverlay(component, merged)
     // M8: the stacking graph + suspension rules live in the broker (plan
     // §13 — behavior identical; the existing modal-stacking tests gate
     // the extraction).
@@ -3740,17 +3933,22 @@ export class TuiApp {
   }
 
   /**
-   * Launch the external editor with the current draft. The TUI stops first
-   * (raw mode released) and restarts after the editor returns; a fullscreen
-   * mode is not restored (the editor session ends in regular mode).
+   * Launch the external editor with the current draft. The ACTIVE screen
+   * suspends first (raw mode released) and resumes after the editor
+   * returns — a fullscreen surface is PRESERVED across the round-trip
+   * (suspendForExternalEditor / resumeFromExternalEditor).
    *
    * SINGLE-FLIGHT: only ONE editor ownership exists at a time. The latch is
    * set synchronously at entry and cleared in the OUTERMOST `finally`, so
-   * no stage — draft read, stop, the editor round-trip, draft apply, start —
-   * can throw and leave the latch stuck: every terminal outcome (success,
-   * failure, cancellation, a restart failure) releases it, and a repeated
-   * Ctrl+G in the same input batch, a macro, or a direct caller can never
-   * start a second editor while one is pending.
+   * no stage — draft read, suspend, the editor round-trip, draft apply,
+   * resume — can throw and leave the latch stuck: every terminal outcome
+   * (success, failure, cancellation, a resume failure) releases it, and a
+   * repeated Ctrl+G in the same input batch, a macro, or a direct caller
+   * can never start a second editor while one is pending.
+   *
+   * The round-trip SUSPENDS the active screen (see
+   * suspendForExternalEditor) instead of stopping the app: a fullscreen
+   * surface is preserved across the editor and re-entered afterwards.
    */
   async launchExternalEditor(): Promise<void> {
     const open = this.events.openExternalEditor
@@ -3763,8 +3961,27 @@ export class TuiApp {
       // back through the decode — the user can switch `! ↔ !! ↔ prompt`
       // in $EDITOR and the mode follows. A plugin editor (no mode) keeps
       // identity.
-      const draft = this.serializeSeatDraft(this.seatEditor().getText())
-      this.stop()
+      // P1 (large-paste loss): expand fork paste markers BEFORE the text
+      // leaves the editor — the later restore clears the paste registry,
+      // so $EDITOR (and the re-staged draft) would otherwise keep only the
+      // literal `[paste #N +123 lines]` marker. Plugin editors without a
+      // registry fall back to getText().
+      const seat = this.seatEditor()
+      const draft = this.serializeSeatDraft(seat.getExpandedText?.() ?? seat.getText())
+      // Round-2 review P1: a PARTIALLY-applied suspend (screen state
+      // mutated, then stop() threw) must not leave the TUI permanently
+      // stopped — attempt a best-effort resume before propagating, so the
+      // outer latch release lands on a surface that still runs.
+      try {
+        this.suspendForExternalEditor()
+      } catch (suspendError) {
+        try {
+          this.resumeFromExternalEditor()
+        } catch {
+          // Best effort: the diagnostics path reports the original throw.
+        }
+        throw suspendError
+      }
       try {
         const next = await open(draft)
         if (this.disposed) return
@@ -3775,7 +3992,7 @@ export class TuiApp {
           this.editorSeatHolder.notifyChanged()
         }
       } finally {
-        if (!this.disposed) this.start()
+        if (!this.disposed) this.resumeFromExternalEditor()
       }
     } finally {
       this.externalEditorInFlight = false
@@ -3993,6 +4210,16 @@ export class TuiApp {
         // Suppress the fork search key even after the host action is remapped
         // so an old default never silently re-enables rendered-line search.
         onBeforeViewportInput: (data) => {
+          // Prompt-turn navigation (X028 seam): claim the fork's prompt-nav keys
+          // before its built-in handler — the fork scans for OSC 133
+          // markers, which the DSH transcript never emits (a stable no-op);
+          // the host's virtual window owns the real turn boundaries.
+          if (getKeybindings().matches(data, 'tui.altScreen.previousPrompt')) {
+            return this.events.onTranscriptTurnOlder?.() === true
+          }
+          if (getKeybindings().matches(data, 'tui.altScreen.nextPrompt')) {
+            return this.events.onTranscriptTurnNewer?.() === true
+          }
           if (this.keybindings.matches(data, 'app.transcript.jumpLatest')) {
             return this.events.onTranscriptJumpLatest?.() === true
           }
@@ -4012,6 +4239,22 @@ export class TuiApp {
         // helpers, OSC 52 last) replaces the vendor's raw OSC 52 write —
         // the alt screen never needs to understand tmux/SSH/Wayland/X11.
         copySelection: this.copySelection,
+        // Fullscreen mouse capture also swallows native OSC 8 link
+        // activation and (on Windows) the native right-click paste — the
+        // host owns both: the opener validates http/https and the paste
+        // reads the clipboard then feeds a bracketed paste to the focused
+        // component.
+        openUrl: this.openExternalUrl,
+        onRightClickPaste: this.readClipboardText === undefined ? undefined : () => {
+          this.rightClickPasteFromClipboard()
+        },
+        // X043: defer the viewport input listener so the host's single
+        // router (installed below) sees every raw chunk BEFORE the
+        // viewport consumes wheel/mouse events and semantic scroll keys —
+        // the unstable raw-capture contract ("see/consume/rewrite ANY
+        // chunk") and the host key ladder must observe the same stream on
+        // BOTH screens.
+        deferViewportListener: true,
       })
       // Fullscreen layout: header and todo pinned, the transcript scrolls in
       // the middle (grow), and the editor + footer stay pinned to the bottom
@@ -4031,8 +4274,10 @@ export class TuiApp {
         { component: this.paintProbe, shrink: 0 },
         { component: this.header, shrink: 0 },
         // grow is a stack-entry option: the transcript pane takes all the
-        // height the pinned rows leave behind.
-        { component: this.fullscreenScroll, grow: 1 },
+        // height the pinned rows leave behind. basis: 0 skips the pane's
+        // intrinsic-height measurement pass (the ScrollView's content
+        // height is irrelevant — grow fills whatever remains).
+        { component: this.fullscreenScroll, basis: 0, grow: 1 },
         { component: this.dock, shrink: 0 },
         { component: this.todoPanel, shrink: 0 },
         { component: this.goalLine, shrink: 0 },
@@ -4044,7 +4289,11 @@ export class TuiApp {
         { component: this.footer, shrink: 0 },
       ])
       alt.setLayoutRoot(root)
+      // Registration order IS dispatch order (X043): the host router goes
+      // in FIRST, then the viewport listener takes whatever the ladder
+      // did not consume.
       alt.addInputListener((data) => this.routeInput(data))
+      alt.installViewportListener()
       this.tui.stop()
       alt.start()
       // The alt screen starts with NO focused component: without this, every
@@ -4188,13 +4437,14 @@ export class TuiApp {
     })
     panel.start()
     this.historyPanel = panel
-    this.historyOverlay = this.showOverlayOnHost(new Frame(panel), { width, maxHeight })
+    this.historyOverlay = this.showOverlayOnHost(new FocusForwardingFrame(panel), { width, maxHeight })
   }
 
   /** Close the history panel (Esc/Ctrl+C, accept, surface dispose). */
   closeHistorySearch(): void {
     if (this.historyOverlay === undefined) return
-    this.historyPanel?.dispose()
+    // The owning FocusForwardingFrame + disposeOnHide release the panel's
+    // debounce timer/controller on hide (X007).
     this.historyOverlay.hide()
     this.historyOverlay = undefined
     this.historyPanel = undefined
@@ -5864,7 +6114,7 @@ export class TuiApp {
     if (this.viewerMode === undefined) {
       // Preserve the main draft in its SERIALIZED wire form, so a
       // shell-mode draft round-trips through the viewer with its mode.
-      this.mainDraftBeforeViewer = this.serializeSeatDraft(this.seatEditor().getText())
+      this.mainDraftBeforeViewer = this.expandedSeatWireDraft()
       // The viewer renders ONLY the child transcript: the main session's
       // local cards (`!` shell runs) must never leak into it. The runner
       // repaints the child folder right after, so the cleared list is
@@ -6002,7 +6252,7 @@ export class TuiApp {
   private parkSubagentDraft(childSessionId: string): void {
     // The slot stores the SERIALIZED wire form (mode + body), so the
     // visible text is serialized the same way before comparing/folding.
-    const visible = this.serializeSeatDraft(this.seatEditor().getText())
+    const visible = this.expandedSeatWireDraft()
     const slotted = this.subagentDrafts.get(childSessionId)
     if (visible === slotted) return
     if (slotted === undefined || slotted === '') {
@@ -6045,11 +6295,12 @@ export class TuiApp {
     const target = this.viewerMode
     if (target === undefined || target.mode !== 'continuable') return
     if (this.events.onSubagentSubmit === undefined) return
-    const text = this.seatEditor().getText()
     // The shell-editor-mode boundary: the visible body is re-serialized
     // into the wire form before it leaves the app (a shell-mode draft
-    // reaches the child exactly as the user would have typed it).
-    const serialized = this.serializeSeatDraft(text)
+    // reaches the child exactly as the user would have typed it) — with
+    // paste markers EXPANDED (round-2 P1): the child wire must never
+    // carry registry-bound marker text.
+    const serialized = this.expandedSeatWireDraft()
     // Emptiness is judged on the SERIALIZED wire form: a bare `!` / `!!`
     // shell mode has an empty BODY but a non-empty wire form, and must
     // reach the child like the literal prefix did before the mode feature.
@@ -6205,7 +6456,7 @@ export class TuiApp {
       if (closed || raw !== undefined) return
       const compiled = compileView(view)
       const component = compiled.isEmpty ? new Text('', 0, 0) : compiled.component
-      raw = this.showOverlayOnHost(component, mountOptions)
+      raw = this.showOverlayOnHost(component, mountOptions, { remountable: true })
       if (hiddenByLease) raw.setHidden(true)
     }
     mount()
@@ -6328,7 +6579,7 @@ export class TuiApp {
       )
       wrapper = created
       this.advancedOverlayWrappers.add(created)
-      raw = this.showOverlayOnHost(created, mountOptions)
+      raw = this.showOverlayOnHost(created, mountOptions, { remountable: true })
       if (hiddenByLease) raw.setHidden(true)
     }
     mount()
@@ -6558,7 +6809,7 @@ export class TuiApp {
       )
       adapter = created
       this.unstableMountAdapters.add(created)
-      raw = this.showOverlayOnHost(created, mountOptions)
+      raw = this.showOverlayOnHost(created, mountOptions, { remountable: true })
       if (hiddenByLease) raw.setHidden(true)
     }
     mount()
@@ -6973,6 +7224,13 @@ export class TuiApp {
     const editor = this.editor
     return {
       getText: () => editor.getText(),
+      // P1 (large-paste external-editor loss): the draft that LEAVES the
+      // editor context must carry the REAL paste content — getText()
+      // returns `[paste #N +123 lines]` markers whose registry is cleared
+      // by the later restore, so $EDITOR and draft snapshots would keep
+      // only the marker text. The fork Editor expands via its registry.
+      getExpandedText: () => editor.getExpandedText(),
+      getExpandedCursor: () => editor.getExpandedCursor(),
       setText: (text) => editor.setText(text),
       isShowingAutocomplete: () => editor.isShowingAutocomplete(),
       getInputMode: () => editor.getInputMode(),
@@ -7116,6 +7374,20 @@ export class TuiApp {
     const seat = this.seatEditor()
     const mode = seat.id === 'host' ? this.editor.getInputMode() : 'prompt'
     return serializeEditorInput(mode, text)
+  }
+
+  /**
+   * The visible seat draft in WIRE form with fork paste markers EXPANDED
+   * (round-2 review P1): every path where draft text LEAVES the editor's
+   * own context — the wire (submit/steer/queue), draft parking slots, the
+   * viewer submission — must carry the REAL paste content; getText()'s
+   * `[paste #N …]` markers orphan as soon as any later restore clears the
+   * registry, silently replacing the pasted content with the marker text.
+   * Plugin editors without a registry fall back to getText().
+   */
+  private expandedSeatWireDraft(): string {
+    const seat = this.seatEditor()
+    return this.serializeSeatDraft(seat.getExpandedText?.() ?? seat.getText())
   }
 
   /**
@@ -7678,9 +7950,9 @@ export class TuiApp {
       const bullet = color.primary(iconPrefix('assistant-bullet', this.iconStyle))
       if (message.content !== undefined && this.imageLoader !== undefined && this.imageTheme !== undefined) {
         return this.renderBlockSequence(message.content, (text) =>
-          new BulletedComponent(new Markdown(text, 0, 0, markdownTheme), bullet), message)
+          new BulletedComponent(new Markdown(text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS), bullet), message)
       }
-      return new BulletedComponent(new Markdown(message.text, 0, 0, markdownTheme), bullet)
+      return new BulletedComponent(new Markdown(message.text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS), bullet)
     }
     if (message.kind === 'thinking') {
       // The unified Thinking disclosure card (plan §4/§13): COMPACT is
@@ -7781,7 +8053,7 @@ export class TuiApp {
       if (expanded) {
         if (counts !== '') card.addChild(new Text(color.textDim(counts), 0, 0))
         if (message.text !== '') {
-          card.addChild(new Markdown(message.text, 0, 0, markdownTheme))
+          card.addChild(new Markdown(message.text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS))
         } else if (message.error !== undefined) {
           card.addChild(new Text(color.textDim(message.error), 0, 0))
         }
@@ -9313,9 +9585,9 @@ export class TuiApp {
    * the wire form). */
   getDraft(): string {
     const target = this.viewerMode
-    if (target === undefined) return this.serializeSeatDraft(this.seatEditor().getText())
+    if (target === undefined) return this.expandedSeatWireDraft()
     if (isViewerAccessInteractive(resolveViewerAccess(target.mode, target.access))) {
-      return this.serializeSeatDraft(this.seatEditor().getText())
+      return this.expandedSeatWireDraft()
     }
     return this.mainDraftBeforeViewer ?? ''
   }
@@ -9933,7 +10205,7 @@ export class TuiApp {
     // restart the cycle even without a selection move — review P2); with
     // no marquee the list mounts directly, exactly as before.
     const mounted = marquee === undefined ? list : new MarqueeFilterAdapter(list, () => marquee.reset())
-    const handle = this.showOverlayOnHost(new Frame(mounted, true), { width: options.width ?? 64, maxHeight: options.maxHeight ?? 24 })
+    const handle = this.showOverlayOnHost(new FocusForwardingFrame(mounted, true), { width: options.width ?? 64, maxHeight: options.maxHeight ?? 24 })
     // Phase 4: an abort signal closes the picker and fires onCancel (the
     // imperative select broker's fiber-cancellation path). The listener
     // is removed on a normal select/cancel AND on the handle's close
@@ -10089,7 +10361,7 @@ export class TuiApp {
       // Search edits inside a category must restart the marquee too (the
       // vendored SelectList fires no selection change for query edits).
       const mounted = marquee === undefined ? next : new MarqueeFilterAdapter(next, () => marquee.reset())
-      overlay = this.showOverlayOnHost(new Frame(mounted, true), { width: options.width ?? 64, maxHeight: options.maxHeight ?? 24 })
+      overlay = this.showOverlayOnHost(new FocusForwardingFrame(mounted, true), { width: options.width ?? 64, maxHeight: options.maxHeight ?? 24 })
     }
     // Phase 4 parity: an abort signal closes the CURRENT overlay and fires
     // onCancel. The listener lives once on the signal — category switches
@@ -10198,15 +10470,16 @@ export class TuiApp {
       },
       () => this.requestRender(),
     )
-    const handle = this.showOverlayOnHost(new Frame(panel, true), { width: options.width ?? 72, maxHeight: options.maxHeight ?? 24 })
+    const handle = this.showOverlayOnHost(new FocusForwardingFrame(panel, true), { width: options.width ?? 72, maxHeight: options.maxHeight ?? 24 })
     // One close path: hide the overlay AND stop the panel's 1s elapsed tick
     // (an unref'd interval must still be cleared — the panel is gone).
     // `close` is a `let` declared before the panel callbacks above reference
     // it; it is assigned here, after `handle` exists. The callbacks only
     // fire on later user input, so the late assignment is safe.
     let close: () => void = () => {}
+    // The owning FocusForwardingFrame + disposeOnHide release the panel
+    // (its 1s elapsed tick) on hide — no manual dispose here (X007).
     close = (): void => {
-      panel.dispose()
       handle.hide()
     }
     return {
@@ -10256,7 +10529,7 @@ export class TuiApp {
       handle?.hide()
       onCancel()
     }, { enableSearch: true })
-    handle = this.showOverlayOnHost(new Frame(settings, true), { width: 72, maxHeight: 28 })
+    handle = this.showOverlayOnHost(new FocusForwardingFrame(settings, true), { width: 72, maxHeight: 28 })
     return () => handle?.hide()
   }
 
@@ -10285,12 +10558,14 @@ export class TuiApp {
   openKeybindingEditor(panel: Component): () => void {
     let handle: OverlayHandle | undefined
     const unregister = this.trackKeybindingEditor(panel)
+    // The owning FocusForwardingFrame + disposeOnHide dispose the panel on
+    // hide (X007); `unregister` still runs first so the tracking set never
+    // holds a closing panel.
     const close = (): void => {
-      panel.dispose?.()
       unregister()
       handle?.hide()
     }
-    handle = this.showOverlayOnHost(new Frame(panel, true), {
+    handle = this.showOverlayOnHost(new FocusForwardingFrame(panel, true), {
       width: 88,
       maxHeight: '100%',
     })
@@ -10363,7 +10638,7 @@ export class TuiApp {
         options.onCancel()
       },
     })
-    handle = this.showOverlayOnHost(new Frame(panel, true), {
+    handle = this.showOverlayOnHost(new FocusForwardingFrame(panel, true), {
       width: 88,
       // The overlay's hard cut must never exceed the terminal: the panel
       // budgets its content to rows-2 (Frame borders add 2), so the
@@ -10414,7 +10689,7 @@ export class TuiApp {
         options.onStop?.()
       }
     }
-    const handle = this.showOverlayOnHost(new Frame(panel, true), { width: 88, maxHeight: 24 })
+    const handle = this.showOverlayOnHost(new FocusForwardingFrame(panel, true), { width: 88, maxHeight: 24 })
     timer = setInterval(() => {
       if (closed) return
       panel.setBody(options.refresh())

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -26,13 +26,6 @@ import { color } from './theme.ts'
 import { classifyFileCompletionContext, FILE_ARGUMENT_COMMANDS } from './file-completion/context.ts'
 import { editorModeFromHistoryEntry, type EditorInputMode } from './editor-input-mode.ts'
 
-/** The fork's private autocomplete surface (runtime methods; kimi's
- * CustomEditor uses the same cast idiom). */
-interface AutocompleteInternals {
-  cancelAutocomplete(): void
-  requestAutocomplete(options: { force: boolean; explicitTab: boolean }): void
-}
-
 /** Host render-routing options for the host editor. */
 export interface TuiEditorOptions {
   /**
@@ -206,11 +199,11 @@ export class TuiEditor extends Editor {
    * request (the host-owned stale-context guard — the declined-key
    * fallback cancels when the staged document differs from the host's
    * current autocomplete context, so a stale dropdown can never accept
-   * candidates into the new document). Named distinctly: the fork's own
-   * `cancelAutocomplete` is private and MUST stay reachable for its
-   * internal callers — a same-named override would shadow it and recurse. */
+   * candidates into the new document). Named distinctly from the fork's
+   * `cancelAutocomplete` (X044): the fork method is PROTECTED and called
+   * directly — a same-named override would shadow it and recurse. */
   cancelHostAutocomplete(): void {
-    ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
+    this.cancelAutocomplete()
   }
 
   /** Switch the input mode. A real change fires onChange (the host's
@@ -223,7 +216,7 @@ export class TuiEditor extends Editor {
   setInputMode(mode: EditorInputMode): void {
     if (this.inputMode === mode) return
     this.inputMode = mode
-    ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
+    this.cancelAutocomplete()
     this.onChange?.(this.getText())
     this.tui.requestRender()
   }
@@ -272,7 +265,7 @@ export class TuiEditor extends Editor {
     // parity — otherwise Esc would immediately reopen the list). This
     // keeps its priority over the shell-mode Esc exit below.
     if (matchesKey(data, 'escape') && this.isShowingAutocomplete()) {
-      ;(this as unknown as AutocompleteInternals).cancelAutocomplete()
+      this.cancelAutocomplete()
       return
     }
     // Esc on an EMPTY shell body cancels the whole shell mode (the app
@@ -316,8 +309,7 @@ export class TuiEditor extends Editor {
       const beforeCursor = this.getLines()[line]?.slice(0, col) ?? ''
       const context = classifyFileCompletionContext(beforeCursor, FILE_ARGUMENT_COMMANDS)
       if (context.kind === 'mention' || context.kind === 'image-argument') {
-        ;(this as unknown as AutocompleteInternals)
-          .requestAutocomplete({ force: true, explicitTab: true })
+        this.requestAutocomplete({ force: true, explicitTab: true })
         return
       }
       const trimmed = beforeCursor.trimStart()
@@ -328,8 +320,7 @@ export class TuiEditor extends Editor {
         // Still run the provider request so the separate extension
         // autocomplete chain can answer ordinary positions. MentionProvider's
         // host file branch remains closed for this `none` context.
-        ;(this as unknown as AutocompleteInternals)
-          .requestAutocomplete({ force: true, explicitTab: true })
+        this.requestAutocomplete({ force: true, explicitTab: true })
         return
       }
     }
@@ -344,8 +335,7 @@ export class TuiEditor extends Editor {
       const beforeCursor = this.getLines()[line]?.slice(0, col) ?? ''
       const trimmed = beforeCursor.trimStart()
       if (trimmed.startsWith('/') && !trimmed.includes(' ')) {
-        ;(this as unknown as AutocompleteInternals)
-          .requestAutocomplete({ force: true, explicitTab: true })
+        this.requestAutocomplete({ force: true, explicitTab: true })
         return
       }
     }
@@ -398,8 +388,7 @@ export class TuiEditor extends Editor {
     const quotedMention = context.query.startsWith('@"')
     const nonstandardBoundary = beforeAt !== undefined && beforeAt !== ' ' && beforeAt !== '\t'
     if (!quotedMention && !nonstandardBoundary) return
-    ;(this as unknown as AutocompleteInternals)
-      .requestAutocomplete({ force: false, explicitTab: false })
+    this.requestAutocomplete({ force: false, explicitTab: false })
   }
 
   /** Stitch a buffered paste-marker prefix onto this chunk. */
@@ -525,8 +514,7 @@ export class TuiEditor extends Editor {
     // per-command hardcode, and never a plain trailing `/` (a `see /tmp/`
     // position stays closed).
     if ((textBeforeCursor.endsWith('/') || textBeforeCursor.endsWith('\\')) && isFileArgumentContext(textBeforeCursor)) {
-      ;(this as unknown as AutocompleteInternals)
-        .requestAutocomplete({ force: false, explicitTab: false })
+      this.requestAutocomplete({ force: false, explicitTab: false })
     }
   }
 }

--- a/test/home-end-keys.test.ts
+++ b/test/home-end-keys.test.ts
@@ -157,6 +157,43 @@ test('registered older-boundary callback preserves history follow state', async 
   app.stop()
 })
 
+test('fullscreen Ctrl+Up/Ctrl+Down drive the host turn navigation (prompt-nav seam)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const olderCalls: number[] = []
+  const newerCalls: number[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onTranscriptTurnOlder: () => {
+      olderCalls.push(Date.now())
+      return true
+    },
+    onTranscriptTurnNewer: () => {
+      newerCalls.push(Date.now())
+      return true
+    },
+  })
+  app.start()
+  app.setTranscript([{
+    kind: 'assistant',
+    turn: 0,
+    text: Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join('\n'),
+  }])
+  app.setFullscreen(true)
+  await vt.waitForRender()
+
+  // Ctrl+Up / Ctrl+Down (the fork's previousPrompt/nextPrompt defaults)
+  // must reach the HOST seams in fullscreen — not vanish into the fork's
+  // OSC 133 scan (a permanent no-op on DSH transcripts).
+  vt.sendInput('\x1b[1;5A') // ctrl+up
+  await vt.waitForRender()
+  vt.sendInput('\x1b[1;5B') // ctrl+down
+  await vt.waitForRender()
+  assert.equal(olderCalls.length, 1, 'Ctrl+Up must reach onTranscriptTurnOlder exactly once')
+  assert.equal(newerCalls.length, 1, 'Ctrl+Down must reach onTranscriptTurnNewer exactly once')
+  app.stop()
+})
+
 test('history window paging preserves the overlap row across uneven heights', async () => {
   const vt = new VirtualTerminal(80, 24)
   const longMarkdown = ['turn-82', ...Array.from({ length: 80 }, (_, index) => `markdown row ${index + 1}`)].join('\n')

--- a/test/input-experience.test.ts
+++ b/test/input-experience.test.ts
@@ -337,6 +337,53 @@ test('two ctrl+g in one input batch start the external editor only once (single-
   app.stop()
 })
 
+test('the external editor round-trip EXPANDS paste markers (P1 large-paste loss)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const seenDrafts: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    openExternalEditor: async (draft) => {
+      seenDrafts.push(draft)
+      return draft
+    },
+    runOwned: owned,
+  })
+  app.start()
+  // A large multi-line paste lands as a `[paste #N +12 lines]` marker in
+  // the editor text; the registry holds the real content.
+  const pasted = Array.from({ length: 12 }, (_, i) => `real line ${i + 1}`).join('\n')
+  vt.sendInput(`\x1b[200~${pasted}\x1b[201~`)
+  await vt.waitForRender()
+  await app.launchExternalEditor()
+  assert.equal(seenDrafts.length, 1)
+  assert.ok(seenDrafts[0]!.includes('real line 12'), `$EDITOR must see the REAL paste content, got: ${seenDrafts[0]}`)
+  assert.ok(!seenDrafts[0]!.includes('[paste #'), 'the marker text must never reach $EDITOR')
+  app.stop()
+})
+
+test('the external editor round-trip preserves fullscreen and the surface generation (P2)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    openExternalEditor: async (draft) => draft,
+    runOwned: owned,
+  })
+  app.start()
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  assert.equal(app.isFullscreen(), true, 'fullscreen is up before the round-trip')
+  const generationBefore = app.getSurfaceGeneration()
+  await app.launchExternalEditor()
+  await vt.waitForRender()
+  assert.equal(app.isFullscreen(), true, 'returning from $EDITOR must re-enter the SAME fullscreen surface')
+  assert.equal(app.getSurfaceGeneration(), generationBefore, 'the round-trip stays inside one surface generation')
+  app.setFullscreen(false)
+  await vt.waitForRender()
+  app.stop()
+})
+
 test('the editor single-flight latch releases after a failed launch', async () => {
   const vt = new VirtualTerminal(80, 24)
   let calls = 0
@@ -373,16 +420,18 @@ test('the editor latch releases even when the TUI restart (start) throws', async
     runOwned: owned,
   })
   app.start()
-  const originalStart = app.start.bind(app)
-  // The first launch's restart throws: the failure lands in diagnostics
-  // (the runOwned error path in production), but the latch MUST still
-  // clear — otherwise the editor capability dies silently for the rest of
-  // the session. Direct calls are used because after a failed restart the
-  // TUI is stopped, so keyboard input no longer reaches the app.
-  app.start = () => { throw new Error('restart failed') }
+  const screen = (app as unknown as { tui: { start: () => void; stop: () => void } }).tui
+  const originalStart = screen.start.bind(screen)
+  // The first launch's resume (screen restart) throws: the failure lands
+  // in diagnostics (the runOwned error path in production), but the latch
+  // MUST still clear — otherwise the editor capability dies silently for
+  // the rest of the session. The resume seam stops/starts the ACTIVE
+  // screen directly (suspendForExternalEditor /
+  // resumeFromExternalEditor), not TuiApp.start.
+  screen.start = () => { throw new Error('restart failed') }
   await app.launchExternalEditor().catch(() => {})
   assert.equal(calls, 1, 'the editor round-trip ran')
-  app.start = originalStart
+  screen.start = originalStart
   await app.launchExternalEditor()
   assert.equal(calls, 2, 'the latch must release even when restart threw')
   app.stop()
@@ -401,11 +450,14 @@ test('the editor latch releases even when the TUI stop throws', async () => {
     runOwned: owned,
   })
   app.start()
-  const originalStop = app.stop.bind(app)
-  app.stop = () => { throw new Error('stop failed') }
+  const screen = (app as unknown as { tui: { start: () => void; stop: () => void } }).tui
+  const originalStop = screen.stop.bind(screen)
+  // The suspend seam stops the ACTIVE screen (suspendForExternalEditor),
+  // not TuiApp.stop — patch the screen's stop.
+  screen.stop = () => { throw new Error('stop failed') }
   await app.launchExternalEditor().catch(() => {})
   assert.equal(calls, 0, 'the editor never opened (stop threw first)')
-  app.stop = originalStop
+  screen.stop = originalStop
   await app.launchExternalEditor()
   assert.equal(calls, 1, 'the latch must release even when stop threw')
   app.stop()

--- a/test/keybinding-integration.test.ts
+++ b/test/keybinding-integration.test.ts
@@ -423,6 +423,52 @@ test('the read-only viewer lets a REMAPPED fold key reach the host fold (effecti
   app.stop()
 })
 
+test('app.input.submit remap does NOT leak into question free-text Inputs (X037)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': 'ctrl+x' }))
+  await vt.waitForRender()
+
+  const answers = app.askQuestions([{ id: 'q1', question: 'Name?', options: [] }])
+  await vt.waitForRender()
+  vt.sendInput('A')
+  vt.sendInput('B')
+  await vt.waitForRender()
+  // The remapped EDITER submit key must NOT commit a plain Input's answer.
+  vt.sendInput('\x18') // ctrl+x
+  await vt.waitForRender()
+  // Enter still submits the free-text answer (Input keeps its own Enter):
+  // first Enter commits the question, second Enter submits the review page.
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  const settled = await Promise.race([answers, new Promise<never>((_, reject) => setTimeout(() => reject(new Error('question never settled')), 500))])
+  assert.deepEqual(settled, [{ id: 'q1', selected: [], custom: 'AB' }], 'ctrl+x must not commit; Enter commits the typed answer')
+  app.stop()
+})
+
+test('app.input.submit remap does NOT leak into the history search Input (X037)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.submit': 'ctrl+x' }))
+  await vt.waitForRender()
+  // Ctrl+R opens the panel; a source must be wired for it to open at all.
+  ;(app as unknown as { historySearchSource: unknown }).historySearchSource = {
+    query: async () => ({ rows: [{ text: 'alpha' }, { text: 'beta' }] }),
+  }
+  app.openHistorySearch()
+  await vt.waitForRender()
+  vt.sendInput('a')
+  vt.sendInput('\x18') // ctrl+x — an editor-only submit key; the search box keeps editing
+  await vt.waitForRender()
+  const viewport = vt.getViewport().map(line => line.replace(/\x1b\[[0-9;]*m/g, '')).join('\n')
+  assert.ok(viewport.includes('a'), 'the search box must still show the typed query')
+  app.closeHistorySearch()
+  app.stop()
+})
+
 test('app.input.submit remap: the NEW key submits and Enter no longer does (PR review)', async () => {
   const vt = new VirtualTerminal(80, 24)
   const submitted: string[] = []

--- a/test/re-vendor-round2.test.ts
+++ b/test/re-vendor-round2.test.ts
@@ -152,3 +152,64 @@ test('openKeybindingEditor disposes a NON-Focusable panel on close (round-5 P2)'
   assert.equal(disposeCount, 1, 'the non-Focusable panel must be disposed exactly once on close')
   app.stop()
 })
+
+test('right-click paste lands in the focused editor with `this` intact (round-9 P2)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    runOwned: (_label, task) => { Promise.resolve(task()).catch(() => {}) },
+  }, {
+    readClipboardText: async () => 'pasted text',
+  })
+  app.start()
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  // The seat editor owns focus in fullscreen.
+  ;(app as unknown as { rightClickPasteFromClipboard(): void }).rightClickPasteFromClipboard()
+  await new Promise(resolve => setTimeout(resolve, 30))
+  const draft = app.getDraft()
+  assert.ok(draft.includes('pasted text'), `the paste must reach the editor draft with a live this:\n${draft}`)
+  app.setFullscreen(false)
+  await vt.waitForRender()
+  app.stop()
+})
+
+test('right-click paste is DROPPED when focus moves during the clipboard read (round-9 P2)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let resolveClipboard!: (text: string) => void
+  const clipboard = new Promise<string>(resolve => { resolveClipboard = resolve })
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    runOwned: (_label, task) => { Promise.resolve(task()).catch(() => {}) },
+  }, {
+    readClipboardText: () => clipboard,
+  })
+  app.start()
+  await vt.waitForRender()
+  const handle = app.unstableSurfaceHandle()
+  const aInputs: string[] = []
+  const bInputs: string[] = []
+  const leaseA = handle.mountComponent({
+    render: () => ['A'],
+    handleInput: (data: string) => { aInputs.push(data) },
+  })
+  await vt.waitForRender()
+  assert.equal(leaseA.focused, true, 'A owns focus (the right-click target)')
+  ;(app as unknown as { rightClickPasteFromClipboard(): void }).rightClickPasteFromClipboard()
+  // While the clipboard read is pending, focus moves to B.
+  const leaseB = handle.mountComponent({
+    render: () => ['B'],
+    handleInput: (data: string) => { bInputs.push(data) },
+  })
+  await vt.waitForRender()
+  assert.equal(leaseB.focused, true, 'B owns focus now')
+  resolveClipboard('X')
+  await new Promise(resolve => setTimeout(resolve, 30))
+  assert.deepEqual(aInputs, [], 'the stale target must never receive the paste')
+  assert.deepEqual(bInputs, [], 'the new focus owner must never receive the paste either')
+  leaseA.close()
+  leaseB.close()
+  app.stop()
+})

--- a/test/re-vendor-round2.test.ts
+++ b/test/re-vendor-round2.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Round-2 review regressions: outbound draft paths must carry EXPANDED
+ * paste content (steer / getDraft / the external-editor suspend rollback)
+ * and the Windows URL launcher must quote transcript-controlled URLs
+ * against cmd.exe metacharacter injection.
+ * @module @xmoon76/dsh-pi-tui/re-vendor-round2.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { openerFor } from '../src/open-url.ts'
+import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+const pasted = Array.from({ length: 12 }, (_, i) => `real line ${i + 1}`).join('\n')
+
+function pasteLarge(vt: VirtualTerminal): void {
+  vt.sendInput(`\x1b[200~${pasted}\x1b[201~`)
+}
+
+test('steer carries the EXPANDED paste content, never the marker text', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const steered: string[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {}, onSteer: (text: string) => steered.push(text) })
+  app.start()
+  app.keybindingsManager().setUserConfiguration(parseUserKeybindings({ 'app.input.steer': 'ctrl+x' }))
+  await vt.waitForRender()
+  pasteLarge(vt)
+  await vt.waitForRender()
+  vt.sendInput('\x18') // ctrl+x — steer
+  await vt.waitForRender()
+  assert.equal(steered.length, 1)
+  assert.ok(steered[0]!.includes('real line 12'), `the steer wire must carry the real paste content: ${steered[0]}`)
+  assert.ok(!steered[0]!.includes('[paste #'), 'marker text must never leave the editor context')
+  app.stop()
+})
+
+test('getDraft returns the EXPANDED wire form after a marker paste', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  await vt.waitForRender()
+  pasteLarge(vt)
+  await vt.waitForRender()
+  const draft = app.getDraft()
+  assert.ok(draft.includes('real line 1'), `getDraft must expand markers: ${draft}`)
+  assert.ok(!draft.includes('[paste #'))
+  app.stop()
+})
+
+test('a partially-applied suspend (stop throws mid-way) is rolled back to a running surface', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  let calls = 0
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    openExternalEditor: async () => {
+      calls += 1
+      return 'edited'
+    },
+    runOwned: (_label, task) => { Promise.resolve(task()).catch(() => {}) },
+  })
+  app.start()
+  await vt.waitForRender()
+  const screen = (app as unknown as { tui: { start: () => void; stop: () => void } }).tui
+  const originalStop = screen.stop.bind(screen)
+  // stop() PARTIALLY applies (the real stop runs and mutates state), then
+  // throws — the suspend must be rolled back so the surface keeps running.
+  screen.stop = () => {
+    originalStop()
+    throw new Error('stop exploded mid-way')
+  }
+  await assert.rejects(app.launchExternalEditor(), /stop exploded/)
+  screen.stop = originalStop
+  // The surface still runs: a second round-trip succeeds (the latch
+  // released AND the resume path works after the rollback).
+  await app.launchExternalEditor()
+  assert.equal(calls, 1, 'the editor opened exactly once (the failed suspend never opened it)')
+  // And input still renders (the screen is live again).
+  app.setDraft('hello')
+  await vt.waitForRender()
+  const view = vt.getViewport().map(line => line.replace(/\x1b\[[0-9;]*m/g, '')).join('\n')
+  assert.ok(view.includes('hello'), `the surface must still render after the rollback:\n${view}`)
+  app.stop()
+})
+
+test('openerFor quotes hostile URLs for cmd.exe (Windows injection guard)', () => {
+  const hostile = 'https://example.com/?a=1&b=2&c=<pipe>'
+  const { command, args } = openerFor(hostile, 'win32')
+  assert.equal(command, 'cmd')
+  assert.deepEqual(args, ['/c', 'start', '', `"${hostile}"`], 'the URL must ride as ONE quoted token — & must never split commands')
+})
+
+test('openerFor passes the URL through on unix platforms', () => {
+  assert.deepEqual(openerFor('https://example.com/x', 'darwin'), { command: 'open', args: ['https://example.com/x'] })
+  assert.deepEqual(openerFor('https://example.com/x', 'linux'), { command: 'xdg-open', args: ['https://example.com/x'] })
+})
+
+const fakeRun = (output: string) => async () => ({ stdout: Buffer.from(output, 'utf8'), stderr: Buffer.alloc(0), code: 0 })
+
+test('readClipboardText preserves a REAL trailing newline on unix backends', async () => {
+  const { readClipboardText } = await import('../src/image/clipboard.ts')
+  const env = {
+    platform: 'darwin',
+    env: {} as Record<string, string | undefined>,
+    exists: () => true,
+  }
+  const text = await readClipboardText(fakeRun('kept\n') as never, env)
+  assert.equal(text, 'kept\n', 'pbpaste output must survive verbatim (round-3 P2)')
+})
+
+test('readClipboardText preserves a REAL trailing newline on Wayland (no --no-newline)', async () => {
+  const { readClipboardText } = await import('../src/image/clipboard.ts')
+  const env = {
+    platform: 'linux',
+    env: { WAYLAND_DISPLAY: 'wayland-0' } as Record<string, string | undefined>,
+    exists: () => true,
+  }
+  const text = await readClipboardText(fakeRun('kept\n') as never, env)
+  assert.equal(text, 'kept\n', 'wl-paste output must survive verbatim (round-4 P2)')
+})
+
+test('readClipboardText strips only the SYNTHETIC PowerShell trailing newline', async () => {
+  const { readClipboardText } = await import('../src/image/clipboard.ts')
+  const env = {
+    platform: 'win32',
+    env: {} as Record<string, string | undefined>,
+    exists: () => true,
+  }
+  const text = await readClipboardText(fakeRun('line\r\n') as never, env)
+  assert.equal(text, 'line', 'Get-Clipboard synthesizes the CRLF — it is not content')
+})
+
+test('openKeybindingEditor disposes a NON-Focusable panel on close (round-5 P2)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  await vt.waitForRender()
+  let disposeCount = 0
+  // A plain Component panel — NOT Focusable — must still be disposed by
+  // the owning FocusForwardingFrame when the overlay closes.
+  const panel: import('@xmoon76/pi-tui').Component = {
+    render: () => ['panel'],
+    invalidate: () => {},
+    dispose: () => { disposeCount += 1 },
+  }
+  const close = app.openKeybindingEditor(panel)
+  await vt.waitForRender()
+  close()
+  await vt.waitForRender()
+  assert.equal(disposeCount, 1, 'the non-Focusable panel must be disposed exactly once on close')
+  app.stop()
+})

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -56,11 +56,17 @@ test('diff detection and line colorization', () => {
   assert.equal(renderDiffLine(' context'), ' context')
 })
 
-test('latex renders inside assistant markdown', async () => {
+test('latex stays RAW in assistant markdown (kimi-parity product decision)', async () => {
+  // renderLatex: false everywhere (HOST_MARKDOWN_OPTIONS): the Earendil
+  // 0.84.4 re-vendor introduced LaTeX-to-Unicode rendering defaulting to
+  // ON, which silently changed transcript rendering; the host keeps the
+  // pre-re-vendor behavior (raw $...$ text) until an explicit setting
+  // opts in.
   const { vt, app } = startApp()
   app.setTranscript([{ kind: 'assistant', turn: 0, text: 'Energy $E=mc^2$ rules' }])
   const view = await viewport(vt)
-  assert.ok(view.includes('²'), `latex not rendered:\n${view}`)
+  assert.ok(view.includes('E=mc^2'), `latex source must render verbatim:\n${view}`)
+  assert.ok(!view.includes('²'), `latex must not render to unicode yet:\n${view}`)
 })
 
 test('ctrl+t toggles the todo panel with markers', async () => {

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -721,3 +721,18 @@ test('steerNow calls the empty-Ctrl+S gate BEFORE any runOwned/ensureSession wor
   assert.ok(gateLine !== -1 && (ensureLine === -1 || gateLine < ensureLine),
     'the empty-Ctrl+S gate must run BEFORE ensureSession — the gate is the deferred-start no-creation contract')
 })
+
+test('the host editor consumes the X044 protected autocomplete seam directly (no private casts)', () => {
+  // X044's whole point is COMPILE-TIME compatibility protection: the
+  // vendored Editor's requestAutocomplete/cancelAutocomplete are protected
+  // and the host subclass must call them directly. A regression to
+  // `as unknown as AutocompleteInternals` casts would silently survive
+  // upstream signature changes and explode at runtime — the exact class
+  // of breakage the re-vendor gates exist to prevent.
+  const path = join(srcDir, 'tui-editor.ts')
+  const source = readFileSync(path, 'utf8')
+  assert.ok(!source.includes('AutocompleteInternals'),
+    'the AutocompleteInternals cast interface must not exist — the host calls the protected seam directly')
+  assert.ok(!source.includes('as unknown as'),
+    'tui-editor.ts must not cast to reach editor internals (X044)')
+})

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -733,6 +733,8 @@ test('the host editor consumes the X044 protected autocomplete seam directly (no
   const source = readFileSync(path, 'utf8')
   assert.ok(!source.includes('AutocompleteInternals'),
     'the AutocompleteInternals cast interface must not exist — the host calls the protected seam directly')
-  assert.ok(!source.includes('as unknown as'),
+  // Narrow on the CAST IDIOM only: an unrelated, legitimate `as unknown
+  // as` in this file (a future compat seam) must not trip the X044 gate.
+  assert.ok(!source.includes('as unknown as AutocompleteInternals'),
     'tui-editor.ts must not cast to reach editor internals (X044)')
 })


### PR DESCRIPTION
## 背景

PR #68（Earendil v0.84.4 重定基）合并后的全面复扫：交叉对照 kimi 原始 fork、上游 0.84.4 tarball 与重定基前快照，逐项代码级复核。审计记录：`temp/1.2-new/dsh-pi-tui-revendor-0.84.4-followup-audit-and-fixes.md`。

**核心教训**（已写入 ledger）："no host consumer" 不能作为删除 Kimi fork patch 的统一标准——PasteBurst 正是因此被误删（editor 内部 terminal-input bugfix 本就不需要 host consumer）。删除标准按四类区分：Host API / 内部 bugfix / 性能契约 / 产品行为。

## 变更（6 commits，39 文件）

### 1. vendored editor 族（X037/X038/X039/X044/X023/X045）
- **X038 PasteBurst 恢复**（P1，PR #68 直接回归）：iTerm2/tmux 丢 bracketed-paste marker 时，快速字符流后的 Enter 应换行而非提交半截 paste；kimi 完整形态（含 `disablePasteBurst` 逃生开关），kimi-exact 单字符语义
- **X037 editor submit 分离**（P1）：新增 `tui.editor.submit` 独立 binding，`tui.input.submit` 不再被 host remap 污染普通 Input
- **X039** width cache 4096 恢复；**X044** autocomplete seam 提升 protected（host 侧 8 处 private cast 已全部改为直接子类调用 + 源码 gate）；**X023** paste registry prune；**X045** `getExpandedCursor()`

### 2. vendored 组件族（X040/X041/X042/X043/X007）
- **X041 canonical filter**（P1）；**X040** setValue 光标；**X042** Focusable 列表；**X043** viewport listener 延迟注册；**X007** dispose 补齐（含 `Box.dispose()` 级联 + SettingsList 同步/异步 stale-callback 守卫）

### 3. host 侧
- **P1 大 paste → Ctrl+G 丢内容**：seat 抽象 `getExpandedText?()`，全部出站草稿路径展开 marker
- **P2 外部编辑器保 fullscreen**：suspend/resume（上游 `preserveScreen`），模态焦点保留、失败回滚
- **P2 接线补齐**：turn 导航、OSC8 链接（cmd 注入防护）、Windows 右键 paste（焦点 race + `this` 绑定均已修，2 个回归测试）、mouse 直通、LaTeX 关闭、IME FocusForwardingFrame

### 4. 文档
- DIVERGENCES.md X037–X045 + 删除标准重写；native 降级说明；tmux PasteBurst trap；双语 changelog

## 验证

- fork **1019/1019**、product **3387/3387**、tooling **217/217**、`gate:pi-surface-compat` **8/8**、typecheck、build、`git diff --check` 全绿
- review-fix-loop 7 轮收敛（accepted）+ 独立复核轮（4 项 P2 + this 绑定 blocker）全部修复

## ⚠️ CI 已知红项（非本 PR 引入，独立跟踪）

`External compatibility / pi2dsh` 失败：`dsh-user-approval does not provide export: effectiveApprovalPolicy`。该 import 不在本 PR diff 中（`next` 更早的 alpha.4 工作引入），本地依赖 alpha.3（有导出），CI lane 按 pi2dsh@0.24.0 声明安装已发布的 alpha.2（无导出）——peer range 与源码事实漂移。已建 **[issue #73](https://github.com/XMoon/dsh-pi-tui/issues/73)** 独立处理；本 PR 其余 lane 全绿。

## 更新记录

- **2026-09 rebase**：已 rebase 到最新 `next`（`5d1e88b`，含 /tmp hygiene 与 dev bootstrap 锁等 10+ commits），仅 changelog 冲突（已合并保留双方条目）；rebase 后全量 gates 复跑全绿。