### PR TITLE
feat: show streaming tool preparation cards

### DIFF
--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -25,6 +25,7 @@ import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@xmoon76/pi-tui
 import { color } from './theme.ts'
 import { formatTokens } from './token-usage.ts'
 import { iconFor, type IconSemantic, type IconStyle } from './icons.ts'
+import { toolTitle } from './present.ts'
 import type { TurnActivity } from './transcript.ts'
 import type { TranscriptMessage } from './transcript.ts'
 
@@ -104,6 +105,34 @@ export function focusDurationText(activity: TurnActivity, now: () => number): st
   if (activity.startedAt === undefined) return undefined
   const end = activity.completed ? (activity.endedAt ?? now()) : now()
   return formatFocusDuration(Math.max(0, end - activity.startedAt))
+}
+
+/** The presentation-only shape needed to summarize one live Preparing row.
+ * It deliberately excludes the call id, turn and arguments: Focus owns no
+ * lifecycle state and only needs the stable visual order plus an optional
+ * display name. */
+export interface FocusPreparingPreview {
+  readonly index: number
+  readonly name?: string
+}
+
+/** The compact Focus-collapsed Tool-slot text for live Preparing rows.
+ * Names that do not map to a known tool title remain generic, so model-facing
+ * names never make the compact Thought card noisy. The input is copied and
+ * sorted so the summary is deterministic even when a caller supplies a fresh
+ * order. */
+export function focusPreparingSummary(
+  previews: readonly FocusPreparingPreview[],
+): string | undefined {
+  if (previews.length === 0) return undefined
+  const ordered = [...previews].sort((left, right) => left.index - right.index)
+  const known = ordered
+    .map(preview => preview.name === undefined || preview.name === '' ? undefined : toolTitle(preview.name))
+    .find(title => title !== undefined && title !== 'Tool' && title !== 'tool')
+  if (known === undefined) {
+    return ordered.length === 1 ? 'Preparing tool…' : `Preparing ${ordered.length} tools…`
+  }
+  return ordered.length === 1 ? `Preparing ${known}…` : `Preparing ${known} +${ordered.length - 1}`
 }
 
 /** Assemble the one-line header, dropping the stat tail progressively so
@@ -210,19 +239,23 @@ function previewTailLines(label: string, text: string, width: number, maxRows: n
  * Think, Tool, Message — then the error reason (plan §24). Think and
  * Tool are at most ONE visual row; Message is the third process slot and
  * shows the latest up to {@link FOCUS_MESSAGE_MAX_ROWS} visual rows of
- * its bounded tail. Only existing slots render. The Tool line's status
- * prefix follows plan §10: none while running, ✓ settled ok, ✗ settled
- * error. */
+ * its bounded tail. Only existing slots render. A live Preparing display,
+ * when supplied, temporarily owns the Tool slot over the formal Tool display.
+ * The formal Tool line's status prefix follows plan §10: none while running,
+ * ✓ settled ok, ✗ settled error. */
 export function focusCollapsedBody(
   activity: TurnActivity,
   width: number,
   toolDisplay?: string,
+  preparingDisplay?: string,
 ): string[] {
   const lines: string[] = []
   if (activity.think !== undefined) {
     lines.push(previewLine('Think:', activity.think.text, width))
   }
-  if (activity.tool !== undefined && toolDisplay !== undefined) {
+  if (preparingDisplay !== undefined) {
+    lines.push(previewLine('Tool:', preparingDisplay, width))
+  } else if (activity.tool !== undefined && toolDisplay !== undefined) {
     const prefix = activity.tool.status === 'ok' ? '✓ ' : activity.tool.status === 'error' ? '✗ ' : ''
     lines.push(previewLine('Tool:', `${prefix}${toolDisplay}`, width))
   }
@@ -244,7 +277,9 @@ export function focusCollapsedBody(
  * icon style) keeps that cheap. The component never mutates Focus state —
  * clicks route through the app's hit map to toggleFocusTurn (plan §17).
  * The Tool line's display text is PRECOMPUTED by the app (presenter-first,
- * plan §38) — the component stays a pure renderer.
+ * plan §38) — the component stays a pure renderer. A collapsed Preparing
+ * summary is presentation input only; expanded rows are composed by TuiApp
+ * after the projected process tail.
  */
 export class FocusActivityComponent {
   private readonly activity: TurnActivity
@@ -252,6 +287,7 @@ export class FocusActivityComponent {
   private readonly now: () => number
   private readonly toolDisplay: string | undefined
   private readonly iconStyle: IconStyle
+  private readonly preparingSummary: string | undefined
 
   constructor(options: {
     activity: TurnActivity
@@ -259,12 +295,14 @@ export class FocusActivityComponent {
     now?: () => number
     toolDisplay?: string
     iconStyle?: IconStyle
+    preparingSummary?: string
   }) {
     this.activity = options.activity
     this.expanded = options.expanded
     this.now = options.now ?? (() => Date.now())
     this.toolDisplay = options.toolDisplay
     this.iconStyle = options.iconStyle ?? 'emoji'
+    this.preparingSummary = options.preparingSummary
   }
 
   /** The Component interface requires invalidate(); the component keeps no
@@ -281,9 +319,15 @@ export class FocusActivityComponent {
     // The header formatter budgets the CONTENT width (the indent is added
     // after), so a header that fits never wraps past the terminal — the
     // fullscreen row hit-map depends on that (review fix).
-    lines.push(`${indent}${color.textDim(formatFocusHeaderLine(this.activity, this.expanded, this.now, contentWidth, this.iconStyle))}`)
+    lines.push(`${indent}${color.textDim(formatFocusHeaderLine(
+      this.activity,
+      this.expanded,
+      this.now,
+      contentWidth,
+      this.iconStyle,
+    ))}`)
     if (!this.expanded) {
-      for (const line of focusCollapsedBody(this.activity, contentWidth, this.toolDisplay)) {
+      for (const line of focusCollapsedBody(this.activity, contentWidth, this.toolDisplay, this.preparingSummary)) {
         lines.push(`${indent}${color.textDim(line)}`)
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -918,6 +918,24 @@ function applyStreamingToolPreviewEvent(
     })
     return
   }
+  if (
+    event.type === 'assistant/chunk'
+    && event.data.chunk.type === 'block-end'
+    && event.data.chunk.block.type === 'tool-call'
+  ) {
+    const chunk = event.data.chunk
+    // ContentBlock is merge-extensible, so retain the runtime tag guard above
+    // and narrow the known tool-call fields structurally here.
+    const block = chunk.block as { type: 'tool-call'; id: ToolCallId; name: string }
+    upsertStreamingToolPreview(previews, {
+      callId: block.id,
+      turn: event.data.turn,
+      step: event.data.step,
+      index: chunk.index,
+      name: block.name,
+    })
+    return
+  }
   if (event.type === 'tool/call') {
     removeStreamingToolPreview(previews, event.data.callId, event.data.turn, event.data.step)
     return

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,8 @@ import { parseFooterCustomItems, type FooterCustomCommandItemSettings, type Foot
 import { FooterCommandRunner } from './footer/command-runner.ts'
 import { FooterDynamicItemRuntime, activeFooterItemIds, executableCommandItemIds } from './footer/dynamic-item-runtime.ts'
 import { color, type ColorPalette } from './theme.ts'
-import { startProcessTui, type CompactionPhase, type QueueItem, type TuiApp } from './tui-app.ts'
+import { startProcessTui, type CompactionPhase, type QueueItem, type StreamingToolPreview, type TuiApp } from './tui-app.ts'
+import { applyStreamingToolPreviewEvent, streamingToolPreviewSnapshot } from './streaming-tool-preparing.ts'
 import { parseUserKeybindings } from './keybindings/config.ts'
 
 import { normalizedKeyToKeyId } from './keybindings/manager.ts'
@@ -895,13 +896,15 @@ function bundleVersion(): string {
 
 /**
  * Repaint the transcript from the active folder's bounded window. Messages,
- * navigation facts, and turn activities come from one fold snapshot so a
- * repaint can never show a stale Thought header against fresh rows.
+ * navigation facts, turn activities and live preparing rows come from one
+ * presentation snapshot so a repaint can never show a stale Thought header
+ * against fresh rows.
  */
 function repaint(
   app: TuiApp,
   folder: TranscriptFolder,
   windowController: TranscriptWindowController,
+  streamingToolPreviews: readonly StreamingToolPreview[],
 ): TranscriptWindow {
   windowController.setTurns(folder.groupedTurns())
   const endTurn = windowController.endTurn()
@@ -911,10 +914,10 @@ function repaint(
   })
   app.setTranscript(projection.messages, folder.turnActivities(), {
     ...windowController.state(),
-     firstTurn: projection.firstTurn,
-     lastTurn: projection.lastTurn,
+    firstTurn: projection.firstTurn,
+    lastTurn: projection.lastTurn,
     hasNewer: projection.hasNewer,
-  })
+  }, streamingToolPreviews)
   return projection
 }
 
@@ -3431,6 +3434,9 @@ export function apply(ctx: Context, config: Config): void {
     // (cheap) but the view rebuild flushes at most every REPAINT_FLUSH_MS,
     // and immediately on turn/end.
     let repaintTimer: NodeJS.Timeout | undefined
+    // Ephemeral previews are isolated per presentation owner: the main live
+    // session and a mounted child viewer never share call ids or rows.
+    const mainStreamingToolPreviews = new Map<ToolCallId, StreamingToolPreview>()
     // P7d: subagent viewer — while set, the transcript shows another live
     // session's log and Esc returns to the parent session. The target is
     // MODE-AWARE: a continuable child's viewer is INTERACTIVE (the editor
@@ -3455,6 +3461,8 @@ export function apply(ctx: Context, config: Config): void {
       access: ViewerAccess
       /** The child session's workspace ('' when unknown, e.g. a cold child). */
       cwd: string
+      /** Live-only preparing rows for this child presentation owner. */
+      previews: Map<ToolCallId, StreamingToolPreview>
     } | undefined
     // Unsettled subagent delegations in the live session, in tool/call order.
     // The viewer matches one of these by description when the user opens a
@@ -3464,19 +3472,34 @@ export function apply(ctx: Context, config: Config): void {
     // transcript (see enterView). Consumed on the matching tool/result.
     const viewCallToChild = new Map<string, SessionId>()
     const activeFolder = (): TranscriptFolder => viewing?.folder ?? folder
-     const activeWindow = (): TranscriptWindowController => viewing?.window ?? windowController
+    const activeWindow = (): TranscriptWindowController => viewing?.window ?? windowController
+    const activeStreamingToolPreviews = (): readonly StreamingToolPreview[] => {
+      if (!activeWindow().isLatest()) return []
+      return streamingToolPreviewSnapshot(viewing?.previews ?? mainStreamingToolPreviews)
+    }
+    const applyOwnerStreamingToolPreviewEvent = (
+      previews: Map<ToolCallId, StreamingToolPreview>,
+      ownerFolder: TranscriptFolder,
+      event: SessionEvent,
+    ): void => {
+      // TranscriptFolder already rejects assistant chunks after a completed
+      // turn. Keep this presentation-only projection aligned without adding a
+      // second completed-turn tombstone or retaining stale event state.
+      if (event.type === 'assistant/chunk' && ownerFolder.turnActivity(event.data.turn)?.completed === true) return
+      applyStreamingToolPreviewEvent(previews, event)
+    }
     const paintNow = (): void => {
       if (repaintTimer !== undefined) {
         clearTimeout(repaintTimer)
         repaintTimer = undefined
       }
-      repaint(app, activeFolder(), activeWindow())
+      repaint(app, activeFolder(), activeWindow(), activeStreamingToolPreviews())
     }
     const schedulePaint = (): void => {
       if (repaintTimer !== undefined) return
       repaintTimer = setTimeout(() => {
         repaintTimer = undefined
-        repaint(app, activeFolder(), activeWindow())
+        repaint(app, activeFolder(), activeWindow(), activeStreamingToolPreviews())
       }, REPAINT_FLUSH_MS)
     }
     // Tool-call arguments by callId, for the approval-preview dialog.
@@ -3520,6 +3543,7 @@ export function apply(ctx: Context, config: Config): void {
     const bumpSessionGeneration = (): number => {
       sessionGeneration += 1
       callArgs.clear()
+      mainStreamingToolPreviews.clear()
       // The new session's subagent delegations are a fresh namespace: stale
       // pending calls from the old session would consume viewer match slots,
       // and dead callId→child maps would silently disable the auto-pop.
@@ -3573,7 +3597,7 @@ export function apply(ctx: Context, config: Config): void {
         // keeps the teardown's intent explicit and ordering-safe). The
         // Esc path uses exitFocusViewerScope instead (restore).
         app.discardFocusViewerScope()
-        repaint(app, folder, windowController)
+        repaint(app, folder, windowController, activeStreamingToolPreviews())
         windowController.isLatest() ? app.scrollToBottom() : app.scrollToTop({ disableFollow: true })
         // The new session's own measurement comes from its initLiveSession
         // deferred path — the teardown refresh is UI-only.
@@ -3610,7 +3634,7 @@ export function apply(ctx: Context, config: Config): void {
       const folder = activeFolder()
       const controller = activeWindow()
       controller.anchorAt(match.turn)
-      repaint(app, folder, controller)
+      repaint(app, folder, controller, activeStreamingToolPreviews())
       app.scrollToBottom({ disableFollow: !controller.isLatest() })
 
       // Focus Mode: the search hits the FULL transcript (hidden process
@@ -3733,13 +3757,16 @@ export function apply(ctx: Context, config: Config): void {
       // commit its child over the current surface (no viewing write, no
       // repaint, no viewer mount, no auto-pop match).
       if (!viewerOpen.isCurrent(request)) return
+      // The viewer replaces the main transcript presentation owner; discard
+      // any main-session preparing rows rather than replaying them on exit.
+      mainStreamingToolPreviews.clear()
       const matched = matchPendingSubagentCall(pendingSubagentCalls, label)
       if (matched !== undefined) viewCallToChild.set(matched.callId, childId)
       viewerSessionAbort = new AbortController()
       viewing = {
         id: childId,
         folder: childFolder,
-         window: childWindow,
+        window: childWindow,
         stats: childStats,
         parentSessionId,
         label: label ?? childId,
@@ -3747,11 +3774,12 @@ export function apply(ctx: Context, config: Config): void {
         activity,
         access,
         cwd: childCwd,
+        previews: new Map(),
       }
       // The child's turn numbers are its OWN namespace: the parent's Focus
       // disclosures must not leak into the child transcript (plan §26).
       app.enterFocusViewerScope()
-      repaint(app, childFolder, childWindow)
+      repaint(app, childFolder, childWindow, activeStreamingToolPreviews())
       // The viewer bar covers the editor (a read-only placeholder for
       // one-shot, the child's own draft for continuable) and the header
       // badges the mode — the transient notify is no longer the only "you
@@ -3768,6 +3796,8 @@ export function apply(ctx: Context, config: Config): void {
     const exitView = (): boolean => {
       viewerOpen.invalidate()
       if (viewing === undefined) return false
+      const previousViewing = viewing
+      previousViewing.previews.clear()
       viewing = undefined
       viewerSessionAbort?.abort() // cancel an in-flight, not-yet-accepted follow-up
       viewerSessionAbort = undefined
@@ -3781,7 +3811,7 @@ export function apply(ctx: Context, config: Config): void {
       // Restore the parent's Focus disclosures BEFORE the repaint so the
       // projection uses them (plan §26).
       app.exitFocusViewerScope()
-      repaint(app, folder, windowController)
+      repaint(app, folder, windowController, activeStreamingToolPreviews())
       // The main transcript may have grown while the viewer covered it (the
       // child's result, the parent's streaming): restore the parent's semantic latest/history position
       // so the pop never loses an intentional history anchor.
@@ -5083,7 +5113,7 @@ export function apply(ctx: Context, config: Config): void {
         const anchor = app.captureTranscriptViewportAnchor()
         const controller = activeWindow()
         if (!controller.moveOlder()) return false
-        repaint(app, activeFolder(), controller)
+        repaint(app, activeFolder(), controller, activeStreamingToolPreviews())
         // Preserve the old top edge at the same rendered row in the overlap.
         if (anchor === undefined) app.scrollToBottom({ disableFollow: true })
         else app.restoreTranscriptViewportAnchor(anchor, 'top')
@@ -5096,7 +5126,7 @@ export function apply(ctx: Context, config: Config): void {
         if (!app.isFullscreen()) return false
         const controller = activeWindow()
         if (!controller.turnOlder()) return false
-        repaint(app, activeFolder(), controller)
+        repaint(app, activeFolder(), controller, activeStreamingToolPreviews())
         app.scrollToBottom({ disableFollow: true })
         return true
       },
@@ -5104,7 +5134,7 @@ export function apply(ctx: Context, config: Config): void {
         if (!app.isFullscreen()) return false
         const controller = activeWindow()
         if (!controller.turnNewer()) return false
-        repaint(app, activeFolder(), controller)
+        repaint(app, activeFolder(), controller, activeStreamingToolPreviews())
         app.scrollToBottom({ disableFollow: true })
         return true
       },
@@ -5112,7 +5142,7 @@ export function apply(ctx: Context, config: Config): void {
         const anchor = app.captureTranscriptViewportAnchor()
         const controller = activeWindow()
         if (!controller.moveNewer()) return false
-        repaint(app, activeFolder(), controller)
+        repaint(app, activeFolder(), controller, activeStreamingToolPreviews())
         if (controller.isLatest()) app.scrollToBottom()
         else if (anchor === undefined) app.scrollToTop({ disableFollow: true })
         else app.restoreTranscriptViewportAnchor(anchor, 'bottom')
@@ -5131,7 +5161,7 @@ export function apply(ctx: Context, config: Config): void {
         const controller = activeWindow()
         const changed = controller.latest()
         if (!changed && !closedSearch && !app.isFullscreen()) return false
-        repaint(app, activeFolder(), controller)
+        repaint(app, activeFolder(), controller, activeStreamingToolPreviews())
         app.scrollToBottom()
         app.setSearchResult(0, 0)
         return true
@@ -5218,7 +5248,7 @@ export function apply(ctx: Context, config: Config): void {
         } else {
           controller.latest()
         }
-        repaint(app, activeFolder(), controller)
+        repaint(app, activeFolder(), controller, activeStreamingToolPreviews())
         if (controller.isLatest()) app.scrollToBottom()
         else app.scrollToTop({ disableFollow: true })
       },
@@ -6625,7 +6655,7 @@ export function apply(ctx: Context, config: Config): void {
       // The subagent-notice notify guard is per-session: a new session's
       // settlements must notify again.
       notifiedSubagentNotices.clear()
-      repaint(app, folder, windowController)
+      repaint(app, folder, windowController, activeStreamingToolPreviews())
       // PR D2: the first usable frame paints with the cached measurement
       // (or none); the context measure is deferred one event-loop turn so
       // cold resume never blocks first paint on a long-session scan.
@@ -7223,6 +7253,7 @@ export function apply(ctx: Context, config: Config): void {
       if (liveAgent === undefined) return
       if (viewing !== undefined) {
         if (session.id === viewing.id) {
+          applyOwnerStreamingToolPreviewEvent(viewing.previews, viewing.folder, event)
           viewing.folder.apply([event])
           viewing.stats.apply([event])
           // The store-activity snapshot moves with the child's own
@@ -7245,6 +7276,8 @@ export function apply(ctx: Context, config: Config): void {
         // main folder below — the viewer never starves the main transcript.
       }
       if (session.id !== liveAgent.session.id) return
+      if (viewing === undefined) applyOwnerStreamingToolPreviewEvent(mainStreamingToolPreviews, folder, event)
+      else mainStreamingToolPreviews.clear()
       // Keep the Direct owner in sync with durable model intent and consume a
       // pending choice only when the exact raw request header was recorded.
       // The structural check keeps this next-version event compatible with

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,8 @@ import type {} from '@deepseek-ai/dsh-settings'
 // P5d service/event merges: goal badge, background jobs, permission
 // presets, session titles, and the workflow/retry folds (transcript.ts).
 import type {} from '@deepseek-ai/dsh-goal'
+// The retry event merge for the live request retry boundary.
+import type {} from '@deepseek-ai/dsh-llm-retry'
 import type {} from '@deepseek-ai/dsh-jobs'
 import type { JobId } from '@deepseek-ai/dsh-jobs'
 import type {} from '@deepseek-ai/dsh-permission-presets'
@@ -115,7 +117,13 @@ import { FooterCommandRunner } from './footer/command-runner.ts'
 import { FooterDynamicItemRuntime, activeFooterItemIds, executableCommandItemIds } from './footer/dynamic-item-runtime.ts'
 import { color, type ColorPalette } from './theme.ts'
 import { startProcessTui, type CompactionPhase, type QueueItem, type StreamingToolPreview, type TuiApp } from './tui-app.ts'
-import { applyStreamingToolPreviewEvent, streamingToolPreviewSnapshot } from './streaming-tool-preparing.ts'
+import {
+  clearStreamingToolPreviewsForStep,
+  clearStreamingToolPreviewsForTurn,
+  removeStreamingToolPreview,
+  streamingToolPreviewSnapshot,
+  upsertStreamingToolPreview,
+} from './streaming-tool-preparing.ts'
 import { parseUserKeybindings } from './keybindings/config.ts'
 
 import { normalizedKeyToKeyId } from './keybindings/manager.ts'
@@ -891,6 +899,39 @@ function bundleVersion(): string {
     return pkg.version ?? '0.0.0'
   } catch {
     return '0.0.0'
+  }
+}
+
+/** Translate official DSH events into the local preview operations. */
+function applyStreamingToolPreviewEvent(
+  previews: Map<string, StreamingToolPreview>,
+  event: SessionEvent,
+): void {
+  if (event.type === 'assistant/chunk' && event.data.chunk.type === 'tool-call-delta') {
+    const chunk = event.data.chunk
+    upsertStreamingToolPreview(previews, {
+      callId: chunk.id,
+      turn: event.data.turn,
+      step: event.data.step,
+      index: chunk.index,
+      name: chunk.name,
+    })
+    return
+  }
+  if (event.type === 'tool/call') {
+    removeStreamingToolPreview(previews, event.data.callId, event.data.turn, event.data.step)
+    return
+  }
+  if (event.type === 'llm/retry' || event.type === 'llm/retry-started') {
+    clearStreamingToolPreviewsForStep(previews, event.data.turn, event.data.step)
+    return
+  }
+  if (event.type === 'step/end') {
+    clearStreamingToolPreviewsForStep(previews, event.data.turn, event.data.step)
+    return
+  }
+  if (event.type === 'turn/end') {
+    clearStreamingToolPreviewsForTurn(previews, event.data.turn)
   }
 }
 
@@ -3436,7 +3477,7 @@ export function apply(ctx: Context, config: Config): void {
     let repaintTimer: NodeJS.Timeout | undefined
     // Ephemeral previews are isolated per presentation owner: the main live
     // session and a mounted child viewer never share call ids or rows.
-    const mainStreamingToolPreviews = new Map<ToolCallId, StreamingToolPreview>()
+    const mainStreamingToolPreviews = new Map<string, StreamingToolPreview>()
     // P7d: subagent viewer — while set, the transcript shows another live
     // session's log and Esc returns to the parent session. The target is
     // MODE-AWARE: a continuable child's viewer is INTERACTIVE (the editor
@@ -3462,7 +3503,7 @@ export function apply(ctx: Context, config: Config): void {
       /** The child session's workspace ('' when unknown, e.g. a cold child). */
       cwd: string
       /** Live-only preparing rows for this child presentation owner. */
-      previews: Map<ToolCallId, StreamingToolPreview>
+      previews: Map<string, StreamingToolPreview>
     } | undefined
     // Unsettled subagent delegations in the live session, in tool/call order.
     // The viewer matches one of these by description when the user opens a
@@ -3478,7 +3519,7 @@ export function apply(ctx: Context, config: Config): void {
       return streamingToolPreviewSnapshot(viewing?.previews ?? mainStreamingToolPreviews)
     }
     const applyOwnerStreamingToolPreviewEvent = (
-      previews: Map<ToolCallId, StreamingToolPreview>,
+      previews: Map<string, StreamingToolPreview>,
       ownerFolder: TranscriptFolder,
       event: SessionEvent,
     ): void => {
@@ -3757,9 +3798,8 @@ export function apply(ctx: Context, config: Config): void {
       // commit its child over the current surface (no viewing write, no
       // repaint, no viewer mount, no auto-pop match).
       if (!viewerOpen.isCurrent(request)) return
-      // The viewer replaces the main transcript presentation owner; discard
-      // any main-session preparing rows rather than replaying them on exit.
-      mainStreamingToolPreviews.clear()
+      // The viewer replaces the main transcript presentation owner, but the
+      // main session's live preview state continues updating off-screen.
       const matched = matchPendingSubagentCall(pendingSubagentCalls, label)
       if (matched !== undefined) viewCallToChild.set(matched.callId, childId)
       viewerSessionAbort = new AbortController()
@@ -7276,8 +7316,7 @@ export function apply(ctx: Context, config: Config): void {
         // main folder below — the viewer never starves the main transcript.
       }
       if (session.id !== liveAgent.session.id) return
-      if (viewing === undefined) applyOwnerStreamingToolPreviewEvent(mainStreamingToolPreviews, folder, event)
-      else mainStreamingToolPreviews.clear()
+      applyOwnerStreamingToolPreviewEvent(mainStreamingToolPreviews, folder, event)
       // Keep the Direct owner in sync with durable model intent and consume a
       // pending choice only when the exact raw request header was recorded.
       // The structural check keeps this next-version event compatible with

--- a/src/present.ts
+++ b/src/present.ts
@@ -702,7 +702,7 @@ function summarizeToolArgs(name: string, argsRaw: string): string | undefined {
 
 /** Classify a tool name into its row variant; unknown names are `others`. */
 export function classifyTool(name: string): ToolVariant {
-  return TOOL_VARIANTS[name] ?? 'others'
+  return Object.prototype.hasOwnProperty.call(TOOL_VARIANTS, name) ? TOOL_VARIANTS[name]! : 'others'
 }
 
 /** The structural icon semantic per exact tool name, for synthetic cards
@@ -738,10 +738,25 @@ const VARIANT_SEMANTICS: Record<ToolVariant, IconSemantic> = {
  * @param name - the tool name.
  */
 export function toolIconSemantic(name: string): IconSemantic {
-  const exact = TOOL_SEMANTICS[name]
+  const exact = Object.prototype.hasOwnProperty.call(TOOL_SEMANTICS, name) ? TOOL_SEMANTICS[name] : undefined
   if (exact !== undefined) return exact
   if (name.startsWith('/')) return 'slash-command'
   return VARIANT_SEMANTICS[classifyTool(name)]
+}
+
+/**
+ * The short title used by live tool-call presentations. Known names reuse the
+ * same exact-title and variant tables as formal tool cards; an unknown tool is
+ * intentionally generic rather than exposing its raw model-facing name.
+ */
+export function toolTitle(name: string): string {
+  if (name === '') return 'tool'
+  const exact = Object.prototype.hasOwnProperty.call(TOOL_TITLES, name)
+    ? TOOL_TITLES[name]
+    : Object.prototype.hasOwnProperty.call(TUI_TOOL_TITLES, name) ? TUI_TOOL_TITLES[name] : undefined
+  if (exact !== undefined) return exact
+  const variant = classifyTool(name)
+  return variant === 'others' ? 'Tool' : VARIANT_TITLES[variant]
 }
 
 /** The rendered card header: design title plus the relativized args summary. */

--- a/src/streaming-tool-preparing.ts
+++ b/src/streaming-tool-preparing.ts
@@ -1,82 +1,80 @@
-/** Live-only projection for tool calls while their arguments are streaming. */
+/** Pure local operations for the live tool-call preparing projection. */
 
-import type { ToolCallId } from '@deepseek-ai/dsh-llm'
-import type { SessionEvent } from '@deepseek-ai/dsh-session'
-// Load the official retry event declarations for the discriminated SessionEvent union.
-import type {} from '@deepseek-ai/dsh-llm-retry'
 import type { StreamingToolPreview } from './tui-app.ts'
 
-function fallbackPreviewKey(turn: number, step: number, index: number): ToolCallId {
-  return `\u0000streaming-tool-preview:${turn}:${step}:${index}` as ToolCallId
+function fallbackPreviewKey(turn: number, step: number, index: number): string {
+  return `\u0000streaming-tool-preview:${turn}:${step}:${index}`
 }
 
 function previewAt(
-  previews: ReadonlyMap<ToolCallId, StreamingToolPreview>,
+  previews: ReadonlyMap<string, StreamingToolPreview>,
   turn: number,
   step: number,
   index: number,
-): [ToolCallId, StreamingToolPreview] | undefined {
+): [string, StreamingToolPreview] | undefined {
   for (const entry of previews) {
     if (entry[1].turn === turn && entry[1].step === step && entry[1].index === index) return entry
   }
   return undefined
 }
 
-function clearStep(previews: Map<ToolCallId, StreamingToolPreview>, turn: number, step: number): void {
+/** Upsert one local preview, preserving a delayed name and stable position. */
+export function upsertStreamingToolPreview(
+  previews: Map<string, StreamingToolPreview>,
+  preview: StreamingToolPreview,
+): void {
+  const previous = previewAt(previews, preview.turn, preview.step, preview.index)
+  const key = preview.callId === ''
+    ? previous?.[0] ?? fallbackPreviewKey(preview.turn, preview.step, preview.index)
+    : preview.callId
+  if (previous !== undefined && previous[0] !== key) previews.delete(previous[0])
+  const existing = previews.get(key)
+  previews.set(key, {
+    callId: preview.callId === '' ? existing?.callId ?? previous?.[1].callId ?? preview.callId : preview.callId,
+    turn: preview.turn,
+    step: preview.step,
+    index: preview.index,
+    name: preview.name ?? existing?.name ?? previous?.[1].name,
+  })
+}
+
+/** Remove the local preview represented by one formal tool call. */
+export function removeStreamingToolPreview(
+  previews: Map<string, StreamingToolPreview>,
+  callId: string,
+  turn: number,
+  step: number,
+): void {
+  previews.delete(callId)
+  for (const [key, preview] of previews) {
+    if (preview.turn === turn && preview.step === step && preview.callId === callId) previews.delete(key)
+  }
+}
+
+/** Clear all orphan previews owned by one step. */
+export function clearStreamingToolPreviewsForStep(
+  previews: Map<string, StreamingToolPreview>,
+  turn: number,
+  step: number,
+): void {
   for (const [key, preview] of previews) {
     if (preview.turn === turn && preview.step === step) previews.delete(key)
   }
 }
 
-/** Apply one live event without entering the durable transcript or Focus state. */
-export function applyStreamingToolPreviewEvent(
-  previews: Map<ToolCallId, StreamingToolPreview>,
-  event: SessionEvent,
+/** Clear all previews owned by one turn. */
+export function clearStreamingToolPreviewsForTurn(
+  previews: Map<string, StreamingToolPreview>,
+  turn: number,
 ): void {
-  if (event.type === 'assistant/chunk' && event.data.chunk.type === 'tool-call-delta') {
-    const chunk = event.data.chunk
-    const previous = previewAt(previews, event.data.turn, event.data.step, chunk.index)
-    const key = chunk.id === ''
-      ? previous?.[0] ?? fallbackPreviewKey(event.data.turn, event.data.step, chunk.index)
-      : chunk.id
-    if (previous !== undefined && previous[0] !== key) previews.delete(previous[0])
-    const existing = previews.get(key)
-    previews.set(key, {
-      callId: chunk.id === '' ? existing?.callId ?? previous?.[1].callId ?? chunk.id : chunk.id,
-      turn: event.data.turn,
-      step: event.data.step,
-      index: chunk.index,
-      name: chunk.name ?? existing?.name ?? previous?.[1].name,
-    })
-    return
-  }
-  if (event.type === 'tool/call') {
-    previews.delete(event.data.callId)
-    for (const [key, preview] of previews) {
-      if (preview.turn === event.data.turn && preview.step === event.data.step && preview.callId === event.data.callId) {
-        previews.delete(key)
-      }
-    }
-    return
-  }
-  if (event.type === 'llm/retry' || event.type === 'llm/retry-started') {
-    clearStep(previews, event.data.turn, event.data.step)
-    return
-  }
-  if (event.type === 'step/end') {
-    clearStep(previews, event.data.turn, event.data.step)
-    return
-  }
-  if (event.type === 'turn/end') {
-    for (const [callId, preview] of previews) {
-      if (preview.turn === event.data.turn) previews.delete(callId)
-    }
+  for (const [key, preview] of previews) {
+    if (preview.turn === turn) previews.delete(key)
   }
 }
 
 /** Return a stable model-order snapshot for one presentation owner. */
 export function streamingToolPreviewSnapshot(
-  previews: ReadonlyMap<ToolCallId, StreamingToolPreview>,
+  previews: ReadonlyMap<string, StreamingToolPreview>,
 ): StreamingToolPreview[] {
   return [...previews.values()].sort((left, right) => left.index - right.index)
 }

--- a/src/streaming-tool-preparing.ts
+++ b/src/streaming-tool-preparing.ts
@@ -1,0 +1,82 @@
+/** Live-only projection for tool calls while their arguments are streaming. */
+
+import type { ToolCallId } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+// Load the official retry event declarations for the discriminated SessionEvent union.
+import type {} from '@deepseek-ai/dsh-llm-retry'
+import type { StreamingToolPreview } from './tui-app.ts'
+
+function fallbackPreviewKey(turn: number, step: number, index: number): ToolCallId {
+  return `\u0000streaming-tool-preview:${turn}:${step}:${index}` as ToolCallId
+}
+
+function previewAt(
+  previews: ReadonlyMap<ToolCallId, StreamingToolPreview>,
+  turn: number,
+  step: number,
+  index: number,
+): [ToolCallId, StreamingToolPreview] | undefined {
+  for (const entry of previews) {
+    if (entry[1].turn === turn && entry[1].step === step && entry[1].index === index) return entry
+  }
+  return undefined
+}
+
+function clearStep(previews: Map<ToolCallId, StreamingToolPreview>, turn: number, step: number): void {
+  for (const [key, preview] of previews) {
+    if (preview.turn === turn && preview.step === step) previews.delete(key)
+  }
+}
+
+/** Apply one live event without entering the durable transcript or Focus state. */
+export function applyStreamingToolPreviewEvent(
+  previews: Map<ToolCallId, StreamingToolPreview>,
+  event: SessionEvent,
+): void {
+  if (event.type === 'assistant/chunk' && event.data.chunk.type === 'tool-call-delta') {
+    const chunk = event.data.chunk
+    const previous = previewAt(previews, event.data.turn, event.data.step, chunk.index)
+    const key = chunk.id === ''
+      ? previous?.[0] ?? fallbackPreviewKey(event.data.turn, event.data.step, chunk.index)
+      : chunk.id
+    if (previous !== undefined && previous[0] !== key) previews.delete(previous[0])
+    const existing = previews.get(key)
+    previews.set(key, {
+      callId: chunk.id === '' ? existing?.callId ?? previous?.[1].callId ?? chunk.id : chunk.id,
+      turn: event.data.turn,
+      step: event.data.step,
+      index: chunk.index,
+      name: chunk.name ?? existing?.name ?? previous?.[1].name,
+    })
+    return
+  }
+  if (event.type === 'tool/call') {
+    previews.delete(event.data.callId)
+    for (const [key, preview] of previews) {
+      if (preview.turn === event.data.turn && preview.step === event.data.step && preview.callId === event.data.callId) {
+        previews.delete(key)
+      }
+    }
+    return
+  }
+  if (event.type === 'llm/retry' || event.type === 'llm/retry-started') {
+    clearStep(previews, event.data.turn, event.data.step)
+    return
+  }
+  if (event.type === 'step/end') {
+    clearStep(previews, event.data.turn, event.data.step)
+    return
+  }
+  if (event.type === 'turn/end') {
+    for (const [callId, preview] of previews) {
+      if (preview.turn === event.data.turn) previews.delete(callId)
+    }
+  }
+}
+
+/** Return a stable model-order snapshot for one presentation owner. */
+export function streamingToolPreviewSnapshot(
+  previews: ReadonlyMap<ToolCallId, StreamingToolPreview>,
+): StreamingToolPreview[] {
+  return [...previews.values()].sort((left, right) => left.index - right.index)
+}

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -130,7 +130,7 @@ import { QuestionFlow } from './question.ts'
 import { MentionProvider } from './mentions.ts'
 import { recentTurnThreshold, textWithImageMarkers, type TranscriptMessage, type TurnActivity } from './transcript.ts'
 import type { TranscriptWindowState } from './transcript-window.ts'
-import { FocusActivityComponent, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
+import { FocusActivityComponent, focusPreparingSummary, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
 import { WorkingIndicator, workingFramesFor } from './working.ts'
 import { iconFor, iconLead, iconPrefix, type IconStyle } from './icons.ts'
 import { indeterminateProgressFrames } from './progress.ts'
@@ -1904,12 +1904,15 @@ function deepFreeze(value: unknown): unknown {
  * one bulk owner: Ctrl+O never touches Thinking. */
 type ExpandHint = 'click' | 'fold' | 'thinking' | undefined
 
-/** One live-only transcript block containing all preparing tool rows. It is
+/** One live-only transcript block containing preparing tool rows. It is
  * kept outside FocusProjectedBlock so no ephemeral row can enter the Focus
- * activity projection or durable transcript model. */
+ * activity projection or durable transcript model. Focus-expanded blocks carry
+ * their owner turn only for visual placement and blank-row hit testing. */
 type TranscriptRenderBlock = FocusProjectedBlock | {
   kind: 'streaming-tool-previews'
   previews: readonly StreamingToolPreview[]
+  turn?: number
+  collapseFocusOwnerOnClick?: number
 }
 
 /** One cached component for a transcript message (stage J render cache). */
@@ -2439,6 +2442,7 @@ export class TuiApp {
     themeRev: number
     iconStyle: IconStyle
     toolDisplay?: string
+    preparingSummary?: string
   }>()
   /** The parent session's expansion set while the subagent viewer covers
    * the surface (turn numbers are per-session — plan §26). */
@@ -5577,16 +5581,89 @@ export class TuiApp {
     return projectFocus(this.messages, this.turnActivities, projectionExpanded, this.focusModeEnabled)
   }
 
-  /** Build the rendered transcript blocks in visual order. Preparing rows are
-   * one live-only block between the durable projection and local cards, so
-   * multiple calls stay contiguous and never enter Focus aggregation. */
+  /** The live Preparing snapshot for one Focus turn, kept in model order. */
+  private streamingToolPreviewsForTurn(turn: number): StreamingToolPreview[] {
+    return this.streamingToolPreviews
+      .filter(preview => preview.turn === turn)
+      .sort((left, right) => left.index - right.index || left.step - right.step || left.callId.localeCompare(right.callId))
+  }
+
+  /** Find the presentation insertion point for one expanded Thought. The
+   * process rows carry the existing owner marker; the final assistant is held
+   * back by projectFocus, so a preview block lands after process content and
+   * before that final answer. A turn without a projected activity is ignored
+   * rather than attaching a preview to an unrelated Thought. */
+  private focusPreparingInsertionIndex(
+    blocks: readonly TranscriptRenderBlock[],
+    turn: number,
+  ): number | undefined {
+    let activityIndex = -1
+    let lastTurnIndex = -1
+    let lastProcessIndex = -1
+    let finalAssistantIndex = -1
+    for (let index = 0; index < blocks.length; index += 1) {
+      const block = blocks[index]!
+      if (block.kind === 'activity') {
+        if (block.activity.turn === turn) {
+          activityIndex = index
+          lastTurnIndex = index
+        }
+        continue
+      }
+      if (block.kind === 'streaming-tool-previews') continue
+      if (!('turn' in block.message) || block.message.turn !== turn) continue
+      lastTurnIndex = index
+      if (block.collapseFocusOwnerOnClick === turn) lastProcessIndex = index
+      if (block.message.kind === 'assistant' && block.collapseFocusOwnerOnClick === undefined) {
+        finalAssistantIndex = index
+      }
+    }
+    if (activityIndex === -1) return undefined
+    if (lastProcessIndex !== -1) return lastProcessIndex + 1
+    if (finalAssistantIndex !== -1) return finalAssistantIndex
+    return lastTurnIndex + 1
+  }
+
+  /** Build the rendered transcript blocks in visual order. Focus keeps the
+   * ephemeral Preparing state outside the durable projection: collapsed rows
+   * are summarized by their Thought header, while expanded rows are inserted
+   * into the owning turn's process tail. Focus OFF retains the original
+   * standalone block between the durable projection and local cards. */
   private transcriptBlocks(projectionExpanded: ReadonlySet<number>): TranscriptRenderBlock[] {
     const blocks: TranscriptRenderBlock[] = [...this.projectedBlocks(projectionExpanded)]
-    if (this.streamingToolPreviews.length > 0) {
-      blocks.push({ kind: 'streaming-tool-previews', previews: this.streamingToolPreviews })
+    if (!this.focusModeEnabled) {
+      if (this.streamingToolPreviews.length > 0) {
+        blocks.push({ kind: 'streaming-tool-previews', previews: this.streamingToolPreviews })
+      }
+    } else if (this.streamingToolPreviews.length > 0) {
+      const previewTurns = new Set(this.streamingToolPreviews.map(preview => preview.turn))
+      for (const turn of previewTurns) {
+        if (!projectionExpanded.has(turn)) continue
+        const previews = this.streamingToolPreviewsForTurn(turn)
+        if (previews.length === 0) continue
+        const insertion = this.focusPreparingInsertionIndex(blocks, turn)
+        if (insertion === undefined) continue
+        blocks.splice(insertion, 0, {
+          kind: 'streaming-tool-previews',
+          turn,
+          previews,
+          // This marker belongs to the preceding spacer's owner only; the
+          // preview block itself has no activity/message and remains inert.
+          collapseFocusOwnerOnClick: turn,
+        })
+      }
     }
     blocks.push(...this.localMessages.map(message => ({ kind: 'message', message }) as FocusProjectedBlock))
     return blocks
+  }
+
+  /** The expanded Focus owner used only for the spacer immediately before a
+   * live Preparing block. The block itself still has no message/activity, so
+   * its content remains inert in the fullscreen hit map. */
+  private focusOwnerForRenderBlock(block: TranscriptRenderBlock): number | undefined {
+    return block.kind === 'message' || block.kind === 'streaming-tool-previews'
+      ? block.collapseFocusOwnerOnClick
+      : undefined
   }
 
   /** Render the live preparing rows with the current semantic tool icon and
@@ -5614,19 +5691,31 @@ export class TuiApp {
    * when the activity OBJECT changed (session/viewer switches mint fresh
    * folder objects, so the same turn number from another session can
    * never reuse this one's component), the activity revision moved, the
-   * disclosure flipped, the theme switched, or the precomputed Tool
-   * display changed (plan §39). render() re-reads Date.now() every frame,
-   * so the running duration is always live. */
-  private focusActivityComponentFor(activity: TurnActivity, expanded: boolean, toolDisplay: string | undefined): FocusActivityComponent {
+   * disclosure flipped, the theme switched, the precomputed Tool display
+   * changed, or the live Preparing summary changed (plan §39). render()
+   * re-reads Date.now() every frame, so the running duration is always live. */
+  private focusActivityComponentFor(
+    activity: TurnActivity,
+    expanded: boolean,
+    toolDisplay: string | undefined,
+    preparingSummary: string | undefined,
+  ): FocusActivityComponent {
     const entry = this.focusActivityComponents.get(activity.turn)
     if (entry !== undefined && entry.activity === activity
       && entry.revision === activity.revision
       && entry.expanded === expanded && entry.themeRev === this.themeRevision
       && entry.iconStyle === this.iconStyle
-      && entry.toolDisplay === toolDisplay) {
+      && entry.toolDisplay === toolDisplay
+      && entry.preparingSummary === preparingSummary) {
       return entry.component
     }
-    const component = new FocusActivityComponent({ activity, expanded, toolDisplay, iconStyle: this.iconStyle })
+    const component = new FocusActivityComponent({
+      activity,
+      expanded,
+      toolDisplay,
+      iconStyle: this.iconStyle,
+      preparingSummary,
+    })
     this.focusActivityComponents.set(activity.turn, {
       activity,
       component,
@@ -5635,6 +5724,7 @@ export class TuiApp {
       themeRev: this.themeRevision,
       iconStyle: this.iconStyle,
       toolDisplay,
+      preparingSummary,
     })
     return component
   }
@@ -5681,6 +5771,7 @@ export class TuiApp {
       let rendered: string[]
       let truncatedMarker = false
       let attachments: ReadonlyArray<{ imageIndex: number; start: number; end: number }> = []
+      const collapseFocusOwnerOnClick = this.focusOwnerForRenderBlock(block)
       if (block.kind === 'activity') {
         // The live Thought disclosure; the hidden process rows (if any)
         // render as ordinary message blocks below it (plan §15).
@@ -5688,6 +5779,9 @@ export class TuiApp {
           block.activity,
           projectionExpanded.has(block.activity.turn),
           this.focusToolDisplayFor(block.activity),
+          this.focusModeEnabled && !projectionExpanded.has(block.activity.turn)
+            ? focusPreparingSummary(this.streamingToolPreviewsForTurn(block.activity.turn))
+            : undefined,
         )
         rendered = component.render(width)
       } else if (block.kind === 'streaming-tool-previews') {
@@ -5717,8 +5811,8 @@ export class TuiApp {
           ...(block.kind === 'message'
             ? { message: block.message }
             : block.kind === 'activity' ? { activity: block.activity } : {}),
-          ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
-            ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
+          ...(collapseFocusOwnerOnClick !== undefined
+            ? { collapseFocusOwnerOnClick }
             : {}),
           height: 0,
           attachments: [],
@@ -5746,8 +5840,8 @@ export class TuiApp {
         ...(block.kind === 'message'
           ? { message: block.message }
           : block.kind === 'activity' ? { activity: block.activity } : {}),
-        ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
-          ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
+        ...(collapseFocusOwnerOnClick !== undefined
+          ? { collapseFocusOwnerOnClick }
           : {}),
         height,
         attachments,
@@ -5880,11 +5974,15 @@ export class TuiApp {
       let rendered: string[]
       let truncatedMarker = false
       let attachments: ReadonlyArray<{ imageIndex: number; start: number; end: number }> = []
+      const collapseFocusOwnerOnClick = this.focusOwnerForRenderBlock(block)
       if (block.kind === 'activity') {
         component = this.focusActivityComponentFor(
           block.activity,
           projectionExpanded.has(block.activity.turn),
           this.focusToolDisplayFor(block.activity),
+          this.focusModeEnabled && !projectionExpanded.has(block.activity.turn)
+            ? focusPreparingSummary(this.streamingToolPreviewsForTurn(block.activity.turn))
+            : undefined,
         )
         rendered = component.render(width)
       } else if (block.kind === 'streaming-tool-previews') {
@@ -5903,8 +6001,8 @@ export class TuiApp {
           ...(block.kind === 'message'
             ? { message: block.message }
             : block.kind === 'activity' ? { activity: block.activity } : {}),
-          ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
-            ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
+          ...(collapseFocusOwnerOnClick !== undefined
+            ? { collapseFocusOwnerOnClick }
             : {}),
           height: 0,
           attachments: [],
@@ -5917,8 +6015,8 @@ export class TuiApp {
         ...(block.kind === 'message'
           ? { message: block.message }
           : block.kind === 'activity' ? { activity: block.activity } : {}),
-        ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
-          ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
+        ...(collapseFocusOwnerOnClick !== undefined
+          ? { collapseFocusOwnerOnClick }
           : {}),
         height,
         attachments,

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -118,6 +118,7 @@ import {
   systemContextBody,
   toolCardHeader,
   toolIconSemantic,
+  toolTitle,
   webCardLines,
   type ToolPresenter,
 } from './present.ts'
@@ -237,6 +238,17 @@ function isFocusSecondaryDisclosure(message: TranscriptMessage): boolean {
  * being committed). Derived by the runner from compaction/start →
  * compaction/summary → compaction/end (foldCompactionEvent). */
 export type CompactionPhase = 'idle' | 'summarizing' | 'applying'
+
+/** One live, ephemeral preview of a tool call whose arguments are still
+ * streaming. This presentation state is deliberately separate from the
+ * durable TranscriptMessage/TurnActivity model. */
+export interface StreamingToolPreview {
+  readonly callId: string
+  readonly turn: number
+  readonly step: number
+  readonly index: number
+  readonly name?: string
+}
 
 /** The indeterminate progress-bar frames shown while a compaction runs:
  * width 12 / block 3, the same visual weight as the footer context bar. */
@@ -1892,6 +1904,14 @@ function deepFreeze(value: unknown): unknown {
  * one bulk owner: Ctrl+O never touches Thinking. */
 type ExpandHint = 'click' | 'fold' | 'thinking' | undefined
 
+/** One live-only transcript block containing all preparing tool rows. It is
+ * kept outside FocusProjectedBlock so no ephemeral row can enter the Focus
+ * activity projection or durable transcript model. */
+type TranscriptRenderBlock = FocusProjectedBlock | {
+  kind: 'streaming-tool-previews'
+  previews: readonly StreamingToolPreview[]
+}
+
 /** One cached component for a transcript message (stage J render cache). */
 interface MessageComponentEntry {
   component: Component
@@ -2055,6 +2075,10 @@ export class TuiApp {
   private readonly questionQueue: QuestionState[] = []
   /** The folded transcript; re-rendered into the messages view on change. */
   private messages: readonly TranscriptMessage[] = []
+  /** Live-only tool-call previews; never part of the folded transcript or
+   * Focus activity state. The runner replaces this snapshot on each coalesced
+   * transcript repaint. */
+  private streamingToolPreviews: readonly StreamingToolPreview[] = []
   /** Local (non-session) cards — e.g. `!` shell runs — rendered after the transcript. */
   private readonly localMessages: TranscriptMessage[] = []
   /** Submitted input history (newest first), mirrored for persistence. */
@@ -5038,14 +5062,18 @@ export class TuiApp {
    * @param activities - the same fold state's per-turn Focus activities
    *   (plan §19: messages and activities must come from ONE fold snapshot,
    *   so a repaint never shows a stale header against fresh rows).
+   * @param streamingToolPreviews - live-only preparing rows for the current
+   *   presentation owner; omitted by legacy callers and never persisted.
    */
   setTranscript(
-     messages: readonly TranscriptMessage[],
-     activities?: ReadonlyMap<number, TurnActivity>,
-     window?: TranscriptWindowState & { firstTurn?: number; lastTurn?: number; hasNewer?: boolean },
-   ): void {
+    messages: readonly TranscriptMessage[],
+    activities?: ReadonlyMap<number, TurnActivity>,
+    window?: TranscriptWindowState & { firstTurn?: number; lastTurn?: number; hasNewer?: boolean },
+    streamingToolPreviews?: readonly StreamingToolPreview[],
+  ): void {
     this.messages = messages
     if (activities !== undefined) this.turnActivities = activities
+    this.streamingToolPreviews = [...(streamingToolPreviews ?? [])]
     this.transcriptWindow = window
     this.refreshTranscriptWindowHint()
     // Repaints do NOT clear the transient notify line: an active session
@@ -5549,6 +5577,30 @@ export class TuiApp {
     return projectFocus(this.messages, this.turnActivities, projectionExpanded, this.focusModeEnabled)
   }
 
+  /** Build the rendered transcript blocks in visual order. Preparing rows are
+   * one live-only block between the durable projection and local cards, so
+   * multiple calls stay contiguous and never enter Focus aggregation. */
+  private transcriptBlocks(projectionExpanded: ReadonlySet<number>): TranscriptRenderBlock[] {
+    const blocks: TranscriptRenderBlock[] = [...this.projectedBlocks(projectionExpanded)]
+    if (this.streamingToolPreviews.length > 0) {
+      blocks.push({ kind: 'streaming-tool-previews', previews: this.streamingToolPreviews })
+    }
+    blocks.push(...this.localMessages.map(message => ({ kind: 'message', message }) as FocusProjectedBlock))
+    return blocks
+  }
+
+  /** Render the live preparing rows with the current semantic tool icon and
+   * title mappings. The arguments stream is intentionally not retained or
+   * parsed; only the tool identity is shown. */
+  private streamingToolPreviewComponent(previews: readonly StreamingToolPreview[]): Component {
+    const lines = previews.map(preview => {
+      const name = preview.name ?? ''
+      const prefix = iconPrefix(toolIconSemantic(name), this.iconStyle)
+      return color.textDim(`${prefix}Preparing ${toolTitle(name)}...`)
+    })
+    return new Text(lines.join('\n'), 0, 0)
+  }
+
   /** The precomputed Focus Tool-line display for one activity: presenter-
    * first, static fallback second (plan §38/§9.4). The FocusActivityComponent
    * stays a pure renderer — the presentation bridge lives here. */
@@ -5623,10 +5675,7 @@ export class TuiApp {
     // a session never reads as one undifferentiated wall of text. The spacer
     // row is charged to the preceding block's height, keeping the fullscreen
     // click hit-testing aligned with the rendered layout.
-    const blocks: FocusProjectedBlock[] = [
-      ...this.projectedBlocks(projectionExpanded),
-      ...this.localMessages.map(message => ({ kind: 'message', message }) as FocusProjectedBlock),
-    ]
+    const blocks = this.transcriptBlocks(projectionExpanded)
     blocks.forEach((block, index) => {
       let component: Component
       let rendered: string[]
@@ -5640,6 +5689,10 @@ export class TuiApp {
           projectionExpanded.has(block.activity.turn),
           this.focusToolDisplayFor(block.activity),
         )
+        rendered = component.render(width)
+      } else if (block.kind === 'streaming-tool-previews') {
+        // Live-only preview block
+        component = this.streamingToolPreviewComponent(block.previews)
         rendered = component.render(width)
       } else {
         // Persistent per-message components (stage J): unchanged messages
@@ -5661,7 +5714,9 @@ export class TuiApp {
         // and the row height — the click map stays aligned (height 0
         // never hits, see handleFullscreenClick).
         rows.push({
-          ...(block.kind === 'message' ? { message: block.message } : { activity: block.activity }),
+          ...(block.kind === 'message'
+            ? { message: block.message }
+            : block.kind === 'activity' ? { activity: block.activity } : {}),
           ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
             ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
             : {}),
@@ -5688,7 +5743,9 @@ export class TuiApp {
       }
       const height = rendered.length + (truncatedMarker ? 1 : 0) + (index < blocks.length - 1 ? 1 : 0)
       rows.push({
-        ...(block.kind === 'message' ? { message: block.message } : { activity: block.activity }),
+        ...(block.kind === 'message'
+          ? { message: block.message }
+          : block.kind === 'activity' ? { activity: block.activity } : {}),
         ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
           ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
           : {}),
@@ -5809,10 +5866,7 @@ export class TuiApp {
     // The derived projection set is computed ONCE per refresh (never per
     // activity block — review finding).
     const projectionExpanded = this.focusProjectionExpandedTurns()
-    const blocks: FocusProjectedBlock[] = [
-      ...this.projectedBlocks(projectionExpanded),
-      ...this.localMessages.map(message => ({ kind: 'message', message }) as FocusProjectedBlock),
-    ]
+    const blocks = this.transcriptBlocks(projectionExpanded)
     const rows: Array<{
       message?: TranscriptMessage
       activity?: TurnActivity
@@ -5833,6 +5887,9 @@ export class TuiApp {
           this.focusToolDisplayFor(block.activity),
         )
         rendered = component.render(width)
+      } else if (block.kind === 'streaming-tool-previews') {
+        component = this.streamingToolPreviewComponent(block.previews)
+        rendered = component.render(width)
       } else {
         component = this.componentForMessage(block.message, boundary, width)
         rendered = component.render(width)
@@ -5843,7 +5900,9 @@ export class TuiApp {
         // Same zero-row rule as rebuildMessages: no spacer row, no height —
         // the click map must mirror the rendered layout exactly.
         rows.push({
-          ...(block.kind === 'message' ? { message: block.message } : { activity: block.activity }),
+          ...(block.kind === 'message'
+            ? { message: block.message }
+            : block.kind === 'activity' ? { activity: block.activity } : {}),
           ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
             ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
             : {}),
@@ -5855,7 +5914,9 @@ export class TuiApp {
       }
       const height = rendered.length + (truncatedMarker ? 1 : 0) + (index < blocks.length - 1 ? 1 : 0)
       rows.push({
-        ...(block.kind === 'message' ? { message: block.message } : { activity: block.activity }),
+        ...(block.kind === 'message'
+          ? { message: block.message }
+          : block.kind === 'activity' ? { activity: block.activity } : {}),
         ...(block.kind === 'message' && block.collapseFocusOwnerOnClick !== undefined
           ? { collapseFocusOwnerOnClick: block.collapseFocusOwnerOnClick }
           : {}),

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -26,6 +26,7 @@ import {
   focusDisclosureIcon,
   focusDisclosureSemantic,
   focusDurationText,
+  focusPreparingSummary,
   focusStatusLabel,
   focusToolStatParts,
   formatFocusDuration,
@@ -1321,6 +1322,37 @@ test('the header never wraps: every candidate fits its width', () => {
   }
 })
 
+test('Focus collapsed Preparing temporarily overrides the formal Tool slot', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'think' } }, 1001, 1),
+    eventAt('tool/call', { turn: 0, step: 0, callId: ToolCallId('c1'), name: 'read', arguments: JSON.stringify({ path: 'src/foo.ts' }) }, 1002, 2),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'text-delta', index: 0, text: 'message' } }, 1003, 3),
+  ])
+  const activity = folder.turnActivity(0)!
+  const formal = focusCollapsedBody(activity, 80, '✓ Read src/foo.ts')
+  const preparing = focusCollapsedBody(activity, 80, '✓ Read src/foo.ts', 'Preparing Edit +1')
+  assert.ok(formal.some(line => line.includes('✓ Read src/foo.ts')), formal.join('\n'))
+  assert.ok(preparing.some(line => line.includes('Tool:    Preparing Edit +1')), preparing.join('\n'))
+  assert.ok(!preparing.some(line => line.includes('Read src/foo.ts')), preparing.join('\n'))
+})
+
+test('focusPreparingSummary is deterministic and keeps unknown names generic', () => {
+  const previews = [
+    { index: 2, name: 'read' },
+    { index: 0, name: 'edit' },
+    { index: 1, name: 'unregistered_tool' },
+  ] as const
+  assert.equal(focusPreparingSummary([]), undefined)
+  assert.equal(focusPreparingSummary([{ index: 0, name: 'edit' }]), 'Preparing Edit…')
+  assert.equal(focusPreparingSummary([{ index: 0 }]), 'Preparing tool…')
+  assert.equal(focusPreparingSummary([{ index: 0 }, { index: 1 }, { index: 2 }]), 'Preparing 3 tools…')
+  assert.equal(focusPreparingSummary(previews), 'Preparing Edit +2')
+  assert.deepEqual(previews.map(preview => preview.index), [2, 0, 1])
+})
+
+// The collapsed body preserves its fixed Think → Tool → Message slot order.
 test('the collapsed body renders the three slots in fixed order — Think, Tool, Message (plan §24/§25/§47)', () => {
   const folder = new TranscriptFolder()
   folder.apply([

--- a/test/focus-ui.test.ts
+++ b/test/focus-ui.test.ts
@@ -17,7 +17,7 @@ import { ToolCallId, MessageId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { visibleWidth } from '@xmoon76/pi-tui'
 import { TranscriptFolder, windowMessages } from '../src/transcript.ts'
-import { EXPAND_RECENT_TURNS, TuiApp, transcriptContentWidth } from '../src/tui-app.ts'
+import { EXPAND_RECENT_TURNS, TuiApp, transcriptContentWidth, type StreamingToolPreview } from '../src/tui-app.ts'
 import type { ToolPresenter } from '../src/present.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
@@ -113,8 +113,8 @@ function click(vt: VirtualTerminal, x: number, y: number): void {
 }
 
 /** Push a folder snapshot into the app (the runner's repaint contract). */
-function show(app: TuiApp, folder: TranscriptFolder): void {
-  app.setTranscript(folder.messages(), folder.turnActivities())
+function show(app: TuiApp, folder: TranscriptFolder, previews?: readonly StreamingToolPreview[]): void {
+  app.setTranscript(folder.messages(), folder.turnActivities(), undefined, previews)
 }
 
 test('Focus ON running: the Thought card is collapsed with previews, the process is hidden, the WorkingIndicator stays', async () => {
@@ -137,6 +137,69 @@ test('Focus ON running: the Thought card is collapsed with previews, the process
   assert.ok(!joined.includes('📖'), `collapsed must hide the tool card:\n${joined}`)
   // The WorkingIndicator (the whale row above the editor) stays — plan §59.
   assert.ok(joined.includes('Working...'), `WorkingIndicator must remain visible:\n${joined}`)
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('Focus collapsed Preparing uses the Tool slot and temporarily overrides the formal tool', async () => {
+  const { vt, app } = startApp()
+  const folder = new TranscriptFolder()
+  folder.apply(runningTurn(0))
+  app.setFocusMode(true)
+  show(app, folder, [
+    { callId: 'p-edit', turn: 1, step: 0, index: 0, name: 'edit' },
+    { callId: 'p-bash', turn: 1, step: 0, index: 1, name: 'bash' },
+  ])
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  let view = vt.getViewport()
+  let joined = view.join('\n')
+  assert.ok(joined.includes('Tool:    Preparing Edit +1'), `Preparing must own the compact Tool slot:\n${joined}`)
+  assert.ok(!joined.includes('Tool:    Read src/transcript.ts'), `the formal Tool slot must be overridden:\n${joined}`)
+  assert.ok(!joined.includes('Preparing Edit...'), `collapsed Focus must not append a standalone preview row:\n${joined}`)
+
+  show(app, folder, [{ callId: 'p-read', turn: 1, step: 0, index: 0, name: 'read' }])
+  await vt.waitForRender()
+  joined = vt.getViewport().join('\n')
+  assert.ok(joined.includes('Tool:    Preparing Read…'), `the live Tool-slot summary must refresh:\n${joined}`)
+  assert.ok(!joined.includes('Preparing Edit +1'), `the cached previous summary must be replaced:\n${joined}`)
+
+  show(app, folder)
+  await vt.waitForRender()
+  view = vt.getViewport()
+  joined = view.join('\n')
+  assert.ok(joined.includes('Tool:    Read src/transcript.ts'), `clearing Preparing must restore the formal Tool slot:\n${joined}`)
+  assert.ok(!joined.includes('Preparing'), `clearing Preparing must remove its presentation:\n${joined}`)
+  app.setFullscreen(false)
+  app.stop()
+})
+
+test('Focus expanded places Preparing rows after the process tail and before the final assistant', async () => {
+  const { vt, app } = startApp()
+  const folder = new TranscriptFolder()
+  folder.apply([...runningTurn(0), ...settleEvents(0)])
+  app.setFocusMode(true)
+  show(app, folder, [
+    { callId: 'p-bash', turn: 1, step: 0, index: 1, name: 'bash' },
+    { callId: 'p-edit', turn: 1, step: 0, index: 0, name: 'edit' },
+  ])
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  const headerRow = findRow(vt.getViewport(), '🐋 Thought')
+  assert.ok(headerRow >= 0, `collapsed Thought missing:\n${vt.getViewport().join('\n')}`)
+  click(vt, 3, headerRow + 1)
+  await vt.waitForRender()
+  const view = vt.getViewport()
+  const joined = view.join('\n')
+  const processRow = findRow(view, 'Read src/transcript.ts')
+  const editRow = findRow(view, 'Preparing Edit...')
+  const bashRow = findRow(view, 'Preparing Bash...')
+  const finalRow = findRow(view, 'The transcript folds events incrementally.')
+  assert.ok(joined.includes('🐳 Thought'), `expanded Thought missing:\n${joined}`)
+  assert.ok(processRow >= 0 && editRow >= 0 && bashRow >= 0 && finalRow >= 0, `expanded ordering rows missing:\n${joined}`)
+  assert.ok(processRow < editRow && editRow < bashRow && bashRow < finalRow, `Preparing rows must be index ordered at the process tail:\n${joined}`)
+  assert.equal((joined.match(/Preparing (?:Edit|Bash)\.\.\./g) ?? []).length, 2, `each preview should render once:\n${joined}`)
+  assert.ok(!joined.includes('Tool:    Preparing'), `expanded Focus must not use the compact Preparing Tool slot:\n${joined}`)
   app.setFullscreen(false)
   app.stop()
 })

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -1117,11 +1117,11 @@ test('the parent Preparing projection keeps updating behind a child viewer', asy
   context.emit('session/event', parent as never, event('assistant/chunk', {
     turn: 1,
     step: 0,
-    chunk: { type: 'tool-call-delta', index: 0, id: 'parent-call-a' as ToolCallId, name: 'edit', argumentsDelta: '{' },
+    chunk: { type: 'tool-call-delta', index: 0, id: '' as ToolCallId, name: 'edit', argumentsDelta: '{' },
   }, 11))
   await new Promise(resolve => setTimeout(resolve, 70))
   await vt.waitForRender()
-  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => preview.callId), ['parent-call-a'])
+  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => preview.callId), [''])
 
   // /tasks opens the real runner browser, and Enter mounts the child viewer.
   const tasksHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('tasks')
@@ -1139,13 +1139,22 @@ test('the parent Preparing projection keeps updating behind a child viewer', asy
   context.emit('session/event', parent as never, event('assistant/chunk', {
     turn: 1,
     step: 0,
-    chunk: { type: 'tool-call-delta', index: 0, id: 'parent-call-a' as ToolCallId, name: 'write', argumentsDelta: '}' },
+    chunk: { type: 'tool-call-delta', index: 0, id: '' as ToolCallId, name: 'write', argumentsDelta: '}' },
   }, 12))
   context.emit('session/event', parent as never, event('assistant/chunk', {
     turn: 1,
     step: 0,
     chunk: { type: 'tool-call-delta', index: 1, id: 'parent-call-b' as ToolCallId, name: 'read', argumentsDelta: '{' },
   }, 13))
+  context.emit('session/event', parent as never, event('assistant/chunk', {
+    turn: 1,
+    step: 0,
+    chunk: {
+      type: 'block-end',
+      index: 0,
+      block: { type: 'tool-call', id: 'parent-call-a' as ToolCallId, name: 'write', arguments: '{}' },
+    },
+  }, 14))
   await new Promise(resolve => setTimeout(resolve, 70))
   await vt.waitForRender()
 
@@ -1161,7 +1170,7 @@ test('the parent Preparing projection keeps updating behind a child viewer', asy
 
   // A parent call that materializes while the child remains visible must be
   // removed from the hidden main map, not recreated when the viewer closes.
-  context.emit('session/event', parent as never, event('turn/end', { turn: 1, reason: { kind: 'completed' } }, 14))
+  context.emit('session/event', parent as never, event('turn/end', { turn: 1, reason: { kind: 'completed' } }, 15))
   await vt.waitForRender()
   await tasksHandler()
   await settle()
@@ -1170,12 +1179,12 @@ test('the parent Preparing projection keeps updating behind a child viewer', asy
   await settle()
   await vt.waitForRender()
   assert.equal(app.getViewerGeneration(), 3, 'the child viewer must reopen')
-  context.emit('session/event', parent as never, event('turn/start', { turn: 2 }, 15))
+  context.emit('session/event', parent as never, event('turn/start', { turn: 2 }, 16))
   context.emit('session/event', parent as never, event('assistant/chunk', {
     turn: 2,
     step: 0,
     chunk: { type: 'tool-call-delta', index: 0, id: 'parent-call-c' as ToolCallId, name: 'edit', argumentsDelta: '{' },
-  }, 16))
+  }, 17))
   await new Promise(resolve => setTimeout(resolve, 70))
   await vt.waitForRender()
   context.emit('session/event', parent as never, event('tool/call', {
@@ -1184,7 +1193,7 @@ test('the parent Preparing projection keeps updating behind a child viewer', asy
     callId: 'parent-call-c' as ToolCallId,
     name: 'edit',
     arguments: '{}',
-  }, 17))
+  }, 18))
   await new Promise(resolve => setTimeout(resolve, 70))
   await vt.waitForRender()
   input('\x1b')

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -137,6 +137,7 @@ interface RunnerHarness {
   readonly createOptions: { provider?: string; model?: string }[]
   readonly createdSessions: FakeSession[]
   readonly commands: unknown
+  readonly subagents?: unknown
 }
 
 function fakeAgent(session: FakeSession): Agent {
@@ -165,6 +166,7 @@ function makeHarness(
   initialDefault: { provider: string; model: string; reasoningEffort?: string } = { provider: 'p', model: 'm' },
   saveDefault?: (next: { provider: string; model: string; reasoningEffort?: string }) => Promise<unknown>,
   createGate?: () => Promise<unknown>,
+  subagents?: unknown,
 ): RunnerHarness {
   const persisted = new Map<string, FakeSession>()
   const live = new Map<string, Agent>()
@@ -254,7 +256,7 @@ function makeHarness(
     execute: async () => ({ result: { kind: 'success' } }),
     handler: (name: string) => definitions.get(name)?.handler,
   }
-  return { persistence, agents, sessions, defaultModel, llm, createOptions, createdSessions, commands }
+  return { persistence, agents, sessions, defaultModel, llm, createOptions, createdSessions, commands, subagents }
 }
 
 async function settle(): Promise<void> {
@@ -413,6 +415,7 @@ async function mountRunner(
   ctx.provide('agentDefaultModel', harness.defaultModel as never)
   ctx.provide('llm', harness.llm as never)
   ctx.provide('commands', harness.commands as never)
+  if (harness.subagents !== undefined) ctx.provide('subagents', harness.subagents as never)
   ctx.provide('loader', { await: async () => {} } as never)
   const fiber = ctx.plugin((pluginCtx) => applyRunner(pluginCtx, config))
   await fiber
@@ -1056,6 +1059,139 @@ test('live repaint preserves manual scrolling in the latest window', async (t) =
   assert.equal(readScroll().isFollowingEnd, true, 'a viewport following the end must remain attached to live output')
   const following = readScroll()
   assert.equal(following.scrollTop, following.maxScrollTop, JSON.stringify(following))
+})
+
+test('the parent Preparing projection keeps updating behind a child viewer', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-parent-preparing-viewer-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const vt = new VirtualTerminal(80, 24)
+  const restoreTerminal = installVirtualProcessTerminal(vt)
+  life.defer(restoreTerminal)
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+
+  const parent: FakeSession = fakeSession({
+    id: 'parent-preparing-viewer-session',
+    header: { id: 'parent-preparing-viewer-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('parent answer'),
+  })
+  const child: FakeSession = fakeSession({
+    id: 'child-preparing-viewer-session',
+    header: { id: 'child-preparing-viewer-session', cwd: home, createdAt: 1_700_000_000_001, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('child answer'),
+  })
+  const subagents = {
+    listDescendants: async () => [{
+      kind: 'child',
+      id: child.id,
+      label: 'child viewer',
+      mode: 'continuable',
+      activity: 'running',
+      hasChildren: false,
+      parentId: parent.id,
+      depth: 1,
+    }],
+  }
+  const harness = makeHarness(home, [parent, child], { provider: 'p', model: 'm' }, undefined, undefined, subagents)
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: parent.id }, { sessionId: parent.id })
+  const app = probe.apps.at(-1)
+  assert.ok(app, 'the production runner must create a TuiApp')
+  const input = (data: string): void => {
+    const tui = (app as unknown as { tui: { handleTerminalInput(data: string): void } }).tui
+    tui.handleTerminalInput(data)
+  }
+
+  // The main session owns the first preview before the viewer opens.
+  context.emit('session/event', parent as never, event('turn/start', { turn: 1 }, 10))
+  context.emit('session/event', parent as never, event('assistant/chunk', {
+    turn: 1,
+    step: 0,
+    chunk: { type: 'tool-call-delta', index: 0, id: 'parent-call-a' as ToolCallId, name: 'edit', argumentsDelta: '{' },
+  }, 11))
+  await new Promise(resolve => setTimeout(resolve, 70))
+  await vt.waitForRender()
+  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => preview.callId), ['parent-call-a'])
+
+  // /tasks opens the real runner browser, and Enter mounts the child viewer.
+  const tasksHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('tasks')
+  assert.ok(tasksHandler, 'the real runner must register /tasks')
+  await tasksHandler()
+  await settle()
+  await vt.waitForRender()
+  input('\r')
+  await settle()
+  await vt.waitForRender()
+  assert.notEqual(app.getViewerGeneration(), 0, 'the child viewer must be mounted')
+
+  // Parent events continue through the runner while the child owns the
+  // visible transcript. Updating A and adding B must both survive the visit.
+  context.emit('session/event', parent as never, event('assistant/chunk', {
+    turn: 1,
+    step: 0,
+    chunk: { type: 'tool-call-delta', index: 0, id: 'parent-call-a' as ToolCallId, name: 'write', argumentsDelta: '}' },
+  }, 12))
+  context.emit('session/event', parent as never, event('assistant/chunk', {
+    turn: 1,
+    step: 0,
+    chunk: { type: 'tool-call-delta', index: 1, id: 'parent-call-b' as ToolCallId, name: 'read', argumentsDelta: '{' },
+  }, 13))
+  await new Promise(resolve => setTimeout(resolve, 70))
+  await vt.waitForRender()
+
+  // Esc returns to the parent surface; its hidden map, not a reset map, is
+  // projected and therefore contains the latest A plus the new B.
+  input('\x1b')
+  await settle()
+  await vt.waitForRender()
+  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => [preview.callId, preview.name]), [
+    ['parent-call-a', 'write'],
+    ['parent-call-b', 'read'],
+  ])
+
+  // A parent call that materializes while the child remains visible must be
+  // removed from the hidden main map, not recreated when the viewer closes.
+  context.emit('session/event', parent as never, event('turn/end', { turn: 1, reason: { kind: 'completed' } }, 14))
+  await vt.waitForRender()
+  await tasksHandler()
+  await settle()
+  await vt.waitForRender()
+  input('\r')
+  await settle()
+  await vt.waitForRender()
+  assert.equal(app.getViewerGeneration(), 3, 'the child viewer must reopen')
+  context.emit('session/event', parent as never, event('turn/start', { turn: 2 }, 15))
+  context.emit('session/event', parent as never, event('assistant/chunk', {
+    turn: 2,
+    step: 0,
+    chunk: { type: 'tool-call-delta', index: 0, id: 'parent-call-c' as ToolCallId, name: 'edit', argumentsDelta: '{' },
+  }, 16))
+  await new Promise(resolve => setTimeout(resolve, 70))
+  await vt.waitForRender()
+  context.emit('session/event', parent as never, event('tool/call', {
+    turn: 2,
+    step: 0,
+    callId: 'parent-call-c' as ToolCallId,
+    name: 'edit',
+    arguments: '{}',
+  }, 17))
+  await new Promise(resolve => setTimeout(resolve, 70))
+  await vt.waitForRender()
+  input('\x1b')
+  await settle()
+  await vt.waitForRender()
+  assert.deepEqual(probe.capturedStreamingToolPreviews, [],
+    'a parent preview materialized behind the viewer must not return on exit')
 })
 
 test('explicit cold resume shows the pre-mount status and clears it before mount; fresh start stays silent', async (t) => {

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -5,14 +5,14 @@ import { join } from 'node:path'
 import test from 'node:test'
 import { Context } from '@deepseek-ai/cordis'
 import { ProcessTerminal } from '@xmoon76/pi-tui'
-import { MessageId } from '@deepseek-ai/dsh-llm'
+import { MessageId, type ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import { SESSION_FORMAT_VERSION, type SessionEvent } from '@deepseek-ai/dsh-session'
 import { apply as applyRunner, type Config } from '../src/index.ts'
 import { StatsFolder } from '../src/stats.ts'
 import { TUI_STARTUP_SERVICE } from '../src/startup.ts'
 import { TranscriptFolder } from '../src/transcript.ts'
-import { TuiApp } from '../src/tui-app.ts'
+import { TuiApp, type StreamingToolPreview } from '../src/tui-app.ts'
 import { testLifecycle } from './support/temp-lifecycle.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
@@ -315,6 +315,7 @@ interface RunnerProbe {
   transcriptHydrateCount: number
   statsHydrateCount: number
   capturedMessages: readonly { kind: string; text?: string }[] | undefined
+  capturedStreamingToolPreviews: readonly StreamingToolPreview[] | undefined
   scrollToBottomCount: number
   capturedModels: string[]
   capturedWelcomeModels: string[]
@@ -330,6 +331,7 @@ function installProbe(): RunnerProbe {
     transcriptHydrateCount: 0,
     statsHydrateCount: 0,
     capturedMessages: undefined,
+    capturedStreamingToolPreviews: undefined,
     scrollToBottomCount: 0,
     capturedModels: [],
     capturedWelcomeModels: [],
@@ -361,9 +363,10 @@ function installProbe(): RunnerProbe {
     probe.statsHydrateCount += 1
     return originalStatsHydrate.call(this, events)
   }
-  TuiApp.prototype.setTranscript = function (messages, activities) {
+  TuiApp.prototype.setTranscript = function (messages, activities, window, streamingToolPreviews) {
     probe.capturedMessages = messages
-    return originalSetTranscript.call(this, messages, activities)
+    probe.capturedStreamingToolPreviews = streamingToolPreviews
+    return originalSetTranscript.call(this, messages, activities, window, streamingToolPreviews)
   }
   TuiApp.prototype.setStatus = function (status) {
     if (typeof status.model === 'string') probe.capturedModels.push(status.model)
@@ -456,7 +459,15 @@ test('the real runner hydrates resume, deferred create, and switch exactly once 
   const resumed: FakeSession = fakeSession({
     id: 'runner-session-a',
     header: { id: 'runner-session-a', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
-    events: [...sessionEvents('resumed answer'), ...modelHistory('provider-a', 'model-a', 'high')],
+    events: [
+      ...sessionEvents('resumed answer'),
+      ...modelHistory('provider-a', 'model-a', 'high'),
+      event('assistant/chunk', {
+        turn: 0,
+        step: 0,
+        chunk: { type: 'tool-call-delta', index: 0, id: 'historical-preview' as ToolCallId, name: 'edit', argumentsDelta: '{"path"' },
+      }, 8),
+    ],
   })
   const resumeHarness = makeHarness(home, resumed, { provider: 'provider-b', model: 'model-b', reasoningEffort: 'max' })
   resumeContext = new Context()
@@ -466,6 +477,7 @@ test('the real runner hydrates resume, deferred create, and switch exactly once 
   assert.equal(probe.transcriptHydrateCount, 1)
   assert.equal(probe.statsHydrateCount, 1)
   assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'resumed answer'))
+  assert.deepEqual(probe.capturedStreamingToolPreviews, [], 'cold hydration must not recreate Preparing rows')
   assert.ok(probe.capturedModels.includes('provider-a/model-a @high'),
     `resume must restore the Session-local model, not the global fallback: ${probe.capturedModels.join(', ')}`)
 
@@ -995,8 +1007,35 @@ test('live repaint preserves manual scrolling in the latest window', async (t) =
     step: 0,
     chunk: { type: 'text-delta', index: 0, text: 'streaming while scrolled up' },
   }, 11))
-  context.emit('session/event', resumed as never, event('turn/end', { turn: 1, reason: { kind: 'completed' } }, 12))
+  context.emit('session/event', resumed as never, event('assistant/chunk', {
+    turn: 1,
+    step: 0,
+    chunk: { type: 'tool-call-delta', index: 0, id: 'preview-call' as ToolCallId, name: 'edit', argumentsDelta: '{"path"' },
+  }, 12))
+  await new Promise(resolve => setTimeout(resolve, 70))
   await vt.waitForRender()
+  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => preview.name), ['edit'])
+  context.emit('session/event', resumed as never, event('tool/call', {
+    turn: 1,
+    step: 0,
+    callId: 'preview-call' as ToolCallId,
+    name: 'edit',
+    arguments: '{"path":"x"}',
+  }, 13))
+  await new Promise(resolve => setTimeout(resolve, 70))
+  await vt.waitForRender()
+  assert.deepEqual(probe.capturedStreamingToolPreviews, [])
+
+  context.emit('session/event', resumed as never, event('turn/end', { turn: 1, reason: { kind: 'completed' } }, 14))
+  await vt.waitForRender()
+  context.emit('session/event', resumed as never, event('assistant/chunk', {
+    turn: 1,
+    step: 0,
+    chunk: { type: 'tool-call-delta', index: 0, id: 'late-preview' as ToolCallId, name: 'write', argumentsDelta: '{' },
+  }, 15))
+  await new Promise(resolve => setTimeout(resolve, 70))
+  await vt.waitForRender()
+  assert.deepEqual(probe.capturedStreamingToolPreviews, [], 'late chunks after turn/end must not resurrect a preview')
   assert.equal(probe.scrollToBottomCount, 0, 'live repaint must not force the latest window to its bottom')
   assert.equal(readScroll().isFollowingEnd, false, 'live repaint must preserve the manually disabled follow-end state')
   assert.ok(readScroll().scrollTop < readScroll().maxScrollTop, 'live repaint must leave the viewport away from the bottom')
@@ -1005,13 +1044,13 @@ test('live repaint preserves manual scrolling in the latest window', async (t) =
   await vt.waitForRender()
   assert.equal(readScroll().isFollowingEnd, true, 'an explicit bottom jump must re-enable follow-end')
   probe.scrollToBottomCount = 0
-  context.emit('session/event', resumed as never, event('turn/start', { turn: 2 }, 13))
+  context.emit('session/event', resumed as never, event('turn/start', { turn: 2 }, 16))
   context.emit('session/event', resumed as never, event('assistant/chunk', {
     turn: 2,
     step: 0,
     chunk: { type: 'text-delta', index: 0, text: 'streaming while following' },
-  }, 14))
-  context.emit('session/event', resumed as never, event('turn/end', { turn: 2, reason: { kind: 'completed' } }, 15))
+  }, 17))
+  context.emit('session/event', resumed as never, event('turn/end', { turn: 2, reason: { kind: 'completed' } }, 18))
   await vt.waitForRender()
   assert.equal(probe.scrollToBottomCount, 0, 'ScrollView follow-end must handle live output without an imperative jump')
   assert.equal(readScroll().isFollowingEnd, true, 'a viewport following the end must remain attached to live output')

--- a/test/streaming-tool-preparing.test.ts
+++ b/test/streaming-tool-preparing.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../src/streaming-tool-preparing.ts'
 import { toolIconSemantic, toolTitle } from '../src/present.ts'
 import { TuiApp, type StreamingToolPreview } from '../src/tui-app.ts'
-import type { TurnActivity } from '../src/transcript.ts'
+import type { TranscriptMessage, TurnActivity } from '../src/transcript.ts'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 function event<K extends SessionEvent['type']>(
@@ -285,15 +285,16 @@ test('preparing rows are inert in the fullscreen hit map', async () => {
     name: 'edit',
   }])
   app.setFullscreen(true)
+  app.expandFocusTurn(1)
   await vt.waitForRender()
 
   const before = vt.getViewport().join('\n')
   const previewRow = vt.getViewport().findIndex(line => line.includes('Preparing Edit...'))
   assert.ok(previewRow >= 0, `preview row missing:\n${before}`)
-  assert.deepEqual(app.focusExpandedTurnsForTest(), new Set())
+  assert.deepEqual(app.focusExpandedTurnsForTest(), new Set([1]))
   click(vt, 10, previewRow + 1)
   await vt.waitForRender()
-  assert.deepEqual(app.focusExpandedTurnsForTest(), new Set(), 'preview click must not toggle a Thought')
+  assert.deepEqual(app.focusExpandedTurnsForTest(), new Set([1]), 'preview click must not toggle a Thought')
   assert.ok(vt.getViewport().join('\n').includes('Preparing Edit...'), 'preview click must be inert')
 })
 
@@ -336,11 +337,23 @@ test('renders preparing rows with the selected icon style and no spinner state',
   assert.ok(!view.includes('~  Preparing Edit...'), `minimal preview kept a symbol prefix:\n${view}`)
 
   app.setFocusMode(true)
-  app.setTranscript([], new Map(), undefined, [preview])
+  const focusActivity: TurnActivity = {
+    turn: 1,
+    completed: false,
+    think: { text: 'still thinking' },
+    assistantMessages: 0,
+    toolCalls: 0,
+    tools: new Map(),
+    revision: 1,
+  }
+  const focusMessages: TranscriptMessage[] = [{ kind: 'assistant', turn: 1, text: 'answer' }]
+  app.setTranscript(focusMessages, new Map([[1, focusActivity]]), undefined, [preview])
   await vt.waitForRender()
-  assert.ok(vt.getViewport().join('\n').includes('Preparing Edit...'), 'Focus must keep the ephemeral row visible')
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Tool:    Preparing Edit…'), `Focus collapsed Tool slot missing:\n${view}`)
+  assert.ok(!view.includes('Preparing Edit...'), `Focus collapsed must not render a standalone row:\n${view}`)
 
-  app.setTranscript([])
+  app.setTranscript(focusMessages, new Map([[1, focusActivity]]))
   await vt.waitForRender()
-  assert.ok(!vt.getViewport().join('\n').includes('Preparing Edit...'), 'omitting the preview snapshot must clear old rows')
+  assert.ok(!vt.getViewport().join('\n').includes('Preparing'), 'omitting the preview snapshot must clear old rows')
 })

--- a/test/streaming-tool-preparing.test.ts
+++ b/test/streaming-tool-preparing.test.ts
@@ -6,8 +6,11 @@ import type { ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { RetryId } from '@deepseek-ai/dsh-llm-retry'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import {
-  applyStreamingToolPreviewEvent,
+  clearStreamingToolPreviewsForStep,
+  clearStreamingToolPreviewsForTurn,
+  removeStreamingToolPreview,
   streamingToolPreviewSnapshot,
+  upsertStreamingToolPreview,
 } from '../src/streaming-tool-preparing.ts'
 import { toolIconSemantic, toolTitle } from '../src/present.ts'
 import { TuiApp, type StreamingToolPreview } from '../src/tui-app.ts'
@@ -43,6 +46,29 @@ function delta(
   }, turn * 100 + step * 10 + index) as SessionEvent
 }
 
+function applyPreviewEvent(previews: Map<string, StreamingToolPreview>, event: SessionEvent): void {
+  if (event.type === 'assistant/chunk' && event.data.chunk.type === 'tool-call-delta') {
+    const chunk = event.data.chunk
+    upsertStreamingToolPreview(previews, {
+      callId: chunk.id,
+      turn: event.data.turn,
+      step: event.data.step,
+      index: chunk.index,
+      name: chunk.name,
+    })
+    return
+  }
+  if (event.type === 'tool/call') {
+    removeStreamingToolPreview(previews, event.data.callId, event.data.turn, event.data.step)
+    return
+  }
+  if (event.type === 'llm/retry' || event.type === 'llm/retry-started' || event.type === 'step/end') {
+    clearStreamingToolPreviewsForStep(previews, event.data.turn, event.data.step)
+    return
+  }
+  if (event.type === 'turn/end') clearStreamingToolPreviewsForTurn(previews, event.data.turn)
+}
+
 function click(vt: VirtualTerminal, x: number, y: number): void {
   vt.sendInput(`\x1b[<0;${x};${y}M`)
   vt.sendInput(`\x1b[<0;${x};${y}m`)
@@ -57,10 +83,10 @@ afterEach(() => {
 })
 
 test('tracks one preview per call, preserves delayed names, and sorts by index', () => {
-  const previews = new Map<ToolCallId, StreamingToolPreview>()
-  applyStreamingToolPreviewEvent(previews, delta(1, 0, 1, 'call-b', '{"path"', 'write'))
-  applyStreamingToolPreviewEvent(previews, delta(1, 0, 0, 'call-a', '{"path"'))
-  applyStreamingToolPreviewEvent(previews, delta(1, 0, 1, 'call-b', ':"x"}'))
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewEvent(previews, delta(1, 0, 1, 'call-b', '{"path"', 'write'))
+  applyPreviewEvent(previews, delta(1, 0, 0, 'call-a', '{"path"'))
+  applyPreviewEvent(previews, delta(1, 0, 1, 'call-b', ':"x"}'))
 
   assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => ({
     callId: preview.callId,
@@ -78,9 +104,9 @@ test('tracks one preview per call, preserves delayed names, and sorts by index',
 })
 
 test('empty ids use the stable chunk position and migrate to a later call id', () => {
-  const previews = new Map<ToolCallId, StreamingToolPreview>()
-  applyStreamingToolPreviewEvent(previews, delta(2, 0, 1, '', '{}', 'write'))
-  applyStreamingToolPreviewEvent(previews, delta(2, 0, 0, '', '{}', 'edit'))
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewEvent(previews, delta(2, 0, 1, '', '{}', 'write'))
+  applyPreviewEvent(previews, delta(2, 0, 0, '', '{}', 'edit'))
 
   assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => ({
     callId: preview.callId,
@@ -91,8 +117,8 @@ test('empty ids use the stable chunk position and migrate to a later call id', (
     { callId: '', index: 1, name: 'write' },
   ])
 
-  applyStreamingToolPreviewEvent(previews, delta(2, 0, 0, 'real-edit', '{}'))
-  applyStreamingToolPreviewEvent(previews, event('tool/call', {
+  applyPreviewEvent(previews, delta(2, 0, 0, 'real-edit', '{}'))
+  applyPreviewEvent(previews, event('tool/call', {
     turn: 2,
     step: 0,
     callId: 'real-edit' as ToolCallId,
@@ -101,7 +127,7 @@ test('empty ids use the stable chunk position and migrate to a later call id', (
   }, 20))
   assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => preview.callId), [''])
 
-  applyStreamingToolPreviewEvent(previews, event('tool/call', {
+  applyPreviewEvent(previews, event('tool/call', {
     turn: 2,
     step: 0,
     callId: '' as ToolCallId,
@@ -112,9 +138,9 @@ test('empty ids use the stable chunk position and migrate to a later call id', (
 })
 
 test('retry boundaries clear partial previews before the next request attempt', () => {
-  const previews = new Map<ToolCallId, StreamingToolPreview>()
-  applyStreamingToolPreviewEvent(previews, delta(4, 1, 0, 'failed-call', '{', 'edit'))
-  applyStreamingToolPreviewEvent(previews, event('llm/retry', {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewEvent(previews, delta(4, 1, 0, 'failed-call', '{', 'edit'))
+  applyPreviewEvent(previews, event('llm/retry', {
     retryId: 'retry-1' as RetryId,
     turn: 4,
     step: 1,
@@ -128,8 +154,8 @@ test('retry boundaries clear partial previews before the next request attempt', 
   }, 41))
   assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
 
-  applyStreamingToolPreviewEvent(previews, delta(4, 1, 0, 'retry-call', '{', 'write'))
-  applyStreamingToolPreviewEvent(previews, event('llm/retry-started', {
+  applyPreviewEvent(previews, delta(4, 1, 0, 'retry-call', '{', 'write'))
+  applyPreviewEvent(previews, event('llm/retry-started', {
     retryId: 'retry-1' as RetryId,
     turn: 4,
     step: 1,
@@ -139,12 +165,12 @@ test('retry boundaries clear partial previews before the next request attempt', 
 })
 
 test('formal materialization and lifecycle boundaries remove only matching previews', () => {
-  const previews = new Map<ToolCallId, StreamingToolPreview>()
-  applyStreamingToolPreviewEvent(previews, delta(2, 0, 0, 'call-a', '{}', 'edit'))
-  applyStreamingToolPreviewEvent(previews, delta(2, 1, 0, 'call-b', '{}', 'bash'))
-  applyStreamingToolPreviewEvent(previews, delta(3, 0, 0, 'call-c', '{}', 'read'))
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewEvent(previews, delta(2, 0, 0, 'call-a', '{}', 'edit'))
+  applyPreviewEvent(previews, delta(2, 1, 0, 'call-b', '{}', 'bash'))
+  applyPreviewEvent(previews, delta(3, 0, 0, 'call-c', '{}', 'read'))
 
-  applyStreamingToolPreviewEvent(previews, event('tool/call', {
+  applyPreviewEvent(previews, event('tool/call', {
     turn: 2,
     step: 0,
     callId: 'call-a' as ToolCallId,
@@ -153,10 +179,10 @@ test('formal materialization and lifecycle boundaries remove only matching previ
   }, 20))
   assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => preview.callId), ['call-b', 'call-c'])
 
-  applyStreamingToolPreviewEvent(previews, event('step/end', { turn: 2, step: 1 }, 21))
+  applyPreviewEvent(previews, event('step/end', { turn: 2, step: 1 }, 21))
   assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => preview.callId), ['call-c'])
 
-  applyStreamingToolPreviewEvent(previews, event('turn/end', { turn: 3, reason: { kind: 'completed' } }, 22))
+  applyPreviewEvent(previews, event('turn/end', { turn: 3, reason: { kind: 'completed' } }, 22))
   assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
 })
 

--- a/test/streaming-tool-preparing.test.ts
+++ b/test/streaming-tool-preparing.test.ts
@@ -58,6 +58,22 @@ function applyPreviewEvent(previews: Map<string, StreamingToolPreview>, event: S
     })
     return
   }
+  if (
+    event.type === 'assistant/chunk'
+    && event.data.chunk.type === 'block-end'
+    && event.data.chunk.block.type === 'tool-call'
+  ) {
+    const chunk = event.data.chunk
+    const block = chunk.block as { type: 'tool-call'; id: ToolCallId; name: string }
+    upsertStreamingToolPreview(previews, {
+      callId: block.id,
+      turn: event.data.turn,
+      step: event.data.step,
+      index: chunk.index,
+      name: block.name,
+    })
+    return
+  }
   if (event.type === 'tool/call') {
     removeStreamingToolPreview(previews, event.data.callId, event.data.turn, event.data.step)
     return
@@ -135,6 +151,57 @@ test('empty ids use the stable chunk position and migrate to a later call id', (
     arguments: '{}',
   }, 21))
   assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
+})
+
+test('empty-id deltas migrate to the authoritative block-end id before materialization', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewEvent(previews, delta(3, 0, 0, '', '{', 'edit'))
+  applyPreviewEvent(previews, event('assistant/chunk', {
+    turn: 3,
+    step: 0,
+    chunk: {
+      type: 'block-end',
+      index: 0,
+      block: { type: 'tool-call', id: 'real-edit' as ToolCallId, name: 'edit', arguments: '{}' },
+    },
+  }, 301))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => preview.callId), ['real-edit'])
+
+  applyPreviewEvent(previews, event('tool/call', {
+    turn: 3,
+    step: 0,
+    callId: 'real-edit' as ToolCallId,
+    name: 'edit',
+    arguments: '{}',
+  }, 302))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
+})
+
+test('block-end materialization removes one empty-id preview without dropping its parallel peer', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewEvent(previews, delta(4, 0, 0, '', '{', 'edit'))
+  applyPreviewEvent(previews, delta(4, 0, 1, '', '{', 'write'))
+  applyPreviewEvent(previews, event('assistant/chunk', {
+    turn: 4,
+    step: 0,
+    chunk: {
+      type: 'block-end',
+      index: 0,
+      block: { type: 'tool-call', id: 'real-edit' as ToolCallId, name: 'edit', arguments: '{}' },
+    },
+  }, 401))
+  applyPreviewEvent(previews, event('tool/call', {
+    turn: 4,
+    step: 0,
+    callId: 'real-edit' as ToolCallId,
+    name: 'edit',
+    arguments: '{}',
+  }, 402))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => ({
+    callId: preview.callId,
+    index: preview.index,
+    name: preview.name,
+  })), [{ callId: '', index: 1, name: 'write' }])
 })
 
 test('retry boundaries clear partial previews before the next request attempt', () => {

--- a/test/streaming-tool-preparing.test.ts
+++ b/test/streaming-tool-preparing.test.ts
@@ -1,0 +1,253 @@
+/** Regression coverage for live-only streaming tool-call preparing rows. */
+
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import type { ToolCallId } from '@deepseek-ai/dsh-llm'
+import type { RetryId } from '@deepseek-ai/dsh-llm-retry'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import {
+  applyStreamingToolPreviewEvent,
+  streamingToolPreviewSnapshot,
+} from '../src/streaming-tool-preparing.ts'
+import { toolIconSemantic, toolTitle } from '../src/present.ts'
+import { TuiApp, type StreamingToolPreview } from '../src/tui-app.ts'
+import type { TurnActivity } from '../src/transcript.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+function event<K extends SessionEvent['type']>(
+  type: K,
+  data: SessionEvent<K>['data'],
+  seq: number,
+): SessionEvent {
+  return { type, seq, time: 1_700_000_000_000 + seq * 1000, data } as SessionEvent
+}
+
+function delta(
+  turn: number,
+  step: number,
+  index: number,
+  id: string,
+  argumentsDelta: string,
+  name?: string,
+): SessionEvent {
+  return event('assistant/chunk', {
+    turn,
+    step,
+    chunk: {
+      type: 'tool-call-delta',
+      index,
+      id: id as ToolCallId,
+      argumentsDelta,
+      ...(name === undefined ? {} : { name }),
+    },
+  }, turn * 100 + step * 10 + index) as SessionEvent
+}
+
+function click(vt: VirtualTerminal, x: number, y: number): void {
+  vt.sendInput(`\x1b[<0;${x};${y}M`)
+  vt.sendInput(`\x1b[<0;${x};${y}m`)
+}
+
+const startedApps = new Set<TuiApp>()
+afterEach(() => {
+  for (const app of startedApps) {
+    startedApps.delete(app)
+    if (!app.isDisposed()) app.dispose()
+  }
+})
+
+test('tracks one preview per call, preserves delayed names, and sorts by index', () => {
+  const previews = new Map<ToolCallId, StreamingToolPreview>()
+  applyStreamingToolPreviewEvent(previews, delta(1, 0, 1, 'call-b', '{"path"', 'write'))
+  applyStreamingToolPreviewEvent(previews, delta(1, 0, 0, 'call-a', '{"path"'))
+  applyStreamingToolPreviewEvent(previews, delta(1, 0, 1, 'call-b', ':"x"}'))
+
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => ({
+    callId: preview.callId,
+    turn: preview.turn,
+    step: preview.step,
+    index: preview.index,
+    name: preview.name,
+  })), [
+    { callId: 'call-a', turn: 1, step: 0, index: 0, name: undefined },
+    { callId: 'call-b', turn: 1, step: 0, index: 1, name: 'write' },
+  ])
+  assert.deepEqual(Object.keys(previews.get('call-b' as ToolCallId)!), [
+    'callId', 'turn', 'step', 'index', 'name',
+  ])
+})
+
+test('empty ids use the stable chunk position and migrate to a later call id', () => {
+  const previews = new Map<ToolCallId, StreamingToolPreview>()
+  applyStreamingToolPreviewEvent(previews, delta(2, 0, 1, '', '{}', 'write'))
+  applyStreamingToolPreviewEvent(previews, delta(2, 0, 0, '', '{}', 'edit'))
+
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => ({
+    callId: preview.callId,
+    index: preview.index,
+    name: preview.name,
+  })), [
+    { callId: '', index: 0, name: 'edit' },
+    { callId: '', index: 1, name: 'write' },
+  ])
+
+  applyStreamingToolPreviewEvent(previews, delta(2, 0, 0, 'real-edit', '{}'))
+  applyStreamingToolPreviewEvent(previews, event('tool/call', {
+    turn: 2,
+    step: 0,
+    callId: 'real-edit' as ToolCallId,
+    name: 'edit',
+    arguments: '{}',
+  }, 20))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => preview.callId), [''])
+
+  applyStreamingToolPreviewEvent(previews, event('tool/call', {
+    turn: 2,
+    step: 0,
+    callId: '' as ToolCallId,
+    name: 'write',
+    arguments: '{}',
+  }, 21))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
+})
+
+test('retry boundaries clear partial previews before the next request attempt', () => {
+  const previews = new Map<ToolCallId, StreamingToolPreview>()
+  applyStreamingToolPreviewEvent(previews, delta(4, 1, 0, 'failed-call', '{', 'edit'))
+  applyStreamingToolPreviewEvent(previews, event('llm/retry', {
+    retryId: 'retry-1' as RetryId,
+    turn: 4,
+    step: 1,
+    provider: 'provider',
+    mode: 'normal',
+    policyKey: 'default',
+    retry: 1,
+    maxRetries: 1,
+    delayMs: 0,
+    failure: { code: 'TEMPORARY', message: 'temporary failure' },
+  }, 41))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
+
+  applyStreamingToolPreviewEvent(previews, delta(4, 1, 0, 'retry-call', '{', 'write'))
+  applyStreamingToolPreviewEvent(previews, event('llm/retry-started', {
+    retryId: 'retry-1' as RetryId,
+    turn: 4,
+    step: 1,
+    retry: 1,
+  }, 42))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
+})
+
+test('formal materialization and lifecycle boundaries remove only matching previews', () => {
+  const previews = new Map<ToolCallId, StreamingToolPreview>()
+  applyStreamingToolPreviewEvent(previews, delta(2, 0, 0, 'call-a', '{}', 'edit'))
+  applyStreamingToolPreviewEvent(previews, delta(2, 1, 0, 'call-b', '{}', 'bash'))
+  applyStreamingToolPreviewEvent(previews, delta(3, 0, 0, 'call-c', '{}', 'read'))
+
+  applyStreamingToolPreviewEvent(previews, event('tool/call', {
+    turn: 2,
+    step: 0,
+    callId: 'call-a' as ToolCallId,
+    name: 'edit',
+    arguments: '{}',
+  }, 20))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => preview.callId), ['call-b', 'call-c'])
+
+  applyStreamingToolPreviewEvent(previews, event('step/end', { turn: 2, step: 1 }, 21))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => preview.callId), ['call-c'])
+
+  applyStreamingToolPreviewEvent(previews, event('turn/end', { turn: 3, reason: { kind: 'completed' } }, 22))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews), [])
+})
+
+test('uses the generic lowercase title only when a delta has no name', () => {
+  assert.equal(toolTitle(''), 'tool')
+  assert.equal(toolTitle('unregistered_tool'), 'Tool')
+  assert.equal(toolTitle('__proto__'), 'Tool')
+  assert.equal(toolTitle('toString'), 'Tool')
+  assert.equal(toolIconSemantic('__proto__'), 'tool-generic')
+  assert.equal(toolIconSemantic('toString'), 'tool-generic')
+})
+
+test('preparing rows are inert in the fullscreen hit map', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  startedApps.add(app)
+  app.start()
+  app.setFocusMode(true)
+  const activity: TurnActivity = {
+    turn: 1,
+    completed: false,
+    think: { text: 'still thinking' },
+    assistantMessages: 0,
+    toolCalls: 0,
+    tools: new Map(),
+    revision: 1,
+  }
+  app.setTranscript([{ kind: 'assistant', turn: 1, text: 'answer' }], new Map([[1, activity]]), undefined, [{
+    callId: 'preview-call',
+    turn: 1,
+    step: 0,
+    index: 0,
+    name: 'edit',
+  }])
+  app.setFullscreen(true)
+  await vt.waitForRender()
+
+  const before = vt.getViewport().join('\n')
+  const previewRow = vt.getViewport().findIndex(line => line.includes('Preparing Edit...'))
+  assert.ok(previewRow >= 0, `preview row missing:\n${before}`)
+  assert.deepEqual(app.focusExpandedTurnsForTest(), new Set())
+  click(vt, 10, previewRow + 1)
+  await vt.waitForRender()
+  assert.deepEqual(app.focusExpandedTurnsForTest(), new Set(), 'preview click must not toggle a Thought')
+  assert.ok(vt.getViewport().join('\n').includes('Preparing Edit...'), 'preview click must be inert')
+})
+
+test('renders preparing rows with the selected icon style and no spinner state', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  startedApps.add(app)
+  app.start()
+  const preview: StreamingToolPreview = {
+    callId: 'call-a',
+    turn: 1,
+    step: 0,
+    index: 0,
+    name: 'edit',
+  }
+
+  const unnamedPreview: StreamingToolPreview = {
+    callId: 'call-b',
+    turn: 1,
+    step: 0,
+    index: 1,
+  }
+  app.setWorking(true)
+  app.setTranscript([], undefined, undefined, [preview, unnamedPreview])
+  await vt.waitForRender()
+  let view = vt.getViewport().join('\n')
+  assert.ok(view.includes('✏️  Preparing Edit...'), `emoji preview missing:\n${view}`)
+  assert.ok(view.includes('🛠️  Preparing tool...'), `unnamed preview missing:\n${view}`)
+  assert.ok(view.includes('Working...'), `preview must not replace the working indicator:\n${view}`)
+
+  app.setIconStyle('symbols')
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('~  Preparing Edit...'), `symbol preview missing:\n${view}`)
+
+  app.setIconStyle('minimal')
+  await vt.waitForRender()
+  view = vt.getViewport().join('\n')
+  assert.ok(view.includes('Preparing Edit...'), `minimal preview missing:\n${view}`)
+  assert.ok(!view.includes('~  Preparing Edit...'), `minimal preview kept a symbol prefix:\n${view}`)
+
+  app.setFocusMode(true)
+  app.setTranscript([], new Map(), undefined, [preview])
+  await vt.waitForRender()
+  assert.ok(vt.getViewport().join('\n').includes('Preparing Edit...'), 'Focus must keep the ephemeral row visible')
+
+  app.setTranscript([])
+  await vt.waitForRender()
+  assert.ok(!vt.getViewport().join('\n').includes('Preparing Edit...'), 'omitting the preview snapshot must clear old rows')
+})


### PR DESCRIPTION
## Summary
- Show ephemeral `Preparing <Tool>...` transcript rows from official streaming tool-call deltas.
- Keep previews isolated from the durable transcript, Focus activity, WorkingIndicator, and persisted/replayed state.
- Handle multiple calls, delayed/empty call IDs, retry and lifecycle cleanup, viewer/session ownership, and existing icon styles.
- Keep preview helpers internal to the bundle rather than expanding the package root API.

## Validation
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:product` (3584 passing)
- Targeted Preparing/runner/TuiApp tests (98 passing)
