### PR TITLE
fix: rebuild geometry-dependent panels and lists on terminal resize

### DIFF
--- a/packages/pi-tui/DIVERGENCES.md
+++ b/packages/pi-tui/DIVERGENCES.md
@@ -62,8 +62,16 @@ Keep `vendor-divergences.json` in sync with this file on every re-vendor.
 - Reason: `SelectList` gains an optional 5th constructor argument
   `SelectListOptions` (`enableSearch`, `header`, `noMatchText`, `showHint`,
   `initialQuery`), `SelectItem.group` + `SelectListTheme.groupHeader`,
-  PageUp/PageDown page navigation, and substring search over
-  value+label+description. `setFilter` is redefined to the same
+  PageUp/PageDown page navigation, substring search over
+  value+label+description, and `setMaxRows()` for host-owned responsive
+  overlay budgets. Render also self-limits to the live row grant: group
+  headers (a window spanning k groups renders k header rows) and the
+  scroll indicator are folded into the same budget, shrinking the item
+  window until the list fits with the hint tail intact. The shrink is
+  RENDER-LOCAL (a `visibleCount` derived from `maxVisible`) — the
+  persistent `maxVisible` stays the budget-derived baseline so a
+  selection move or a PageUp/PageDown can use the full grant again.
+  `setFilter` is redefined to the same
   case-insensitive substring filter (upstream prefix-matched value only).
   The filter query's canonical single-source-of-truth (getFilter/setItems
   stay in sync with setFilter) is X041 — re-apply both together.
@@ -860,7 +868,15 @@ Keep `vendor-divergences.json` in sync with this file on every re-vendor.
   package README states the wrapper contract ("every wrapper owning an
   Input/Editor must implement Focusable") but the kimi list components
   themselves did not implement it either; the host compensates with its
-  FocusForwardingFrame for the Frame layer.
+  FocusForwardingFrame for the Frame layer. Both lists also expose
+  `setMaxRows()` so a responsive host can lower the item window while
+  preserving the live filter, selection and submenu state, and their
+  render caps the selected row's description block to the grant so the
+  hint always survives — on degenerate tiny grants the render keeps the
+  tail (hint + trailing rows) rather than the head. SettingsList also
+  exposes the `RowBudgetAware` seam: the current grant is forwarded to
+  an open submenu that implements it, so nested lists (the host's /model
+  pickers) reflow on resize without SettingsList knowing their type.
 - Consumer: host pickers/settings overlays (mounted behind frames).
 - Upstream status: absent.
 - Tests: fork lifecycle/X041 suites assert the focused flag shape; the

--- a/packages/pi-tui/src/components/select-list.ts
+++ b/packages/pi-tui/src/components/select-list.ts
@@ -280,9 +280,11 @@ export class SelectList implements Component, Focusable {
 		// hint > header).
 		const withoutHeader = this.options.header === undefined ? compact : compact.slice(1);
 		if (withoutHeader.length <= limit) return withoutHeader;
-		// Extreme grant: keep the head — the search input, then the
-		// message — per priority.
-		return compact.slice(0, limit);
+		// Extreme grant: keep the head of the HEADER-FREE rows — the search
+		// input, then the no-match message. Slicing `compact` here would
+		// re-introduce the header and drop the message, which the declared
+		// priority places ABOVE the header.
+		return withoutHeader.slice(0, limit);
 	}
 
 	/** Render the item window (group headers + item rows + scroll indicator)

--- a/packages/pi-tui/src/components/select-list.ts
+++ b/packages/pi-tui/src/components/select-list.ts
@@ -93,7 +93,11 @@ export class SelectList implements Component, Focusable {
 	/** Lowercased value+label+description per item, rebuilt on setItems. */
 	private searchTexts = new Map<SelectItem, string>();
 	private selectedIndex: number = 0;
+	/** Caller-configured item cap; the host may lower it for a short frame. */
+	private configuredMaxVisible: number;
 	private maxVisible: number = 5;
+	/** Inner row budget supplied by a root-owned responsive overlay. */
+	private maxRows = Number.POSITIVE_INFINITY;
 	private theme: SelectListTheme;
 	private layout: SelectListLayoutOptions;
 	private options: SelectListOptions;
@@ -130,7 +134,8 @@ export class SelectList implements Component, Focusable {
 		this.items = items;
 		this.filteredItems = items;
 		this.searchTexts = this.buildSearchTexts(items);
-		this.maxVisible = maxVisible;
+		this.configuredMaxVisible = Math.max(1, Math.floor(maxVisible));
+		this.maxVisible = this.configuredMaxVisible;
 		this.theme = theme;
 		this.layout = layout;
 		this.options = options;
@@ -143,6 +148,24 @@ export class SelectList implements Component, Focusable {
 				this.applyFilter(initial);
 			}
 		}
+	}
+
+	/** Update the live inner row budget without resetting filter or selection. */
+	setMaxRows(rows: number): void {
+		this.maxRows = Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : Number.POSITIVE_INFINITY;
+		this.recomputeVisibleBudget();
+	}
+
+	/** Reserve the list chrome before deriving the item count. */
+	private recomputeVisibleBudget(): void {
+		const prefix = (this.options.header === undefined ? 0 : 2) + (this.searchEnabled ? 2 : 0);
+		const hint = this.options.showHint === true || this.searchEnabled ? 2 : 0;
+		const indicator = this.filteredItems.length > 1 ? 1 : 0;
+		const group = this.filteredItems.some(item => item.group !== undefined) ? 1 : 0;
+		const budget = this.maxRows === Number.POSITIVE_INFINITY
+			? this.configuredMaxVisible
+			: this.maxRows - prefix - hint - indicator - group;
+		this.maxVisible = Math.max(1, Math.min(this.configuredMaxVisible, budget));
 	}
 
 	/**
@@ -205,17 +228,74 @@ export class SelectList implements Component, Focusable {
 		if (this.filteredItems.length === 0) {
 			lines.push(this.theme.noMatch(this.options.noMatchText ?? "  No matching commands"));
 			if (this.options.showHint === true || this.searchEnabled) this.addHintLine(lines, width);
-			return lines;
+			return this.finalizeEmpty(lines);
 		}
 
 		const primaryColumnWidth = this.getPrimaryColumnWidth();
+		const showHint = this.options.showHint === true || this.searchEnabled;
+		const limit = Number.isFinite(this.maxRows) ? Math.max(1, Math.floor(this.maxRows)) : Number.POSITIVE_INFINITY;
+		const hintRows = showHint ? 2 : 0;
+
+		let visibleCount = this.maxVisible;
+		let window = this.renderItemWindow(width, primaryColumnWidth, visibleCount);
+		// Group headers consume physical rows beyond the reserved one: a
+		// window spanning k groups renders k headers, so the assembled list
+		// can exceed the host-granted row budget. Shrink the WINDOW (still
+		// selection-centered) until the whole list fits; the hint is the
+		// non-negotiable tail (setMaxRows contract). Only the local
+		// `visibleCount` shrinks — `maxVisible` stays the budget-derived
+		// baseline, so a later selection move can use the full grant again
+		// (a render-time ratchet would permanently shrink PageUp/PageDown).
+		while (Number.isFinite(this.maxRows)
+			&& lines.length + window.length + hintRows > this.maxRows
+			&& visibleCount > 1) {
+			visibleCount -= 1;
+			window = this.renderItemWindow(width, primaryColumnWidth, visibleCount);
+		}
+		lines.push(...window);
+		if (showHint) this.addHintLine(lines, width);
+		if (Number.isFinite(this.maxRows) && lines.length > this.maxRows) {
+			// Degenerate tiny grants: keep the tail (the hint plus as many
+			// trailing rows as fit) instead of letting the compositor slice
+			// the hint away.
+			return lines.slice(lines.length - this.maxRows);
+		}
+		return lines;
+	}
+
+	/** Finalize the empty/no-match assembly against the live grant. The
+	 * setMaxRows contract covers every path: `render().length <= maxRows`
+	 * with the semantic priority search input > no-match message > hint >
+	 * header > blank spacers, so the hint survives whenever the grant
+	 * physically allows it. */
+	private finalizeEmpty(lines: string[]): string[] {
+		if (!Number.isFinite(this.maxRows)) return lines;
+		const limit = Math.max(1, Math.floor(this.maxRows));
+		if (lines.length <= limit) return lines;
+		// Blank spacers are the lowest-value rows: drop them first (the
+		// content stays together and keeps its visual order).
+		const compact = lines.filter(line => line !== "");
+		if (compact.length <= limit) return compact;
+		// The header is chrome: yield it before any content (priority:
+		// hint > header).
+		const withoutHeader = this.options.header === undefined ? compact : compact.slice(1);
+		if (withoutHeader.length <= limit) return withoutHeader;
+		// Extreme grant: keep the head — the search input, then the
+		// message — per priority.
+		return compact.slice(0, limit);
+	}
+
+	/** Render the item window (group headers + item rows + scroll indicator)
+	 * at `visibleCount`, centered on the selected row. */
+	private renderItemWindow(width: number, primaryColumnWidth: number, visibleCount: number): string[] {
+		const lines: string[] = [];
 
 		// Calculate visible range with scrolling
 		const startIndex = Math.max(
 			0,
-			Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), this.filteredItems.length - this.maxVisible),
+			Math.min(this.selectedIndex - Math.floor(visibleCount / 2), this.filteredItems.length - visibleCount),
 		);
-		const endIndex = Math.min(startIndex + this.maxVisible, this.filteredItems.length);
+		const endIndex = Math.min(startIndex + visibleCount, this.filteredItems.length);
 
 		// Group counts over the full (filtered) sequence, so a header inside
 		// the visible window can show how many items its group holds.
@@ -254,8 +334,6 @@ export class SelectList implements Component, Focusable {
 			// Truncate if too long for terminal
 			lines.push(this.theme.scrollInfo(truncateToWidth(scrollText, width - 2, "")));
 		}
-
-		if (this.options.showHint === true || this.searchEnabled) this.addHintLine(lines, width);
 
 		return lines;
 	}
@@ -341,6 +419,7 @@ export class SelectList implements Component, Focusable {
 					: searchable.includes(needle);
 			});
 		}
+		this.recomputeVisibleBudget();
 		if (previousValue !== undefined) {
 			const index = this.filteredItems.findIndex(item => item.value === previousValue);
 			if (index !== -1) {

--- a/packages/pi-tui/src/components/settings-list.ts
+++ b/packages/pi-tui/src/components/settings-list.ts
@@ -35,12 +35,27 @@ export interface SettingsListOptions {
 	enableSearch?: boolean;
 }
 
+/**
+ * Structural seam: a submenu component that accepts the host's live row
+ * grant. SettingsList forwards its own `setMaxRows` value to an open
+ * submenu that implements this, and re-forwards on every grant change, so
+ * nested lists (e.g. the /model picker) reflow instead of being clipped
+ * by the compositor — without SettingsList knowing the submenu's type.
+ */
+export interface RowBudgetAware {
+	setMaxRows?(rows: number): void;
+}
+
 export class SettingsList implements Component, Focusable {
 	private items: SettingItem[];
 	private filteredItems: SettingItem[];
 	private theme: SettingsListTheme;
 	private selectedIndex = 0;
+	/** Caller-configured item cap; the host may lower it for a short frame. */
+	private configuredMaxVisible: number;
 	private maxVisible: number;
+	/** Inner row budget supplied by a root-owned responsive overlay. */
+	private maxRows = Number.POSITIVE_INFINITY;
 	private onChange: (id: string, newValue: string) => void;
 	private onCancel: () => void;
 	private searchInput?: Input;
@@ -95,7 +110,8 @@ export class SettingsList implements Component, Focusable {
 	) {
 		this.items = items;
 		this.filteredItems = items;
-		this.maxVisible = maxVisible;
+		this.configuredMaxVisible = Math.max(1, Math.floor(maxVisible));
+		this.maxVisible = this.configuredMaxVisible;
 		this.theme = theme;
 		this.onChange = onChange;
 		this.onCancel = onCancel;
@@ -103,6 +119,31 @@ export class SettingsList implements Component, Focusable {
 		if (this.searchEnabled) {
 			this.searchInput = new Input();
 		}
+	}
+
+	/** Update the live inner row budget without resetting selection or submenu. */
+	setMaxRows(rows: number): void {
+		this.maxRows = Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : Number.POSITIVE_INFINITY;
+		this.recomputeVisibleBudget();
+		this.forwardBudgetToSubmenu();
+	}
+
+	/** Forward the current grant to an open submenu that accepts it, so
+	 * nested lists stay within the same row budget on resize. */
+	private forwardBudgetToSubmenu(): void {
+		const child = this.submenuComponent as RowBudgetAware | null;
+		child?.setMaxRows?.(this.maxRows);
+	}
+
+	/** Reserve search, scroll and hint rows before deriving the item count. */
+	private recomputeVisibleBudget(): void {
+		const prefix = this.searchEnabled ? 2 : 0;
+		const indicator = this.filteredItems.length > 1 ? 1 : 0;
+		const hint = 2;
+		const budget = this.maxRows === Number.POSITIVE_INFINITY
+			? this.configuredMaxVisible
+			: this.maxRows - prefix - indicator - hint;
+		this.maxVisible = Math.max(1, Math.min(this.configuredMaxVisible, budget));
 	}
 
 	/** Update an item's currentValue */
@@ -161,25 +202,92 @@ export class SettingsList implements Component, Focusable {
 			if (this.searchEnabled) {
 				this.addHintLine(lines, width);
 			}
-			return lines;
+			return this.finalizeEmpty(lines);
 		}
 
 		const displayItems = this.searchEnabled ? this.filteredItems : this.items;
 		if (displayItems.length === 0) {
 			lines.push(truncateToWidth(this.theme.hint("  No matching settings"), width));
 			this.addHintLine(lines, width);
-			return lines;
+			return this.finalizeEmpty(lines);
 		}
+
+		// Calculate max label width for alignment
+		const maxLabelWidth = Math.min(36, Math.max(...this.items.map((item) => visibleWidth(item.label))));
+
+		let visibleCount = this.maxVisible;
+		let window = this.renderItemWindow(width, maxLabelWidth, displayItems, visibleCount);
+		// The selected row's description (1 blank + k wrapped rows) renders
+		// outside the item window, so it is unaccounted by the budget
+		// reservation. Shrink the WINDOW (selection-centered) until the
+		// assembled list fits the grant with room for the description block
+		// and the hint tail (setMaxRows contract). Only the local
+		// `visibleCount` shrinks — `maxVisible` stays the budget-derived
+		// baseline, so moving to a row without a description restores the
+		// full window (no render-time ratchet on PageUp/PageDown).
+		while (Number.isFinite(this.maxRows)
+			&& lines.length + window.length + this.descriptionRowCount(width, displayItems) + 2 > this.maxRows
+			&& visibleCount > 1) {
+			visibleCount -= 1;
+			window = this.renderItemWindow(width, maxLabelWidth, displayItems, visibleCount);
+		}
+		lines.push(...window);
+
+		// Description for the selected item — wrapped, then capped to the
+		// rows left after the hint, so the hint below always survives.
+		const descBudget = Number.isFinite(this.maxRows)
+			? Math.max(0, this.maxRows - lines.length - 2)
+			: Number.POSITIVE_INFINITY;
+		const selectedItem = displayItems[this.selectedIndex];
+		if (selectedItem?.description && descBudget > 0) {
+			const wrappedDesc = wrapTextWithAnsi(selectedItem.description, width - 4);
+			lines.push("");
+			const keep = descBudget === Number.POSITIVE_INFINITY
+				? wrappedDesc.length
+				: Math.min(wrappedDesc.length, Math.max(0, descBudget - 1));
+			for (const line of wrappedDesc.slice(0, keep)) {
+				lines.push(this.theme.description(`  ${line}`));
+			}
+		}
+
+		// Add hint
+		this.addHintLine(lines, width);
+
+		// Keep the hint tail on degenerate tiny grants (mirrors SelectList):
+		// a head slice would cut the hint, the non-negotiable tail row.
+		if (Number.isFinite(this.maxRows) && lines.length > this.maxRows) {
+			return lines.slice(lines.length - this.maxRows);
+		}
+		return lines;
+	}
+
+	/** Finalize the empty/no-match assembly against the live grant
+	 * (setMaxRows contract covers every path): `render().length <=
+	 * maxRows` with priority search input > no-match message > hint >
+	 * blank spacers. SettingsList has no header, so after the blank
+	 * spacers only an extreme grant needs to yield rows. */
+	private finalizeEmpty(lines: string[]): string[] {
+		if (!Number.isFinite(this.maxRows)) return lines;
+		const limit = Math.max(1, Math.floor(this.maxRows));
+		if (lines.length <= limit) return lines;
+		const compact = lines.filter(line => line !== "");
+		if (compact.length <= limit) return compact;
+		// Extreme grant: keep the head (the search input, then the
+		// message) per priority.
+		return compact.slice(0, limit);
+	}
+
+	/** Render the item window (rows + scroll indicator) at `visibleCount`,
+	 * centered on the selected row. */
+	private renderItemWindow(width: number, maxLabelWidth: number, displayItems: SettingItem[], visibleCount: number): string[] {
+		const lines: string[] = [];
 
 		// Calculate visible range with scrolling
 		const startIndex = Math.max(
 			0,
-			Math.min(this.selectedIndex - Math.floor(this.maxVisible / 2), displayItems.length - this.maxVisible),
+			Math.min(this.selectedIndex - Math.floor(visibleCount / 2), displayItems.length - visibleCount),
 		);
-		const endIndex = Math.min(startIndex + this.maxVisible, displayItems.length);
-
-		// Calculate max label width for alignment
-		const maxLabelWidth = Math.min(36, Math.max(...this.items.map((item) => visibleWidth(item.label))));
+		const endIndex = Math.min(startIndex + visibleCount, displayItems.length);
 
 		// Render visible items
 		for (let i = startIndex; i < endIndex; i++) {
@@ -210,20 +318,15 @@ export class SettingsList implements Component, Focusable {
 			lines.push(this.theme.hint(truncateToWidth(scrollText, width - 2, "")));
 		}
 
-		// Add description for selected item
-		const selectedItem = displayItems[this.selectedIndex];
-		if (selectedItem?.description) {
-			lines.push("");
-			const wrappedDesc = wrapTextWithAnsi(selectedItem.description, width - 4);
-			for (const line of wrappedDesc) {
-				lines.push(this.theme.description(`  ${line}`));
-			}
-		}
-
-		// Add hint
-		this.addHintLine(lines, width);
-
 		return lines;
+	}
+
+	/** The rendered row count of the selected item's description block
+	 * (1 blank + wrapped lines) at the current width. */
+	private descriptionRowCount(width: number, displayItems: SettingItem[]): number {
+		const selectedItem = displayItems[this.selectedIndex];
+		if (!selectedItem?.description) return 0;
+		return 1 + wrapTextWithAnsi(selectedItem.description, width - 4).length;
 	}
 
 	handleInput(data: string): void {
@@ -298,8 +401,12 @@ export class SettingsList implements Component, Focusable {
 			// The freshly opened submenu becomes the input the user types
 			// into: forward the current focus state so its CURSOR_MARKER
 			// (IME positioning) matches the list's focus (dsh-pi-tui
-			// divergence).
+			// divergence). A submenu that accepts row budgets also inherits
+			// the CURRENT grant immediately (async submenus like /model
+			// open on a loading shell and swap in their list later, so the
+			// forward must also happen on the swap path).
 			this.propagateFocus();
+			this.forwardBudgetToSubmenu();
 		} else if (item.values && item.values.length > 0) {
 			// Cycle through values
 			const currentIndex = item.values.indexOf(item.currentValue);
@@ -334,6 +441,7 @@ export class SettingsList implements Component, Focusable {
 	private applyFilter(query: string): void {
 		this.filteredItems = fuzzyFilter(this.items, query, (item) => item.label);
 		this.selectedIndex = 0;
+		this.recomputeVisibleBudget();
 	}
 
 	private addHintLine(lines: string[], width: number): void {

--- a/packages/pi-tui/src/index.ts
+++ b/packages/pi-tui/src/index.ts
@@ -31,7 +31,7 @@ export {
 	type SelectListTheme,
 	type SelectListTruncatePrimaryContext,
 } from "./components/select-list.ts";
-export { type SettingItem, SettingsList, type SettingsListTheme } from "./components/settings-list.ts";
+export { type SettingItem, SettingsList, type RowBudgetAware, type SettingsListTheme } from "./components/settings-list.ts";
 export { Spacer } from "./components/spacer.ts";
 export { Text } from "./components/text.ts";
 export { TruncatedText } from "./components/truncated-text.ts";

--- a/packages/pi-tui/test/select-list.test.ts
+++ b/packages/pi-tui/test/select-list.test.ts
@@ -297,6 +297,23 @@ describe("SelectList", () => {
 			assert.ok(rendered.some((line) => line.includes("No matching")), "message must survive");
 			assert.ok(rendered.some((line) => line.includes("esc close")), "hint must survive");
 		});
+
+		it("keeps the message over the header on an extreme no-match grant", () => {
+			const list = new SelectList(
+				[{ value: "a", label: "alpha" }],
+				10,
+				testTheme,
+				{},
+				{ header: "items", enableSearch: true },
+			);
+			list.setMaxRows(2); // compact rows: header/search/message/hint = 4 > 2
+			list.handleInput("zzz"); // no match
+			const rendered = list.render(80);
+			assert.ok(rendered.length <= 2, `extreme no-match must fit the grant (${rendered.length})`);
+			assert.ok(rendered.some((line) => line.includes("No matching")),
+				"the no-match message must beat the header");
+			assert.ok(!rendered.some((line) => line.includes("items")), "the header must yield");
+		});
 	});
 
 	describe("group headers (dsh-pi-tui extension)", () => {

--- a/packages/pi-tui/test/select-list.test.ts
+++ b/packages/pi-tui/test/select-list.test.ts
@@ -229,6 +229,74 @@ describe("SelectList", () => {
 			const rendered = list.render(80);
 			assert.ok(!rendered.some((line) => line.includes("navigate")), "hint must not render by default");
 		});
+
+		it("reflows to a live row budget without losing selection or hint", () => {
+			const list = new SelectList(
+				Array.from({ length: 12 }, (_, index) => ({ value: `v${index}`, label: `item ${index}` })),
+				10,
+				testTheme,
+				{},
+				{ header: "items", showHint: true },
+			);
+			for (let index = 0; index < 8; index++) list.handleInput(String.fromCharCode(0x1b) + "[B");
+			list.setMaxRows(8);
+			const rendered = list.render(80);
+			assert.ok(rendered.some((line) => line.includes("item 8")), "selected item must remain visible");
+			assert.ok(rendered.some((line) => line.includes("esc close")), "hint must remain visible");
+			assert.ok(rendered.length <= 8, "list must fit the live row budget");
+		});
+
+		it("keeps the hint when a grouped window exceeds a small row budget", () => {
+			const items = Array.from({ length: 9 }, (_, index) => ({
+				value: `v${index}`,
+				label: `item ${index}`,
+				group: index < 3 ? "alpha" : index < 6 ? "beta" : "gamma",
+			}));
+			const list = new SelectList(items, 10, testTheme, {}, { header: "items", showHint: true });
+			// 6-row grant: header(2) + hint(2) + indicator(1) + group(1)
+			// leaves a zero item budget; the render must still fit the grant
+			// and keep the hint plus the selected row.
+			list.setMaxRows(6);
+			list.handleInput(String.fromCharCode(0x1b) + "[B"); // select item 1 (still alpha)
+			const rendered = list.render(80);
+			assert.ok(rendered.length <= 6, `grouped list must fit the grant (${rendered.length})`);
+			assert.ok(rendered.some((line) => line.includes("esc close")), "hint must remain visible");
+			assert.ok(rendered.some((line) => line.includes("item 1")), "selected item must remain visible");
+		});
+
+		it("restores the full window after a selection move (no render-time ratchet)", () => {
+			// Runs: a[0,1], b[2-6], c[7,8], d[9-11]. At selection 0 the
+			// window straddles a/b and shrinks; moving into the b run must
+			// restore the full 4-item window — the render-time shrink is a
+			// LOCAL adjustment, never a persistent maxVisible ratchet.
+			const groups = ["a", "a", "b", "b", "b", "b", "b", "c", "c", "d", "d", "d"];
+			const items = groups.map((group, index) => ({ value: `v${index}`, label: `item ${index}`, group }));
+			const list = new SelectList(items, 10, testTheme, {}, { header: "items", showHint: true });
+			list.setMaxRows(10); // budget: header 2 + hint 2 + indicator 1 + group 1 -> 4
+			const first = list.render(80);
+			assert.ok(first.some((line) => line.includes("item 1")), "first window must show the selected region");
+			for (let index = 0; index < 4; index++) list.handleInput(String.fromCharCode(0x1b) + "[B"); // -> item 4
+			const second = list.render(80);
+			assert.ok(second.some((line) => line.includes("item 2")),
+				`the full 4-item window must return inside the b run (${JSON.stringify(second)})`);
+			assert.ok(second.some((line) => line.includes("item 5")), "the window must reach item 5");
+		});
+
+		it("fits the no-match state to the row grant, keeping the message and hint", () => {
+			const list = new SelectList(
+				[{ value: "a", label: "alpha" }, { value: "b", label: "beta" }],
+				10,
+				testTheme,
+				{},
+				{ header: "items", enableSearch: true },
+			);
+			list.setMaxRows(6); // header 2 + search 2 + message 1 + hint 2 = 7 > 6
+			list.handleInput("zzz"); // no match
+			const rendered = list.render(80);
+			assert.ok(rendered.length <= 6, `no-match must fit the grant (${rendered.length})`);
+			assert.ok(rendered.some((line) => line.includes("No matching")), "message must survive");
+			assert.ok(rendered.some((line) => line.includes("esc close")), "hint must survive");
+		});
 	});
 
 	describe("group headers (dsh-pi-tui extension)", () => {

--- a/packages/pi-tui/test/settings-list.test.ts
+++ b/packages/pi-tui/test/settings-list.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { SettingsList, type SettingsListTheme } from "../src/components/settings-list.ts";
+import { SettingsList, type SettingsListTheme, type RowBudgetAware } from "../src/components/settings-list.ts";
+import type { Component } from "../src/tui.ts";
 
 const testTheme: SettingsListTheme = {
 	label: (text) => text,
@@ -54,5 +55,112 @@ describe("SettingsList", () => {
 		list.handleInput(" ");
 
 		assert.deepStrictEqual(changes, [{ id: "tui-mode", value: "fullscreen" }]);
+	});
+});
+
+describe("SettingsList setMaxRows (dsh-pi-tui extension)", () => {
+	it("keeps the selected row and hint when a long description exceeds a small budget", () => {
+		const rows = Array.from({ length: 12 }, (_, index) => ({
+			id: `setting-${index}`,
+			label: `setting ${index}`,
+			currentValue: "on",
+			values: ["on", "off"],
+			// A long description wraps to several rows: unaccounted by the
+			// item-window budget, it must be capped so the hint survives.
+			description: "this row has a long description that wraps " + "across many lines ".repeat(6),
+		}));
+		const list = new SettingsList(rows, 10, testTheme, () => {}, () => {});
+		list.setMaxRows(8);
+		const rendered = list.render(80);
+		assert.ok(rendered.length <= 8, `settings list must fit the grant (${rendered.length})`);
+		assert.ok(rendered.some((line) => line.includes("Esc to cancel")), "hint must remain visible");
+		assert.ok(rendered.some((line) => line.includes("setting 0")), "selected row must remain visible");
+	});
+
+	it("keeps the hint with search enabled under a small budget", () => {
+		const rows = Array.from({ length: 12 }, (_, index) => ({
+			id: `setting-${index}`,
+			label: `setting ${index}`,
+			currentValue: "on",
+		}));
+		const list = new SettingsList(rows, 10, testTheme, () => {}, () => {}, { enableSearch: true });
+		list.setMaxRows(6);
+		const rendered = list.render(80);
+		assert.ok(rendered.length <= 6, `searchable settings list must fit the grant (${rendered.length})`);
+		assert.ok(rendered.some((line) => line.includes("Esc to cancel")), "hint must remain visible");
+	});
+
+	it("keeps the hint tail on a degenerate 5-row searchable grant", () => {
+		const rows = Array.from({ length: 12 }, (_, index) => ({
+			id: `setting-${index}`,
+			label: `setting ${index}`,
+			currentValue: "on",
+		}));
+		const list = new SettingsList(rows, 10, testTheme, () => {}, () => {}, { enableSearch: true });
+		// 5-row grant: search prefix(2) + one item + indicator(1) + hint(2)
+		// already exceed it; the tail slice must keep the hint and the
+		// selected row rather than the search box (settings is always
+		// search-enabled, so this is the host-reachable ≤7-row terminal).
+		list.setMaxRows(5);
+		const rendered = list.render(80);
+		assert.ok(rendered.length <= 5, `settings list must fit the grant (${rendered.length})`);
+		assert.ok(rendered.some((line) => line.includes("Esc to cancel")), "hint must survive the tail slice");
+		assert.ok(rendered.some((line) => line.includes("setting 0")), "selected row must survive the tail slice");
+	});
+
+	it("restores the full window after moving off a described row (no render-time ratchet)", () => {
+		const rows = Array.from({ length: 12 }, (_, index) => ({
+			id: `setting-${index}`,
+			label: `setting ${index}`,
+			currentValue: "on",
+			// Only the FIRST row carries a long description, so selecting it
+			// shrinks the window; moving to a plain row must restore it.
+			description: index === 0 ? "a long description " + "that wraps ".repeat(40) : undefined,
+		}));
+		const list = new SettingsList(rows, 10, testTheme, () => {}, () => {});
+		list.setMaxRows(10); // budget: no search prefix + indicator 1 + hint 2 -> 7
+		list.render(80);
+		for (let index = 0; index < 5; index++) list.handleInput("\x1b[B"); // -> setting 5 (no description)
+		const rendered = list.render(80);
+		assert.ok(rendered.some((line) => line.includes("setting 5")), "selected row must be visible");
+		assert.ok(rendered.some((line) => line.includes("setting 8")),
+			`the full window must return after moving off the described row (${JSON.stringify(rendered)})`);
+	});
+
+	it("forwards the row grant to an open submenu that accepts it", () => {
+		const received: number[] = [];
+		const child = { setMaxRows: (rows: number) => { received.push(rows); } } as unknown as RowBudgetAware;
+		const list = new SettingsList(
+			[{
+				id: "a",
+				label: "Alpha",
+				currentValue: "",
+				submenu: () => child as unknown as Component,
+			}],
+			5,
+			testTheme,
+			() => {},
+			() => {},
+		);
+		list.handleInput("\r"); // Enter: open the submenu
+		assert.deepStrictEqual(received, [Number.POSITIVE_INFINITY], "submenu must inherit the grant at open");
+		list.setMaxRows(8);
+		assert.deepStrictEqual(received, [Number.POSITIVE_INFINITY, 8], "a grant change must reach the open submenu");
+		list.setMaxRows(12);
+		assert.deepStrictEqual(received, [Number.POSITIVE_INFINITY, 8, 12], "every grant change must forward");
+	});
+
+	it("fits the no-match state to a small searchable grant", () => {
+		const rows = [
+			{ id: "a", label: "alpha", currentValue: "on" },
+			{ id: "b", label: "beta", currentValue: "on" },
+		];
+		const list = new SettingsList(rows, 10, testTheme, () => {}, () => {}, { enableSearch: true });
+		list.setMaxRows(4); // search 2 + message 1 + hint 2 = 5 > 4
+		list.handleInput("z"); // no match
+		const rendered = list.render(80);
+		assert.ok(rendered.length <= 4, `no-match must fit the grant (${rendered.length})`);
+		assert.ok(rendered.some((line) => line.includes("No matching settings")), "message must survive");
+		assert.ok(rendered.some((line) => line.includes("Esc to cancel")), "hint must survive");
 	});
 });

--- a/src/history-panel.ts
+++ b/src/history-panel.ts
@@ -54,6 +54,40 @@ export const HISTORY_PANEL_CHROME_ROWS = 4
 /** The footer hint (plan §59 — `Enter use`, not `Enter select`). */
 export const HISTORY_PANEL_FOOTER = 'type filter · ↑↓ select · Enter use · Tab scope · Esc cancel'
 
+/** The live geometry budget for the history overlay. */
+export interface HistoryOverlayGeometry {
+  width: number
+  maxHeight: number
+  panelRows: number
+}
+
+/**
+ * Derive the history overlay geometry from the CURRENT terminal dimensions.
+ * The outer Frame owns two rows, so `panelRows` is the budget passed to the
+ * stateful HistoryPanel. Every dimension is clamped so a very small terminal
+ * still receives a usable positive layout instead of a negative overlay size.
+ */
+export function historyOverlayGeometry(columns: number, rows: number): HistoryOverlayGeometry {
+  const safeColumns = Number.isFinite(columns) ? Math.max(1, Math.floor(columns)) : 1
+  const safeRows = Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : 1
+  const availableWidth = Math.max(1, safeColumns - 2)
+  const width = Math.max(1, Math.min(
+    availableWidth,
+    Math.max(20, Math.min(100, safeColumns - 6)),
+  ))
+  const availableHeight = Math.max(1, safeRows - 2)
+  const maxHeight = Math.max(1, Math.min(
+    availableHeight,
+    Math.max(8, Math.min(30, safeRows - 4)),
+  ))
+  return { width, maxHeight, panelRows: Math.max(1, maxHeight - 2) }
+}
+
+/** Normalize a host-provided row budget without allowing a zero-row panel. */
+function normalizeMaxRows(rows: number): number {
+  return Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : 24
+}
+
 /** Panel constructor options. */
 export interface HistoryPanelOptions {
   /** The injected search source (the runner wires the file-backed one). */
@@ -148,8 +182,9 @@ export class HistoryPanel implements Component, Focusable {
   private readonly onClose: () => void
   private readonly onResultsChanged: (() => void) | undefined
   private readonly debounceMs: number
-  private readonly maxRows: number
+  private maxRows: number
   private _focused = false
+  private disposed = false
   private timer: ReturnType<typeof setTimeout> | undefined
   private controller: AbortController | undefined
 
@@ -165,7 +200,7 @@ export class HistoryPanel implements Component, Focusable {
     // overlay height (maxHeight minus the Frame border), so a tiny
     // terminal gets a tiny panel — a floor here would push the framed
     // output past the overlay and clip the footer.
-    this.maxRows = options.maxRows ?? 24
+    this.maxRows = normalizeMaxRows(options.maxRows ?? 24)
     this.input = new Input()
     // The default scope: `session` when a live session identity exists
     // (the agent-session model — the current session's inputs are the
@@ -181,6 +216,11 @@ export class HistoryPanel implements Component, Focusable {
     }
     this.state.query = options.initialQuery ?? ''
     this.input.setValue(this.state.query)
+  }
+
+  /** Update the host-granted row budget while preserving all search state. */
+  setMaxRows(rows: number): void {
+    this.maxRows = normalizeMaxRows(rows)
   }
 
   get focused(): boolean {
@@ -241,11 +281,14 @@ export class HistoryPanel implements Component, Focusable {
 
   /** Open-time init: run the initial (empty-query) search immediately. */
   start(): void {
+    if (this.disposed) return
     void this.refresh() // allowlist: refresh() never rejects (errors land in the panel state)
   }
 
   /** Cancel and forget (called by the host on close). */
   dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
     // Invalidate the generation: a source that ignores the abort and
     // settles LATE (resolve OR reject) must never commit into the closed
     // panel — the refresh's generation check is the fence for both paths.

--- a/src/model-menu.ts
+++ b/src/model-menu.ts
@@ -19,7 +19,7 @@
  * @module @xmoon76/dsh-pi-tui/model-menu
  */
 
-import { SettingsList, Text, matchesKey, type Component } from '@xmoon76/pi-tui'
+import { SettingsList, Text, matchesKey, type Component, type RowBudgetAware } from '@xmoon76/pi-tui'
 import { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { ModelSelection } from '@deepseek-ai/dsh-agent'
 import type { OwnedTaskOptions } from './detached.ts'
@@ -87,12 +87,23 @@ class EscDismiss implements Component {
  * parent close latches `disposed` and aborts the info load; a resolve or
  * reject that settles afterwards is ignored (debug diagnostics only).
  */
-class EffortSubmenu implements Component {
+class EffortSubmenu implements Component, RowBudgetAware {
   private inner: Component
   private readonly requestRender: () => void
   /** Latched by every close path; late async results must not act after. */
   private disposed = false
   private readonly abort = new AbortController()
+  /** The last host row grant, re-applied to each swapped-in inner list. */
+  private rowGrant = Number.POSITIVE_INFINITY
+
+  /** Host row-budget seam: keep the grant and forward it to the inner
+   * list, so a list swapped in asynchronously after a resize still
+   * reflows (the outer SettingsList forwards through this seam). */
+  setMaxRows(rows: number): void {
+    this.rowGrant = rows
+    const inner = this.inner as RowBudgetAware
+    inner.setMaxRows?.(rows)
+  }
 
   constructor(providerId: string, modelId: string, currentEffort: string | undefined, deps: SubmenuDeps) {
     // Every close path funnels through done(); wrapping it lets the submenu
@@ -153,6 +164,8 @@ class EffortSubmenu implements Component {
           () => close(),
           {},
         )
+        // The async list lands AFTER any resize: re-apply the last grant.
+        this.setMaxRows(this.rowGrant)
         this.requestRender()
       },
       onError: () => {
@@ -183,12 +196,23 @@ class EffortSubmenu implements Component {
  * cancellation discipline as {@link EffortSubmenu}: a late model list must
  * neither repaint a closed menu nor swap in stale content.
  */
-export class ModelSubmenu implements Component {
+export class ModelSubmenu implements Component, RowBudgetAware {
   private inner: Component
   private readonly requestRender: () => void
   /** Latched by every close path; late async results must not act after. */
   private disposed = false
   private readonly abort = new AbortController()
+  /** The last host row grant, re-applied to each swapped-in inner list. */
+  private rowGrant = Number.POSITIVE_INFINITY
+
+  /** Host row-budget seam: keep the grant and forward it to the inner
+   * list, so a list swapped in asynchronously after a resize still
+   * reflows (the outer SettingsList forwards through this seam). */
+  setMaxRows(rows: number): void {
+    this.rowGrant = rows
+    const inner = this.inner as RowBudgetAware
+    inner.setMaxRows?.(rows)
+  }
 
   constructor(providerId: string, currentModel: string, currentEffort: string | undefined, deps: SubmenuDeps) {
     const close = (selected?: string): void => {
@@ -232,6 +256,8 @@ export class ModelSubmenu implements Component {
           () => close(),
           { enableSearch: true },
         )
+        // The async list lands AFTER any resize: re-apply the last grant.
+        this.setMaxRows(this.rowGrant)
         this.requestRender()
       },
       onError: () => {

--- a/src/subagent-model-menu.ts
+++ b/src/subagent-model-menu.ts
@@ -23,7 +23,7 @@
  * @module @xmoon76/dsh-pi-tui/subagent-model-menu
  */
 
-import { SettingsList, Text, matchesKey, type Component } from '@xmoon76/pi-tui'
+import { SettingsList, Text, matchesKey, type Component, type RowBudgetAware } from '@xmoon76/pi-tui'
 import type { OwnedTaskOptions } from './detached.ts'
 import type { SubagentAllowedModelRoute, SubagentModelSelectionConfig } from './runtime/config-port.ts'
 import { settingsListTheme } from './theme.ts'
@@ -95,6 +95,17 @@ export class SubagentModelAllowlistSubmenu implements Component {
    * slow earlier write can never land after a newer one (the review's
    * concurrent-toggle race). */
   private mutationChain: Promise<void> = Promise.resolve()
+  /** The last host row grant, re-applied to each swapped-in inner list. */
+  private rowGrant = Number.POSITIVE_INFINITY
+
+  /** Host row-budget seam: keep the grant and forward it to the inner
+   * list, so a list swapped in asynchronously after a resize still
+   * reflows (the outer SettingsList forwards through this seam). */
+  setMaxRows(rows: number): void {
+    this.rowGrant = rows
+    const inner = this.inner as RowBudgetAware
+    inner.setMaxRows?.(rows)
+  }
 
   constructor(deps: AllowlistSubmenuDeps) {
     const current = deps.selection.get()
@@ -108,6 +119,7 @@ export class SubagentModelAllowlistSubmenu implements Component {
       deps.done(selected)
     }
     this.inner = this.providerList(deps, close)
+    this.setMaxRows(this.rowGrant)
   }
 
   private providerList(deps: AllowlistSubmenuDeps, close: (selected?: string) => void): Component {
@@ -145,6 +157,7 @@ export class SubagentModelAllowlistSubmenu implements Component {
       this.modelListProvider = undefined
       this.modelListIds = []
       this.inner = this.providerList(deps, close)
+      this.setMaxRows(this.rowGrant)
       this.requestRender()
     }
     this.inner = new EscDismissText('Loading models…', backToProviders)
@@ -176,6 +189,8 @@ export class SubagentModelAllowlistSubmenu implements Component {
         this.modelListProvider = providerId
         this.modelListIds = models.map(model => model.id)
         this.inner = list
+        // The async list lands AFTER any resize: re-apply the last grant.
+        this.setMaxRows(this.rowGrant)
         this.requestRender()
       },
       onError: () => {

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -843,24 +843,30 @@ export class TaskBrowserPanel implements Component, Focusable {
       listLines = buildWindow(itemCount, start)
       candidate = assemble()
     }
-    // The ACTUAL viewport is the window the fit left. Record it BEFORE
-    // the exposure ack so viewportItems()/onViewportExpose and the
-    // PageUp/PageDown step agree with the rows physically painted — the
-    // budget baseline can be larger than what details/sidebar allow.
-    this.lastRenderedStart = start
-    this.lastRenderedCount = itemCount
-    this.hasRenderedViewport = true
-    this.exposeViewport()
-    if (candidate.length <= limit) return candidate
+    if (candidate.length <= limit) {
+      // The ACTUAL viewport is the window the fit left. Record it BEFORE
+      // the exposure ack so viewportItems()/onViewportExpose and the
+      // PageUp/PageDown step agree with the rows physically painted — the
+      // budget baseline can be larger than what details/sidebar allow.
+      this.lastRenderedStart = start
+      this.lastRenderedCount = itemCount
+      this.hasRenderedViewport = true
+      this.exposeViewport()
+      return candidate
+    }
 
     // Very short grants: true semantic degradation — search input
     // (searchMode) > selected main > hint > header > group > detail >
     // indicator > blank spacers. The selected main row is never squeezed
     // out by decorative blanks or the header (this path does not keep the
-    // chrome prefix unconditionally).
+    // chrome prefix unconditionally). The final layout is decided BEFORE
+    // the exposure ack: an extreme grant can drop the selected row
+    // entirely (a 1-row grant + search mode paints only the search
+    // input), and only rows the FINAL layout actually paints may be
+    // acknowledged.
     const entries = this.windowEntries(start, itemCount, listWidth)
     const selectedEntry = entries.find(entry => entry.selected)
-    return this.degradedFallback(
+    const degraded = this.degradedFallback(
       selectedEntry,
       searchRowText,
       searchEmpty,
@@ -869,6 +875,11 @@ export class TaskBrowserPanel implements Component, Focusable {
       limit,
       hintLine,
     )
+    this.lastRenderedStart = degraded.paintsSelectedMain ? start : 0
+    this.lastRenderedCount = degraded.paintsSelectedMain ? 1 : 0
+    this.hasRenderedViewport = true
+    this.exposeViewport()
+    return degraded.lines
   }
 
   /** True semantic degradation for very short grants. The declared
@@ -876,7 +887,8 @@ export class TaskBrowserPanel implements Component, Focusable {
    * detail > indicator) is enforced by INCLUSION — the chrome prefix is
    * rebuilt from the hoisted texts and only kept when it fits after the
    * mandatory content, so the selected main row cannot lose to two
-   * decorative blanks + the header. */
+   * decorative blanks + the header. Returns whether the selected main row
+   * is actually painted, so the callers ack only what the user saw. */
   private degradedFallback(
     selectedEntry: { group: string | undefined; main: string; details: string[] } | undefined,
     searchRowText: string,
@@ -885,7 +897,7 @@ export class TaskBrowserPanel implements Component, Focusable {
     indicatorText: string | undefined,
     limit: number,
     hintLine: string,
-  ): string[] {
+  ): { lines: string[]; paintsSelectedMain: boolean } {
     const mainRow = selectedEntry?.main
     const groupRow = selectedEntry !== undefined && selectedEntry.group !== undefined
       ? color.textMuted(`── ${selectedEntry.group} ──`)
@@ -898,7 +910,10 @@ export class TaskBrowserPanel implements Component, Focusable {
     const content: string[] = []
     if (searchShown !== '') content.push(searchShown)
     if (mainRow !== undefined) content.push(mainRow)
-    if (content.length >= limit) return content.slice(0, limit)
+    if (content.length >= limit) {
+      const kept = content.slice(0, limit)
+      return { lines: kept, paintsSelectedMain: mainRow !== undefined && kept.includes(mainRow) }
+    }
     const hintIncluded = content.length + 1 <= limit
     let used = content.length + (hintIncluded ? 1 : 0)
     // Optional chrome (priority 4-7) fills the leftover rows.
@@ -924,7 +939,9 @@ export class TaskBrowserPanel implements Component, Focusable {
     out.push(...detailsShown)
     if (indicatorShown) out.push(color.textMuted(indicatorText!))
     if (hintIncluded) out.push(...(hintBlank ? ['', hintLine] : [hintLine]))
-    return out
+    // The main row is always painted in this branch (the extreme branch
+    // above was the only path that could drop it).
+    return { lines: out, paintsSelectedMain: mainRow !== undefined }
   }
 
   /** The visible window as STRUCTURED rows (main + detail lines kept

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -972,8 +972,11 @@ export class TaskBrowserPanel implements Component, Focusable {
     // The header is chrome: yield it before any content.
     const withoutHeader = this.options.header === undefined ? compact : compact.slice(1)
     if (withoutHeader.length <= limit) return withoutHeader
-    // Extreme grant: keep the head — the search input, then the message.
-    return compact.slice(0, limit)
+    // Extreme grant: keep the head of the HEADER-FREE rows — the search
+    // input, then the no-match message. Slicing `compact` here would
+    // re-introduce the header and drop the message, which the declared
+    // priority places ABOVE the header.
+    return withoutHeader.slice(0, limit)
   }
 
 

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -147,6 +147,12 @@ export class TaskBrowserPanel implements Component, Focusable {
   private maxVisible: number
   /** Total inner rows granted by the surrounding Frame. */
   private maxRows = Number.POSITIVE_INFINITY
+  /** The ACTUAL viewport the last render painted (after the fit loop
+   * shrunk the budget estimate): the ack scope for viewportItems()/
+   * onViewportExpose and the PageUp/PageDown step — never the budget
+   * baseline, which detail rows / the sidebar can undershoot. */
+  private lastRenderedStart = 0
+  private lastRenderedCount = 1
   private readonly options: TaskPanelOptions
   private readonly searchInput = new Input()
   private searchEnabled: boolean
@@ -180,6 +186,9 @@ export class TaskBrowserPanel implements Component, Focusable {
     this.items = [...items]
     this.configuredMaxVisible = Math.max(1, Math.floor(maxVisible))
     this.maxVisible = this.configuredMaxVisible
+    // Pre-render default: the budget window. The first render's fit loop
+    // overwrites it with the ACTUAL painted window.
+    this.lastRenderedCount = this.maxVisible
     this.options = options
     this.onSelect = onSelect
     this.onCancel = onCancel
@@ -288,6 +297,9 @@ export class TaskBrowserPanel implements Component, Focusable {
     this.loading = state === 'loading'
     this.refreshError = state === 'stale' ? error ?? 'Refresh failed' : undefined
     if (state === 'ready') this.loading = false
+    // A stale banner row changes the chrome: re-derive the budget now, so
+    // paging/ack do not keep the pre-banner window until the next projection.
+    this.recomputeVisibleBudget()
     this.requestRender()
   }
 
@@ -296,10 +308,12 @@ export class TaskBrowserPanel implements Component, Focusable {
     return this.filtered
   }
 
-  /** ONLY the rows the current viewport actually renders (the ack scope:
-   * a failure the user has not scrolled to was never "seen"). */
+  /** ONLY the rows the CURRENT painted viewport actually rendered (the
+   * ack scope: a failure the user never physically saw was never "seen").
+   * Reflects the render-time fit (detail rows / the sidebar can shrink
+   * the painted window below the budget baseline), never `maxVisible`. */
   viewportItems(): readonly TaskPanelItem[] {
-    return this.filtered.slice(this.scroll, this.scroll + this.maxVisible)
+    return this.filtered.slice(this.lastRenderedStart, this.lastRenderedStart + this.lastRenderedCount)
   }
 
   /**
@@ -428,6 +442,8 @@ export class TaskBrowserPanel implements Component, Focusable {
     this.searchMode = true
     this.searchInput.focused = this._focused
     this.selectionTouched = true
+    // The search chrome (2 rows) enters the budget estimate immediately.
+    this.recomputeVisibleBudget()
     this.requestRender()
   }
 
@@ -435,6 +451,8 @@ export class TaskBrowserPanel implements Component, Focusable {
     if (!this.searchMode) return
     this.searchMode = false
     this.searchInput.focused = false
+    // The search chrome (2 rows) leaves the budget estimate immediately.
+    this.recomputeVisibleBudget()
     this.requestRender()
   }
 
@@ -450,7 +468,11 @@ export class TaskBrowserPanel implements Component, Focusable {
     if (this.filtered.length === 0) return
     this.pendingStopValue = undefined
     this.selectionTouched = true
-    this.selected = Math.max(0, Math.min(this.filtered.length - 1, this.selected + direction * this.maxVisible))
+    // Page by the ACTUAL last-rendered window (the fit loop may have
+    // shrunk it below the budget baseline), so a page never skips rows
+    // the user just saw.
+    const pageSize = Math.max(1, this.lastRenderedCount)
+    this.selected = Math.max(0, Math.min(this.filtered.length - 1, this.selected + direction * pageSize))
     this.ensureVisible()
   }
 
@@ -703,10 +725,22 @@ export class TaskBrowserPanel implements Component, Focusable {
     const safeWidth = Math.max(1, width)
     const lines: string[] = []
     const explicit = this.explicitMode
+    const limit = Number.isFinite(this.maxRows) ? Math.max(1, Math.floor(this.maxRows)) : Number.POSITIVE_INFINITY
+    const hintLine = color.textMuted(`  ${this.hint()}`)
+    const searchOn = explicit ? this.searchMode : this.searchEnabled
+    // Hoisted chrome texts: the short-grant degradation rebuilds from
+    // them without the unconditionally-kept blank spacers.
+    const headerText = this.options.header === undefined ? undefined
+      : truncateToWidth(explicit ? this.headerText() : this.legacyHeaderText(), safeWidth, '…')
+    const searchEmpty = this.getFilter() === ''
+    const searchRowText = !searchOn ? '' : (() => {
+      const searchLine = this.searchInput.render(Math.max(1, safeWidth - 2))[0] ?? ''
+      const stripped = searchLine.startsWith('> ') ? searchLine.slice(2) : searchLine
+      return searchEmpty ? (explicit ? ' / search…' : ' search…') : ` ${stripped}`
+    })()
 
-    if (this.options.header !== undefined) {
-      const header = explicit ? this.headerText() : this.legacyHeaderText()
-      lines.push(color.textStrong(truncateToWidth(header, safeWidth, '…')))
+    if (headerText !== undefined) {
+      lines.push(color.textStrong(headerText))
       lines.push('')
     }
 
@@ -714,35 +748,29 @@ export class TaskBrowserPanel implements Component, Focusable {
       lines.push(color.textDim('Loading tasks…'))
       if (this.refreshError !== undefined) lines.push(color.textMuted(`${this.refreshError} · R retry`))
       lines.push('')
-      lines.push(color.textMuted(`  ${this.hint()}`))
+      lines.push(hintLine)
+      this.lastRenderedStart = 0
+      this.lastRenderedCount = 0
       return this.finalizeEmpty(lines)
     }
 
-    if (this.explicitMode && this.searchMode) {
-      const searchLine = this.searchInput.render(Math.max(1, safeWidth - 2))[0] ?? ''
-      const stripped = searchLine.startsWith('> ') ? searchLine.slice(2) : searchLine
-      lines.push(this.getFilter() === '' ? color.textDim(' / search…') : ` ${stripped}`)
-      lines.push('')
-    } else if (!explicit && this.searchEnabled) {
-      const searchLine = this.searchInput.render(Math.max(1, safeWidth - 2))[0] ?? ''
-      const stripped = searchLine.startsWith('> ') ? searchLine.slice(2) : searchLine
-      lines.push(this.getFilter() === '' ? color.textDim(' search…') : ` ${stripped}`)
+    if (searchOn) {
+      lines.push(searchEmpty ? color.textDim(searchRowText) : searchRowText)
       lines.push('')
     }
 
-    const limit = Number.isFinite(this.maxRows) ? Math.max(1, Math.floor(this.maxRows)) : Number.POSITIVE_INFINITY
-    const hintLine = color.textMuted(`  ${this.hint()}`)
     const rows = this.filtered
     if (rows.length === 0) {
       lines.push(color.textDim(this.refreshError === undefined ? (this.options.noMatchText ?? 'No matching tasks') : 'Could not load tasks'))
       if (this.refreshError !== undefined) lines.push(color.textMuted(`${this.refreshError} · R retry`))
       lines.push('')
       lines.push(hintLine)
+      this.lastRenderedStart = 0
+      this.lastRenderedCount = 0
       return this.finalizeEmpty(lines)
     }
 
     this.ensureVisible()
-    this.exposeViewport()
     const listWidth = safeWidth >= 110 ? Math.max(40, Math.floor((safeWidth - 3) * 0.58)) : safeWidth
     let itemCount = Math.min(rows.length, this.maxVisible)
     let start = this.scroll
@@ -803,28 +831,83 @@ export class TaskBrowserPanel implements Component, Focusable {
       listLines = buildWindow(itemCount, start)
       candidate = assemble()
     }
+    // The ACTUAL viewport is the window the fit left. Record it BEFORE
+    // the exposure ack so viewportItems()/onViewportExpose and the
+    // PageUp/PageDown step agree with the rows physically painted — the
+    // budget baseline can be larger than what details/sidebar allow.
+    this.lastRenderedStart = start
+    this.lastRenderedCount = itemCount
+    this.exposeViewport()
     if (candidate.length <= limit) return candidate
 
-    // A single detail-rich row can still exceed the grant. Apply the
-    // semantic priority (never tail-slice the flat array, or the selected
-    // MAIN row would yield to its own detail lines):
-    //   selected main row > hint tail > group header > detail > indicator.
-    const tail = limit - lines.length >= 2 ? ['', hintLine] : [hintLine]
-    const budget = Math.max(0, limit - lines.length - tail.length)
+    // Very short grants: true semantic degradation — search input
+    // (searchMode) > selected main > hint > header > group > detail >
+    // indicator > blank spacers. The selected main row is never squeezed
+    // out by decorative blanks or the header (this path does not keep the
+    // chrome prefix unconditionally).
     const entries = this.windowEntries(start, itemCount, listWidth)
     const selectedEntry = entries.find(entry => entry.selected)
-    let kept: string[] = []
-    if (selectedEntry !== undefined) {
-      const group = selectedEntry.group !== undefined && budget >= 2
-        ? [color.textMuted(`── ${selectedEntry.group} ──`)]
-        : []
-      if (budget >= 1) kept = [...group, selectedEntry.main]
-      const rest = budget - kept.length
-      if (rest > 0) kept = [...kept, ...selectedEntry.details.slice(0, rest)]
-    } else {
-      kept = listLines.slice(0, budget)
+    return this.degradedFallback(
+      selectedEntry,
+      searchRowText,
+      headerText,
+      rows.length > itemCount ? `  ${this.selected + 1}/${rows.length}` : undefined,
+      limit,
+      hintLine,
+    )
+  }
+
+  /** True semantic degradation for very short grants. The declared
+   * priority (search input > selected main > hint > header > group >
+   * detail > indicator) is enforced by INCLUSION — the chrome prefix is
+   * rebuilt from the hoisted texts and only kept when it fits after the
+   * mandatory content, so the selected main row cannot lose to two
+   * decorative blanks + the header. */
+  private degradedFallback(
+    selectedEntry: { group: string | undefined; main: string; details: string[] } | undefined,
+    searchRowText: string,
+    headerText: string | undefined,
+    indicatorText: string | undefined,
+    limit: number,
+    hintLine: string,
+  ): string[] {
+    const mainRow = selectedEntry?.main
+    const groupRow = selectedEntry !== undefined && selectedEntry.group !== undefined
+      ? color.textMuted(`── ${selectedEntry.group} ──`)
+      : undefined
+    const detailRows = selectedEntry?.details ?? []
+    // Mandatory content (priority 1-2): search row, then the selected
+    // main row; the hint text follows (priority 3).
+    const content: string[] = []
+    if (searchRowText !== '') content.push(color.textDim(searchRowText))
+    if (mainRow !== undefined) content.push(mainRow)
+    if (content.length >= limit) return content.slice(0, limit)
+    const hintIncluded = content.length + 1 <= limit
+    let used = content.length + (hintIncluded ? 1 : 0)
+    // Optional chrome (priority 4-7) fills the leftover rows.
+    let headerShown = false
+    if (headerText !== undefined && used + 1 <= limit) { headerShown = true; used += 1 }
+    let groupShown = false
+    if (groupRow !== undefined && used + 1 <= limit) { groupShown = true; used += 1 }
+    const detailsShown: string[] = []
+    for (const detail of detailRows) {
+      if (used + 1 > limit) break
+      detailsShown.push(detail)
+      used += 1
     }
-    return [...lines, ...kept, ...tail].slice(0, limit)
+    let indicatorShown = false
+    if (indicatorText !== undefined && used + 1 <= limit) { indicatorShown = true; used += 1 }
+    // Blank spacers last: only the hint's leading blank rides along.
+    const hintBlank = used + 1 <= limit
+    const out: string[] = []
+    if (headerShown) out.push(color.textStrong(headerText!))
+    if (searchRowText !== '') out.push(color.textDim(searchRowText))
+    if (groupShown) out.push(groupRow!)
+    if (mainRow !== undefined) out.push(mainRow)
+    out.push(...detailsShown)
+    if (indicatorShown) out.push(color.textMuted(indicatorText!))
+    if (hintIncluded) out.push(...(hintBlank ? ['', hintLine] : [hintLine]))
+    return out
   }
 
   /** The visible window as STRUCTURED rows (main + detail lines kept

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -142,7 +142,11 @@ export class TaskBrowserPanel implements Component, Focusable {
   private selectionTouched = false
   private readonly expandedIds: Set<string>
   private readonly collapsedIds: Set<string>
-  private readonly maxVisible: number
+  /** Caller-configured item cap; the live terminal budget may lower it. */
+  private readonly configuredMaxVisible: number
+  private maxVisible: number
+  /** Total inner rows granted by the surrounding Frame. */
+  private maxRows = Number.POSITIVE_INFINITY
   private readonly options: TaskPanelOptions
   private readonly searchInput = new Input()
   private searchEnabled: boolean
@@ -174,7 +178,8 @@ export class TaskBrowserPanel implements Component, Focusable {
     requestRender: () => void,
   ) {
     this.items = [...items]
-    this.maxVisible = Math.max(1, maxVisible)
+    this.configuredMaxVisible = Math.max(1, Math.floor(maxVisible))
+    this.maxVisible = this.configuredMaxVisible
     this.options = options
     this.onSelect = onSelect
     this.onCancel = onCancel
@@ -217,6 +222,29 @@ export class TaskBrowserPanel implements Component, Focusable {
     this.reproject(false)
     this.selectPreferred()
     this.startTick()
+  }
+
+  /** Update the live inner row budget without resetting selection, filters
+   * or disclosure state (the responsive frame calls this on every resize;
+   * the recompute uses the CURRENT chrome: header + search + hint tail +
+   * indicator + optional refresh-error line). */
+  setMaxRows(rows: number): void {
+    this.maxRows = Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : Number.POSITIVE_INFINITY
+    this.recomputeVisibleBudget()
+    this.ensureVisible()
+  }
+
+  /** Derive the item window from the current chrome and row budget. */
+  private recomputeVisibleBudget(): void {
+    const searchOn = this.explicitMode ? this.searchMode : this.searchEnabled
+    const prefix = (this.options.header === undefined ? 0 : 2) + (searchOn ? 2 : 0)
+    const trailing = 2 // blank separator + navigation hint
+    const refreshLine = this.refreshError !== undefined ? 1 : 0
+    const group = this.filtered.some(item => item.group !== undefined) ? 1 : 0
+    const budget = this.maxRows === Number.POSITIVE_INFINITY
+      ? this.configuredMaxVisible
+      : this.maxRows - prefix - trailing - refreshLine - group
+    this.maxVisible = Math.max(1, Math.min(this.configuredMaxVisible, budget))
   }
 
   /** Replace rows while preserving the selected identity where possible. */
@@ -359,6 +387,9 @@ export class TaskBrowserPanel implements Component, Focusable {
         canOpen: true,
       })
     }
+    // The projection changed the row set: re-derive the live item budget
+    // (the group/chrome estimate follows the current view).
+    this.recomputeVisibleBudget()
     if (resetSelection) {
       this.selected = 0
       this.scroll = 0
@@ -684,7 +715,7 @@ export class TaskBrowserPanel implements Component, Focusable {
       if (this.refreshError !== undefined) lines.push(color.textMuted(`${this.refreshError} · R retry`))
       lines.push('')
       lines.push(color.textMuted(`  ${this.hint()}`))
-      return lines
+      return this.finalizeEmpty(lines)
     }
 
     if (this.explicitMode && this.searchMode) {
@@ -699,59 +730,152 @@ export class TaskBrowserPanel implements Component, Focusable {
       lines.push('')
     }
 
+    const limit = Number.isFinite(this.maxRows) ? Math.max(1, Math.floor(this.maxRows)) : Number.POSITIVE_INFINITY
+    const hintLine = color.textMuted(`  ${this.hint()}`)
     const rows = this.filtered
     if (rows.length === 0) {
       lines.push(color.textDim(this.refreshError === undefined ? (this.options.noMatchText ?? 'No matching tasks') : 'Could not load tasks'))
       if (this.refreshError !== undefined) lines.push(color.textMuted(`${this.refreshError} · R retry`))
       lines.push('')
-      lines.push(color.textMuted(`  ${this.hint()}`))
-      return lines
+      lines.push(hintLine)
+      return this.finalizeEmpty(lines)
     }
 
     this.ensureVisible()
     this.exposeViewport()
-    const start = this.scroll
-    const end = Math.min(rows.length, start + this.maxVisible)
-    const visibleRows = rows.slice(start, end)
     const listWidth = safeWidth >= 110 ? Math.max(40, Math.floor((safeWidth - 3) * 0.58)) : safeWidth
-    const listLines: string[] = []
-    let lastGroup: string | undefined
-    for (let i = 0; i < visibleRows.length; i += 1) {
-      const item = visibleRows[i]!
-      const group = displayGroup(item.group, this.options.groupLabels === true)
-      if (group !== lastGroup) {
-        if (group !== undefined) listLines.push(color.textMuted(`── ${group} ──`))
-        lastGroup = group
+    let itemCount = Math.min(rows.length, this.maxVisible)
+    let start = this.scroll
+    const buildWindow = (count: number, from: number): string[] => {
+      const end = Math.min(rows.length, from + count)
+      const visibleRows = rows.slice(from, end)
+      const listLines: string[] = []
+      let lastGroup: string | undefined
+      for (let i = 0; i < visibleRows.length; i += 1) {
+        const item = visibleRows[i]!
+        const group = displayGroup(item.group, this.options.groupLabels === true)
+        if (group !== lastGroup) {
+          if (group !== undefined) listLines.push(color.textMuted(`── ${group} ──`))
+          lastGroup = group
+        }
+        const selected = from + i === this.selected
+        listLines.push(...this.renderRow(item, selected, listWidth))
+        if (safeWidth >= 70 && safeWidth < 110 && selected && item.kind !== 'view-full') {
+          listLines.push(...this.renderInlineDetail(item, safeWidth))
+        }
       }
-      const selected = start + i === this.selected
-      listLines.push(...this.renderRow(item, selected, listWidth))
-      if (safeWidth >= 70 && safeWidth < 110 && selected && item.kind !== 'view-full') {
-        listLines.push(...this.renderInlineDetail(item, safeWidth))
-      }
+      return listLines
     }
-
-    if (safeWidth >= 110) {
-      const detail = this.detailLines(this.selectedItem())
-      const merged: string[] = []
-      const detailWidth = Math.max(24, safeWidth - listWidth - 3)
-      const max = Math.max(listLines.length, detail.length)
-      for (let i = 0; i < max; i += 1) {
-        const left = truncateToWidth(listLines[i] ?? '', listWidth, '…')
-        const leftPad = ' '.repeat(Math.max(0, listWidth - visibleWidth(left)))
-        const right = truncateToWidth(detail[i] ?? '', detailWidth, '…')
-        merged.push(`${left}${leftPad} ${color.border('│')} ${right}`)
+    let listLines = buildWindow(itemCount, start)
+    const assemble = (): string[] => {
+      const out = [...lines]
+      if (safeWidth >= 110) {
+        const detail = this.detailLines(this.selectedItem())
+        const merged: string[] = []
+        const detailWidth = Math.max(24, safeWidth - listWidth - 3)
+        const max = Math.max(listLines.length, detail.length)
+        for (let i = 0; i < max; i += 1) {
+          const left = truncateToWidth(listLines[i] ?? '', listWidth, '…')
+          const leftPad = ' '.repeat(Math.max(0, listWidth - visibleWidth(left)))
+          const right = truncateToWidth(detail[i] ?? '', detailWidth, '…')
+          merged.push(`${left}${leftPad} ${color.border('│')} ${right}`)
+        }
+        out.push(...merged)
+      } else {
+        out.push(...listLines)
       }
-      lines.push(...merged)
+      if (rows.length > itemCount) out.push(color.textMuted(`  ${this.selected + 1}/${rows.length}`))
+      if (this.refreshError !== undefined) out.push(color.textMuted(`  ${this.refreshError} · R retry`))
+      out.push('')
+      out.push(hintLine)
+      return out
+    }
+    let candidate = assemble()
+    // Details, group headers and the detail pane consume physical rows
+    // beyond the item count: shrink the selected-preserving window until
+    // the whole component fits the live grant, instead of letting the
+    // compositor clip the hint or the selected row.
+    while (candidate.length > limit && itemCount > 1) {
+      itemCount -= 1
+      const desired = Math.max(0, this.selected - Math.floor(itemCount / 2))
+      start = Math.min(desired, Math.max(0, rows.length - itemCount))
+      this.scroll = start
+      listLines = buildWindow(itemCount, start)
+      candidate = assemble()
+    }
+    if (candidate.length <= limit) return candidate
+
+    // A single detail-rich row can still exceed the grant. Apply the
+    // semantic priority (never tail-slice the flat array, or the selected
+    // MAIN row would yield to its own detail lines):
+    //   selected main row > hint tail > group header > detail > indicator.
+    const tail = limit - lines.length >= 2 ? ['', hintLine] : [hintLine]
+    const budget = Math.max(0, limit - lines.length - tail.length)
+    const entries = this.windowEntries(start, itemCount, listWidth)
+    const selectedEntry = entries.find(entry => entry.selected)
+    let kept: string[] = []
+    if (selectedEntry !== undefined) {
+      const group = selectedEntry.group !== undefined && budget >= 2
+        ? [color.textMuted(`── ${selectedEntry.group} ──`)]
+        : []
+      if (budget >= 1) kept = [...group, selectedEntry.main]
+      const rest = budget - kept.length
+      if (rest > 0) kept = [...kept, ...selectedEntry.details.slice(0, rest)]
     } else {
-      lines.push(...listLines)
+      kept = listLines.slice(0, budget)
     }
-
-    if (rows.length > this.maxVisible) lines.push(color.textMuted(`  ${this.selected + 1}/${rows.length}`))
-    if (this.refreshError !== undefined) lines.push(color.textMuted(`  ${this.refreshError} · R retry`))
-    lines.push('')
-    lines.push(color.textMuted(`  ${this.hint()}`))
-    return lines
+    return [...lines, ...kept, ...tail].slice(0, limit)
   }
+
+  /** The visible window as STRUCTURED rows (main + detail lines kept
+   * apart), so a tiny-grant fallback can prioritize the selected main row
+   * over its detail lines instead of tail-slicing a flat array. The
+   * compact-layout inline detail (70-110 wide, selected row only) rides
+   * with its entry; the wide-layout side pane is not part of the window. */
+  private windowEntries(start: number, count: number, width: number): Array<{
+    group: string | undefined
+    main: string
+    details: string[]
+    selected: boolean
+  }> {
+    const entries: Array<{
+      group: string | undefined
+      main: string
+      details: string[]
+      selected: boolean
+    }> = []
+    const end = Math.min(this.filtered.length, start + count)
+    for (let index = start; index < end; index += 1) {
+      const item = this.filtered[index]
+      if (item === undefined) continue
+      const main = this.renderRow(item, index === this.selected, width)[0]!
+      const details = index === this.selected && item.kind !== 'view-full'
+        ? this.renderInlineDetail(item, width)
+        : []
+      entries.push({ group: item.group, main, details, selected: index === this.selected })
+    }
+    return entries
+  }
+
+  /** Finalize the empty/no-match assembly against the live grant
+   * (setMaxRows contract covers every path): `render().length <= maxRows`
+   * with priority search input > no-match message > hint > header > blank
+   * spacers, so the hint survives whenever the grant physically allows it
+   * (a head-keep slice would cut the hint on a short terminal). */
+  private finalizeEmpty(lines: string[]): string[] {
+    if (!Number.isFinite(this.maxRows)) return lines
+    const limit = Math.max(1, Math.floor(this.maxRows))
+    if (lines.length <= limit) return lines
+    // Blank spacers are the lowest-value rows: drop them first.
+    const compact = lines.filter(line => line !== '')
+    if (compact.length <= limit) return compact
+    // The header is chrome: yield it before any content.
+    const withoutHeader = this.options.header === undefined ? compact : compact.slice(1)
+    if (withoutHeader.length <= limit) return withoutHeader
+    // Extreme grant: keep the head — the search input, then the message.
+    return compact.slice(0, limit)
+  }
+
 
   private legacyHeaderText(): string {
     const chip = this.activeType === null ? '' : `  [${this.activeType}]`

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -152,7 +152,11 @@ export class TaskBrowserPanel implements Component, Focusable {
    * onViewportExpose and the PageUp/PageDown step — never the budget
    * baseline, which detail rows / the sidebar can undershoot. */
   private lastRenderedStart = 0
-  private lastRenderedCount = 1
+  private lastRenderedCount = 0
+  /** Whether render() recorded a painted viewport yet. Until the first
+   * paint no row was ever seen, so the pre-paint default (0 rows) must
+   * not over-claim; setMaxRows still bounds it to the live grant. */
+  private hasRenderedViewport = false
   private readonly options: TaskPanelOptions
   private readonly searchInput = new Input()
   private searchEnabled: boolean
@@ -186,8 +190,10 @@ export class TaskBrowserPanel implements Component, Focusable {
     this.items = [...items]
     this.configuredMaxVisible = Math.max(1, Math.floor(maxVisible))
     this.maxVisible = this.configuredMaxVisible
-    // Pre-render default: the budget window. The first render's fit loop
-    // overwrites it with the ACTUAL painted window.
+    // Pre-render default: the configured window (direct embedders have no
+    // frame to tighten it). A framed mount's setMaxRows bounds it to the
+    // live grant before the first paint; the first render overwrites it
+    // with the ACTUAL painted window.
     this.lastRenderedCount = this.maxVisible
     this.options = options
     this.onSelect = onSelect
@@ -241,6 +247,10 @@ export class TaskBrowserPanel implements Component, Focusable {
     this.maxRows = Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : Number.POSITIVE_INFINITY
     this.recomputeVisibleBudget()
     this.ensureVisible()
+    // Before the first paint the recorded viewport is the live grant (the
+    // configured cap may be larger than what the frame allows); after a
+    // render the PAINTED window is authoritative and untouched here.
+    if (!this.hasRenderedViewport) this.lastRenderedCount = this.maxVisible
   }
 
   /** Derive the item window from the current chrome and row budget. */
@@ -751,6 +761,7 @@ export class TaskBrowserPanel implements Component, Focusable {
       lines.push(hintLine)
       this.lastRenderedStart = 0
       this.lastRenderedCount = 0
+      this.hasRenderedViewport = true
       return this.finalizeEmpty(lines)
     }
 
@@ -767,6 +778,7 @@ export class TaskBrowserPanel implements Component, Focusable {
       lines.push(hintLine)
       this.lastRenderedStart = 0
       this.lastRenderedCount = 0
+      this.hasRenderedViewport = true
       return this.finalizeEmpty(lines)
     }
 
@@ -837,6 +849,7 @@ export class TaskBrowserPanel implements Component, Focusable {
     // budget baseline can be larger than what details/sidebar allow.
     this.lastRenderedStart = start
     this.lastRenderedCount = itemCount
+    this.hasRenderedViewport = true
     this.exposeViewport()
     if (candidate.length <= limit) return candidate
 
@@ -850,6 +863,7 @@ export class TaskBrowserPanel implements Component, Focusable {
     return this.degradedFallback(
       selectedEntry,
       searchRowText,
+      searchEmpty,
       headerText,
       rows.length > itemCount ? `  ${this.selected + 1}/${rows.length}` : undefined,
       limit,
@@ -866,6 +880,7 @@ export class TaskBrowserPanel implements Component, Focusable {
   private degradedFallback(
     selectedEntry: { group: string | undefined; main: string; details: string[] } | undefined,
     searchRowText: string,
+    searchEmpty: boolean,
     headerText: string | undefined,
     indicatorText: string | undefined,
     limit: number,
@@ -876,10 +891,12 @@ export class TaskBrowserPanel implements Component, Focusable {
       ? color.textMuted(`── ${selectedEntry.group} ──`)
       : undefined
     const detailRows = selectedEntry?.details ?? []
+    // A typed query renders plain (the placeholder dims) — main-path parity.
+    const searchShown = searchRowText === '' ? '' : (searchEmpty ? color.textDim(searchRowText) : searchRowText)
     // Mandatory content (priority 1-2): search row, then the selected
     // main row; the hint text follows (priority 3).
     const content: string[] = []
-    if (searchRowText !== '') content.push(color.textDim(searchRowText))
+    if (searchShown !== '') content.push(searchShown)
     if (mainRow !== undefined) content.push(mainRow)
     if (content.length >= limit) return content.slice(0, limit)
     const hintIncluded = content.length + 1 <= limit
@@ -901,7 +918,7 @@ export class TaskBrowserPanel implements Component, Focusable {
     const hintBlank = used + 1 <= limit
     const out: string[] = []
     if (headerShown) out.push(color.textStrong(headerText!))
-    if (searchRowText !== '') out.push(color.textDim(searchRowText))
+    if (searchShown !== '') out.push(searchShown)
     if (groupShown) out.push(groupRow!)
     if (mainRow !== undefined) out.push(mainRow)
     out.push(...detailsShown)

--- a/src/theme-menu.ts
+++ b/src/theme-menu.ts
@@ -28,7 +28,7 @@
  * @module @xmoon76/dsh-pi-tui/theme-menu
  */
 
-import { SettingsList } from '@xmoon76/pi-tui'
+import { SettingsList, type RowBudgetAware } from '@xmoon76/pi-tui'
 import { settingsListTheme } from './theme.ts'
 import type { ThemeRegistry } from './theme-registry.ts'
 import { themePickerRows, normalizePersistedTheme } from './theme-source.ts'
@@ -70,8 +70,15 @@ export function themeDisplayName(value: string | undefined, themes: ThemeRegistr
  * P3. The outer row's display string is presentational only and is never
  * consulted for identity.
  */
-export class ThemeSubmenu {
+export class ThemeSubmenu implements RowBudgetAware {
   private readonly inner: SettingsList
+
+  /** Host row-budget seam: forward the outer SettingsList's live grant so
+   * the theme list reflows on a short terminal instead of being clipped
+   * by the compositor (the outer forwards on open and on every change). */
+  setMaxRows(rows: number): void {
+    this.inner.setMaxRows(rows)
+  }
 
   constructor(
     currentSelection: string,

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -11097,33 +11097,34 @@ export class TuiApp {
       },
       () => this.requestRender(),
     )
-    // Full (Task Center) mode is a margin-inset full-terminal overlay; the
-    // fork resolves '100%' against the inset area, so the live grant is the
-    // terminal minus the two margin rows (the responsive frame re-derives
-    // it on every resize). An ABSENT mode keeps the legacy 72-wide fixed
-    // mount (direct embedders / the historical openTaskBrowser contract).
+    // Sizing contract (TaskBrowserOptions.width/maxHeight accept numbers
+    // AND percentages; an EXPLICIT option always wins, exactly like the
+    // pre-Task-Center mount: `options.width ?? (mode==='full' ? '100%' :
+    // 72)`). The responsive frame's geometry resolver mirrors the fork's
+    // parseSizeValue rules — a percentage resolves against the terminal
+    // dimension, then everything clamps to the margin-inset available
+    // area (full mode keeps the 1-cell margin).
     const fullMode = options.mode === 'full'
-    const numericWidth = typeof options.width === 'number' && Number.isFinite(options.width)
-      ? Math.max(1, Math.floor(options.width))
-      : undefined
-    const numericMaxHeight = typeof options.maxHeight === 'number' && Number.isFinite(options.maxHeight)
-      ? Math.max(1, Math.floor(options.maxHeight))
-      : undefined
+    const overlayWidth: number | `${number}%` = options.width ?? (fullMode ? '100%' : 72)
+    const overlayMaxHeight: number | `${number}%` = options.maxHeight ?? (fullMode ? '100%' : 16)
+    const resolveSize = (value: number | `${number}%`, dimension: number, avail: number): number => {
+      const pixels = typeof value === 'number' ? value : Math.floor((dimension * parseFloat(value)) / 100)
+      return Math.max(1, Math.min(pixels, avail))
+    }
     const geometryOf = (): ResponsiveOverlayGeometry => {
-      const width = fullMode
-        ? this.terminal.columns
-        : Math.max(1, Math.min(this.terminal.columns, numericWidth ?? 72))
-      const maxHeight = fullMode
-        ? Math.max(1, this.terminal.rows - 2)
-        : Math.max(1, Math.min(this.terminal.rows, numericMaxHeight ?? 16))
+      const marginInset = fullMode ? 2 : 0
+      const availWidth = Math.max(1, this.terminal.columns - marginInset)
+      const availHeight = Math.max(1, this.terminal.rows - marginInset)
+      const width = resolveSize(overlayWidth, this.terminal.columns, availWidth)
+      const maxHeight = resolveSize(overlayMaxHeight, this.terminal.rows, availHeight)
       return { width, maxHeight, key: `${width}:${maxHeight}` }
     }
     const frame = new ResponsiveOverlayFrame(panel, geometryOf, geometry => {
       panel.setMaxRows(Math.max(1, geometry.maxHeight - 2))
     })
     const handle = this.showOverlayOnHost(frame, {
-      width: fullMode ? '100%' : (numericWidth ?? 72),
-      maxHeight: fullMode ? '100%' : (numericMaxHeight ?? 16),
+      width: overlayWidth,
+      maxHeight: overlayMaxHeight,
       margin: fullMode ? 1 : undefined,
     })
     // One close path: hide the overlay AND stop the panel's 1s elapsed tick

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -11105,8 +11105,16 @@ export class TuiApp {
     // dimension, then everything clamps to the margin-inset available
     // area (full mode keeps the 1-cell margin).
     const fullMode = options.mode === 'full'
-    const overlayWidth: number | `${number}%` = options.width ?? (fullMode ? '100%' : 72)
-    const overlayMaxHeight: number | `${number}%` = options.maxHeight ?? (fullMode ? '100%' : 16)
+    // A non-finite numeric option (NaN) falls back to the mode default —
+    // the fork would otherwise resolve the geometry to NaN (review NIT).
+    const widthOption = typeof options.width === 'number' && !Number.isFinite(options.width)
+      ? undefined
+      : options.width
+    const maxHeightOption = typeof options.maxHeight === 'number' && !Number.isFinite(options.maxHeight)
+      ? undefined
+      : options.maxHeight
+    const overlayWidth: number | `${number}%` = widthOption ?? (fullMode ? '100%' : 72)
+    const overlayMaxHeight: number | `${number}%` = maxHeightOption ?? (fullMode ? '100%' : 16)
     const resolveSize = (value: number | `${number}%`, dimension: number, avail: number): number => {
       const pixels = typeof value === 'number' ? value : Math.floor((dimension * parseFloat(value)) / 100)
       return Math.max(1, Math.min(pixels, avail))

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -123,7 +123,7 @@ import {
 } from './present.ts'
 import { TranscriptSearchComponent } from './search.ts'
 import { CompactTextPreview } from './compact-text-preview.ts'
-import { HistoryPanel } from './history-panel.ts'
+import { HistoryPanel, historyOverlayGeometry } from './history-panel.ts'
 import type { HistorySearchSource } from './history-search.ts'
 import { QuestionFlow } from './question.ts'
 import { MentionProvider } from './mentions.ts'
@@ -444,6 +444,58 @@ class FocusForwardingFrame extends Frame implements Focusable {
     if (this.disposed) return
     this.disposed = true
     this.ownedChild.dispose?.()
+  }
+}
+
+/** Geometry passed to a live responsive overlay frame. */
+interface ResponsiveOverlayGeometry {
+  width: number
+  maxHeight: number
+  key: string
+}
+
+/**
+ * A root-owned responsive overlay shell. The fork re-resolves percentage
+ * overlay options each frame, while this shell keeps a first-party frame's
+ * content width and row budget derived from the same current geometry. It
+ * centers a narrower design width inside the full-width overlay canvas, so
+ * no modal handle needs to be replaced during a resize (and its broker graph
+ * remains untouched).
+ */
+class ResponsiveOverlayFrame extends FocusForwardingFrame {
+  private readonly geometryOf: () => ResponsiveOverlayGeometry
+  private readonly onGeometry: ((geometry: ResponsiveOverlayGeometry) => void) | undefined
+  private lastGeometryKey = ''
+
+  constructor(
+    child: Component,
+    geometryOf: () => ResponsiveOverlayGeometry,
+    onGeometry?: (geometry: ResponsiveOverlayGeometry) => void,
+  ) {
+    super(child, true)
+    this.geometryOf = geometryOf
+    this.onGeometry = onGeometry
+    this.syncGeometry()
+  }
+
+  /** Re-run the geometry callback without scheduling a frame. */
+  syncGeometry(): ResponsiveOverlayGeometry {
+    const geometry = this.geometryOf()
+    if (geometry.key !== this.lastGeometryKey) {
+      this.lastGeometryKey = geometry.key
+      this.onGeometry?.(geometry)
+    }
+    return geometry
+  }
+
+  render(width: number): string[] {
+    const geometry = this.syncGeometry()
+    const availableWidth = Math.max(1, Math.floor(width))
+    const frameWidth = Math.max(1, Math.min(availableWidth, Math.floor(geometry.width)))
+    const lines = super.render(frameWidth)
+    if (frameWidth === availableWidth) return lines
+    const left = Math.max(0, Math.floor((availableWidth - frameWidth) / 2))
+    return lines.map(line => `${' '.repeat(left)}${line}${' '.repeat(Math.max(0, availableWidth - left - visibleWidth(line)))}`)
   }
 }
 
@@ -898,6 +950,55 @@ function capWrappedToMarker(text: string, width: number, budget: number): { text
   }
 }
 
+/**
+ * The state-free approval content surface. It rebuilds from the original
+ * request when the live width/height budget changes, while keeping the
+ * pending promise and modal handle untouched.
+ */
+class ApprovalDialogSurface implements Component {
+  private readonly request: ApprovalPromptRequest
+  private readonly geometryOf: () => ApprovalOverlayGeometry
+  private readonly build: (request: ApprovalPromptRequest, geometry: ApprovalOverlayGeometry) => Component
+  private cached: Component | undefined
+  private cacheKey = ''
+
+  constructor(
+    request: ApprovalPromptRequest,
+    geometryOf: () => ApprovalOverlayGeometry,
+    build: (request: ApprovalPromptRequest, geometry: ApprovalOverlayGeometry) => Component,
+  ) {
+    this.request = request
+    this.geometryOf = geometryOf
+    this.build = build
+  }
+
+  invalidate(): void {
+    this.cached?.invalidate?.()
+    this.cached = undefined
+    this.cacheKey = ''
+  }
+
+  render(width: number): string[] {
+    const geometry = this.geometryOf()
+    const contentWidth = Math.max(1, Math.floor(width))
+    const key = `${geometry.maxHeight}:${contentWidth}`
+    if (this.cached === undefined || this.cacheKey !== key) {
+      this.cached?.dispose?.()
+      this.cached = this.build(this.request, {
+        ...geometry,
+        contentWidth: Math.min(geometry.contentWidth, contentWidth),
+      })
+      this.cacheKey = key
+    }
+    return this.cached.render(contentWidth)
+  }
+
+  dispose(): void {
+    this.cached?.dispose?.()
+    this.cached = undefined
+  }
+}
+
 /** The live job-output viewer body: a title line + refreshable text panel. */
 class OutputViewerPanel implements Component {
   private readonly title: Text
@@ -1292,6 +1393,21 @@ export interface ApprovalPromptRequest {
 /** Closed approval outcomes the user can produce at the prompt. */
 export type ApprovalOutcome = 'allowed-once' | 'rejected' | 'cancelled'
 
+/** The live geometry budget for the approval overlay. */
+export interface ApprovalOverlayGeometry {
+  width: number
+  maxHeight: number
+  contentWidth: number
+}
+
+/** Derive approval geometry from the CURRENT terminal dimensions. */
+export function approvalOverlayGeometry(columns: number, rows: number): ApprovalOverlayGeometry {
+  const width = Number.isFinite(columns) ? Math.max(1, Math.floor(columns)) : 1
+  const height = Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : 1
+  const maxHeight = Math.max(1, Math.min(height, 16, Math.max(8, height - 2)))
+  return { width, maxHeight, contentWidth: Math.max(1, width - 8) }
+}
+
 /** One todo entry as logged by todo/write; statuses and text verbatim. */
 export interface TodoItem {
   content: string
@@ -1567,6 +1683,8 @@ interface PendingApproval {
   request: ApprovalPromptRequest
   resolve: (outcome: ApprovalOutcome) => void
   handle?: OverlayHandle
+  /** The live geometry wrapper behind the current approval handle. */
+  responsiveFrame?: ResponsiveOverlayFrame
   onAbort?: () => void
   /** Settled once: an abort and a user decision must not double-resolve. */
   settled?: boolean
@@ -2059,6 +2177,8 @@ export class TuiApp {
   private historyPanel: HistoryPanel | undefined
   /** The overlay handle of the history panel (hide() closes it). */
   private historyOverlay: OverlayHandle | undefined
+  /** The responsive shell survives a resize and a fullscreen screen swap. */
+  private historyResponsiveFrame: ResponsiveOverlayFrame | undefined
   /** Footer configurators own paste timers outside the generic overlay
    * disposal path; final surface disposal closes every still-open one. */
   private readonly footerConfiguratorClosers = new Set<() => void>()
@@ -4461,6 +4581,7 @@ export class TuiApp {
     const active = this.fullscreen !== undefined
     if (enabled === active) return
     const pending = this.activeApproval
+    const history = this.historyPanel
     pending?.handle?.hide()
     this.disposeTrackedKeybindingEditors()
     // overlayHandles holds RAW handles (showOverlayOnHost stores them before
@@ -4630,6 +4751,12 @@ export class TuiApp {
     this.remountExtensionOverlays()
     this.remountAdvancedOverlays()
     this.remountUnstableMounts()
+    // The old screen's raw history handle was removed above without
+    // disposing its remountable panel. Reattach that same stateful panel to
+    // the new screen before restoring any modal that sat above it.
+    this.historyOverlay = undefined
+    this.historyResponsiveFrame = undefined
+    if (history !== undefined) this.mountHistoryOverlay(history)
     if (pending !== undefined) this.renderApprovalDialog(pending)
     // A question survives the switch through the SHARED seat (both screens'
     // layouts hold the same editorSeat): keep its frame focused on the new
@@ -4701,14 +4828,7 @@ export class TuiApp {
     if (this.historyPanel !== undefined) return
     if (this.historySearchSource === undefined) return
     if (this.disposed) return
-    const columns = this.terminal.columns
-    const rows = this.terminal.rows
-    // The overlay must NEVER exceed the terminal (plan §51): width/height
-    // are clamped to the real columns/rows (a 50×10 terminal must not
-    // request a 60×14 panel). The panel's row budget is the overlay's
-    // maxHeight minus the Frame's two border rows.
-    const width = Math.min(columns - 2, Math.max(20, Math.min(100, columns - 6)))
-    const maxHeight = Math.min(rows - 2, Math.max(8, Math.min(30, rows - 4)))
+    const geometry = historyOverlayGeometry(this.terminal.columns, this.terminal.rows)
     const panel = new HistoryPanel({
       source: this.historySearchSource,
       // Resolve the cwd at OPEN time (session switches move it): the
@@ -4720,7 +4840,7 @@ export class TuiApp {
       // the panel's whole lifetime (a switch while the panel is up keeps
       // the search stable; the next open re-resolves).
       sessionId: this.historySearchSessionId?.(),
-      maxRows: maxHeight - 2, // the Frame adds its two border rows
+      maxRows: geometry.panelRows,
       onResultsChanged: () => this.requestRender(),
       onAccept: (content) => {
         this.closeHistorySearch()
@@ -4733,17 +4853,42 @@ export class TuiApp {
     })
     panel.start()
     this.historyPanel = panel
-    this.historyOverlay = this.showOverlayOnHost(new FocusForwardingFrame(panel), { width, maxHeight })
+    this.mountHistoryOverlay(panel)
+  }
+
+  /** Mount an existing history panel on the current physical screen. */
+  private mountHistoryOverlay(panel: HistoryPanel): void {
+    const geometryOf = (): ResponsiveOverlayGeometry => {
+      const geometry = historyOverlayGeometry(this.terminal.columns, this.terminal.rows)
+      return {
+        width: geometry.width,
+        maxHeight: geometry.maxHeight,
+        key: `${geometry.width}:${geometry.maxHeight}:${geometry.panelRows}`,
+      }
+    }
+    const frame = new ResponsiveOverlayFrame(panel, geometryOf, geometry => {
+      panel.setMaxRows(Math.max(1, geometry.maxHeight - 2))
+    })
+    this.historyResponsiveFrame = frame
+    this.historyOverlay = this.showOverlayOnHost(
+      frame,
+      { width: '100%', maxHeight: '100%' },
+      { remountable: true },
+    )
   }
 
   /** Close the history panel (Esc/Ctrl+C, accept, surface dispose). */
   closeHistorySearch(): void {
-    if (this.historyOverlay === undefined) return
-    // The owning FocusForwardingFrame + disposeOnHide release the panel's
-    // debounce timer/controller on hide (X007).
-    this.historyOverlay.hide()
+    const overlay = this.historyOverlay
+    const panel = this.historyPanel
     this.historyOverlay = undefined
+    this.historyResponsiveFrame = undefined
     this.historyPanel = undefined
+    overlay?.hide()
+    // Remountable history overlays intentionally opt out of disposeOnHide so
+    // fullscreen migration can retain query/results/selection. The final
+    // close owns the panel lifecycle explicitly.
+    panel?.dispose()
   }
 
   /** Publish the current match position for the overlay header (1-based, total). */
@@ -9245,6 +9390,8 @@ export class TuiApp {
     try {
       const width = this.terminal.columns
       const height = this.terminal.rows
+      const widthChanged = width !== this.lastTranscriptWidth
+      const heightChanged = height !== this.lastAdvancedGeometry.height
       // The transcript folds bake width-dependent truncations at build
       // time (folded tool/system/compaction/local-shell rows): a WIDTH
       // change must rebuild them at the new content width — a stale bake
@@ -9252,9 +9399,16 @@ export class TuiApp {
       // contract (the right-gutter resize matrix). The latch skips the
       // first geometry pass (nothing built yet); the rebuild re-enters
       // requestRender, where the latch is already updated, so no loop.
-      if (width !== this.lastTranscriptWidth) {
+      if (widthChanged) {
         this.lastTranscriptWidth = width
         if (this.messageRows.length > 0) this.rebuildMessages()
+      }
+      if (widthChanged) {
+        // Queue/todo rows are width-baked strings, not merely live-wrapped
+        // components. Rebuild from their raw state before chrome measurement
+        // so fullscreen hit-testing and footer budgets see the new geometry.
+        this.rebuildQueuePane(width)
+        this.rebuildTodoPanel(width)
       }
       // M5: a material WIDTH change refreshes the command surface (the
       // runner coalesces to its interval).
@@ -9272,6 +9426,10 @@ export class TuiApp {
         this.lastAdvancedGeometry = { width, height }
         this.recompileAdvancedOverlays()
       }
+      if (widthChanged || heightChanged) {
+        this.historyResponsiveFrame?.syncGeometry()
+        this.activeApproval?.responsiveFrame?.syncGeometry()
+      }
       // PR #57 review (P1): the footer's physical-line budget derives from
       // the terminal GEOMETRY, the ACTIVE SURFACE and the MEASURED chrome
       // heights — a resize (height AND width), a fullscreen toggle or a
@@ -9287,13 +9445,13 @@ export class TuiApp {
       const host = this.extensionHost
       if (host !== undefined) {
         const current = host.state().surface
-      // focusedSeat derives from the actual focus state (follow-up P1): the
-      // seat tracker is updated by showOverlayOnHost/closeOverlayHandle/
-      // question/approval/fullscreen entry; the requestRender mirror only
-      // publishes it here (plus the stale-frame safety net below). The LIVE
-      // focusSeat (not the microtask-published copy) is authoritative — a
-      // publish that changed nothing must still mirror the real seat.
-      this.publishFocusSeat()
+        // focusedSeat derives from the actual focus state (follow-up P1): the
+        // seat tracker is updated by showOverlayOnHost/closeOverlayHandle/
+        // question/approval/fullscreen entry; the requestRender mirror only
+        // publishes it here (plus the stale-frame safety net below). The LIVE
+        // focusSeat (not the microtask-published copy) is authoritative — a
+        // publish that changed nothing must still mirror the real seat.
+        this.publishFocusSeat()
         const focusedSeat = this.focusSeat
         if (current.width !== width || current.height !== height || current.focusedSeat !== focusedSeat) {
           host.updateSurface({ width, height, focusedSeat })
@@ -9308,6 +9466,12 @@ export class TuiApp {
           }
         }
       }
+      // Height-only resizes must re-bake the widget row budgets after the
+      // surface snapshot adopted the new height. A width change already
+      // reaches renderWidgets() through refreshChrome() below, so gate the
+      // explicit call on `!widthChanged` to avoid a second identical bake.
+      if (heightChanged && !widthChanged && host !== undefined && host.state().surface.width === width
+        && host.state().surface.height === height) this.renderWidgets()
       // The footer recompose runs LAST: the budget is keyed on the
       // MEASURED effective total (surface + geometry + actual chrome
       // heights), so a widget-zone bake, a resize or a mode switch all
@@ -9463,7 +9627,7 @@ export class TuiApp {
    * (in_progress first, then pending, then completed (strikethrough)); the
    * full list when expanded (fullscreen click on the panel toggles).
    */
-  private renderTodoPanel(): void {
+  private rebuildTodoPanel(width: number): void {
     if (!this.todoPanelVisible) {
       this.todoPanel.setText('')
       return
@@ -9477,8 +9641,8 @@ export class TuiApp {
       ...this.todoItems.filter(todo => todo.status === 'completed'),
     ]
     const shown = this.todoExpanded ? ordered : ordered.slice(0, TODO_COMPACT_LIMIT)
-    const width = Math.max(1, this.terminal.columns)
-    const border = color.border(` ${'─'.repeat(Math.max(0, width - 2))} `)
+    const safeWidth = Math.max(1, Math.floor(width))
+    const border = color.border(` ${'─'.repeat(Math.max(0, safeWidth - 2))} `)
     // Title: bold, two-cell indent.
     const title = color.textStrong('  Todo')
     if (shown.length === 0) {
@@ -9490,6 +9654,11 @@ export class TuiApp {
       return `${mark(todo)} ${body}`
     })
     this.todoPanel.setText([border, title, ...lines].join('\n'))
+  }
+
+  /** Rebuild the todo panel from the current terminal width. */
+  private renderTodoPanel(): void {
+    this.rebuildTodoPanel(this.terminal.columns)
   }
 
   /** Whether Thinking blocks currently render FULL (true) or COMPACT with
@@ -9879,21 +10048,20 @@ export class TuiApp {
   /** Notice rows shown in full before the `+N more` fold (user rows are never folded). */
   private static readonly MAX_NOTICE_ROWS = 5
 
-  /** Rebuild the queue pane text from the current inbox rows. */
-  private renderQueuePane(): void {
+  /** Rebuild the queue pane text from the current inbox rows and width. */
+  private rebuildQueuePane(width: number): void {
     const items = this.queueItems
     if (items.length === 0) {
       // An emptied pane must not leave its previously painted rows behind
       // (fork trap): the empty Text renders no lines and the requested
       // frame repaints the region.
       this.queuePane.setText('')
-      this.requestRender()
       return
     }
-    const width = Math.max(1, this.terminal.columns)
+    const safeWidth = Math.max(1, Math.floor(width))
     // Panel border rules indent one cell on each side so the boundary never
     // reads as the editor's full-width border.
-    const lines = [color.border(` ${'─'.repeat(Math.max(0, width - 2))} `)]
+    const lines = [color.border(` ${'─'.repeat(Math.max(0, safeWidth - 2))} `)]
     // User-origin rows are the user's OWN queued input: always fully
     // visible, never folded. Notice rows (plugin notifications, subagent
     // reports, injected instructions) are at-a-glance transport only:
@@ -9906,7 +10074,7 @@ export class TuiApp {
     const shownNotices = noticeRows.slice(0, TuiApp.MAX_NOTICE_ROWS)
     for (const item of userRows) {
       const text = item.text.replace(/\s+/g, ' ').trim()
-      const truncated = truncateToWidth(text, Math.max(1, width - visibleWidth('❯ ')), '…')
+      const truncated = truncateToWidth(text, Math.max(1, safeWidth - visibleWidth('❯ ')), '…')
       // User-origin rows carry the SAME brand-blue ❯ as the transcript
       // bubbles and the editor prompt — one marker for the user's own
       // input everywhere (pending here, delivered up there).
@@ -9919,14 +10087,14 @@ export class TuiApp {
       // steer/edit verbs when nothing else is queued.
       const text = item.text.replace(/\s+/g, ' ').trim()
       const lead = iconLead('queue-notice', this.iconStyle)
-      const truncated = truncateToWidth(text, Math.max(1, width - visibleWidth(lead)), '…')
+      const truncated = truncateToWidth(text, Math.max(1, safeWidth - visibleWidth(lead)), '…')
       lines.push(`${color.textDim(lead)}${color.textDim(truncated)}`)
     }
     const folded = noticeRows.length - shownNotices.length
     if (folded > 0) {
       lines.push(color.textDim(truncateToWidth(
         `  +${folded} more notices pending · they deliver as the next turn runs`,
-        Math.max(1, width - 2),
+        Math.max(1, safeWidth - 2),
         '…',
       )))
     }
@@ -9934,8 +10102,13 @@ export class TuiApp {
     const hint = hasSteerable
       ? `${(this.keybindings.keyHint('app.input.steer') || 'the steer key').toLowerCase()} to steer all · ${(this.keybindings.keyHint('app.input.dequeue') || 'the recall key').toLowerCase()} to edit all`
       : 'notices deliver after the current task · /tasks to view'
-    lines.push(color.textDim(truncateToWidth(`  ${hint}`, Math.max(1, width - 2), '…')))
+    lines.push(color.textDim(truncateToWidth(`  ${hint}`, Math.max(1, safeWidth - 2), '…')))
     this.queuePane.setText(lines.join('\n'))
+  }
+
+  /** Rebuild the queue pane at the current terminal width and repaint. */
+  private renderQueuePane(): void {
+    this.rebuildQueuePane(this.terminal.columns)
     this.requestRender()
   }
 
@@ -10604,7 +10777,17 @@ export class TuiApp {
     // restart the cycle even without a selection move — review P2); with
     // no marquee the list mounts directly, exactly as before.
     const mounted = marquee === undefined ? list : new MarqueeFilterAdapter(list, () => marquee.reset())
-    const handle = this.showOverlayOnHost(new FocusForwardingFrame(mounted, true), { width: options.width ?? 64, maxHeight: options.maxHeight ?? 24 })
+    const configuredWidth = Number.isFinite(options.width) ? Math.max(1, Math.floor(options.width!)) : 64
+    const configuredMaxHeight = Number.isFinite(options.maxHeight) ? Math.max(1, Math.floor(options.maxHeight!)) : 24
+    const geometryOf = (): ResponsiveOverlayGeometry => {
+      const width = Math.max(1, Math.min(this.terminal.columns, configuredWidth))
+      const maxHeight = Math.max(1, Math.min(this.terminal.rows, configuredMaxHeight))
+      return { width, maxHeight, key: `${width}:${maxHeight}` }
+    }
+    const frame = new ResponsiveOverlayFrame(mounted, geometryOf, geometry => {
+      list.setMaxRows(Math.max(1, geometry.maxHeight - 2))
+    })
+    const handle = this.showOverlayOnHost(frame, { width: configuredWidth, maxHeight: configuredMaxHeight })
     // Phase 4: an abort signal closes the picker and fires onCancel (the
     // imperative select broker's fiber-cancellation path). The listener
     // is removed on a normal select/cancel AND on the handle's close
@@ -10760,7 +10943,17 @@ export class TuiApp {
       // Search edits inside a category must restart the marquee too (the
       // vendored SelectList fires no selection change for query edits).
       const mounted = marquee === undefined ? next : new MarqueeFilterAdapter(next, () => marquee.reset())
-      overlay = this.showOverlayOnHost(new FocusForwardingFrame(mounted, true), { width: options.width ?? 64, maxHeight: options.maxHeight ?? 24 })
+      const configuredWidth = Number.isFinite(options.width) ? Math.max(1, Math.floor(options.width!)) : 64
+      const configuredMaxHeight = Number.isFinite(options.maxHeight) ? Math.max(1, Math.floor(options.maxHeight!)) : 24
+      const geometryOf = (): ResponsiveOverlayGeometry => {
+        const width = Math.max(1, Math.min(this.terminal.columns, configuredWidth))
+        const maxHeight = Math.max(1, Math.min(this.terminal.rows, configuredMaxHeight))
+        return { width, maxHeight, key: `${width}:${maxHeight}` }
+      }
+      const frame = new ResponsiveOverlayFrame(mounted, geometryOf, geometry => {
+        next.setMaxRows(Math.max(1, geometry.maxHeight - 2))
+      })
+      overlay = this.showOverlayOnHost(frame, { width: configuredWidth, maxHeight: configuredMaxHeight })
     }
     // Phase 4 parity: an abort signal closes the CURRENT overlay and fires
     // onCancel. The listener lives once on the signal — category switches
@@ -10904,10 +11097,34 @@ export class TuiApp {
       },
       () => this.requestRender(),
     )
-    const handle = this.showOverlayOnHost(new FocusForwardingFrame(panel, true), {
-      width: options.width ?? (options.mode === 'full' ? '100%' : 72),
-      maxHeight: options.maxHeight ?? (options.mode === 'full' ? '100%' : 16),
-      margin: options.mode === 'full' ? 1 : undefined,
+    // Full (Task Center) mode is a margin-inset full-terminal overlay; the
+    // fork resolves '100%' against the inset area, so the live grant is the
+    // terminal minus the two margin rows (the responsive frame re-derives
+    // it on every resize). An ABSENT mode keeps the legacy 72-wide fixed
+    // mount (direct embedders / the historical openTaskBrowser contract).
+    const fullMode = options.mode === 'full'
+    const numericWidth = typeof options.width === 'number' && Number.isFinite(options.width)
+      ? Math.max(1, Math.floor(options.width))
+      : undefined
+    const numericMaxHeight = typeof options.maxHeight === 'number' && Number.isFinite(options.maxHeight)
+      ? Math.max(1, Math.floor(options.maxHeight))
+      : undefined
+    const geometryOf = (): ResponsiveOverlayGeometry => {
+      const width = fullMode
+        ? this.terminal.columns
+        : Math.max(1, Math.min(this.terminal.columns, numericWidth ?? 72))
+      const maxHeight = fullMode
+        ? Math.max(1, this.terminal.rows - 2)
+        : Math.max(1, Math.min(this.terminal.rows, numericMaxHeight ?? 16))
+      return { width, maxHeight, key: `${width}:${maxHeight}` }
+    }
+    const frame = new ResponsiveOverlayFrame(panel, geometryOf, geometry => {
+      panel.setMaxRows(Math.max(1, geometry.maxHeight - 2))
+    })
+    const handle = this.showOverlayOnHost(frame, {
+      width: fullMode ? '100%' : (numericWidth ?? 72),
+      maxHeight: fullMode ? '100%' : (numericMaxHeight ?? 16),
+      margin: fullMode ? 1 : undefined,
     })
     // One close path: hide the overlay AND stop the panel's 1s elapsed tick
     // (an unref'd interval must still be cleared — the panel is gone).
@@ -10986,7 +11203,17 @@ export class TuiApp {
       handle?.hide()
       onCancel()
     }, { enableSearch: true })
-    handle = this.showOverlayOnHost(new FocusForwardingFrame(settings, true), { width: 72, maxHeight: 28 })
+    const configuredWidth = 72
+    const configuredMaxHeight = 28
+    const geometryOf = (): ResponsiveOverlayGeometry => {
+      const width = Math.max(1, Math.min(this.terminal.columns, configuredWidth))
+      const maxHeight = Math.max(1, Math.min(this.terminal.rows, configuredMaxHeight))
+      return { width, maxHeight, key: `${width}:${maxHeight}` }
+    }
+    const frame = new ResponsiveOverlayFrame(settings, geometryOf, geometry => {
+      settings.setMaxRows(Math.max(1, geometry.maxHeight - 2))
+    })
+    handle = this.showOverlayOnHost(frame, { width: configuredWidth, maxHeight: configuredMaxHeight })
     return () => handle?.hide()
   }
 
@@ -11382,13 +11609,30 @@ export class TuiApp {
 
   /** Build and mount the approval dialog for one prompt on the active screen. */
   private renderApprovalDialog(pending: PendingApproval): void {
-    // Full terminal width (kimi dialog parity): a fixed 60-wide box on a
-    // narrow terminal left base-content slivers glued to the border (the
-    // "stray characters" report). The Box pads every row to the width, so
-    // the frame spans the whole terminal and the base stays covered.
-    const width = this.terminal.columns
-    const maxHeight = Math.max(8, Math.min(16, this.terminal.rows - 2))
-    const contentWidth = Math.max(1, width - 8)
+    const geometryOf = (): ApprovalOverlayGeometry => approvalOverlayGeometry(
+      this.terminal.columns,
+      this.terminal.rows,
+    )
+    const surface = new ApprovalDialogSurface(
+      pending.request,
+      geometryOf,
+      (request, geometry) => this.buildApprovalDialog(request, geometry),
+    )
+    const frame = new ResponsiveOverlayFrame(surface, () => {
+      const geometry = geometryOf()
+      return {
+        width: geometry.width,
+        maxHeight: geometry.maxHeight,
+        key: `${geometry.width}:${geometry.maxHeight}:${geometry.contentWidth}`,
+      }
+    })
+    pending.responsiveFrame = frame
+    pending.handle = this.showOverlayOnHost(frame, { width: '100%', maxHeight: '100%' })
+  }
+
+  /** Build approval content for the current geometry without mounting it. */
+  private buildApprovalDialog(request: ApprovalPromptRequest, geometry: ApprovalOverlayGeometry): Component {
+    const { maxHeight, contentWidth } = geometry
     // Height budget in WRAPPED rows: the dialog must NEVER lose the key
     // hints or the bottom border to the maxHeight slice. The title and the
     // danger banner are width-cropped so each is exactly ONE display row;
@@ -11396,8 +11640,8 @@ export class TuiApp {
     // (shrunk when the terminal is too small for it). Fixed chrome = 1
     // title + danger + 1 blank spacer + hint rows + 2 Box paddingY
     // (Box(1,1)) + 2 Frame borders — keep in sync with the geometry below.
-    const titleShown = truncateToWidth(`Approve ${pending.request.toolName}?`, contentWidth, '…')
-    const dangerShown = pending.request.danger === true
+    const titleShown = truncateToWidth(`Approve ${request.toolName}?`, contentWidth, '…')
+    const dangerShown = request.danger === true
       ? truncateToWidth('⚠ DANGEROUS COMMAND — confirm carefully', contentWidth, '…')
       : ''
     const HINTS = '[y] allow once   [n] reject   [esc/ctrl+c] cancel'
@@ -11411,7 +11655,7 @@ export class TuiApp {
     // section ends in a `... N more` marker row that rides inside its
     // budget, so the dialog tells the user what was dropped.
     const reasonBudget = Math.max(0, maxHeight - chrome)
-    const reasonRaw = pending.request.reason ?? ''
+    const reasonRaw = request.reason ?? ''
     const reasonShown = capWrappedToMarker(reasonRaw, contentWidth, reasonBudget).text
     const reasonWrapped = reasonShown === '' ? 0 : wrapTextWithAnsi(reasonShown, contentWidth).length
     const previewBudget = Math.max(0, maxHeight - chrome - reasonWrapped)
@@ -11420,11 +11664,11 @@ export class TuiApp {
     if (dangerShown !== '') {
       dialog.addChild(new Text(color.error(dangerShown), 1, 0))
     }
-    if (pending.request.arguments !== undefined && pending.request.arguments !== '' && previewBudget > 0) {
+    if (request.arguments !== undefined && request.arguments !== '' && previewBudget > 0) {
       // Preview the first six argument lines; the marker helper owns ALL
       // truncation (a separate 240-char '…' pre-cap left an uncounted cut
       // when the capped string still fit the budget).
-      const sixLines = pending.request.arguments.split('\n').slice(0, 6).join('\n')
+      const sixLines = request.arguments.split('\n').slice(0, 6).join('\n')
       const previewShown = capWrappedToMarker(sixLines, contentWidth, previewBudget).text
       if (previewShown !== '') {
         dialog.addChild(new Text(color.textDim(previewShown), 1, 0))
@@ -11435,7 +11679,7 @@ export class TuiApp {
     }
     dialog.addChild(new Text(' ', 1, 0))
     dialog.addChild(new Text(hintShown, 1, 0))
-    pending.handle = this.showOverlayOnHost(new Frame(dialog), { width, maxHeight })
+    return dialog
   }
 
   /** Route a key while a prompt is showing; every key is consumed. */
@@ -11461,6 +11705,7 @@ export class TuiApp {
     if (this.activeApproval === pending) {
       this.activeApproval = undefined
       pending.handle?.hide()
+      pending.responsiveFrame = undefined
       this.activeScreen.setFocus(this.seatEditor().component)
       // The approval dialog is gone: the seat is the editor again (or the
       // next queued prompt's — showNextApproval re-derives it) (follow-up P1).

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -76,6 +76,47 @@ test('approval prompt with long args and reason keeps the frame and key hints in
   assert.equal(await decision, 'rejected')
 })
 
+test('approval dialog rebuilds original content across a wide-to-narrow-to-wide resize', async () => {
+  const { vt, app } = startApp()
+  vt.resize(120, 30)
+  await viewport(vt)
+  const marker = 'WIDE_APPROVAL_CONTENT_RESTORED'
+  const decision = app.showApprovalPrompt({
+    toolName: 'bash',
+    reason: 'wide reason '.repeat(8) + marker,
+    arguments: 'arg one\narg two\narg three',
+  })
+  let view = await viewport(vt)
+  assert.ok(view.includes(marker), `wide approval content missing before shrink:\n${view}`)
+  vt.resize(50, 10)
+  view = await viewport(vt)
+  assertDialogIntact(view)
+  vt.resize(120, 30)
+  view = await viewport(vt)
+  assert.ok(view.includes(marker), `wide approval content was not restored:\n${view}`)
+  vt.sendInput('n')
+  assert.equal(await decision, 'rejected')
+})
+
+test('approval dialog reflows a narrow-open prompt when the terminal grows', async () => {
+  const { vt, app } = startApp()
+  vt.resize(50, 10)
+  await viewport(vt)
+  const marker = 'NARROW_OPEN_APPROVAL_RESTORED'
+  const decision = app.showApprovalPrompt({
+    toolName: 'edit_file',
+    reason: 'narrow reason '.repeat(24) + marker,
+    arguments: 'first argument\nsecond argument',
+  })
+  let view = await viewport(vt)
+  assertDialogIntact(view)
+  vt.resize(120, 30)
+  view = await viewport(vt)
+  assert.ok(view.includes(marker), `grown approval content missing:\n${view}`)
+  vt.sendInput('n')
+  assert.equal(await decision, 'rejected')
+})
+
 test('dangerous approval with long content keeps hints and both borders', async () => {
   const { vt, app } = startApp()
   const decision = app.showApprovalPrompt({

--- a/test/history-panel.test.ts
+++ b/test/history-panel.test.ts
@@ -374,6 +374,24 @@ test('panel: the detail pane is suppressed (never truncated) when the budget can
   assert.ok(roomyLines.some(line => line.includes('Session:')), 'Session must render')
 })
 
+test('panel: setMaxRows reflows the live row budget without losing selection', async () => {
+  const source = new FakeSource()
+  source.rows = Array.from({ length: 20 }, (_, index) => row(`entry ${index}`, 20 - index))
+  const { panel } = makePanel(source, { maxRows: 16 })
+  panel.start()
+  await settle()
+  for (let step = 0; step < 12; step += 1) panel.handleInput('\x1b[B')
+  assert.equal(panel.selected()?.content, 'entry 12')
+  panel.setMaxRows(8)
+  const narrow = panel.render(80)
+  assert.ok(narrow.length <= 8, `setMaxRows must cap the render (got ${narrow.length})`)
+  assert.ok(narrow.some(line => line.includes('entry 12')), 'the selected row must survive a shrink')
+  panel.setMaxRows(16)
+  const wide = panel.render(80)
+  assert.ok(wide.length > narrow.length, 'growing the budget must reflow more rows')
+  assert.ok(wide.some(line => line.includes('entry 12')), 'the selected row must survive a grow')
+})
+
 test('panel: maxRows 1–2 never overflows (the chrome yields, not the budget)', () => {
   // Round-6 repro: render() always emitted title + search + one body row
   // (3 rows), overflowing maxRows 1 and 2.

--- a/test/model-menu.test.ts
+++ b/test/model-menu.test.ts
@@ -111,6 +111,47 @@ async function settle(): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, 30))
 }
 
+test('model submenu reflows to a short terminal without losing the selected model or hint', async () => {
+  const applied: ModelSelection[] = []
+  const { vt } = await openModelFlow(
+    fakeLlm({ models: Array.from({ length: 12 }, (_, index) => ({ id: `m${index}` })), efforts: undefined }),
+    applied,
+  )
+  await settle()
+  for (let index = 0; index < 6; index += 1) vt.sendInput('\x1b[B') // select m6
+  await vt.waitForRender()
+  vt.resize(80, 10) // shrink: the outer grant (maxRows = min(rows,28) − 2) must reach the inner model list
+  await settle()
+  const view = await viewport(vt)
+  assert.ok(view.includes('m6'), `selected model must survive the shrink:\n${view}`)
+  assert.ok(view.includes('Esc to cancel'), `submenu hint must survive the shrink:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
+test('model submenu applies the row budget to a list that lands after a resize', async () => {
+  const applied: ModelSelection[] = []
+  let resolveModels!: (rows: readonly { id: string }[]) => void
+  const deferred = {
+    listModels: () => new Promise<readonly { id: string }[]>((resolve) => { resolveModels = resolve }),
+    resolveModelInfo: async (): Promise<unknown> => ({}),
+  }
+  const { vt } = await openModelFlow(deferred, applied)
+  // Resize WHILE the model list is still loading: the grant lands on the
+  // loading shell and must be re-applied when the async list swaps in —
+  // without the rowGrant re-apply the inner list would keep maxVisible 6
+  // and the 8-row frame would clip the hint.
+  vt.resize(80, 10)
+  await vt.waitForRender()
+  resolveModels(Array.from({ length: 12 }, (_, index) => ({ id: `m${index}` })))
+  await settle()
+  const view = await viewport(vt)
+  assert.ok(view.includes('m0'), `the swapped-in model list must render the selected row:\n${view}`)
+  assert.ok(view.includes('Esc to cancel'), `the swapped-in list must honor the grant (hint needs re-apply):\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
 test('model submenu loads the model list in place and applies on selection', async () => {
   const applied: ModelSelection[] = []
   const { vt } = await openModelFlow(

--- a/test/task-panel.test.ts
+++ b/test/task-panel.test.ts
@@ -75,6 +75,33 @@ test('the extreme no-match grant keeps the message over the header', () => {
   assert.ok(!joined.includes('tasks · subagents'), `the header must yield:\n${joined}`)
 })
 
+test('a 1-row search-mode grant paints only the search input and acks nothing', () => {
+  const exposed: string[] = []
+  const panel = new TaskBrowserPanel(
+    [runningJob({ attention: true })],
+    10,
+    {
+      header: 'tasks · subagents',
+      enableSearch: true,
+      onViewportExpose: (ids) => { exposed.push(...ids) },
+    },
+    () => {},
+    () => {},
+    () => {},
+  )
+  panel.setMaxRows(1)
+  panel.render(100)
+  // The degraded layout drops the selected main row (only the search
+  // input fits): the exposure ack must NOT claim a row that was never
+  // painted — ack scope == paint scope.
+  assert.deepEqual(exposed, [], 'nothing may be acked when the selected row is not painted')
+  const lines = panel.render(100).map(strip)
+  const joined = lines.join('\n')
+  assert.ok(lines.length <= 1, `the render must fit the grant (${lines.length})`)
+  assert.ok(joined.includes('search…'), 'the search input is the one painted row')
+  assert.ok(!joined.includes('bash · pnpm build'), `the selected task must not be painted:\n${joined}`)
+})
+
 test('rows render a status dot, kind · label, and right-aligned status + elapsed', () => {
   const now = Date.now()
   const { panel, rendered } = makePanel([

--- a/test/task-panel.test.ts
+++ b/test/task-panel.test.ts
@@ -60,6 +60,21 @@ function makePanel(
   return { panel, rendered: () => panel.render(100) }
 }
 
+test('the extreme no-match grant keeps the message over the header', () => {
+  const { panel, rendered } = makePanel([runningJob()], { enableSearch: true })
+  // A 2-row panel grant: compact rows are header/search/message/hint; the
+  // header must yield BEFORE the no-match message (declared priority:
+  // search > message > hint > header).
+  panel.setMaxRows(2)
+  for (const key of 'zz') panel.handleInput(key) // no match
+  const lines = rendered().map(strip)
+  const joined = lines.join('\n')
+  assert.ok(lines.length <= 2, `the extreme no-match must fit the grant (${lines.length})`)
+  assert.ok(joined.includes('no active tasks'), `the message must beat the header:\n${joined}`)
+  assert.ok(joined.includes('zz'), 'the search row must survive')
+  assert.ok(!joined.includes('tasks · subagents'), `the header must yield:\n${joined}`)
+})
+
 test('rows render a status dot, kind · label, and right-aligned status + elapsed', () => {
   const now = Date.now()
   const { panel, rendered } = makePanel([

--- a/test/theme-picker.test.ts
+++ b/test/theme-picker.test.ts
@@ -8,7 +8,7 @@
  */
 
 import assert from 'node:assert/strict'
-import test from 'node:test'
+import test, { afterEach } from 'node:test'
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
@@ -17,6 +17,8 @@ import { customThemesDir, darkColors, loadCustomTheme, settingsListTheme } from 
 import { ThemeRegistry } from '../src/theme-registry.ts'
 import { resolveThemeSelection, themePickerRows } from '../src/theme-source.ts'
 import { ThemeSubmenu, themeDisplayName } from '../src/theme-menu.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
 
 /** Register one plugin theme into a fresh registry. */
 function pluginTheme(registry: ThemeRegistry, id: string, name: string, owner = 'acme-plugin'): void {
@@ -521,4 +523,57 @@ test('INTEGRATION: a STALE pick (the contribution unloads between open and confi
   const reopened = list!.render(80).join('\n')
   const autoMarked = reopened.split('\n').filter(line => line.includes('auto') && line.includes('← current'))
   assert.equal(autoMarked.length, 1, `the auto row carries the marker after the rollback:\n${reopened}`)
+})
+
+/** Re-vendor lifecycle follow-up P3: every TuiApp started here is stopped
+ * after each test (the process's single-live-TUI slot is held only by
+ * live surfaces). */
+const startedApps = new Set<TuiApp>()
+afterEach(() => {
+  for (const app of [...startedApps]) {
+    startedApps.delete(app)
+    if (app.isDisposed()) continue
+    try { app.dispose() } catch {}
+  }
+})
+
+test('INTEGRATION: the Theme submenu inherits the live row budget and keeps the selected theme + hint after a shrink', async () => {
+  // Many rows so the inner list (maxVisible min(8, rows)) overflows a
+  // short grant: without the RowBudgetAware seam the compositor would
+  // clip the hint from the bottom.
+  const registry = new ThemeRegistry()
+  for (let index = 0; index < 14; index += 1) {
+    // Zero-padded so the lexicographic picker order matches the numeric
+    // order (Palette 10 sits after Palette 09, not after Palette 01).
+    const padded = String(index).padStart(2, '0')
+    pluginTheme(registry, `palette-${padded}`, `Palette ${padded}`)
+  }
+  const vt = new VirtualTerminal(80, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.openSettings(
+    [{
+      id: 'theme',
+      label: 'Theme',
+      currentValue: 'auto',
+      submenu: (_currentValue, done) => new ThemeSubmenu('auto', registry, done),
+    }],
+    () => {},
+    () => {},
+  )
+  await vt.waitForRender()
+  vt.sendInput('\r') // Enter: open the Theme submenu
+  await vt.waitForRender()
+  for (let index = 0; index < 10; index += 1) vt.sendInput('\x1b[B') // 10 downs: past auto/dark/light, onto plugin 7 of 14
+  await vt.waitForRender()
+  vt.resize(80, 10) // shrink: the outer grant (10 − 2) must reach the submenu list
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  // 17 rows total (3 builtins first + 14 plugins), so row 11/17 is
+  // 'Palette 07' — the selected row and the hint must survive the shrink.
+  assert.ok(view.includes('Palette 07'), `selected theme must survive the shrink:\n${view}`)
+  assert.ok(view.includes('Esc to cancel'), `theme submenu hint must survive the shrink:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
 })

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -606,6 +606,116 @@ test('task browser no-match state fits a short terminal without clipping the hin
   await vt.waitForRender()
 })
 
+test('Task Center full mode keeps the selected task on a very short terminal', async () => {
+  const { vt, app } = startApp()
+  vt.resize(80, 8)
+  await vt.waitForRender()
+  app.openTaskBrowser(
+    Array.from({ length: 20 }, (_, index) => ({
+      value: `task-${index}`,
+      label: `task ${index}`,
+      status: 'running',
+      group: 'jobs',
+    })),
+    () => {},
+    () => {},
+    { mode: 'full', header: 'Tasks', maxVisible: 10 },
+  )
+  await vt.waitForRender()
+  for (let index = 0; index < 3; index += 1) vt.sendInput('\x1b[B') // select task 3
+  await vt.waitForRender()
+  // 80x8 full mode: margin 2 + frame borders 2 leave a 4-row panel grant.
+  // The semantic degradation must keep the SELECTED task row (header and
+  // hint may share the grant, but never squeeze the main row out).
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('task 3'), `selected task must survive the 4-row grant:\n${view}`)
+  assert.ok(view.includes('╰'), `frame bottom must not be clipped:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
+test('Task Center full mode keeps search input and the selected task at 10 rows', async () => {
+  const { vt, app } = startApp()
+  vt.resize(80, 10)
+  await vt.waitForRender()
+  app.openTaskBrowser(
+    Array.from({ length: 20 }, (_, index) => ({
+      value: `task-${index}`,
+      label: `task ${index}`,
+      status: 'running',
+      group: 'jobs',
+    })),
+    () => {},
+    () => {},
+    { mode: 'full', header: 'Tasks', maxVisible: 10, initialSearchMode: true },
+  )
+  await vt.waitForRender()
+  for (let index = 0; index < 2; index += 1) vt.sendInput('\x1b[B') // select task 2
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes(' / search…'), `search input must survive the 6-row grant:\n${view}`)
+  assert.ok(view.includes('task 2'), `selected task must survive the 6-row grant:\n${view}`)
+  assert.ok(view.includes('╰'), `frame bottom must not be clipped:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
+test('openTaskBrowser honors percentage width and maxHeight (fork sizing rules)', async () => {
+  const items = [{ value: 'job:1', label: 'bash · build', status: 'running', group: 'jobs' }]
+  const strip = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, '').trim()
+  // width '50%' of a 100-column terminal → the frame spans exactly 50.
+  {
+    const vt = new VirtualTerminal(100, 24)
+    const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+    app.start()
+    startedApps.add(app)
+    app.openTaskBrowser(items, () => {}, () => {}, { width: '50%' })
+    await vt.waitForRender()
+    const lines = vt.getViewport().map(strip)
+    const top = lines.findIndex(line => line.includes('╭'))
+    assert.ok(top >= 0, `percentage width must render a frame:\n${lines.join('\n')}`)
+    assert.equal(visibleWidth(lines[top]!), 50, 'width 50% must resolve to 50 columns')
+    app.dispose()
+  }
+  // maxHeight '70%' of a 40-row terminal → the frame is at most 28 rows.
+  {
+    const vt = new VirtualTerminal(80, 40)
+    const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+    app.start()
+    startedApps.add(app)
+    app.openTaskBrowser(items, () => {}, () => {}, { maxHeight: '70%' })
+    await vt.waitForRender()
+    const lines = vt.getViewport().map(strip)
+    const top = lines.findIndex(line => line.includes('╭'))
+    const bottom = lines.findIndex(line => line.includes('╰'))
+    assert.ok(top >= 0 && bottom >= top, `maxHeight 70% must render a frame:\n${lines.join('\n')}`)
+    assert.ok(bottom - top + 1 <= 28, `frame must be capped at 28 rows (${bottom - top + 1})`)
+    app.dispose()
+  }
+})
+
+test('openTaskBrowser full mode honors explicit numeric width and maxHeight', async () => {
+  const items = [{ value: 'job:1', label: 'bash · build', status: 'running', group: 'jobs' }]
+  const strip = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, '').trim()
+  const vt = new VirtualTerminal(120, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  // Explicit options always win, even in full mode: 100 wide / 20 tall
+  // (clamped by the margin-inset available area, never forced to 100%).
+  app.openTaskBrowser(items, () => {}, () => {}, { mode: 'full', width: 100, maxHeight: 20 })
+  await vt.waitForRender()
+  const lines = vt.getViewport().map(strip)
+  const top = lines.findIndex(line => line.includes('╭'))
+  const bottom = lines.findIndex(line => line.includes('╰'))
+  assert.ok(top >= 0 && bottom >= top, `full-mode explicit size must render a frame:\n${lines.join('\n')}`)
+  assert.equal(visibleWidth(lines[top]!), 100, 'explicit width 100 must win over the full-mode default')
+  assert.ok(bottom - top + 1 <= 20, `explicit maxHeight 20 must cap the frame (${bottom - top + 1})`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+  app.dispose()
+})
+
 test('task browser keeps the selected row and hint visible after a height shrink', async () => {
   const { vt, app } = startApp()
   vt.resize(80, 30)

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -18,7 +18,9 @@ import { testLifecycle } from './support/temp-lifecycle.ts'
 import { toolPresenterFrom } from '../src/present.ts'
 import { TranscriptFolder } from '../src/transcript.ts'
 import { TuiApp } from '../src/tui-app.ts'
-import { visibleWidth } from '@xmoon76/pi-tui'
+import { Text, visibleWidth } from '@xmoon76/pi-tui'
+import { ExtensionLedger } from '../src/extension/internal/ledger.ts'
+import { SurfaceHost } from '../src/extension/internal/surface-host.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 /** Re-vendor lifecycle follow-up P3: every TuiApp started in this file is
@@ -449,6 +451,237 @@ test('notice rows beyond the fold collapse into a +N more line; user rows never 
   view = vt.getViewport().join('\n')
   assert.ok(!view.includes('more notices pending'), `fold line must vanish after drain:\n${view}`)
   assert.ok(view.includes('❯ my first queued message'), `user row must survive the drain:\n${view}`)
+})
+
+test('queue pane reflows from raw items across a narrow-to-wide resize', async () => {
+  const { vt, app } = startApp()
+  const fullNotice = 'NOTICE-RESIZE ' + 'the original notice survives the narrow frame '.repeat(2)
+  app.setQueueItems([{ id: 'notice-1', text: fullNotice, mode: 'steer', notice: true }])
+  await vt.waitForRender()
+  vt.resize(40, 24)
+  await vt.waitForRender()
+  let lines = vt.getViewport()
+  const narrowNotice = lines.findIndex(line => line.includes('NOTICE-RESIZE'))
+  assert.ok(narrowNotice > 0, `notice must remain visible after narrowing:\n${lines.join('\n')}`)
+  let borderRows = 0
+  for (let index = narrowNotice - 1; index >= 0 && lines[index]!.includes('─'); index -= 1) borderRows += 1
+  assert.equal(borderRows, 1, `a narrow queue must have one border row, not stale wrapped rows:\n${lines.join('\n')}`)
+  assert.equal(visibleWidth(lines[narrowNotice - 1]!), 40)
+  vt.resize(120, 24)
+  await vt.waitForRender()
+  lines = vt.getViewport()
+  assert.ok(lines.some(line => line.includes(fullNotice)), `the wide queue must recover the raw notice:\n${lines.join('\n')}`)
+})
+
+test('todo panel rebuilds its border from the live width', async () => {
+  const { vt, app } = startApp()
+  vt.resize(120, 24)
+  await vt.waitForRender()
+  app.setTodoSummary(Array.from({ length: 8 }, (_, index) => ({
+    content: `todo ${index}`,
+    status: 'pending' as const,
+  })))
+  app.toggleTodoPanel()
+  await vt.waitForRender()
+  const borderRowsBefore = (width: number): number => {
+    const lines = vt.getViewport()
+    const title = lines.findIndex(line => line.includes('Todo'))
+    assert.ok(title > 0, `todo title missing at ${width} columns:\n${lines.join('\n')}`)
+    let count = 0
+    for (let index = title - 1; index >= 0 && lines[index]!.includes('─'); index -= 1) count += 1
+    assert.equal(visibleWidth(lines[title - 1]!), width)
+    return count
+  }
+  assert.equal(borderRowsBefore(120), 1)
+  vt.resize(40, 24)
+  await vt.waitForRender()
+  assert.equal(borderRowsBefore(40), 1, 'the narrow todo border must not retain stale wrapped rows')
+  vt.resize(120, 24)
+  await vt.waitForRender()
+  assert.equal(borderRowsBefore(120), 1)
+})
+
+test('height-only resize refreshes the extension widget row budget', async () => {
+  const vt = new VirtualTerminal(80, 16)
+  const ledger = new ExtensionLedger()
+  let app!: TuiApp
+  const host = new SurfaceHost(ledger, () => app.requestRender())
+  app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { extensionHost: host })
+  startedApps.add(app)
+  host.attach({ header: new Text('', 0, 0), dock: new Text('', 0, 0), footer: new Text('', 0, 0) }, {
+    surfaceId: host.surfaceId,
+    generation: 1,
+    width: 80,
+    height: 16,
+    fullscreen: false,
+    focusedSeat: 'editor',
+    themeId: 'dark',
+    themeRevision: 0,
+  })
+  ledger.register('input.widget.below', { id: 'resize-widget' }, {
+    view: { kind: 'rows', rows: [
+      { kind: 'text', spans: [{ text: 'row one' }] },
+      { kind: 'text', spans: [{ text: 'row two' }] },
+      { kind: 'text', spans: [{ text: 'row three' }] },
+    ] },
+  }, 'resize-test')
+  host.refreshOutlets()
+  app.start()
+  const widgetRows = (): number => host.widgetsBelowText().split('\n').filter(line => line !== '').length
+  await vt.waitForRender()
+  assert.equal(widgetRows(), 3)
+  vt.resize(80, 7)
+  await vt.waitForRender()
+  assert.equal(widgetRows(), 1, `height-only shrink must reduce the below-widget budget (surface=${JSON.stringify(host.state().surface)})`)
+  vt.resize(80, 10)
+  await vt.waitForRender()
+  assert.equal(widgetRows(), 2)
+  vt.resize(80, 16)
+  await vt.waitForRender()
+  assert.equal(widgetRows(), 3)
+})
+
+test('history overlay reflows geometry without restarting its search state', async () => {
+  const rows = [
+    { id: 'a', content: 'entry alpha', cwd: '/work/project', ts: 1_700_000_000_000, sourceFile: '/history.jsonl', sourceByteOffset: 0 },
+    { id: 'b', content: 'entry beta', cwd: '/work/project', ts: 1_700_000_000_001, sourceFile: '/history.jsonl', sourceByteOffset: 1 },
+  ]
+  const source: import('../src/history-search.ts').HistorySearchSource = {
+    search: async () => ({ results: rows, exhausted: true }),
+  }
+  const vt = new VirtualTerminal(50, 10)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { historySearchSource: source })
+  app.start()
+  startedApps.add(app)
+  app.openHistorySearch()
+  await vt.waitForRender()
+  vt.sendInput('x')
+  await new Promise(resolve => setTimeout(resolve, 100))
+  await vt.waitForRender()
+  vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('x'), `history query missing before resize:\n${view}`)
+  assert.ok(view.includes('entry beta'), `history selection missing before resize:\n${view}`)
+  vt.resize(120, 40)
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('entry beta'), `history selection lost after grow:\n${view}`)
+  // The overlay design width is capped at 100 and the Frame consumes 4 of
+  // its columns, so the panel inner width (≤ 96) never reaches the 100-wide
+  // split threshold — the grown layout stays stacked. Assert the frame
+  // actually reflowed to span the grown width instead of a split marker.
+  const stripAnsi = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, '')
+  const frameTop = vt.getViewport().map(stripAnsi).find(line => line.includes('╭'))
+  assert.ok(frameTop !== undefined && visibleWidth(frameTop.trimEnd()) >= 100,
+    `history frame must span the grown terminal:\n${view}`)
+  assert.ok(view.includes('Current directory'), `history tabs did not reflow after grow:\n${view}`)
+  vt.resize(50, 10)
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('╭') && view.includes('╰'), `history frame must survive shrink:\n${view}`)
+  assert.ok(view.includes('type filter') && view.includes('╰'), `history footer must survive shrink:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
+test('task browser no-match state fits a short terminal without clipping the hint', async () => {
+  const { vt, app } = startApp()
+  vt.resize(80, 8)
+  await vt.waitForRender()
+  app.openTaskBrowser(
+    [{ value: 'job:1', label: 'bash · build', status: 'running', group: 'jobs' }],
+    () => {},
+    () => {},
+    { header: 'Tasks', enableSearch: true, noMatchText: 'no matching tasks' },
+  )
+  await vt.waitForRender()
+  for (const key of 'zzzz') vt.sendInput(key) // no match
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('no matching tasks'), `no-match message must survive:\n${view}`)
+  assert.ok(view.includes('esc close'), `no-match hint must survive:\n${view}`)
+  assert.ok(view.includes('╰'), `frame bottom must not be clipped:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
+test('task browser keeps the selected row and hint visible after a height shrink', async () => {
+  const { vt, app } = startApp()
+  vt.resize(80, 30)
+  await vt.waitForRender()
+  app.openTaskBrowser(
+    Array.from({ length: 24 }, (_, index) => ({
+      value: `task-${index}`,
+      label: `task ${index}`,
+      status: 'running',
+      group: 'jobs',
+      // Real task rows carry detail lines under the main row; a tiny-grant
+      // fallback must keep the SELECTED MAIN row, not its detail tail.
+      detail: `detail line ${index}`,
+    })),
+    () => {},
+    () => {},
+    { header: 'Tasks', maxVisible: 10, enableSearch: true },
+  )
+  await vt.waitForRender()
+  for (let index = 0; index < 17; index += 1) vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  vt.resize(80, 10)
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('task 17'), `selected task main row must remain visible after shrink:\n${view}`)
+  assert.ok(view.includes('esc close'), `task hint must remain visible after shrink:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
+test('generic picker preserves its selected row and hint after a short resize', async () => {
+  const { vt, app } = startApp()
+  vt.resize(80, 30)
+  await vt.waitForRender()
+  app.openPicker(
+    Array.from({ length: 24 }, (_, index) => ({ value: `choice-${index}`, label: `choice ${index}` })),
+    () => {},
+    () => {},
+    { header: 'Choices', showHint: true },
+  )
+  await vt.waitForRender()
+  for (let index = 0; index < 17; index += 1) vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  vt.resize(80, 10)
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('choice 17'), `selected picker row must remain visible:\n${view}`)
+  assert.ok(view.includes('esc close'), `picker hint must remain visible:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
+})
+
+test('settings list preserves its selected row and hint after a short resize', async () => {
+  const { vt, app } = startApp()
+  vt.resize(80, 30)
+  await vt.waitForRender()
+  app.openSettings(
+    Array.from({ length: 24 }, (_, index) => ({
+      id: `setting-${index}`,
+      label: `setting ${index}`,
+      currentValue: 'on',
+      values: ['on', 'off'],
+    })),
+    () => {},
+    () => {},
+  )
+  await vt.waitForRender()
+  for (let index = 0; index < 17; index += 1) vt.sendInput('\x1b[B')
+  await vt.waitForRender()
+  vt.resize(80, 10)
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('setting 17'), `selected settings row must remain visible:\n${view}`)
+  assert.ok(view.includes('Esc to cancel'), `settings hint must remain visible:\n${view}`)
+  vt.sendInput('\x1b')
+  await vt.waitForRender()
 })
 
 test('down opens the task browser only with active tasks and an empty editor; ctrl+j is inert', async () => {


### PR DESCRIPTION
## What

Fixes the resize display bug on `next`: geometry-dependent surfaces now rebuild or reflow from raw state whenever the terminal size changes, without losing component state, focus, or overlay semantics.

## Changes

- **Queue pane / todo panel**: width-baked rows rebuild from raw state (`queueItems`/`todoItems`) on width change, before chrome measurement — stale wrapped rows and misaligned borders are gone.
- **History overlay**: new `ResponsiveOverlayFrame` shell re-derives width/maxHeight from the live terminal each pass; the panel keeps query/scope/results/selection/generation across resizes **and** fullscreen screen swaps (remountable mount, explicit final disposal, idempotent `start()`/`dispose()`).
- **Approval dialog**: state-free `ApprovalDialogSurface` rebuilds content from the original request at the live geometry — pending Promise, FIFO queue, abort and settlement semantics untouched; hints and both borders always visible.
- **Task browser / picker / settings**: `setMaxRows()` live row budget on the vendored `SelectList`/`SettingsList` (divergence ledger + manifest updated); render self-limits to the grant (group headers, description block, scroll indicator and hint all budgeted) so the selected row and hint survive shrink.
- **Extension widget rows**: height-only resizes now re-bake the `input.widget.below` row budget.

## Validation

- `pnpm typecheck`, `pnpm build`, `pnpm gate:pi-vendor-diff`, `git diff --check` — all green
- Fork suite: **1040/1040**; product suite: **3506/3506** (incl. 12 new resize regressions)
- Review-loop: three rounds with `ollama/deepseek-v4-flash:0731-cloud @high` — **PASS** each; no BLOCKER/MAJOR findings outstanding (remaining MINOR is a ≤3-row degenerate terminal case, consistent with pre-existing behavior)
