### PR TITLE
fix(settings): guide subagent model selection setup

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1455,16 +1455,12 @@ export function registerTuiCommands(
           // `subagent-model-selection` section): when enabled, a NEW
           // session's `subagent` tool may pick a child provider/model from
           // the allowlist below. Sampled at session composition — turning
-          // it on never rewrites an already-running session's tools.
+          // it on never rewrites an already-running session's tools. The
+          // ALLOWLIST row comes FIRST: the UI order expresses the setup
+          // dependency (configure allowed routes, then enable selection).
           ...(runner.config.subagentModelSelection.available() && runner.catalog.models.available()) ? (() => {
             const subagentSelection = runner.config.subagentModelSelection.get()
             return [{
-              id: 'subagent-model-selection',
-              label: 'Subagent model selection',
-              description: 'Let new sessions pick a child provider/model in the subagent tool (official DSH setting; needs at least one allowed route)',
-              currentValue: subagentSelection.enabled ? 'on' : 'off',
-              values: ['off', 'on'],
-            }, {
               id: 'subagent-model-allowlist',
               label: 'Subagent allowed models',
               description: 'The child LLM routes the official subagent tool may pick from',
@@ -1487,6 +1483,12 @@ export function registerTuiCommands(
                 allowlistMenu = menu
                 return menu
               },
+            }, {
+              id: 'subagent-model-selection',
+              label: 'Subagent model selection',
+              description: 'Let new sessions pick a child provider/model in the subagent tool (official DSH setting; needs at least one allowed route)',
+              currentValue: subagentSelection.enabled ? 'on' : 'off',
+              values: ['off', 'on'],
             }]
           })() : [],
           {
@@ -1636,7 +1638,7 @@ export function registerTuiCommands(
             ...(row.values.length > 0 ? { values: [...row.values] } : {}),
           })),
         ],
-        (id, value, revert) => {
+        (id, value, revert, navigate) => {
           if (id === 'approval') {
             if ((value === 'ask' || value === 'never') && liveAgent !== undefined) {
               runner.interaction.setApprovalPolicy(liveAgent.session.id, value)
@@ -1662,6 +1664,20 @@ export function registerTuiCommands(
               const current = runner.config.subagentModelSelection.get()
               const previous = current.enabled ? 'on' : 'off'
               const desired = value === 'on'
+              // EMPTY-ALLOWLIST UX GATE: enabling with no allowed routes
+              // is a SETUP PRECONDITION, not a write failure. Skip the
+              // official write entirely (no Host settings mutation), keep
+              // the row off, and guide the user to configure the allowlist
+              // first — the ConfigPort/Host validation stays as the
+              // fail-closed boundary for non-UI callers (the TUI never
+              // auto-fills the allowlist: it is the user's explicit grant
+              // of which child routes the subagent tool may use).
+              if (desired && current.allowedModels.length === 0) {
+                revert(previous)
+                app.notify('Select at least one Subagent allowed model before enabling model selection.', 'info')
+                navigate?.('subagent-model-allowlist')
+                return
+              }
               subagentModelWriteChain = subagentModelWriteChain
                 .then(() => runner.config.subagentModelSelection.set({
                   enabled: desired,

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -10588,13 +10588,21 @@ export class TuiApp {
    * @param onChange - called with (id, newValue) on confirm. The third
    *   argument `revert` restores a row's DISPLAYED value (used by the M5
    *   plugin-settings path when the row's onChange rejects — the fork
-   *   optimistically mutates the row before the callback runs).
+   *   optimistically mutates the row before the callback runs). The
+   *   optional fourth argument `navigate` moves the list cursor to another
+   *   row (the fork's public `selectItem` seam — used to guide the user to
+   *   a prerequisite row instead of failing a write).
    * @param onCancel - called when the user closes without applying.
    * @returns a function that closes the overlay.
    */
   openSettings(
     items: SettingItem[],
-    onChange: (id: string, value: string, revert: (previousValue: string) => void) => void,
+    onChange: (
+      id: string,
+      value: string,
+      revert: (previousValue: string) => void,
+      navigate?: (targetId: string) => void,
+    ) => void,
     onCancel: () => void,
   ): () => void {
     // SettingsList fires onCancel on Esc/ctrl+c; the overlay must close too,
@@ -10611,7 +10619,11 @@ export class TuiApp {
       // panel must not keep the rejected value). The CALLER supplies the
       // previous value (the registry still holds it before apply commits).
       const revert = (previousValue: string): void => settings.updateValue(id, previousValue)
-      onChange(id, value, revert)
+      // The navigate callback rides the fork's PUBLIC selectItem seam (no
+      // private cursor access): a no-op when the target row is filtered out
+      // by an active search — the caller's notice still guides the user.
+      const navigate = (targetId: string): void => settings.selectItem(targetId)
+      onChange(id, value, revert, navigate)
     }, () => {
       handle?.hide()
       onCancel()

--- a/test/subagent-model-settings-row.test.ts
+++ b/test/subagent-model-settings-row.test.ts
@@ -236,6 +236,12 @@ test('the /settings panel exposes the official subagent model-selection rows', a
   const allowlist = items!.find(item => item.id === 'subagent-model-allowlist')
   assert.ok(allowlist !== undefined, 'the allowlist row must exist')
   assert.equal(allowlist!.currentValue, '0 routes')
+  // The UI order expresses the setup dependency: configure the allowed
+  // routes BEFORE enabling selection (the allowlist row comes first).
+  assert.ok(
+    items!.indexOf(allowlist!) < items!.indexOf(toggle!),
+    'the allowlist row must precede the selection toggle',
+  )
 })
 
 test('rapid toggles SERIALIZE: a slow earlier write never lands after a newer one', async () => {
@@ -257,18 +263,75 @@ test('rapid toggles SERIALIZE: a slow earlier write never lands after a newer on
   assert.equal(harness.settings.doc.enabled, false, 'the LAST toggle wins')
 })
 
-test('a rejected toggle rolls the row back and notifies', async () => {
+test('enabling with an EMPTY allowlist is a setup guide, not a write: no settings write, row stays off', async () => {
   const harness = makeHarness({ enabled: false, allowedModels: [] })
   await openSettingsPanel(harness)
   const change = harness.settingsChange!
   const reverted: string[] = []
-  // Enabling with an EMPTY allowlist is refused by the official rule.
-  change('subagent-model-selection', 'on', (previous) => { reverted.push(previous) })
+  const navigated: string[] = []
+  // Enabling with an EMPTY allowlist is a UI precondition: the toggle must
+  // NOT call the official section write at all (no Host settings mutation),
+  // keep the row off, and guide the user to the allowlist row.
+  change('subagent-model-selection', 'on', (previous) => { reverted.push(previous) }, (targetId) => { navigated.push(targetId) })
   for (let i = 0; i < 8; i += 1) await Promise.resolve()
+  assert.equal(harness.settings.writes.length, 0, 'no official section write may be produced')
   assert.equal(harness.settings.doc.enabled, false, 'the section stays off')
   assert.deepEqual(reverted, ['off'], 'the row display rolls back to the previous value')
-  assert.equal(harness.notices.at(-1)?.kind, 'error')
-  assert.match(harness.notices.at(-1)?.message ?? '', /requires at least one allowed model/u)
+  assert.deepEqual(navigated, ['subagent-model-allowlist'], 'the cursor moves to the allowlist row')
+  const notice = harness.notices.at(-1)
+  assert.equal(notice?.kind, 'info', 'the guidance is an info notice, not an error')
+  assert.match(notice?.message ?? '', /Select at least one Subagent allowed model/i)
+  assert.doesNotMatch(notice?.message ?? '', /write failed/i, 'a setup precondition must never surface as a write failure')
+})
+
+test('enabling with a NON-EMPTY allowlist writes the whole official section', async () => {
+  const harness = makeHarness({ enabled: false, allowedModels: [{ provider: 'p', model: 'm1' }] })
+  await openSettingsPanel(harness)
+  const change = harness.settingsChange!
+  const reverted: string[] = []
+  change('subagent-model-selection', 'on', (previous) => { reverted.push(previous) })
+  await settle(harness, 1)
+  assert.equal(harness.settings.writes.length, 1, 'the official section write must happen')
+  assert.deepEqual(harness.settings.writes[0], {
+    enabled: true,
+    allowedModels: [{ provider: 'p', model: 'm1' }],
+  }, 'the whole section rides along: enabled flips, the allowlist is preserved')
+  assert.equal(harness.settings.doc.enabled, true, 'the section commits enabled')
+  assert.deepEqual(reverted, ['on'], 'the row re-syncs to the committed state')
+  assert.equal(harness.notices.length, 0, 'a legal write produces no notice')
+})
+
+test('first-time setup happy path: add an allowed route, then enable selection', async () => {
+  // The complete first-configuration flow: 0 routes + off → open the
+  // allowlist submenu → pick provider p / model m1 → back to the settings
+  // list → toggle selection ON. The whole section must commit with the
+  // route the user just granted.
+  const harness = makeHarness({ enabled: false, allowedModels: [] })
+  await openSettingsPanel(harness)
+  const allowlistRow = harness.settingsItems!.find(item => item.id === 'subagent-model-allowlist')
+  assert.ok(allowlistRow?.submenu !== undefined, 'the allowlist row must carry the submenu')
+  const dones: Array<string | undefined> = []
+  const menu = allowlistRow.submenu!('0 routes', (selected) => { dones.push(selected) }) as { handleInput(data: string): void }
+  menu.handleInput(ENTER) // open provider p's models
+  for (let i = 0; i < 8; i += 1) await Promise.resolve()
+  menu.handleInput(ENTER) // toggle m1 ON — commits the first route
+  await settle(harness, 1)
+  assert.deepEqual(harness.settings.doc.allowedModels, [{ provider: 'p', model: 'm1' }], 'the first route commits')
+  menu.handleInput('\x1b') // Esc: model list -> provider list
+  menu.handleInput('\x1b') // Esc: provider list -> close, report the summary
+  assert.deepEqual(dones.at(-1), '1 route', 'the outer row shows the fresh route count')
+  // Now the toggle may be enabled: the gate must NOT block a non-empty
+  // allowlist, and the write carries the committed routes.
+  const change = harness.settingsChange!
+  change('subagent-model-selection', 'on', () => {})
+  await settle(harness, 2)
+  assert.equal(harness.settings.writes.length, 2, 'the allowlist write plus the enable write')
+  assert.deepEqual(harness.settings.writes[1], {
+    enabled: true,
+    allowedModels: [{ provider: 'p', model: 'm1' }],
+  })
+  assert.equal(harness.settings.doc.enabled, true, 'selection commits enabled')
+  assert.equal(harness.notices.length, 0, 'the happy path produces no notice')
 })
 
 test('closing the WHOLE settings panel disposes the allowlist submenu (no late toast, row converges)', async () => {


### PR DESCRIPTION
## Summary

Improves the first-time setup UX of the official DSH `subagent-model-selection` setting in `/settings`.

Previously, toggling **Subagent model selection → on** with an empty allowlist produced a rejected Host settings write and an error toast (`subagent model selection write failed: ...`), even though the real issue is a normal setup precondition: the official rule requires at least one allowed route before enabling.

Now, with 0 allowed routes, toggling on:

1. does **not** call `ConfigPort.subagentModelSelection.set()` — no Host settings write at all
2. keeps the toggle at `off`
3. shows an `info` guidance notice: *"Select at least one Subagent allowed model before enabling model selection."*
4. moves the list cursor to the **Subagent allowed models** row (via the vendored SettingsList's public `selectItem` seam — no private access, no fork modification)

Also reorders the `/settings` rows so **Subagent allowed models** comes before **Subagent model selection**, expressing the setup dependency in the UI. Row ids and persisted setting ids are unchanged.

## What is NOT changed (by design)

- DSH official `subagent-model-selection` schema / Host validator — untouched
- `ConfigPort` still fails closed on `set({ enabled: true, allowedModels: [] })` for non-UI callers
- Allowlist submenu rules (last-route-while-enabled still refused)
- Whole-section serialized write semantics (rapid toggles, last intent wins)
- Composition semantics: changes apply to newly composed sessions only; existing sessions are not hot-updated
- No auto-filling of the allowlist (it is the user's explicit grant)

## Tests

- `test/subagent-model-settings-row.test.ts`: new gate regression (zero writes, row stays off, info notice, no `write failed`, navigate to allowlist), non-empty allowlist enable path, full first-time happy path (add route → enable), row-order assertion
- Adapter-level rejection (`test/config-port.test.ts`) and last-route protection (`test/subagent-model-menu.test.ts`) unchanged and still green

## Verification

- `pnpm typecheck:bundle` ✅
- targeted subagent tests: 44 passed ✅
- `pnpm test:bundle`: 224 passed ✅
- `pnpm build` ✅
- `pnpm gate:boundary` / `pnpm gate:keybindings` / `node scripts/naming-gate.mjs` / `git diff --check` ✅
- External review loop: 1 round, verdict **accepted**, no findings