### PR TITLE
chore(dsh): branch-level DSH mode policy (dsh-mode.json); switch next to npm

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -38,14 +38,18 @@ from the tracked registry metadata.
 
 Mode selection is policy-driven, not branch-name-driven:
 
-- A worktree with `test/compat/dsh-source.json` uses source mode by default.
-- A worktree without that source pin uses npm mode by default.
+- A worktree with `test/compat/dsh-mode.json` follows its tracked `mode`
+  (`npm` or `source`) — the SINGLE branch-level switch.
+- Legacy fallback (checkouts without the mode file): a worktree with
+  `test/compat/dsh-source.json` uses source mode; without it, npm mode.
 - `DSH_DEV_MODE` or `--mode` can explicitly select a mode for a one-off check.
 
-The main branch intentionally has no source-pin file so its default remains
-npm. The next branch carries its own tracked `test/compat/dsh-source.json`; a
-main-to-next merge must preserve that next-only policy rather than adding it to
-main.
+The main branch intentionally has no mode file and no source-pin file, so
+its default remains npm. The next branch carries BOTH tracked files:
+`test/compat/dsh-mode.json` (the live switch) and `test/compat/dsh-source.json`
+(the source fallback's exact SHA — never deleted, so the branch can flip
+back to source with a one-line diff). A main-to-next merge must preserve
+that next-only policy rather than adding it to main.
 
 ### main / npm mode
 
@@ -61,8 +65,15 @@ pnpm dev:bootstrap
 
 ### next / source mode
 
-The next worktree reads the repository and exact 40-character commit SHA from
-`test/compat/dsh-source.json`. The source pack cache is keyed by:
+Flip the tracked policy to source (one line), commit, push:
+
+```diff
+- "mode": "npm"
++ "mode": "source"
+```
+
+The next worktree then reads the repository and exact 40-character commit SHA
+from `test/compat/dsh-source.json`. The source pack cache is keyed by:
 
 ```text
 repository + exact commit SHA

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -42,7 +42,11 @@ Mode selection is policy-driven, not branch-name-driven:
   (`npm` or `source`) — the SINGLE branch-level switch.
 - Legacy fallback (checkouts without the mode file): a worktree with
   `test/compat/dsh-source.json` uses source mode; without it, npm mode.
-- `DSH_DEV_MODE` or `--mode` can explicitly select a mode for a one-off check.
+- `DSH_MODE` or `--mode` can explicitly select a mode for a one-off check
+  (a user override that beats the tracked policy).
+- `DSH_DEV_MODE` is GENERATED development state (what `dev:bootstrap`
+  materialized into `.dsh-dev-env`); it is only a legacy fallback when no
+  tracked mode policy exists, and never overrides `dsh-mode.json`.
 
 The main branch intentionally has no mode file and no source-pin file, so
 its default remains npm. The next branch carries BOTH tracked files:

--- a/scripts/dsh-ci-context.mjs
+++ b/scripts/dsh-ci-context.mjs
@@ -2,13 +2,16 @@
 /**
  * Resolve the one DSH distribution mode used by a GitHub Actions run.
  *
- * Tags are always npm mode. A push to next and a pull request targeting next
- * use the pinned source pack. All other branches/PR bases use npm mode.
+ * Tags are always npm mode. A push to next and a pull request targeting
+ * next follow the TRACKED branch-level mode policy
+ * (test/compat/dsh-mode.json) — one line flips the whole branch between
+ * the pinned source pack and the registry-backed npm distribution. All
+ * other branches/PR bases use npm mode.
  *
  * @module dsh-ci-context
  */
 
-import { appendFileSync, readFileSync } from 'node:fs'
+import { appendFileSync, existsSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
@@ -18,25 +21,50 @@ import { DEFAULT_SOURCE_CONFIG, loadDshSourceConfig } from './lib/dsh-distributi
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(SCRIPT_DIR, '..')
 const PI2DSH_MANIFEST = join(ROOT, 'test', 'compat', 'pi2dsh.json')
+const MODE_CONFIG = join(ROOT, 'test', 'compat', 'dsh-mode.json')
 
 function fail(message) {
   throw new Error(message)
 }
 
 /**
- * Resolve source/npm mode from GitHub event context.
- * @param {{eventName?: string, ref?: string, baseRef?: string, forcedMode?: string}} context
+ * Read the tracked branch-level DSH mode policy. The file is the SINGLE
+ * source of truth for next's distribution; a missing or malformed file
+ * is an explicit error (next always carries it).
+ * @param {string} path - the mode-config path (injectable for tests).
  * @returns {'source'|'npm'}
  */
-export function resolveDshMode({ eventName = '', ref = '', baseRef = '', forcedMode } = {}) {
+export function readTrackedMode(path = MODE_CONFIG) {
+  if (!existsSync(path)) fail(`DSH mode config is missing: ${path}`)
+  let value
+  try {
+    value = JSON.parse(readFileSync(path, 'utf8'))
+  } catch (error) {
+    fail(`DSH mode config could not be read: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) fail('DSH mode config must be an object')
+  if (value.schemaVersion !== 1) fail(`unsupported DSH mode config schema ${JSON.stringify(value.schemaVersion)}`)
+  const mode = value.mode
+  if (mode !== 'source' && mode !== 'npm') {
+    fail(`unsupported DSH mode ${JSON.stringify(mode)}; expected source or npm`)
+  }
+  return mode
+}
+
+/**
+ * Resolve source/npm mode from GitHub event context.
+ * @param {{eventName?: string, ref?: string, baseRef?: string, forcedMode?: string, modeConfigPath?: string}} context
+ * @returns {'source'|'npm'}
+ */
+export function resolveDshMode({ eventName = '', ref = '', baseRef = '', forcedMode, modeConfigPath = MODE_CONFIG } = {}) {
   const tag = ref.startsWith('refs/tags/')
+  const isNext = (eventName === 'pull_request' && baseRef === 'next')
+    || (eventName === 'push' && ref === 'refs/heads/next')
   const computed = tag
     ? 'npm'
-    : eventName === 'pull_request' && baseRef === 'next'
-      ? 'source'
-      : eventName === 'push' && ref === 'refs/heads/next'
-        ? 'source'
-        : 'npm'
+    : isNext
+      ? readTrackedMode(modeConfigPath)
+      : 'npm'
   if (tag && forcedMode === 'source') fail('release tag events must never use DSH source mode')
   if (forcedMode !== undefined && forcedMode !== computed) {
     fail(`forced DSH mode ${forcedMode} disagrees with resolved mode ${computed}`)
@@ -56,9 +84,9 @@ function readTargetVersion() {
 }
 
 /** Resolve and validate all context outputs. */
-export function resolveDshContext({ eventName, ref, baseRef, configPath = DEFAULT_SOURCE_CONFIG, forcedMode } = {}) {
+export function resolveDshContext({ eventName, ref, baseRef, configPath = DEFAULT_SOURCE_CONFIG, forcedMode, modeConfigPath = MODE_CONFIG } = {}) {
   const config = loadDshSourceConfig(configPath)
-  const mode = resolveDshMode({ eventName, ref, baseRef, forcedMode })
+  const mode = resolveDshMode({ eventName, ref, baseRef, forcedMode, modeConfigPath })
   return {
     mode,
     version: readTargetVersion() ?? config.expectedVersion,

--- a/scripts/dsh-dev-context.mjs
+++ b/scripts/dsh-dev-context.mjs
@@ -170,19 +170,22 @@ export function resolveDshDevContext({ root = process.cwd(), mode, config, distr
   const packageJson = readPackageJson(directory)
   const packageManager = packageManagerInfo(packageJson.value)
   const generatedEnvBelongsHere = generatedEnvironmentBelongsToRoot(directory, environment)
-  const environmentMode = generatedEnvBelongsHere
-    ? environment.DSH_DEV_MODE ?? environment.DSH_MODE
-    : undefined
-  const configuredMode = mode ?? environmentMode
+  const configuredMode = mode ?? (generatedEnvBelongsHere ? environment.DSH_MODE : undefined)
   const configPath = sourceConfigPath(directory, config, environment)
-  // Mode precedence: explicit option → environment override → the
+  // Mode precedence: explicit option → DSH_MODE (a USER override) → the
   // tracked branch-level mode policy (test/compat/dsh-mode.json) → the
-  // legacy fallback (a workspace carrying the source pin uses source
-  // mode; otherwise npm). The legacy fallback keeps older checkouts and
-  // main working without a mode file.
+  // legacy fallback (DSH_DEV_MODE, the state dev:bootstrap materialized
+  // into .dsh-dev-env, then the source-pin presence). DSH_DEV_MODE must
+  // NOT override the tracked policy: it is generated state, and letting
+  // it win would lock an existing worktree into its old mode after the
+  // branch flips (doctor/bootstrap would keep re-materializing the stale
+  // mode forever). The legacy fallback keeps older checkouts and main
+  // working without a mode file.
   const modeConfigPath = resolve(directory, MODE_CONFIG_RELATIVE)
+  const hasModePolicy = existsSync(modeConfigPath)
   const modeFromPolicy = configuredMode
-    ?? (existsSync(modeConfigPath) ? readModeConfig(modeConfigPath) : undefined)
+    ?? (hasModePolicy ? readModeConfig(modeConfigPath) : undefined)
+    ?? (generatedEnvBelongsHere ? environment.DSH_DEV_MODE : undefined)
     ?? (existsSync(configPath) ? 'source' : 'npm')
   if (modeFromPolicy !== 'source' && modeFromPolicy !== 'npm') {
     fail(`unsupported DSH development mode ${modeFromPolicy}; expected source or npm`)

--- a/scripts/dsh-dev-context.mjs
+++ b/scripts/dsh-dev-context.mjs
@@ -25,6 +25,7 @@ import {
 } from './lib/dsh-distribution.mjs'
 
 export const SOURCE_CONFIG_RELATIVE = join('test', 'compat', 'dsh-source.json')
+export const MODE_CONFIG_RELATIVE = join('test', 'compat', 'dsh-mode.json')
 export const DEV_STATE_FILE = '.dsh-dev-state.json'
 export const DEV_ENV_FILE = '.dsh-dev-env'
 export const CACHE_DIRECTORY_NAME = 'dsh-pi-tui'
@@ -87,6 +88,26 @@ export function loadSourceConfig(path) {
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error))
   }
+}
+
+/**
+ * Read the tracked branch-level DSH mode policy (test/compat/dsh-mode.json).
+ * The file is the SINGLE source of truth for which distribution a branch
+ * uses; the legacy dsh-source.json presence check below is only the
+ * fallback for checkouts that predate the mode file.
+ * @param {string} path - the resolved mode-config path.
+ * @returns {'source'|'npm'}
+ */
+export function readModeConfig(path) {
+  const resolved = resolve(path)
+  if (!existsSync(resolved) || !statSync(resolved).isFile()) fail(`DSH mode config is missing: ${resolved}`)
+  const value = readJsonFile(resolved, 'DSH mode config')
+  if (value.schemaVersion !== 1) fail(`unsupported DSH mode config schema ${JSON.stringify(value.schemaVersion)}`)
+  const mode = value.mode
+  if (mode !== 'source' && mode !== 'npm') {
+    fail(`unsupported DSH mode ${JSON.stringify(mode)}; expected source or npm`)
+  }
+  return mode
 }
 
 export function cacheRoot(environment = process.env) {
@@ -154,7 +175,15 @@ export function resolveDshDevContext({ root = process.cwd(), mode, config, distr
     : undefined
   const configuredMode = mode ?? environmentMode
   const configPath = sourceConfigPath(directory, config, environment)
-  const modeFromPolicy = configuredMode ?? (existsSync(configPath) ? 'source' : 'npm')
+  // Mode precedence: explicit option → environment override → the
+  // tracked branch-level mode policy (test/compat/dsh-mode.json) → the
+  // legacy fallback (a workspace carrying the source pin uses source
+  // mode; otherwise npm). The legacy fallback keeps older checkouts and
+  // main working without a mode file.
+  const modeConfigPath = resolve(directory, MODE_CONFIG_RELATIVE)
+  const modeFromPolicy = configuredMode
+    ?? (existsSync(modeConfigPath) ? readModeConfig(modeConfigPath) : undefined)
+    ?? (existsSync(configPath) ? 'source' : 'npm')
   if (modeFromPolicy !== 'source' && modeFromPolicy !== 'npm') {
     fail(`unsupported DSH development mode ${modeFromPolicy}; expected source or npm`)
   }

--- a/test/compat/dsh-mode.json
+++ b/test/compat/dsh-mode.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "mode": "npm"
+}

--- a/test/dev-environment.test.mjs
+++ b/test/dev-environment.test.mjs
@@ -62,7 +62,7 @@ function packageJson() {
   }
 }
 
-function fixture(life, { source = false } = {}) {
+function fixture(life, { source = false, mode } = {}) {
   const root = life.tempDir('dsh-dev-environment-test-')
   writeFileSync(join(root, 'package.json'), `${JSON.stringify(packageJson(), null, 2)}\n`)
   writeFileSync(join(root, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n')
@@ -72,6 +72,16 @@ function fixture(life, { source = false } = {}) {
       repository: DSH_REPOSITORY,
       ref: SHA,
       expectedVersion: VERSION,
+    })}\n`)
+  }
+  if (mode !== undefined) {
+    // The resolver reads the mode policy at its tracked default path
+    // (test/compat/dsh-mode.json), unlike the source config which the
+    // tests pass explicitly.
+    mkdirSync(join(root, 'test', 'compat'), { recursive: true })
+    writeFileSync(join(root, 'test', 'compat', 'dsh-mode.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      mode,
     })}\n`)
   }
   return root
@@ -188,6 +198,55 @@ test('source mode is selected by an exact source config and can be explicitly ov
   })
   assert.equal(manual.mode, 'source')
   assert.equal(manual.sourceConfigPath, config)
+})
+
+test('the tracked mode policy beats a generated DSH_DEV_MODE (branch flip self-heals)', (t) => {
+  const life = testLifecycle(t)
+  // A worktree whose bootstrap previously materialized SOURCE state
+  // (DSH_DEV_MODE=source in .dsh-dev-env) after the branch flipped its
+  // tracked policy to npm: the generated state must NOT override the
+  // policy, or doctor/bootstrap would keep re-materializing the stale
+  // source mode forever.
+  const root = fixture(life, { source: true, mode: 'npm' })
+  const config = join(root, 'test-compat-dsh-source.json')
+  const generated = {
+    DSH_DEV_ROOT: root,
+    DSH_DEV_MODE: 'source',
+    DSH_SOURCE_CONFIG: config,
+  }
+  const context = resolveDshDevContext({ root, environment: generated })
+  assert.equal(context.mode, 'npm', 'the tracked npm policy must win over the generated source state')
+  assert.equal(context.source, undefined)
+
+  // The reverse flip: policy says source, generated state says npm.
+  const sourceRoot = fixture(life, { source: true, mode: 'source' })
+  const sourceConfig = join(sourceRoot, 'test-compat-dsh-source.json')
+  const source = resolveDshDevContext({
+    root: sourceRoot,
+    environment: { DSH_DEV_ROOT: sourceRoot, DSH_DEV_MODE: 'npm', DSH_SOURCE_CONFIG: sourceConfig },
+  })
+  assert.equal(source.mode, 'source', 'the tracked source policy must win over the generated npm state')
+  assert.equal(source.source.ref, SHA)
+
+  // A USER override (DSH_MODE) still beats the tracked policy.
+  const overridden = resolveDshDevContext({
+    root,
+    environment: { ...generated, DSH_MODE: 'source' },
+  })
+  assert.equal(overridden.mode, 'source', 'DSH_MODE is a user override and stays authoritative')
+})
+
+test('DSH_DEV_MODE still works as the legacy fallback without a mode policy', (t) => {
+  const life = testLifecycle(t)
+  // Older checkouts / main have no dsh-mode.json: the generated
+  // DSH_DEV_MODE keeps its historical meaning.
+  const root = fixture(life, { source: true })
+  const config = join(root, 'test-compat-dsh-source.json')
+  const context = resolveDshDevContext({
+    root,
+    environment: { DSH_DEV_ROOT: root, DSH_DEV_MODE: 'source', DSH_SOURCE_CONFIG: config },
+  })
+  assert.equal(context.mode, 'source', 'without a mode policy the generated state remains the fallback')
 })
 
 test('generated source environment variables cannot cross worktrees', (t) => {

--- a/test/dsh-ci-context.test.mjs
+++ b/test/dsh-ci-context.test.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
   resolveDshContext,
@@ -8,14 +11,51 @@ import {
 
 const nextSha = '4e84901e6471b79ec0338099867ebb4606d12bb5'
 
-test('DSH mode resolver selects source only for next branch compatibility', () => {
-  assert.equal(resolveDshMode({ eventName: 'push', ref: 'refs/heads/next' }), 'source')
-  assert.equal(resolveDshMode({ eventName: 'pull_request', ref: 'refs/pull/1/merge', baseRef: 'next' }), 'source')
+/** A temp mode-config file with the given mode (the tracked policy is
+ * injectable so the source branch of the resolver is testable without
+ * mutating the repository). */
+function tempModeConfig(mode) {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-mode-test-'))
+  const path = join(dir, 'dsh-mode.json')
+  writeFileSync(path, JSON.stringify({ schemaVersion: 1, mode }))
+  return { dir, path }
+}
+
+test('DSH mode resolver follows the tracked policy for next, npm elsewhere', () => {
+  // The tracked test/compat/dsh-mode.json currently says npm.
+  assert.equal(resolveDshMode({ eventName: 'push', ref: 'refs/heads/next' }), 'npm')
+  assert.equal(resolveDshMode({ eventName: 'pull_request', ref: 'refs/pull/1/merge', baseRef: 'next' }), 'npm')
   assert.equal(resolveDshMode({ eventName: 'push', ref: 'refs/heads/main' }), 'npm')
   assert.equal(resolveDshMode({ eventName: 'pull_request', ref: 'refs/pull/2/merge', baseRef: 'main' }), 'npm')
   assert.equal(resolveDshMode({ eventName: 'push', ref: 'refs/heads/feature/next' }), 'npm')
   assert.equal(resolveDshMode({ eventName: 'workflow_dispatch', ref: 'refs/heads/next' }), 'npm')
   assert.equal(resolveDshMode({ eventName: 'schedule', ref: 'refs/heads/next' }), 'npm')
+})
+
+test('a tracked source policy flips next to source mode (one-line branch switch)', () => {
+  const { dir, path } = tempModeConfig('source')
+  try {
+    assert.equal(resolveDshMode({ eventName: 'push', ref: 'refs/heads/next', modeConfigPath: path }), 'source')
+    assert.equal(
+      resolveDshMode({ eventName: 'pull_request', ref: 'refs/pull/1/merge', baseRef: 'next', modeConfigPath: path }),
+      'source',
+    )
+    // Non-next branches ignore the policy.
+    assert.equal(resolveDshMode({ eventName: 'push', ref: 'refs/heads/main', modeConfigPath: path }), 'npm')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a missing or malformed mode policy is an explicit error on next', () => {
+  const { dir, path } = tempModeConfig('npm')
+  try {
+    assert.throws(() => resolveDshMode({ eventName: 'push', ref: 'refs/heads/next', modeConfigPath: join(dir, 'missing.json') }), /missing/u)
+    writeFileSync(path, JSON.stringify({ schemaVersion: 1, mode: 'bogus' }))
+    assert.throws(() => resolveDshMode({ eventName: 'push', ref: 'refs/heads/next', modeConfigPath: path }), /unsupported DSH mode/u)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('all release tags force npm mode, including next-v tags', () => {
@@ -26,13 +66,23 @@ test('all release tags force npm mode, including next-v tags', () => {
 })
 
 test('context exposes the tracked source pin only in source mode', () => {
-  const source = resolveDshContext({ eventName: 'push', ref: 'refs/heads/next' })
-  assert.equal(source.mode, 'source')
-  assert.equal(source.sourceRef, nextSha)
-  assert.equal(source.sourceExpectedVersion, '0.1.2-alpha.4')
-
-  const npm = resolveDshContext({ eventName: 'push', ref: 'refs/heads/main' })
+  const npm = resolveDshContext({ eventName: 'push', ref: 'refs/heads/next' })
   assert.equal(npm.mode, 'npm')
   assert.equal(npm.sourceRef, '')
   assert.equal(npm.sourceExpectedVersion, '')
+
+  const main = resolveDshContext({ eventName: 'push', ref: 'refs/heads/main' })
+  assert.equal(main.mode, 'npm')
+  assert.equal(main.sourceRef, '')
+  assert.equal(main.sourceExpectedVersion, '')
+
+  const { dir, path } = tempModeConfig('source')
+  try {
+    const source = resolveDshContext({ eventName: 'push', ref: 'refs/heads/next', modeConfigPath: path })
+    assert.equal(source.mode, 'source')
+    assert.equal(source.sourceRef, nextSha)
+    assert.equal(source.sourceExpectedVersion, '0.1.2-alpha.4')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary

Replaces the hardcoded "next = source" DSH distribution rule with a **tracked branch-level mode policy** — one line flips the whole `next` branch between the pinned source pack and the registry-backed npm distribution.

## Changes

- **`test/compat/dsh-mode.json` (NEW)**: `{ "schemaVersion": 1, "mode": "npm" }` — the single switch. `dsh-source.json` is **kept forever** as the source fallback's exact SHA, so flipping back to source is a one-line diff, never a re-add.
- **`scripts/dsh-dev-context.mjs`**: mode precedence = explicit `--mode` → env override → tracked `dsh-mode.json` → legacy fallback (source pin present → source, else npm). Older checkouts and `main` keep working without a mode file.
- **`scripts/dsh-ci-context.mjs`**: release tags stay npm; `next` push / PR → `next` now read the tracked `dsh-mode.json` (missing/malformed is an explicit error); all other branches stay npm. The existing CI lanes (source artifact vs frozen install) are untouched.
- **`test/dsh-ci-context.test.mjs`**: next resolves npm under the tracked policy; a temp source policy flips next to source; missing/malformed policy errors; tags stay npm.
- **`docs/local-development.md`**: documents the mode file and the one-line branch switch.

## Why this shape

- `main` needs no mode file (legacy fallback keeps it npm).
- `next` keeps its source capability dormant: when upstream has unpublished fixes, flip `dsh-mode.json` to `source` (one line) instead of re-adding the pin and re-wiring CI.
- Current window is ideal: `dsh-source.json` pins `4e84901…` → `0.1.2-alpha.4`, and the lockfile already resolves the registry `0.1.2-alpha.4` family.

## Verification

- `test/dsh-ci-context.test.mjs` 5/5, `test/dev-environment.test.mjs` 35/35, tooling suite 222/222
- `node scripts/dsh-dev-context.mjs` → `"mode": "npm"` (was source)
- `node scripts/dsh-ci-context.mjs --event push --ref refs/heads/next` → `mode=npm`
- Source flip verified via injected temp policy → `source`