### PR TITLE
feat(cards): make action payloads first-class in compact tool cards

### DIFF
--- a/src/compact-text-preview.ts
+++ b/src/compact-text-preview.ts
@@ -79,7 +79,9 @@ export class CompactTextPreview implements Component {
       ? this.indent
       : truncateToWidth(this.indent, indentWidth, '')
     const bodyWidth = Math.max(1, safeWidth - visibleWidth(prefix))
-    const wrapped = wrapTextWithAnsi(this.text, bodyWidth)
+    // Drop empty wrapped rows: a first grapheme wider than the body width
+    // would otherwise emit a leading blank row at tiny terminal widths.
+    const wrapped = wrapTextWithAnsi(this.text, bodyWidth).filter(row => row !== '')
     const truncated = wrapped.length > this.maxVisualRows
     const shown = wrapped.slice(0, this.maxVisualRows)
     if (truncated && shown.length > 0) {

--- a/src/compact-text-preview.ts
+++ b/src/compact-text-preview.ts
@@ -1,0 +1,103 @@
+/**
+ * A small live, width-aware preview for folded cards.
+ *
+ * The component deliberately derives its rows in render(width), rather than
+ * baking a terminal width into the transcript message cache. A resize can
+ * therefore reveal more text after a narrow preview without rebuilding the
+ * host card or rerunning a tool presenter.
+ * @module @xmoon76/dsh-pi-tui/compact-text-preview
+ */
+
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from '@xmoon76/pi-tui'
+
+export interface CompactTextPreviewOptions {
+  /** The text to preview. Newlines remain logical breaks during wrapping. */
+  readonly text: string
+  /** Maximum number of physical rows returned by the preview. */
+  readonly maxVisualRows: number
+  /** Prefix applied to every returned row, normally two spaces. */
+  readonly indent?: string
+}
+
+/**
+ * Append an overflow marker while keeping the complete row within `width`.
+ * `truncateToWidth` owns Unicode/ANSI slicing; reserving the marker cell here
+ * also handles a source row that already consumes the whole available width.
+ */
+function appendEllipsis(text: string, width: number): string {
+  const safeWidth = Math.max(1, Math.floor(width))
+  const markerWidth = Math.max(1, visibleWidth('…'))
+  if (visibleWidth(text) + markerWidth <= safeWidth) return `${text}…`
+  return `${truncateToWidth(text, Math.max(0, safeWidth - markerWidth), '')}…`
+}
+
+/**
+ * Folded text preview whose wrapping and truncation are derived at render
+ * time. The per-width cache keeps steady frames reference-stable while still
+ * making narrow → wide → narrow resize sequences lossless.
+ */
+export class CompactTextPreview implements Component {
+  private readonly text: string
+  private readonly maxVisualRows: number
+  private readonly indent: string
+  private readonly cached = new Map<number, string[]>()
+
+  constructor(options: CompactTextPreviewOptions)
+  constructor(text: string, maxVisualRows: number, indent?: string)
+  constructor(optionsOrText: CompactTextPreviewOptions | string, maxVisualRows?: number, indent = '  ') {
+    if (typeof optionsOrText === 'string') {
+      this.text = optionsOrText
+      this.maxVisualRows = maxVisualRows ?? 0
+      this.indent = indent
+    } else {
+      this.text = optionsOrText.text
+      this.maxVisualRows = optionsOrText.maxVisualRows
+      this.indent = optionsOrText.indent ?? '  '
+    }
+  }
+
+  invalidate(): void {
+    this.cached.clear()
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, Math.floor(width))
+    const existing = this.cached.get(safeWidth)
+    if (existing !== undefined) return existing
+    if (this.text === '' || this.maxVisualRows <= 0) {
+      const empty: string[] = []
+      this.cached.set(safeWidth, empty)
+      return empty
+    }
+
+    // Reserve one cell for content when the requested indent is wider than a
+    // tiny terminal. The final truncate is still a defensive boundary for
+    // ANSI and unusual Unicode-width implementations.
+    const requestedIndentWidth = visibleWidth(this.indent)
+    const indentWidth = Math.min(requestedIndentWidth, Math.max(0, safeWidth - 1))
+    const prefix = indentWidth === requestedIndentWidth
+      ? this.indent
+      : truncateToWidth(this.indent, indentWidth, '')
+    const bodyWidth = Math.max(1, safeWidth - visibleWidth(prefix))
+    const wrapped = wrapTextWithAnsi(this.text, bodyWidth)
+    const truncated = wrapped.length > this.maxVisualRows
+    const shown = wrapped.slice(0, this.maxVisualRows)
+    if (truncated && shown.length > 0) {
+      const last = shown.length - 1
+      shown[last] = appendEllipsis(shown[last] ?? '', bodyWidth)
+    }
+    const lines = shown.map(line => truncateToWidth(`${prefix}${line}`, safeWidth, '…'))
+    this.cached.set(safeWidth, lines)
+    return lines
+  }
+}
+
+/** Pure convenience form for callers that do not need a retained component. */
+export function compactTextPreviewLines(
+  text: string,
+  width: number,
+  maxVisualRows: number,
+  indent = '  ',
+): string[] {
+  return new CompactTextPreview({ text, maxVisualRows, indent }).render(width)
+}

--- a/src/compact-text-preview.ts
+++ b/src/compact-text-preview.ts
@@ -79,9 +79,10 @@ export class CompactTextPreview implements Component {
       ? this.indent
       : truncateToWidth(this.indent, indentWidth, '')
     const bodyWidth = Math.max(1, safeWidth - visibleWidth(prefix))
-    // Drop empty wrapped rows: a first grapheme wider than the body width
-    // would otherwise emit a leading blank row at tiny terminal widths.
-    const wrapped = wrapTextWithAnsi(this.text, bodyWidth).filter(row => row !== '')
+    // Drop visually empty wrapped rows: a first grapheme wider than the body
+    // width would otherwise emit a leading blank row at tiny terminal widths
+    // — as plain text or as a row carrying only style codes.
+    const wrapped = wrapTextWithAnsi(this.text, bodyWidth).filter(row => visibleWidth(row) > 0)
     const truncated = wrapped.length > this.maxVisualRows
     const shown = wrapped.slice(0, this.maxVisualRows)
     if (truncated && shown.length > 0) {

--- a/src/compact-text-preview.ts
+++ b/src/compact-text-preview.ts
@@ -17,6 +17,12 @@ export interface CompactTextPreviewOptions {
   readonly maxVisualRows: number
   /** Prefix applied to every returned row, normally two spaces. */
   readonly indent?: string
+  /**
+   * Whether blank content lines survive the row filter. The folded preview
+   * compresses them away by default (compact semantics); expanded bodies
+   * must preserve the original paragraph breaks.
+   */
+  readonly preserveBlankLines?: boolean
 }
 
 /**
@@ -40,19 +46,22 @@ export class CompactTextPreview implements Component {
   private readonly text: string
   private readonly maxVisualRows: number
   private readonly indent: string
+  private readonly preserveBlankLines: boolean
   private readonly cached = new Map<number, string[]>()
 
   constructor(options: CompactTextPreviewOptions)
-  constructor(text: string, maxVisualRows: number, indent?: string)
-  constructor(optionsOrText: CompactTextPreviewOptions | string, maxVisualRows?: number, indent = '  ') {
+  constructor(text: string, maxVisualRows: number, indent?: string, preserveBlankLines?: boolean)
+  constructor(optionsOrText: CompactTextPreviewOptions | string, maxVisualRows?: number, indent = '  ', preserveBlankLines = false) {
     if (typeof optionsOrText === 'string') {
       this.text = optionsOrText
       this.maxVisualRows = maxVisualRows ?? 0
       this.indent = indent
+      this.preserveBlankLines = preserveBlankLines
     } else {
       this.text = optionsOrText.text
       this.maxVisualRows = optionsOrText.maxVisualRows
       this.indent = optionsOrText.indent ?? '  '
+      this.preserveBlankLines = optionsOrText.preserveBlankLines ?? false
     }
   }
 
@@ -64,7 +73,7 @@ export class CompactTextPreview implements Component {
     const safeWidth = Math.max(1, Math.floor(width))
     const existing = this.cached.get(safeWidth)
     if (existing !== undefined) return existing
-    if (this.text === '' || this.maxVisualRows <= 0) {
+    if (this.maxVisualRows <= 0) {
       const empty: string[] = []
       this.cached.set(safeWidth, empty)
       return empty
@@ -78,11 +87,23 @@ export class CompactTextPreview implements Component {
     const prefix = indentWidth === requestedIndentWidth
       ? this.indent
       : truncateToWidth(this.indent, indentWidth, '')
+    if (this.text === '') {
+      // A blank content line survives only under preserveBlankLines: it
+      // renders as the bare indent row (the paragraph break). The folded
+      // compact mode omits it entirely.
+      const blank: string[] = this.preserveBlankLines ? [prefix] : []
+      this.cached.set(safeWidth, blank)
+      return blank
+    }
     const bodyWidth = Math.max(1, safeWidth - visibleWidth(prefix))
     // Drop visually empty wrapped rows: a first grapheme wider than the body
     // width would otherwise emit a leading blank row at tiny terminal widths
-    // — as plain text or as a row carrying only style codes.
-    const wrapped = wrapTextWithAnsi(this.text, bodyWidth).filter(row => visibleWidth(row) > 0)
+    // — as plain text or as a row carrying only style codes. Expanded bodies
+    // opt into preserveBlankLines, keeping genuine paragraph breaks.
+    const wrapped = wrapTextWithAnsi(this.text, bodyWidth).filter(row => {
+      if (visibleWidth(row) > 0) return true
+      return this.preserveBlankLines && row === ''
+    })
     const truncated = wrapped.length > this.maxVisualRows
     const shown = wrapped.slice(0, this.maxVisualRows)
     if (truncated && shown.length > 0) {

--- a/src/present.ts
+++ b/src/present.ts
@@ -221,6 +221,346 @@ export function foldedResultSummaryFor(name: string, text: string): string | und
   return undefined
 }
 
+/** The small semantic model used by host fallback cards for action tools. */
+export interface CompactToolPresentation {
+  /** Human-facing action title, e.g. `Send message`. */
+  readonly title: string
+  /** Stable identity shown in the card header (target, session, or scope). */
+  readonly summary?: string
+  /** User-meaningful call input retained for the folded preview. */
+  readonly payload?: string
+  /** A meaningful settled result, or an error identity. */
+  readonly result?: string
+  /** Whether an acknowledgement-only success result should be omitted. */
+  readonly suppressSuccessResult?: boolean
+}
+
+/** Structured failure information available on a transcript tool card. */
+export interface CompactToolPresentationOptions {
+  readonly isError?: boolean
+  readonly error?: { readonly name: string; readonly code: string }
+}
+
+/** Counts from one historical `list_agents` result snapshot. */
+export interface AgentListSummary {
+  readonly total: number
+  readonly running: number
+  readonly idle: number
+  readonly ready: number
+  readonly diagnostics?: number
+}
+
+export interface SendMessageCallPresentation {
+  readonly target: string
+  readonly message: string
+}
+
+export interface TerminalSendCallPresentation {
+  readonly sessionId: string
+  readonly text: string
+}
+
+export interface InterruptAgentCallPresentation {
+  readonly target: string
+}
+
+export interface ListAgentsCallPresentation {
+  readonly scope: 'children' | 'descendants'
+}
+
+function nonBlankString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined
+}
+
+/** Parse standard and Agent Teams-compatible send_message arguments. */
+export function sendMessageCallPresentation(argsRaw: string): SendMessageCallPresentation | undefined {
+  const parsed = parseArgs(argsRaw)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+  const args = parsed as Record<string, unknown>
+  // The two currently known producers use agent_id and target respectively;
+  // nullish selection keeps a valid standard field authoritative.
+  const target = nonBlankString(args.agent_id) ?? nonBlankString(args.target)
+  if (target === undefined || typeof args.message !== 'string') return undefined
+  return { target, message: args.message }
+}
+
+/** Parse standard and Agent Teams-compatible interrupt_agent arguments. */
+export function interruptAgentCallPresentation(argsRaw: string): InterruptAgentCallPresentation | undefined {
+  const parsed = parseArgs(argsRaw)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+  const args = parsed as Record<string, unknown>
+  const target = nonBlankString(args.agent_id) ?? nonBlankString(args.target)
+  return target === undefined ? undefined : { target }
+}
+
+/** Parse the terminal_send identity and payload. */
+export function terminalSendCallPresentation(argsRaw: string): TerminalSendCallPresentation | undefined {
+  const parsed = parseArgs(argsRaw)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+  const args = parsed as Record<string, unknown>
+  const sessionId = nonBlankString(args.sessionId)
+  if (sessionId === undefined || typeof args.text !== 'string') return undefined
+  return { sessionId, text: args.text }
+}
+
+/** Parse list_agents scope without consulting any live registry. */
+export function listAgentsCallPresentation(argsRaw: string): ListAgentsCallPresentation | undefined {
+  // No-parameter tools are recorded as `{}` in normal events, but an older
+  // replay can retain an empty argument string; both mean the default scope.
+  const parsed = argsRaw.trim() === '' ? {} : parseArgs(argsRaw)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+  const scope = (parsed as Record<string, unknown>).scope
+  if (scope === undefined) return { scope: 'children' }
+  return scope === 'children' || scope === 'descendants' ? { scope } : undefined
+}
+
+/** Count one structured list_agents snapshot. */
+function summarizeAgentEntries(entries: readonly unknown[]): AgentListSummary {
+  let running = 0
+  let idle = 0
+  let ready = 0
+  let diagnostics = 0
+  for (const entry of entries) {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      diagnostics += 1
+      continue
+    }
+    const value = entry as Record<string, unknown>
+    if (value.kind === 'diagnostic') {
+      diagnostics += 1
+      continue
+    }
+    // The standard snapshot uses `kind: child`; Agent Teams returns member
+    // rows without a kind. A recognized status is enough for the latter.
+    if (value.kind !== undefined && value.kind !== 'child' && value.kind !== 'agent') {
+      diagnostics += 1
+      continue
+    }
+    switch (value.status) {
+      case 'running': running += 1; break
+      case 'idle': idle += 1; break
+      case 'ready': ready += 1; break
+      default: diagnostics += 1; break
+    }
+  }
+  const total = running + idle + ready + diagnostics
+  return { total, running, idle, ready, ...(diagnostics === 0 ? {} : { diagnostics }) }
+}
+
+/** Parse both the structured snapshot and the standard rendered text. */
+export function summarizeAgentListResult(text: string): AgentListSummary | undefined {
+  const parsed = parseJsonValue(text)
+  if (Array.isArray(parsed)) return summarizeAgentEntries(parsed)
+
+  const trimmed = text.trim()
+  if (trimmed === '(no subagents)') return { total: 0, running: 0, idle: 0, ready: 0 }
+  if (trimmed === '') return undefined
+  let running = 0
+  let idle = 0
+  let ready = 0
+  let diagnostics = 0
+  let matched = 0
+  for (const line of trimmed.split(/\r\n|\r|\n/)) {
+    if (/\[running\](?:\s|$)/.test(line)) { running += 1; matched += 1; continue }
+    if (/\[idle\](?:\s|$)/.test(line)) { idle += 1; matched += 1; continue }
+    if (/\[ready\](?:\s|$)/.test(line)) { ready += 1; matched += 1; continue }
+    if (/\[diagnostic:\s*[^\]]+\]/.test(line)) { diagnostics += 1; matched += 1 }
+  }
+  if (matched === 0) return undefined
+  const total = running + idle + ready + diagnostics
+  return { total, running, idle, ready, ...(diagnostics === 0 ? {} : { diagnostics }) }
+}
+
+/** Format a list snapshot without treating diagnostics as agents. */
+export function formatAgentListSummary(summary: AgentListSummary): string {
+  if (summary.total === 0) return 'no subagents'
+  const agents = summary.running + summary.idle + summary.ready
+  const diagnostics = summary.diagnostics ?? 0
+  const parts = [
+    diagnostics > 0 ? `${summary.total} ${summary.total === 1 ? 'entry' : 'entries'}` : `${agents} ${agents === 1 ? 'agent' : 'agents'}`,
+  ]
+  if (summary.running > 0) parts.push(`${summary.running} running`)
+  if (summary.idle > 0) parts.push(`${summary.idle} idle`)
+  if (summary.ready > 0) parts.push(`${summary.ready} ready`)
+  if (diagnostics > 0) parts.push(`${diagnostics} ${diagnostics === 1 ? 'diagnostic' : 'diagnostics'}`)
+  return parts.join(' · ')
+}
+
+/** A compact result line for a non-JSON action acknowledgement/error. */
+function firstActionResultDetail(text: string): string | undefined {
+  const trimmed = text.trim()
+  if (trimmed === '') return undefined
+  const parsed = parseJsonValue(text)
+  if (typeof parsed === 'string') return firstLine(parsed)
+  // A malformed/unknown object is still protocol noise; never expose it as a
+  // folded preview merely because it failed to parse.
+  if (parsed !== undefined || /^[\[{]/.test(trimmed)) return undefined
+  return firstLine(trimmed)
+}
+
+/** Pull a human detail out of a structured action error without raw JSON. */
+function actionErrorDetail(text: string): string | undefined {
+  const parsed = parseJsonValue(text)
+  if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+    const value = parsed as Record<string, unknown>
+    const code = nonBlankString(value.code)
+    const message = nonBlankString(value.message ?? value.error ?? value.detail ?? value.reason)
+    if (code !== undefined && message !== undefined) return `${code}: ${message}`
+    return message ?? code
+  }
+  // Failure text is user-facing evidence, even when a malformed JSON-looking
+  // payload cannot be safely summarized. Success-only protocol-noise rules do
+  // not get to hide an error.
+  const detail = firstActionResultDetail(text)
+  return detail ?? (text.trim() === '' ? undefined : firstLine(text.trim()))
+}
+
+/** Combine a structured error identity with any safe human detail. */
+function actionErrorResult(text: string, options: CompactToolPresentationOptions): string | undefined {
+  const identity = options.error === undefined ? undefined : `${options.error.name}: ${options.error.code}`
+  const detail = actionErrorDetail(text)
+  return identity === undefined ? detail : detail === undefined ? identity : `${identity}: ${detail}`
+}
+
+const ACKNOWLEDGEMENT_STATUSES = new Set(['accepted', 'completed', 'delivered', 'ok', 'sent', 'success'])
+
+/** Derive a meaningful result for one action tool; receipt-only results vanish. */
+function actionResultSummary(
+  kind: 'send_message' | 'terminal_send' | 'interrupt_agent',
+  text: string,
+): string | undefined {
+  const trimmed = text.trim()
+  if (trimmed === '') return undefined
+  const parsed = parseJsonValue(text)
+  if (kind === 'terminal_send') {
+    // Foreground terminal output is useful only in the expanded body; the
+    // folded card keeps the sent text. A background job id is the exception:
+    // it is new information the user needs for job_output/job_kill.
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const value = parsed as Record<string, unknown>
+      if (nonBlankString(value.status)?.toLowerCase() === 'queued') return 'queued'
+      if (value.kind === 'background') {
+        const jobId = nonBlankString(value.jobId)
+        return jobId === undefined ? undefined : `started background job ${jobId}`
+      }
+      return undefined
+    }
+    const value = typeof parsed === 'string' ? firstLine(parsed) : firstLine(trimmed)
+    if (/^started background job\b/i.test(value)) return value
+    return /\bqueued\b/i.test(value) ? 'queued' : undefined
+  }
+  if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+    const value = parsed as Record<string, unknown>
+    const status = nonBlankString(value.status)?.toLowerCase()
+    if (status === 'queued') return 'queued'
+    if (status !== undefined && !ACKNOWLEDGEMENT_STATUSES.has(status)) return status
+    if (kind === 'interrupt_agent') {
+      const previous = nonBlankString(value.previousStatus)
+      if (previous !== undefined) return `was ${previous}`
+    }
+    return undefined
+  }
+  const value = typeof parsed === 'string' ? firstLine(parsed) : firstLine(trimmed)
+  if (value === '') return undefined
+  if (kind === 'send_message' && /^message\s+(?:delivered|sent|accepted)\b/i.test(value)) return /\bqueued\b/i.test(value) ? 'queued' : undefined
+  if (kind === 'interrupt_agent' && /^interrupt\s+requested\s+for\s+agent\b/i.test(value)) return undefined
+  return firstActionResultDetail(value)
+}
+
+/**
+ * Derive action semantics from the recorded call/result only. This is the
+ * host fallback boundary: extension-owned renderers still take precedence in
+ * the TUI, while replay remains deterministic and registry-independent.
+ */
+export function compactToolPresentation(
+  name: string,
+  argsRaw: string,
+  result = '',
+  options: CompactToolPresentationOptions = {},
+): CompactToolPresentation | undefined {
+  const send = name === 'send_message' ? sendMessageCallPresentation(argsRaw) : undefined
+  if (send !== undefined) {
+    const failed = options.isError === true || options.error !== undefined
+    const resultText = failed
+      ? actionErrorResult(result, options)
+      : actionResultSummary('send_message', result)
+    return {
+      title: 'Send message', summary: send.target, payload: send.message,
+      ...(resultText === undefined ? {} : { result: resultText }),
+      suppressSuccessResult: true,
+    }
+  }
+
+  const terminal = name === 'terminal_send' ? terminalSendCallPresentation(argsRaw) : undefined
+  if (terminal !== undefined) {
+    const failed = options.isError === true || options.error !== undefined
+    const resultText = failed
+      ? actionErrorResult(result, options)
+      : actionResultSummary('terminal_send', result)
+    return {
+      title: 'Terminal', summary: terminal.sessionId, payload: terminal.text,
+      ...(resultText === undefined ? {} : { result: resultText }),
+      suppressSuccessResult: true,
+    }
+  }
+
+  const interrupt = name === 'interrupt_agent' ? interruptAgentCallPresentation(argsRaw) : undefined
+  if (interrupt !== undefined) {
+    const failed = options.isError === true || options.error !== undefined
+    const resultText = failed
+      ? actionErrorResult(result, options)
+      : actionResultSummary('interrupt_agent', result)
+    return {
+      title: 'Interrupt agent', summary: interrupt.target,
+      ...(resultText === undefined ? {} : { result: resultText }),
+      suppressSuccessResult: true,
+    }
+  }
+
+  const list = name === 'list_agents' ? listAgentsCallPresentation(argsRaw) : undefined
+  if (list !== undefined) {
+    const failed = options.isError === true || options.error !== undefined
+    const summary = failed
+      ? actionErrorResult(result, options)
+      : (() => {
+        const snapshot = summarizeAgentListResult(result)
+        return snapshot === undefined ? undefined : formatAgentListSummary(snapshot)
+      })()
+    return {
+      title: 'List agents', summary: list.scope,
+      ...(summary === undefined ? {} : { result: summary }),
+    }
+  }
+  return undefined
+}
+
+/** Whether a valid action-tool call uses the compact semantic fallback. */
+export function isCompactActionTool(name: string, argsRaw: string): boolean {
+  return compactToolPresentation(name, argsRaw) !== undefined
+}
+
+/** Expanded semantic lines for action cards; list_agents keeps its history snapshot. */
+export function compactToolExpandedLines(
+  name: string,
+  argsRaw: string,
+  result = '',
+  options: CompactToolPresentationOptions = {},
+): string[] | undefined {
+  const presentation = compactToolPresentation(name, argsRaw, result, options)
+  if (presentation === undefined) return undefined
+  if (name === 'list_agents' && options.isError !== true && options.error === undefined) {
+    const parsed = parseJsonValue(result)
+    if (Array.isArray(parsed)) return JSON.stringify(parsed, null, 2).split('\n')
+    // The standard tool records its render() text, not the execute return:
+    // preserve that readable historical snapshot verbatim when it is plain
+    // text (`(no subagents)` or one row per child).
+    if (result.trim() !== '') return result.split(/\r\n|\r|\n/)
+  }
+  const lines = presentation.payload === undefined ? [] : presentation.payload.split(/\r\n|\r|\n/)
+  if (presentation.result !== undefined) lines.push(presentation.result)
+  return lines
+}
+
 /** Summary key preference per variant (args-derived). */
 const SUMMARY_KEYS: Record<string, string[]> = {
   bash: ['description', 'command'],
@@ -713,6 +1053,12 @@ export function readFoldedPreview(result: string): string {
  * @param cwd - workspace root for relativization; optional.
  */
 export function toolCardHeader(name: string, argsRaw: string, cwd?: string): ToolCardHeader {
+  // Action cards use a shape-level semantic title/identity instead of the
+  // generic first-string rule (`agent_id`/`sessionId` is identity, not the
+  // payload). Invalid or unknown shapes deliberately keep the old fallback.
+  const action = compactToolPresentation(name, argsRaw)
+  if (action !== undefined) return { title: action.title, summary: action.summary ?? '' }
+
   const variant = classifyTool(name)
   const toolTitle = TOOL_TITLES[name] ?? TUI_TOOL_TITLES[name]
   // Tool-specific summaries replace the args-derived base before the
@@ -1136,6 +1482,13 @@ function formatOwnedCallForCompactFocus(view: ToolCallView): string {
  * generic "Tool call" — the compact line names the actual tool instead
  * (plan §9.3: an unknown custom tool is still a Tool). */
 function focusToolFallbackDisplay(name: string, argsRaw: string, cwd?: string): string {
+  const action = compactToolPresentation(name, argsRaw)
+  if (action !== undefined) {
+    const identity = action.summary === undefined ? action.title : `${action.title} ${action.summary}`
+    const payload = action.payload === undefined || action.payload === '' ? '' : ` · ${firstLine(action.payload)}`
+    return `${identity}${payload}`
+  }
+
   const header = toolCardHeader(name, argsRaw, cwd)
   const known = classifyTool(name) !== 'others'
     || TOOL_TITLES[name] !== undefined

--- a/src/present.ts
+++ b/src/present.ts
@@ -369,7 +369,11 @@ export function summarizeAgentListResult(text: string): AgentListSummary | undef
     if (/\[running\](?:\s|$)/.test(line)) { running += 1; matched += 1; continue }
     if (/\[idle\](?:\s|$)/.test(line)) { idle += 1; matched += 1; continue }
     if (/\[ready\](?:\s|$)/.test(line)) { ready += 1; matched += 1; continue }
-    if (/\[diagnostic:\s*[^\]]+\]/.test(line)) { diagnostics += 1; matched += 1 }
+    if (/\[diagnostic:\s*[^\]]+\]/.test(line)) { diagnostics += 1; matched += 1; continue }
+    // Any other bracketed status token is an unrecognized row: count it as a
+    // diagnostic instead of silently dropping it (mirrors the structured
+    // path's default branch, so a mixed snapshot never undercounts `total`).
+    if (/\[[a-z][^\]]*\]/.test(line)) { diagnostics += 1; matched += 1 }
   }
   if (matched === 0) return undefined
   const total = running + idle + ready + diagnostics

--- a/src/present.ts
+++ b/src/present.ts
@@ -231,8 +231,6 @@ export interface CompactToolPresentation {
   readonly payload?: string
   /** A meaningful settled result, or an error identity. */
   readonly result?: string
-  /** Whether an acknowledgement-only success result should be omitted. */
-  readonly suppressSuccessResult?: boolean
 }
 
 /** Structured failure information available on a transcript tool card. */
@@ -334,15 +332,19 @@ function summarizeAgentEntries(entries: readonly unknown[]): AgentListSummary {
       continue
     }
     // The standard snapshot uses `kind: child`; Agent Teams returns member
-    // rows without a kind. A recognized status is enough for the latter.
+    // rows without a kind. A recognized status is enough for the latter:
+    // provisioning counts as running (spawning), inactive as ready (cold-
+    // resumable), failed as a diagnostic.
     if (value.kind !== undefined && value.kind !== 'child' && value.kind !== 'agent') {
       diagnostics += 1
       continue
     }
     switch (value.status) {
-      case 'running': running += 1; break
+      case 'running':
+      case 'provisioning': running += 1; break
       case 'idle': idle += 1; break
-      case 'ready': ready += 1; break
+      case 'ready':
+      case 'inactive': ready += 1; break
       default: diagnostics += 1; break
     }
   }
@@ -467,6 +469,10 @@ function actionResultSummary(
   if (value === '') return undefined
   if (kind === 'send_message' && /^message\s+(?:delivered|sent|accepted)\b/i.test(value)) return /\bqueued\b/i.test(value) ? 'queued' : undefined
   if (kind === 'interrupt_agent' && /^interrupt\s+requested\s+for\s+agent\b/i.test(value)) return undefined
+  // Bare acknowledgement words are the same receipt class as their JSON
+  // equivalents and never add folded-card information (the terminal_send
+  // branch above already returned for every non-queued result).
+  if (/^(?:ok|accepted|done|success|succeeded|sent|delivered)$/i.test(value)) return undefined
   return firstActionResultDetail(value)
 }
 
@@ -490,7 +496,6 @@ export function compactToolPresentation(
     return {
       title: 'Send message', summary: send.target, payload: send.message,
       ...(resultText === undefined ? {} : { result: resultText }),
-      suppressSuccessResult: true,
     }
   }
 
@@ -503,7 +508,6 @@ export function compactToolPresentation(
     return {
       title: 'Terminal', summary: terminal.sessionId, payload: terminal.text,
       ...(resultText === undefined ? {} : { result: resultText }),
-      suppressSuccessResult: true,
     }
   }
 
@@ -516,7 +520,6 @@ export function compactToolPresentation(
     return {
       title: 'Interrupt agent', summary: interrupt.target,
       ...(resultText === undefined ? {} : { result: resultText }),
-      suppressSuccessResult: true,
     }
   }
 

--- a/src/present.ts
+++ b/src/present.ts
@@ -278,7 +278,8 @@ export function sendMessageCallPresentation(argsRaw: string): SendMessageCallPre
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
   const args = parsed as Record<string, unknown>
   // The two currently known producers use agent_id and target respectively;
-  // nullish selection keeps a valid standard field authoritative.
+  // prefer the first non-blank field so malformed optional data cannot hide a
+  // valid Team target during replay.
   const target = nonBlankString(args.agent_id) ?? nonBlankString(args.target)
   if (target === undefined || typeof args.message !== 'string') return undefined
   return { target, message: args.message }
@@ -300,6 +301,8 @@ export function terminalSendCallPresentation(argsRaw: string): TerminalSendCallP
   const args = parsed as Record<string, unknown>
   const sessionId = nonBlankString(args.sessionId)
   if (sessionId === undefined || typeof args.text !== 'string') return undefined
+  if (args.submit !== undefined && typeof args.submit !== 'boolean') return undefined
+  if (args.run_in_background !== undefined && typeof args.run_in_background !== 'boolean') return undefined
   return { sessionId, text: args.text }
 }
 

--- a/src/present.ts
+++ b/src/present.ts
@@ -369,7 +369,7 @@ export function summarizeAgentListResult(text: string): AgentListSummary | undef
     if (/\[running\](?:\s|$)/.test(line)) { running += 1; matched += 1; continue }
     if (/\[idle\](?:\s|$)/.test(line)) { idle += 1; matched += 1; continue }
     if (/\[ready\](?:\s|$)/.test(line)) { ready += 1; matched += 1; continue }
-    if (/\[diagnostic:\s*[^\]]+\]/.test(line)) { diagnostics += 1; matched += 1; continue }
+    if (/\[diagnostic:[^\]]+\]/.test(line)) { diagnostics += 1; matched += 1; continue }
     // Any other bracketed status token is an unrecognized row: count it as a
     // diagnostic instead of silently dropping it (mirrors the structured
     // path's default branch, so a mixed snapshot never undercounts `total`).

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -8730,7 +8730,9 @@ export class TuiApp {
         const styled = message.status === 'error' && action.result !== undefined && index === lines.length - 1
           ? color.error(line)
           : color.textDim(line)
-        card.addChild(new Text(`  ${styled}`, 0, 0))
+        // Reuse the live width-aware wrapper for expanded payload lines too:
+        // long coordination text keeps its two-cell continuation indent.
+        card.addChild(new CompactTextPreview(styled, Number.MAX_SAFE_INTEGER, '  '))
       }
       return
     }
@@ -8740,12 +8742,12 @@ export class TuiApp {
       // output/exit-code path merely to make the payload visible.
       if (action.payload !== undefined && action.payload !== '') {
         for (const line of action.payload.split(/\r\n|\r|\n/)) {
-          card.addChild(new Text(color.textDim(`  ${line}`), 0, 0))
+          card.addChild(new CompactTextPreview(color.textDim(line), Number.MAX_SAFE_INTEGER, '  '))
         }
       }
       if (message.status === 'running') return
       if (message.status === 'error') {
-        if (action.result !== undefined) card.addChild(new Text(color.error(`  ${action.result}`), 0, 0))
+        if (action.result !== undefined) card.addChild(new CompactTextPreview(color.error(action.result), Number.MAX_SAFE_INTEGER, '  '))
         return
       }
     }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -111,6 +111,9 @@ import {
   GOAL_TOOL_NAMES,
   foldedResultSummaryFor,
   FOLDED_JSON_RESULT_TOOLS,
+  compactToolPresentation,
+  compactToolExpandedLines,
+  isCompactActionTool,
   focusToolDisplay,
   systemContextBody,
   toolCardHeader,
@@ -119,6 +122,7 @@ import {
   type ToolPresenter,
 } from './present.ts'
 import { TranscriptSearchComponent } from './search.ts'
+import { CompactTextPreview } from './compact-text-preview.ts'
 import { HistoryPanel } from './history-panel.ts'
 import type { HistorySearchSource } from './history-search.ts'
 import { QuestionFlow } from './question.ts'
@@ -8016,7 +8020,7 @@ export class TuiApp {
 
   /**
    * Whether a HOST build bakes width-dependent truncation into the
-   * component at build time — the FOLDED system / compaction / tool
+   * component at build time — the FOLDED system / compaction / legacy tool
    * cards (their preview rows truncate to the content width once, so a
    * terminal resize must rebuild them at the new width). Render-time
    * width-aware builds (assistant/user markdown and bubbles, Thinking
@@ -8028,7 +8032,8 @@ export class TuiApp {
    */
   private bakesFoldedWidth(message: TranscriptMessage, expanded: boolean): boolean {
     if (expanded) return false
-    return message.kind === 'system' || message.kind === 'compaction' || message.kind === 'tool'
+    return message.kind === 'system' || message.kind === 'compaction'
+      || (message.kind === 'tool' && !isCompactActionTool(message.name, message.args))
   }
 
   /**
@@ -8374,7 +8379,13 @@ export class TuiApp {
     // pill keeps its semantic color (ok/error/running).
     const card = new Container()
     const header = toolCardHeader(message.name, message.args, this.workspaceRoot)
-    const summary = header.summary === '' ? '' : ` ${header.summary}`
+    const action = compactToolPresentation(message.name, message.args, message.result, {
+      isError: message.status === 'error',
+      ...(message.error === undefined ? {} : { error: message.error }),
+    })
+    // Action identities use a dot separator (`Send message · child-1`) while
+    // the existing Web-style rows retain their historical space separator.
+    const summary = header.summary === '' ? '' : action !== undefined ? ` · ${header.summary}` : ` ${header.summary}`
     // The glyph resolves through the icon registry against the CURRENT
     // style; iconPrefix drops the separator when the style hides the icon
     // (minimal) — the header starts directly with the title.
@@ -8390,7 +8401,9 @@ export class TuiApp {
     // cannot fill the TUI, expanded only while the expand switch is on.
     const localShell = isLocalShellCard(message)
     if (expanded) {
-      card.addChild(new Text(head, 0, 0))
+      // Action headers and payloads are live width-aware components; every
+      // other host card keeps its existing Text path and cache behavior.
+      card.addChild(action === undefined ? new Text(head, 0, 0) : new CompactTextPreview(head, 1, ''))
       // An explicitly expanded card renders diff bodies in full; the
       // default recent-turn view caps them (kimi parity). The flag is
       // the FULL REVEAL: the per-card override (the fullscreen secondary
@@ -8398,6 +8411,20 @@ export class TuiApp {
       // regular mode would have no mouse affordance to open it.
       this.renderToolBody(card, message, fullReveal)
     } else {
+      if (action !== undefined) {
+        // Action cards deliberately keep the stable header separate from the
+        // payload. CompactTextPreview wraps/truncates at render time, so this
+        // same cached card remains correct after every resize.
+        card.addChild(new CompactTextPreview(head, 1, ''))
+        if (action.payload !== undefined && action.payload !== '') {
+          card.addChild(new CompactTextPreview(color.textDim(action.payload), 2, '  '))
+        }
+        if (action.result !== undefined && action.result !== '') {
+          const result = message.status === 'error' ? color.error(action.result) : color.textDim(action.result)
+          card.addChild(new CompactTextPreview(result, 1, '  '))
+        }
+        return card
+      }
       // Folded cards render 2–3 rows instead of one cramped line: the header
       // row, then the call preview (bash `$ command` / edit-write diff —
       // kimi parity: the command and the change are visible without
@@ -8687,6 +8714,41 @@ export class TuiApp {
       }
       return
     }
+
+    const action = compactToolPresentation(message.name, message.args, message.result, {
+      isError: message.status === 'error',
+      ...(message.error === undefined ? {} : { error: message.error }),
+    })
+    if (action !== undefined && message.name !== 'terminal_send') {
+      // Action bodies are semantic too: send/interrupt cards never expose a
+      // delivery receipt, while list_agents keeps the historical snapshot.
+      const lines = compactToolExpandedLines(message.name, message.args, message.result, {
+        isError: message.status === 'error',
+        ...(message.error === undefined ? {} : { error: message.error }),
+      }) ?? []
+      for (const [index, line] of lines.entries()) {
+        const styled = message.status === 'error' && action.result !== undefined && index === lines.length - 1
+          ? color.error(line)
+          : color.textDim(line)
+        card.addChild(new Text(`  ${styled}`, 0, 0))
+      }
+      return
+    }
+    if (action !== undefined && message.name === 'terminal_send') {
+      // terminal_send may also have a dedicated result presenter. Its sent
+      // text belongs above that existing terminal output; do not replace the
+      // output/exit-code path merely to make the payload visible.
+      if (action.payload !== undefined && action.payload !== '') {
+        for (const line of action.payload.split(/\r\n|\r|\n/)) {
+          card.addChild(new Text(color.textDim(`  ${line}`), 0, 0))
+        }
+      }
+      if (message.status === 'running') return
+      if (message.status === 'error') {
+        if (action.result !== undefined) card.addChild(new Text(color.error(`  ${action.result}`), 0, 0))
+        return
+      }
+    }
     // Workflow run cards: the body is the run's member tree, grouped by phase
     // in arrival order (Web WorkflowRunPanel parity). Rows render even while
     // the run is still streaming (members land incrementally).
@@ -8820,6 +8882,9 @@ export class TuiApp {
       isError: message.status === 'error',
       ...message.meta === undefined ? {} : { meta: message.meta },
     })
+    // A dedicated terminal presenter, when available, remains authoritative
+    // for output and exit status. Without one, the legacy raw-result fallback
+    // below keeps the expanded viewport/wait/session snapshot intact.
     if (resultView !== undefined) {
       switch (resultView.card) {
         case 'read': {

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -8731,8 +8731,9 @@ export class TuiApp {
           ? color.error(line)
           : color.textDim(line)
         // Reuse the live width-aware wrapper for expanded payload lines too:
-        // long coordination text keeps its two-cell continuation indent.
-        card.addChild(new CompactTextPreview(styled, Number.MAX_SAFE_INTEGER, '  '))
+        // long coordination text keeps its two-cell continuation indent, and
+        // original blank lines (paragraph breaks) stay visible.
+        card.addChild(new CompactTextPreview(styled, Number.MAX_SAFE_INTEGER, '  ', true))
       }
       return
     }
@@ -8742,12 +8743,12 @@ export class TuiApp {
       // output/exit-code path merely to make the payload visible.
       if (action.payload !== undefined && action.payload !== '') {
         for (const line of action.payload.split(/\r\n|\r|\n/)) {
-          card.addChild(new CompactTextPreview(color.textDim(line), Number.MAX_SAFE_INTEGER, '  '))
+          card.addChild(new CompactTextPreview(color.textDim(line), Number.MAX_SAFE_INTEGER, '  ', true))
         }
       }
       if (message.status === 'running') return
       if (message.status === 'error') {
-        if (action.result !== undefined) card.addChild(new CompactTextPreview(color.error(action.result), Number.MAX_SAFE_INTEGER, '  '))
+        if (action.result !== undefined) card.addChild(new CompactTextPreview(color.error(action.result), Number.MAX_SAFE_INTEGER, '  ', true))
         return
       }
     }

--- a/test/action-tool-card.test.ts
+++ b/test/action-tool-card.test.ts
@@ -194,7 +194,8 @@ test('CompactTextPreview is Unicode-safe, capped, and re-derived on resize', () 
   for (const line of wide) assert.ok(visibleWidth(line) <= 60, JSON.stringify(line))
   assert.deepEqual(preview.render(12), narrow, 'narrow cache must remain deterministic after a wide render')
   // Visually empty wrapped rows (blank lines, or rows carrying only style
-  // codes at tiny widths) never surface as blank preview rows.
+  // codes at tiny widths) never surface as blank preview rows in the
+  // COMPACT mode…
   const styled = new CompactTextPreview({
     text: 'line one\n\nline three',
     maxVisualRows: 3,
@@ -204,6 +205,17 @@ test('CompactTextPreview is Unicode-safe, capped, and re-derived on resize', () 
   assert.equal(rows.length, 2, `blank middle row must be dropped: ${rows.join('|')}`)
   assert.ok(rows[0]?.includes('line one'), rows.join('|'))
   assert.ok(rows[1]?.includes('line three'), rows.join('|'))
+  // …while EXPANDED bodies opt into preserveBlankLines: paragraph breaks
+  // in the original message must not be collapsed away.
+  const preserved = new CompactTextPreview({
+    text: 'line one\n\nline three',
+    maxVisualRows: 3,
+    indent: '  ',
+    preserveBlankLines: true,
+  })
+  const kept = preserved.render(60)
+  assert.equal(kept.length, 3, `blank paragraph row must survive: ${kept.join('|')}`)
+  assert.equal(stripTerminalSequences(kept[1] ?? ''), '  ', 'the paragraph row must render as the bare indent')
 })
 
 test('folded action cards show payloads and suppress successful receipts', async () => {
@@ -246,14 +258,19 @@ test('expanded action cards keep payloads, historical snapshots, and terminal ou
   startedApps.add(app)
   app.setToolOutputExpanded(true)
   app.setTranscript([
-    actionMessage('send_message', { agent_id: 'child-1', message: 'first line\nsecond line\nthird line' }, 'message delivered to agent child-1'),
+    actionMessage('send_message', { agent_id: 'child-1', message: 'First instruction.\n\nSecond instruction.' }, 'message delivered to agent child-1'),
     actionMessage('terminal_send', { sessionId: 'pty-3', text: 'export FOO=1\nmake test' }, 'viewport output\n[wait: stdin_read]'),
     actionMessage('list_agents', { scope: 'children' }, '1 [running] — a\n2 [ready] — b'),
   ])
   const view = await viewport(vt)
-  assert.ok(view.includes('first line'), view)
-  assert.ok(view.includes('second line'), view)
-  assert.ok(view.includes('third line'), view)
+  const clean = view.split('\n').map(stripTerminalSequences)
+  assert.ok(view.includes('First instruction.'), view)
+  assert.ok(view.includes('Second instruction.'), view)
+  // Expanded fidelity: the original blank paragraph line survives between
+  // the two payload rows (row indices differ by two).
+  const first = clean.findIndex(line => line.includes('First instruction.'))
+  const second = clean.findIndex(line => line.includes('Second instruction.'))
+  assert.ok(first >= 0 && second - first === 2, `blank paragraph row missing:\n${view}`)
   assert.ok(view.includes('export FOO=1'), view)
   assert.ok(view.includes('make test'), view)
   assert.ok(view.includes('viewport output'), view)

--- a/test/action-tool-card.test.ts
+++ b/test/action-tool-card.test.ts
@@ -193,6 +193,17 @@ test('CompactTextPreview is Unicode-safe, capped, and re-derived on resize', () 
   assert.ok(wide.some(line => line.includes('second payload')), `wide render lost later payload: ${wide.join('|')}`)
   for (const line of wide) assert.ok(visibleWidth(line) <= 60, JSON.stringify(line))
   assert.deepEqual(preview.render(12), narrow, 'narrow cache must remain deterministic after a wide render')
+  // Visually empty wrapped rows (blank lines, or rows carrying only style
+  // codes at tiny widths) never surface as blank preview rows.
+  const styled = new CompactTextPreview({
+    text: 'line one\n\nline three',
+    maxVisualRows: 3,
+    indent: '  ',
+  })
+  const rows = styled.render(60)
+  assert.equal(rows.length, 2, `blank middle row must be dropped: ${rows.join('|')}`)
+  assert.ok(rows[0]?.includes('line one'), rows.join('|'))
+  assert.ok(rows[1]?.includes('line three'), rows.join('|'))
 })
 
 test('folded action cards show payloads and suppress successful receipts', async () => {

--- a/test/action-tool-card.test.ts
+++ b/test/action-tool-card.test.ts
@@ -109,6 +109,12 @@ test('compact action presentations are payload-first and receipt-safe', () => {
     'interrupt requested for agent reviewer',
   )
   assert.equal(interrupt?.result, undefined)
+  // A team interrupt carries the previous runtime status as new information.
+  assert.equal(compactToolPresentation(
+    'interrupt_agent',
+    JSON.stringify({ target: 'reviewer' }),
+    JSON.stringify({ previousStatus: 'running' }),
+  )?.result, 'was running')
   // Bare acknowledgement words are the same receipt class as JSON statuses.
   assert.equal(compactToolPresentation('send_message', JSON.stringify({ agent_id: 'c', message: 'x' }), 'ok')?.result, undefined)
   assert.equal(compactToolPresentation('send_message', JSON.stringify({ agent_id: 'c', message: 'x' }), 'accepted')?.result, undefined)
@@ -129,6 +135,9 @@ test('compact action presentations are payload-first and receipt-safe', () => {
     title: 'Terminal', summary: 'pty-3',
   })
   assert.equal(focusToolDisplay({ name: 'send_message', args: JSON.stringify({ target: 'reviewer', message: 'Inspect the card.' }) }), 'Send message reviewer · Inspect the card.')
+  assert.equal(focusToolDisplay({ name: 'terminal_send', args: JSON.stringify({ sessionId: 'pty-3', text: 'make test' }) }), 'Terminal pty-3 · make test')
+  assert.equal(focusToolDisplay({ name: 'interrupt_agent', args: JSON.stringify({ agent_id: 'child-1' }) }), 'Interrupt agent child-1')
+  assert.equal(focusToolDisplay({ name: 'list_agents', args: '{}' }), 'List agents children')
 })
 
 test('list_agents summarizes structured and rendered historical snapshots', () => {
@@ -145,6 +154,12 @@ test('list_agents summarizes structured and rendered historical snapshots', () =
   assert.equal(formatAgentListSummary(summarizeAgentListResult('1 [running] — a\n2 [idle] — b\n3 [ready] — c')!), '3 agents · 1 running · 1 idle · 1 ready')
   assert.equal(formatAgentListSummary(summarizeAgentListResult('(no subagents)')!), 'no subagents')
   assert.equal(formatAgentListSummary(summarizeAgentListResult('x [diagnostic: corrupt]')!), '1 entry · 1 diagnostic')
+  // Descendants rows carry parent/depth position; the status regex must not
+  // confuse them with diagnostics.
+  assert.equal(formatAgentListSummary(summarizeAgentListResult('1 [running] parent=0 depth=1 — a\n2 [ready] parent=1 depth=1 — b')!), '2 agents · 1 running · 1 ready')
+  // An unrecognized bracketed status is NOT silently dropped: it counts as a
+  // diagnostic so `total` never undercounts a mixed snapshot.
+  assert.equal(formatAgentListSummary(summarizeAgentListResult('1 [running] — a\n2 [unknown-state] — b')!), '2 entries · 1 running · 1 diagnostic')
   // Agent Teams member rows are kind-less with a wider status enum:
   // provisioning counts as running, inactive as ready, failed as diagnostic.
   const team = summarizeAgentListResult(JSON.stringify([
@@ -191,6 +206,7 @@ test('folded action cards show payloads and suppress successful receipts', async
     actionMessage('interrupt_agent', { agent_id: 'child-1' }, 'interrupt requested for agent child-1'),
     actionMessage('list_agents', { scope: 'children' }, '1 [running] — a\n2 [idle] — b\n3 [ready] — c'),
     actionMessage('send_message', { target: 'reviewer', message: 'Inspect the failed target.' }, JSON.stringify({ messageId: 'm1', status: 'accepted' })),
+    actionMessage('send_message', { target: 'sleeper', message: 'Wake up.' }, JSON.stringify({ messageId: 'm2', status: 'queued' })),
   ])
   const view = await viewport(vt)
   assert.ok(view.includes('Send message · child-1 [ok]'), view)
@@ -202,6 +218,10 @@ test('folded action cards show payloads and suppress successful receipts', async
   assert.ok(view.includes('List agents · children [ok]'), view)
   assert.ok(view.includes('3 agents · 1 running · 1 idle · 1 ready'), view)
   assert.ok(view.includes('Inspect the failed target.'), view)
+  assert.ok(view.includes('Wake up.'), view)
+  // A team queued state is the one receipt that adds information: it keeps a
+  // short folded row and never leaks the raw JSON.
+  assert.ok(view.includes('queued'), view)
   assert.ok(!view.includes('message delivered to agent'), view)
   assert.ok(!view.includes('interrupt requested for agent'), view)
   assert.ok(!view.includes('viewport output'), view)
@@ -294,20 +314,26 @@ test('action errors remain visible in folded cards', async () => {
 })
 
 test('folded CJK payloads stay width-safe on a tiny terminal', async () => {
-  const vt = new VirtualTerminal(12, 24)
-  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
-  app.start()
-  startedApps.add(app)
-  app.setTranscript([actionMessage(
-    'send_message',
-    { agent_id: 'child-1', message: '检查 CI 失败\n对比过渡 fence 行为' },
-    'message delivered to agent child-1',
-  )])
-  const view = await viewport(vt)
-  const clean = view.split('\n').map(stripTerminalSequences)
-  assert.ok(clean.some(line => line.includes('检查')), view)
-  for (const line of clean) {
-    assert.ok(visibleWidth(line) <= 12, `row exceeds 12 cols: ${JSON.stringify(line)}`)
+  for (const columns of [8, 12]) {
+    const vt = new VirtualTerminal(columns, 24)
+    const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+    app.start()
+    startedApps.add(app)
+    app.setTranscript([actionMessage(
+      'send_message',
+      { agent_id: 'child-1', message: '检查 CI 失败\n对比过渡 fence 行为' },
+      'message delivered to agent child-1',
+    )])
+    const view = await viewport(vt)
+    const clean = view.split('\n').map(stripTerminalSequences)
+    assert.ok(clean.some(line => line.includes('检查')), `width ${columns}: ${view}`)
+    for (const line of clean) {
+      assert.ok(visibleWidth(line) <= columns, `width ${columns} row exceeds: ${JSON.stringify(line)}`)
+    }
+    // The process slot is released only by the final dispose: stop the
+    // surface before the next width starts a new app.
+    startedApps.delete(app)
+    app.dispose()
   }
 })
 
@@ -414,6 +440,26 @@ function actionTurnEvents(): SessionEvent[] {
     { type: 'turn/end', seq: 5, time: time + 7000, data: { turn: 1, reason: { kind: 'completed' } } },
   ] as SessionEvent[]
 }
+
+// Plan §17 guard: the pre-optimized tool families keep their established
+// folded semantics — the action branch must never leak into them.
+test('legacy optimized tool cards are untouched by the action fallback', async () => {
+  const vt = new VirtualTerminal(100, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([
+    actionMessage('read', { path: 'src/index.ts' }, '<path>src/index.ts</path><type>text</type><content>1: line one\n2: line two</content>'),
+    actionMessage('bash', { command: 'echo hi' }, 'hello from bash'),
+    actionMessage('ask_user_question', { questions: [{ id: 'q', question: 'Go?' }] }, JSON.stringify({ answers: [{ id: 'q', selected: ['y'] }] })),
+  ])
+  const view = await viewport(vt)
+  assert.ok(view.includes('Read src/index.ts [ok]'), view)
+  assert.ok(view.includes('— 2 lines'), view)
+  assert.ok(view.includes('$ echo hi'), view)
+  assert.ok(view.includes('Question Go? [ok]'), view)
+  assert.ok(view.includes('— 1/1 answered'), view)
+})
 
 // Keep the imported model type checked as a public data-only contract.
 const _compactModelTypeCheck: CompactToolPresentation | undefined = compactToolPresentation('send_message', '{}')

--- a/test/action-tool-card.test.ts
+++ b/test/action-tool-card.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
+import { MessageId, ToolCallId } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { stripTerminalSequences, visibleWidth } from '@xmoon76/pi-tui'
 import {
   compactToolExpandedLines,
@@ -73,7 +75,6 @@ test('compact action presentations are payload-first and receipt-safe', () => {
     title: 'Send message',
     summary: 'child-1',
     payload: 'Review the CI failure.',
-    suppressSuccessResult: true,
   })
   const accepted = compactToolPresentation(
     'send_message',
@@ -95,7 +96,7 @@ test('compact action presentations are payload-first and receipt-safe', () => {
     'viewport output\n[wait: stdin_read]\n[session: running]',
   )
   assert.deepEqual(terminal, {
-    title: 'Terminal', summary: 'pty-3', payload: 'make test', suppressSuccessResult: true,
+    title: 'Terminal', summary: 'pty-3', payload: 'make test',
   })
   assert.equal(compactToolPresentation(
     'terminal_send',
@@ -108,6 +109,10 @@ test('compact action presentations are payload-first and receipt-safe', () => {
     'interrupt requested for agent reviewer',
   )
   assert.equal(interrupt?.result, undefined)
+  // Bare acknowledgement words are the same receipt class as JSON statuses.
+  assert.equal(compactToolPresentation('send_message', JSON.stringify({ agent_id: 'c', message: 'x' }), 'ok')?.result, undefined)
+  assert.equal(compactToolPresentation('send_message', JSON.stringify({ agent_id: 'c', message: 'x' }), 'accepted')?.result, undefined)
+  assert.equal(compactToolPresentation('interrupt_agent', JSON.stringify({ agent_id: 'c' }), 'done')?.result, undefined)
   const failure = compactToolPresentation(
     'send_message',
     JSON.stringify({ agent_id: 'child-1', message: 'retry' }),
@@ -139,6 +144,16 @@ test('list_agents summarizes structured and rendered historical snapshots', () =
   ]))!), '1 entry · 1 diagnostic')
   assert.equal(formatAgentListSummary(summarizeAgentListResult('1 [running] — a\n2 [idle] — b\n3 [ready] — c')!), '3 agents · 1 running · 1 idle · 1 ready')
   assert.equal(formatAgentListSummary(summarizeAgentListResult('(no subagents)')!), 'no subagents')
+  assert.equal(formatAgentListSummary(summarizeAgentListResult('x [diagnostic: corrupt]')!), '1 entry · 1 diagnostic')
+  // Agent Teams member rows are kind-less with a wider status enum:
+  // provisioning counts as running, inactive as ready, failed as diagnostic.
+  const team = summarizeAgentListResult(JSON.stringify([
+    { id: '1', role: 'teammate', status: 'running' },
+    { id: '2', role: 'teammate', status: 'provisioning' },
+    { id: '3', role: 'lead', status: 'inactive' },
+    { id: '4', role: 'teammate', status: 'failed' },
+  ]))!
+  assert.equal(formatAgentListSummary(team), '4 entries · 2 running · 1 ready · 1 diagnostic')
 
   const list = compactToolPresentation('list_agents', '{}', '1 [running] — a\n2 [idle] — b\n3 [ready] — c')
   assert.equal(list?.title, 'List agents')
@@ -201,13 +216,15 @@ test('expanded action cards keep payloads, historical snapshots, and terminal ou
   app.setToolOutputExpanded(true)
   app.setTranscript([
     actionMessage('send_message', { agent_id: 'child-1', message: 'first line\nsecond line\nthird line' }, 'message delivered to agent child-1'),
-    actionMessage('terminal_send', { sessionId: 'pty-3', text: 'make test' }, 'viewport output\n[wait: stdin_read]'),
+    actionMessage('terminal_send', { sessionId: 'pty-3', text: 'export FOO=1\nmake test' }, 'viewport output\n[wait: stdin_read]'),
     actionMessage('list_agents', { scope: 'children' }, '1 [running] — a\n2 [ready] — b'),
   ])
   const view = await viewport(vt)
   assert.ok(view.includes('first line'), view)
   assert.ok(view.includes('second line'), view)
   assert.ok(view.includes('third line'), view)
+  assert.ok(view.includes('export FOO=1'), view)
+  assert.ok(view.includes('make test'), view)
   assert.ok(view.includes('viewport output'), view)
   assert.ok(view.includes('[wait: stdin_read]'), view)
   assert.ok(view.includes('1 [running] — a'), view)
@@ -275,6 +292,128 @@ test('action errors remain visible in folded cards', async () => {
   assert.ok(view.includes('SubagentError: NOT_INTERRUPTIBLE'), view)
   assert.ok(view.includes('target is not interruptible'), view)
 })
+
+test('folded CJK payloads stay width-safe on a tiny terminal', async () => {
+  const vt = new VirtualTerminal(12, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([actionMessage(
+    'send_message',
+    { agent_id: 'child-1', message: '检查 CI 失败\n对比过渡 fence 行为' },
+    'message delivered to agent child-1',
+  )])
+  const view = await viewport(vt)
+  const clean = view.split('\n').map(stripTerminalSequences)
+  assert.ok(clean.some(line => line.includes('检查')), view)
+  for (const line of clean) {
+    assert.ok(visibleWidth(line) <= 12, `row exceeds 12 cols: ${JSON.stringify(line)}`)
+  }
+})
+
+test('an extension tool renderer still wins over the host action fallback', async () => {
+  const { RendererRegistry } = await import('../src/renderer-registry.ts')
+  const registry = new RendererRegistry()
+  registry.registerToolRenderer({
+    id: 'custom-send', toolName: 'send_message',
+    render: () => ({ kind: 'text', spans: [{ text: 'CUSTOM SEND' }] }),
+  }, 'plugin')
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { renderers: registry })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([actionMessage('send_message', { agent_id: 'child-1', message: 'x' }, 'receipt')])
+  const view = await viewport(vt)
+  assert.ok(view.includes('CUSTOM SEND'), view)
+  assert.ok(!view.includes('Send message'), view)
+})
+
+test('regular Focus: an expanded root full-reveals the send_message payload, never the receipt', async () => {
+  const { TranscriptFolder } = await import('../src/transcript.ts')
+  const folder = new TranscriptFolder()
+  folder.apply(actionTurnEvents())
+  const vt = new VirtualTerminal(80, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setFocusMode(true)
+  app.setTranscript(folder.messages(), folder.turnActivities())
+  app.expandFocusTurn(1)
+  const view = await viewport(vt)
+  assert.ok(view.includes('Send message · child-1 [ok]'), view)
+  assert.ok(view.includes('Review the CI failure.'), view)
+  assert.ok(view.includes('Check the fence.'), view)
+  assert.ok(!view.includes('message delivered to agent'), view)
+})
+
+test('fullscreen Focus: the secondary send_message card stays compact with its payload', async () => {
+  const { TranscriptFolder } = await import('../src/transcript.ts')
+  const folder = new TranscriptFolder()
+  folder.apply(actionTurnEvents())
+  const vt = new VirtualTerminal(80, 30)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setFocusMode(true)
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages(), folder.turnActivities())
+  app.expandFocusTurn(1)
+  const view = await viewport(vt)
+  // The collapsed-slot one-liner (`Send message <target> · <first line>`) is
+  // covered by the pure focusToolDisplay assertion; here the expanded root
+  // renders the secondary card COMPACT: identity + two-row payload, no
+  // receipt.
+  assert.ok(view.includes('Send message · child-1 [ok]'), view)
+  assert.ok(view.includes('Review the CI failure.'), view)
+  assert.ok(view.includes('Check the fence.'), view)
+  assert.ok(!view.includes('message delivered to agent'), view)
+})
+
+// A settled turn carrying one send_message call, driven through real events.
+function actionTurnEvents(): SessionEvent[] {
+  const time = Date.now() - 60_000
+  return [
+    { type: 'turn/start', seq: 0, time, data: { turn: 1 } },
+    {
+      type: 'user/message', seq: 1, time: time + 1,
+      data: {
+        id: MessageId('u1'), role: 'user',
+        content: [{ type: 'text', text: 'ping the child' }],
+        source: { kind: 'user' },
+      },
+    },
+    {
+      type: 'tool/call', seq: 2, time: time + 2,
+      data: {
+        turn: 1, step: 0, callId: ToolCallId('c1'), name: 'send_message',
+        arguments: JSON.stringify({ agent_id: 'child-1', message: 'Review the CI failure.\nCheck the fence.' }),
+      },
+    },
+    {
+      type: 'tool/result', seq: 3, time: time + 5000,
+      data: {
+        turn: 1, step: 0,
+        message: {
+          id: MessageId('r1'), role: 'user',
+          content: [{ type: 'tool-result', toolCallId: ToolCallId('c1'), content: [{ type: 'text', text: 'message delivered to agent child-1' }] }],
+          source: { kind: 'tool', callId: ToolCallId('c1') },
+        },
+      },
+    },
+    {
+      type: 'assistant/message', seq: 4, time: time + 6000,
+      data: {
+        turn: 1, step: 1,
+        message: {
+          id: MessageId('a1'), role: 'assistant',
+          content: [{ type: 'text', text: 'done.' }],
+          source: { kind: 'model', provider: 'p', model: 'm' },
+        },
+      },
+    },
+    { type: 'turn/end', seq: 5, time: time + 7000, data: { turn: 1, reason: { kind: 'completed' } } },
+  ] as SessionEvent[]
+}
 
 // Keep the imported model type checked as a public data-only contract.
 const _compactModelTypeCheck: CompactToolPresentation | undefined = compactToolPresentation('send_message', '{}')

--- a/test/action-tool-card.test.ts
+++ b/test/action-tool-card.test.ts
@@ -1,0 +1,281 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { stripTerminalSequences, visibleWidth } from '@xmoon76/pi-tui'
+import {
+  compactToolExpandedLines,
+  compactToolPresentation,
+  formatAgentListSummary,
+  focusToolDisplay,
+  interruptAgentCallPresentation,
+  listAgentsCallPresentation,
+  sendMessageCallPresentation,
+  summarizeAgentListResult,
+  terminalSendCallPresentation,
+  toolCardHeader,
+} from '../src/present.ts'
+import type { CompactToolPresentation } from '../src/present.ts'
+import { CompactTextPreview } from '../src/compact-text-preview.ts'
+import { TuiApp, transcriptContentWidth } from '../src/tui-app.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+const startedApps = new Set<TuiApp>()
+afterEach(() => {
+  for (const app of startedApps) {
+    startedApps.delete(app)
+    if (!app.isDisposed()) app.dispose()
+  }
+})
+
+async function viewport(vt: VirtualTerminal): Promise<string> {
+  await vt.waitForRender()
+  return vt.getViewport().join('\n')
+}
+
+function actionMessage(
+  name: string,
+  args: Record<string, unknown>,
+  result: string,
+  status: 'ok' | 'error' | 'running' = 'ok',
+  error?: { name: string; code: string },
+) {
+  return { kind: 'tool' as const, turn: 0, name, args: JSON.stringify(args), result, status, error }
+}
+
+test('action call presenters normalize standard and Team shapes', () => {
+  assert.deepEqual(sendMessageCallPresentation(JSON.stringify({ agent_id: 'child-1', message: 'review' })), {
+    target: 'child-1', message: 'review',
+  })
+  assert.deepEqual(sendMessageCallPresentation(JSON.stringify({ target: 'reviewer', message: 'inspect' })), {
+    target: 'reviewer', message: 'inspect',
+  })
+  assert.deepEqual(interruptAgentCallPresentation(JSON.stringify({ agent_id: 'child-1' })), { target: 'child-1' })
+  assert.deepEqual(interruptAgentCallPresentation(JSON.stringify({ target: 'reviewer' })), { target: 'reviewer' })
+  assert.deepEqual(terminalSendCallPresentation(JSON.stringify({ sessionId: 'pty-3', text: 'make test' })), {
+    sessionId: 'pty-3', text: 'make test',
+  })
+  assert.deepEqual(listAgentsCallPresentation('{}'), { scope: 'children' })
+  assert.deepEqual(listAgentsCallPresentation(''), { scope: 'children' })
+  assert.deepEqual(listAgentsCallPresentation('{"scope":"descendants"}'), { scope: 'descendants' })
+
+  assert.equal(sendMessageCallPresentation(JSON.stringify({ agent_id: 'child-1' })), undefined)
+  assert.equal(interruptAgentCallPresentation(JSON.stringify({ target: '' })), undefined)
+  assert.equal(terminalSendCallPresentation(JSON.stringify({ sessionId: 'pty-3' })), undefined)
+  assert.equal(listAgentsCallPresentation('{"scope":"invalid"}'), undefined)
+})
+
+test('compact action presentations are payload-first and receipt-safe', () => {
+  const standard = compactToolPresentation(
+    'send_message',
+    JSON.stringify({ agent_id: 'child-1', message: 'Review the CI failure.' }),
+    'message delivered to agent child-1',
+  )
+  assert.deepEqual(standard, {
+    title: 'Send message',
+    summary: 'child-1',
+    payload: 'Review the CI failure.',
+    suppressSuccessResult: true,
+  })
+  const accepted = compactToolPresentation(
+    'send_message',
+    JSON.stringify({ target: 'reviewer', message: 'Inspect the card.' }),
+    JSON.stringify({ messageId: 'm1', status: 'accepted' }),
+  )
+  assert.equal(accepted?.result, undefined)
+  assert.equal(accepted?.payload, 'Inspect the card.')
+  const queued = compactToolPresentation(
+    'send_message',
+    JSON.stringify({ target: 'reviewer', message: 'Wake the reviewer.' }),
+    JSON.stringify({ messageId: 'm2', status: 'queued' }),
+  )
+  assert.equal(queued?.result, 'queued')
+
+  const terminal = compactToolPresentation(
+    'terminal_send',
+    JSON.stringify({ sessionId: 'pty-3', text: 'make test' }),
+    'viewport output\n[wait: stdin_read]\n[session: running]',
+  )
+  assert.deepEqual(terminal, {
+    title: 'Terminal', summary: 'pty-3', payload: 'make test', suppressSuccessResult: true,
+  })
+  assert.equal(compactToolPresentation(
+    'terminal_send',
+    JSON.stringify({ sessionId: 'pty-3', text: 'make test', run_in_background: true }),
+    'started background job job-1',
+  )?.result, 'started background job job-1')
+  const interrupt = compactToolPresentation(
+    'interrupt_agent',
+    JSON.stringify({ target: 'reviewer' }),
+    'interrupt requested for agent reviewer',
+  )
+  assert.equal(interrupt?.result, undefined)
+  const failure = compactToolPresentation(
+    'send_message',
+    JSON.stringify({ agent_id: 'child-1', message: 'retry' }),
+    'target is not a direct continuable child',
+    { isError: true },
+  )
+  assert.equal(failure?.result, 'target is not a direct continuable child')
+  assert.equal(compactToolPresentation('send_message', '{"agent_id":"child-1"}'), undefined)
+
+  assert.deepEqual(toolCardHeader('send_message', JSON.stringify({ agent_id: 'child-1', message: 'review' })), {
+    title: 'Send message', summary: 'child-1',
+  })
+  assert.deepEqual(toolCardHeader('terminal_send', JSON.stringify({ sessionId: 'pty-3', text: 'make' })), {
+    title: 'Terminal', summary: 'pty-3',
+  })
+  assert.equal(focusToolDisplay({ name: 'send_message', args: JSON.stringify({ target: 'reviewer', message: 'Inspect the card.' }) }), 'Send message reviewer · Inspect the card.')
+})
+
+test('list_agents summarizes structured and rendered historical snapshots', () => {
+  const structured = summarizeAgentListResult(JSON.stringify([
+    { kind: 'child', id: '1', label: 'a', status: 'running' },
+    { kind: 'child', id: '2', label: 'b', status: 'idle' },
+    { kind: 'child', id: '3', label: 'c', status: 'ready' },
+  ]))!
+  assert.equal(formatAgentListSummary(structured), '3 agents · 1 running · 1 idle · 1 ready')
+  assert.equal(formatAgentListSummary(summarizeAgentListResult('[]')!), 'no subagents')
+  assert.equal(formatAgentListSummary(summarizeAgentListResult(JSON.stringify([
+    { kind: 'diagnostic', id: 'x', reason: 'unavailable' },
+  ]))!), '1 entry · 1 diagnostic')
+  assert.equal(formatAgentListSummary(summarizeAgentListResult('1 [running] — a\n2 [idle] — b\n3 [ready] — c')!), '3 agents · 1 running · 1 idle · 1 ready')
+  assert.equal(formatAgentListSummary(summarizeAgentListResult('(no subagents)')!), 'no subagents')
+
+  const list = compactToolPresentation('list_agents', '{}', '1 [running] — a\n2 [idle] — b\n3 [ready] — c')
+  assert.equal(list?.title, 'List agents')
+  assert.equal(list?.summary, 'children')
+  assert.equal(list?.result, '3 agents · 1 running · 1 idle · 1 ready')
+  assert.deepEqual(compactToolExpandedLines('list_agents', '{}', '1 [running] — a\n2 [idle] — b'), [
+    '1 [running] — a', '2 [idle] — b',
+  ])
+})
+
+test('CompactTextPreview is Unicode-safe, capped, and re-derived on resize', () => {
+  const preview = new CompactTextPreview({
+    text: '检查 👨‍💻 flow and 🧪 regression.\nsecond payload with more details',
+    maxVisualRows: 2,
+    indent: '  ',
+  })
+  const narrow = preview.render(12)
+  assert.equal(narrow.length, 2)
+  assert.ok(narrow.some(line => line.includes('…')), `overflow marker missing: ${narrow.join('|')}`)
+  for (const line of narrow) assert.ok(visibleWidth(line) <= 12, JSON.stringify(line))
+  const wide = preview.render(60)
+  assert.ok(wide.some(line => line.includes('second payload')), `wide render lost later payload: ${wide.join('|')}`)
+  for (const line of wide) assert.ok(visibleWidth(line) <= 60, JSON.stringify(line))
+  assert.deepEqual(preview.render(12), narrow, 'narrow cache must remain deterministic after a wide render')
+})
+
+test('folded action cards show payloads and suppress successful receipts', async () => {
+  const vt = new VirtualTerminal(100, 32)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([
+    actionMessage('send_message', { agent_id: 'child-1', message: 'Review the CI failure.\nCompare the transition fence.' }, 'message delivered to agent child-1'),
+    actionMessage('terminal_send', { sessionId: 'pty-3', text: 'make test' }, 'viewport output\n[wait: stdin_read]'),
+    actionMessage('interrupt_agent', { agent_id: 'child-1' }, 'interrupt requested for agent child-1'),
+    actionMessage('list_agents', { scope: 'children' }, '1 [running] — a\n2 [idle] — b\n3 [ready] — c'),
+    actionMessage('send_message', { target: 'reviewer', message: 'Inspect the failed target.' }, JSON.stringify({ messageId: 'm1', status: 'accepted' })),
+  ])
+  const view = await viewport(vt)
+  assert.ok(view.includes('Send message · child-1 [ok]'), view)
+  assert.ok(view.includes('Review the CI failure.'), view)
+  assert.ok(view.includes('Compare the transition fence.'), view)
+  assert.ok(view.includes('Terminal · pty-3 [ok]'), view)
+  assert.ok(view.includes('make test'), view)
+  assert.ok(view.includes('Interrupt agent · child-1 [ok]'), view)
+  assert.ok(view.includes('List agents · children [ok]'), view)
+  assert.ok(view.includes('3 agents · 1 running · 1 idle · 1 ready'), view)
+  assert.ok(view.includes('Inspect the failed target.'), view)
+  assert.ok(!view.includes('message delivered to agent'), view)
+  assert.ok(!view.includes('interrupt requested for agent'), view)
+  assert.ok(!view.includes('viewport output'), view)
+  assert.ok(!view.includes('"messageId"'), view)
+})
+
+test('expanded action cards keep payloads, historical snapshots, and terminal output', async () => {
+  const vt = new VirtualTerminal(100, 40)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setToolOutputExpanded(true)
+  app.setTranscript([
+    actionMessage('send_message', { agent_id: 'child-1', message: 'first line\nsecond line\nthird line' }, 'message delivered to agent child-1'),
+    actionMessage('terminal_send', { sessionId: 'pty-3', text: 'make test' }, 'viewport output\n[wait: stdin_read]'),
+    actionMessage('list_agents', { scope: 'children' }, '1 [running] — a\n2 [ready] — b'),
+  ])
+  const view = await viewport(vt)
+  assert.ok(view.includes('first line'), view)
+  assert.ok(view.includes('second line'), view)
+  assert.ok(view.includes('third line'), view)
+  assert.ok(view.includes('viewport output'), view)
+  assert.ok(view.includes('[wait: stdin_read]'), view)
+  assert.ok(view.includes('1 [running] — a'), view)
+  assert.ok(view.includes('2 [ready] — b'), view)
+  assert.ok(!view.includes('message delivered to agent'), view)
+})
+
+test('terminal_send payload is added above a dedicated terminal result view', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({ card: 'terminal', title: 'make test' }),
+      result: () => ({ card: 'terminal', output: 'terminal output', exitCode: 0 }),
+    },
+  })
+  app.start()
+  startedApps.add(app)
+  app.setToolOutputExpanded(true)
+  app.setTranscript([actionMessage(
+    'terminal_send',
+    { sessionId: 'pty-3', text: 'make test' },
+    'rendered viewport',
+  )])
+  const view = await viewport(vt)
+  assert.ok(view.includes('make test'), view)
+  assert.ok(view.includes('terminal output'), view)
+  assert.ok(view.includes('[exit 0]'), view)
+})
+
+test('action payload preview survives narrow-wide-narrow resize without stale truncation', async () => {
+  const vt = new VirtualTerminal(24, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([actionMessage(
+    'send_message',
+    { agent_id: 'child-1', message: 'alpha beta gamma delta epsilon\nsecond payload' },
+    'message delivered to agent child-1',
+  )])
+  const narrow = await viewport(vt)
+  assert.ok(!narrow.includes('second payload'), narrow)
+  vt.resize(80, 24)
+  const wide = await viewport(vt)
+  assert.ok(wide.includes('second payload'), wide)
+  assert.ok(visibleWidth(stripTerminalSequences(wide.split('\n').find(line => line.includes('second payload')) ?? '')) <= transcriptContentWidth(80), wide)
+  vt.resize(24, 24)
+  const narrowAgain = await viewport(vt)
+  assert.ok(!narrowAgain.includes('second payload'), narrowAgain)
+})
+
+test('action errors remain visible in folded cards', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([actionMessage(
+    'interrupt_agent',
+    { target: 'missing-child' },
+    'target is not interruptible',
+    'error',
+    { name: 'SubagentError', code: 'NOT_INTERRUPTIBLE' },
+  )])
+  const view = await viewport(vt)
+  assert.ok(view.includes('Interrupt agent · missing-child [error]'), view)
+  assert.ok(view.includes('SubagentError: NOT_INTERRUPTIBLE'), view)
+  assert.ok(view.includes('target is not interruptible'), view)
+})
+
+// Keep the imported model type checked as a public data-only contract.
+const _compactModelTypeCheck: CompactToolPresentation | undefined = compactToolPresentation('send_message', '{}')
+void _compactModelTypeCheck


### PR DESCRIPTION
## Summary

Implements the action-payload compact tool card plan (`temp/20260902/dsh-pi-tui-next-action-payload-compact-tool-card-plan.md`) on `next`: `send_message` / `terminal_send` / `interrupt_agent` / `list_agents` cards are now payload-first, receipt-safe, and error-first.

### What changed

- **`src/present.ts`** — semantic model (`CompactToolPresentation`) and parsers for the four action tools:
  - Titles: `Send message` / `Terminal` / `Interrupt agent` / `List agents`; identity (target / sessionId / scope) in the header, payload on its own folded rows.
  - Compatible with both known shapes: standard subagent control (`agent_id`) and Agent Teams (`target`, `{messageId,status:accepted|queued}`, `previousStatus`).
  - Receipt suppression for text and JSON forms; `queued` / `was <status>` / background-job ids kept as meaningful results; errors always surface (identity + detail).
  - `list_agents` folds to a historical snapshot summary from the real rendered text (`<id> [<status>] parent=… depth=… — <label>`, `(no subagents)`, `[diagnostic: <reason>]`) or the structured array; unknown status tokens count as diagnostics; expanded keeps the full snapshot.
  - `toolCardHeader` / `focusToolDisplay` wired through the same pure model (no dsh internals, no live registry reads).
- **`src/compact-text-preview.ts`** (new, small) — render-time width-aware preview component (per-width cache, Unicode/ANSI/emoji/ZWJ safe, zero-width row filtering, tiny-width indent clamping).
- **`src/tui-app.ts`** — folded action cards render header / payload (≤2 rows) / meaningful result as separate rows; expanded keeps payload + terminal output (payload above dedicated presenter or legacy raw fallback); action cards excluded from width-baking so resizes re-derive without stale truncation; extension renderer precedence untouched.
- **`test/action-tool-card.test.ts`** (14 tests) — shapes, receipts, error precedence, Team variants, rendered-text snapshots, width/CJK/tiny-terminal, resize round-trip, Focus regular + fullscreen, extension precedence, and a plan §17 legacy-tool regression guard.

### Verification

- `pnpm typecheck` clean; `pnpm build` clean; `pnpm test:product` **3510/3510** pass.
- Review-loop rounds 2–4 (including round 3–4 run on `ollama/deepseek-v4-flash:0731-cloud @ high`): 1×P2 + 5×P3 findings all addressed; round 4 confirmed no P0/P1/P2 and closed the loop.
- No vendored `packages/pi-tui` changes; no new dependencies; English-only strings and comments.