### PR TITLE
feat: present finalized content blocks

### DIFF
--- a/docs/client-server-migration.md
+++ b/docs/client-server-migration.md
@@ -58,6 +58,20 @@ never serialized. A future Remote adapter must map it to official
 connection/client operation cancellation rather than sending the `AbortSignal`
 over the wire. Stage B completes this contract and is not Remote backend work.
 
+### Finalized content presentation (Stage C1 / pre-M2)
+
+Stage C1 presents already-finalized `ContentBlock` values without changing
+stream lifecycle or Host ownership. Transcript-facing flat projections retain
+image and file attachment markers; FileBlocks render from durable name/byte
+metadata only; and unknown finalized blocks use an explicit bounded JSON
+fallback. The shared visibility rule covers transcript search and rewind
+candidate eligibility/warnings; rewind preview/editor restoration remain
+text-only by policy. Readable markdown export uses the richer projection.
+Queue/steer/dequeue behavior remains outside this finalized-only stage; only
+its rewind notification wording is generalized, and rewind does not re-stage
+content. No attachment bytes/paths are resolved; migration remains
+M2 NOT STARTED with Direct as the production backend.
+
 ## Target
 
 A DSH-native client: the TUI keeps terminal/editor/overlays/keybindings/

--- a/docs/image-completion-and-markers.md
+++ b/docs/image-completion-and-markers.md
@@ -113,8 +113,9 @@ had the right convention (`🖼️ shot.png` inline).
 
 ### Fix
 
-- `textWithImageMarkers(blocks)` (src/transcript.ts): text blocks verbatim,
-  image blocks as an inline `🖼️ name` marker AT their position. A marker
+- `textWithAttachmentMarkers(blocks)` (src/content-block-presentation.ts,
+  re-exported by `src/transcript.ts`): text blocks verbatim,
+  image/file blocks as inline `🖼️ name` / `📄 name` markers AT their position. A marker
   boundary always carries one separating space — the `/image` insertion
   leaves NO space before the placeholder, so `这张图是啥[image…]` must not
   read as `这张图是啥🖼️ shot.png` — while a space the user already typed is

--- a/src/components/media/file-attachment.ts
+++ b/src/components/media/file-attachment.ts
@@ -1,0 +1,44 @@
+/**
+ * Synchronous presentation of one durable FileBlock attachment.
+ *
+ * Only the sanitized name and byte count are rendered. The opaque attachment
+ * id is not a path and is intentionally omitted from the ordinary TUI.
+ * @module @xmoon76/dsh-pi-tui/components/media/file-attachment
+ */
+
+import { truncateToWidth, type Component } from '@xmoon76/pi-tui'
+import { fileAttachmentSummary, type FileAttachmentPresentationRef } from '../../content-block-presentation.ts'
+
+/** The caller-owned color surface for attachment rows. */
+export interface FileAttachmentTheme {
+  fallbackColor(text: string): string
+}
+
+/** One width-aware, stateless FileBlock row. */
+export class FileAttachmentComponent implements Component {
+  private readonly attachment: FileAttachmentPresentationRef
+  private readonly theme: FileAttachmentTheme
+  private readonly cached = new Map<number, string[]>()
+
+  constructor(attachment: FileAttachmentPresentationRef, theme: FileAttachmentTheme) {
+    this.attachment = attachment
+    this.theme = theme
+  }
+
+  invalidate(): void {
+    this.cached.clear()
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(1, Math.floor(width))
+    const existing = this.cached.get(safeWidth)
+    if (existing !== undefined) return existing
+    const lines = [this.theme.fallbackColor(truncateToWidth(
+      fileAttachmentSummary(this.attachment),
+      safeWidth,
+      '…',
+    ))]
+    this.cached.set(safeWidth, lines)
+    return lines
+  }
+}

--- a/src/content-block-presentation.ts
+++ b/src/content-block-presentation.ts
@@ -1,0 +1,86 @@
+/**
+ * Client-local presentation helpers for finalized ContentBlocks.
+ *
+ * These functions consume only durable metadata. They never resolve attachment
+ * bytes or paths, and unknown finalized blocks stay explicit and bounded.
+ * @module @xmoon76/dsh-pi-tui/content-block-presentation
+ */
+
+import type { ContentBlock } from '@deepseek-ai/dsh-llm'
+import { formatBytes } from './image/errors.ts'
+
+/** Match the Web JsonBlock serialized-payload bound. */
+export const FINALIZED_BLOCK_PAYLOAD_MAX_CHARS = 20_000
+
+/** The durable metadata needed for a file's human-facing summary. */
+export interface FileAttachmentPresentationRef {
+  readonly name: string
+  readonly bytes: number
+}
+
+/** Render a FileBlock attachment without exposing its opaque storage id. */
+export function fileAttachmentSummary(attachment: FileAttachmentPresentationRef): string {
+  return `📄 ${attachment.name} · ${formatBytes(attachment.bytes)}`
+}
+
+/** The flat marker for one known attachment occurrence. */
+function attachmentMarker(block: ContentBlock): string | undefined {
+  if (block.type === 'image') return `🖼️ ${block.attachment.name ?? 'image'}`
+  if (block.type === 'file') return `📄 ${block.attachment.name}`
+  return undefined
+}
+
+/**
+ * Build the lightweight ordered text projection used by user transcript
+ * search and loader-less rendering. Known attachments retain their positions;
+ * other non-text blocks remain in their structured content only.
+ */
+export function textWithAttachmentMarkers(blocks: readonly ContentBlock[]): string {
+  let text = ''
+  let boundary = false
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      if (boundary && text !== '' && !/\s$/.test(text) && !/^\s/.test(block.text)) text += ' '
+      boundary = false
+      text += block.text
+      continue
+    }
+    const marker = attachmentMarker(block)
+    if (marker === undefined) continue
+    if (text !== '' && !/\s$/.test(text)) text += ' '
+    text += marker
+    boundary = true
+  }
+  return text
+}
+
+/** Read and bound the type tag for the explicit unknown-block heading. */
+function blockType(block: unknown): string {
+  if (typeof block !== 'object' || block === null) return 'unknown'
+  const type = (block as { readonly type?: unknown }).type
+  if (typeof type !== 'string') return 'unknown'
+  const safeType = type.replace(/[\u0000-\u001f\u007f-\u009f]/g, '')
+  if (safeType === '') return 'unknown'
+  return safeType.length <= 120 ? safeType : `${safeType.slice(0, 119)}…`
+}
+
+/** Serialize one finalized block and keep its payload bounded. */
+function boundedSerializedBlock(block: unknown): string {
+  const serialized = JSON.stringify(block, null, 2) ?? String(block)
+  if (serialized.length <= FINALIZED_BLOCK_PAYLOAD_MAX_CHARS) return serialized
+  return `${serialized.slice(0, FINALIZED_BLOCK_PAYLOAD_MAX_CHARS)}\n… block payload truncated (${serialized.length} characters)`
+}
+
+/**
+ * Explicit bounded fallback for a finalized block that has no first-class
+ * renderer. Callers should route known text/image/file/reasoning/tool-call
+ * blocks through their existing semantics before using this fallback.
+ */
+export function finalizedBlockFallbackText(block: unknown): string {
+  return `Unknown block: ${blockType(block)}\n${boundedSerializedBlock(block)}`
+}
+
+/** Whether a user message contains content the transcript should retain. */
+export function userBlocksVisibleNow(blocks: readonly ContentBlock[]): boolean {
+  return blocks.some(block => block.type !== 'text' || block.text.trim() !== '')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6892,10 +6892,10 @@ export function apply(ctx: Context, config: Config): void {
               }
               // The swap COMMITTED: staged drafts are per-session UI state —
               // drop the unpinned ones now, exactly like /new and /fork (a
-              // historic attachment is never silently re-staged).
+              // historic non-text content is never silently re-staged).
               draftImages.clearUnpinned()
               if (outcome.hasNonTextContent) {
-                app.notify(`rewound to turn ${outcome.turn}; original attachments were not re-staged — reattach them before sending`, 'error')
+                app.notify(`rewound to turn ${outcome.turn}; original non-text content was not re-staged — review it before sending`, 'error')
               } else {
                 app.notify(`rewound to turn ${outcome.turn}`, 'info')
               }

--- a/src/present.ts
+++ b/src/present.ts
@@ -13,6 +13,7 @@ import type { ContentBlock } from '@deepseek-ai/dsh-llm'
 import type {
   FileDiff, ToolCallView, ToolResult, ToolResultView, WebFetchResultView, WebSearchResultView,
 } from '@deepseek-ai/dsh-tools'
+import { finalizedBlockFallbackText, fileAttachmentSummary } from './content-block-presentation.ts'
 import { type IconSemantic } from './icons.ts'
 
 /**
@@ -1203,9 +1204,10 @@ export function genericRawInputLines(name: string, rawInput: unknown): string[] 
 
 /**
  * Flatten a settled result's content blocks to display lines, with the Web's
- * `resultText` semantics: text blocks verbatim, other block shapes as pretty
- * JSON. Empty content on a failed call falls back to the structured error's
- * `name: code` line (the Web's error summary).
+ * `resultText` semantics: text blocks verbatim, known file blocks as a
+ * metadata-only row, images as a compact placeholder, and unknown finalized
+ * blocks as an explicit bounded fallback. Empty content on a failed call
+ * falls back to the structured error's `name: code` line.
  * @param blocks - the result content blocks.
  * @param error - the structured error, when the call failed.
  * @returns the display lines (may be empty).
@@ -1216,9 +1218,14 @@ export function resultTextLines(blocks: readonly ContentBlock[], error?: { name:
     if (block.type === 'text') lines.push(...block.text.split('\n'))
     // An image block carries base64 payload: never dump it into the
     // transcript as pretty JSON (read_image cards render their envelope
-    // summary instead). Other non-text blocks keep the JSON projection.
+    // summary instead).
     else if (block.type === 'image') lines.push('[image]')
-    else lines.push(JSON.stringify(block, null, 2))
+    else if (block.type === 'file') lines.push(fileAttachmentSummary(block.attachment))
+    else if (block.type === 'reasoning' || block.type === 'tool-call' || block.type === 'tool-result') {
+      // Preserve the existing raw projection for known process blocks; their
+      // dedicated transcript surfaces own ordinary rendering.
+      lines.push(JSON.stringify(block, null, 2))
+    } else lines.push(finalizedBlockFallbackText(block))
   }
   if (lines.length === 0 && error !== undefined) lines.push(`${error.name}: ${error.code}`)
   return lines

--- a/src/rewind.ts
+++ b/src/rewind.ts
@@ -20,6 +20,7 @@
 
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { ContentBlock } from '@deepseek-ai/dsh-llm'
+import { userBlocksVisibleNow } from './content-block-presentation.ts'
 import { textOf } from './transcript.ts'
 import type { PickerItem } from './tui-app.ts'
 
@@ -36,9 +37,9 @@ export interface RewindCandidate {
   editorText: string
   /** One-line, width-bounded preview for the picker row. */
   preview: string
-  /** Whether the selected prompt contains non-text content (image blocks):
-   * the rewind still forks, the editor gets the text part only, and the UI
-   * must warn that attachments were not re-staged. */
+  /** Whether the selected prompt contains non-text content (attachment or
+   * future finalized blocks): the rewind still forks, the editor gets the
+   * text part only, and the UI warns that non-text content was not re-staged. */
   hasNonTextContent: boolean
 }
 
@@ -60,10 +61,10 @@ export function isHumanTurnMessage(event: SessionEvent<'user/message'>): boolean
   return event.data.source.kind === 'user'
 }
 
-/** Whether a message is empty for rewind purposes: no text and no image —
- * mirror of the transcript's empty-user-message rule. */
+/** Whether a message is empty for rewind purposes: mirror the
+ * transcript's finalized user-content visibility rule. */
 function isEmptyMessage(blocks: readonly ContentBlock[]): boolean {
-  return textOf(blocks) === '' && !blocks.some(block => block.type === 'image')
+  return !userBlocksVisibleNow(blocks)
 }
 
 /** One-line, width-bounded preview of a prompt (whitespace collapsed). */
@@ -150,13 +151,13 @@ export function rewindSeed(events: readonly SessionEvent[], candidate: RewindCan
  * the selection resolves against the candidate list captured at open time
  * (stale selections are rejected by the workflow's generation gates). */
 export function rewindPickerItem(candidate: RewindCandidate): PickerItem {
-  const tag = candidate.hasNonTextContent ? '[image] ' : ''
-  const preview = candidate.preview === '' && candidate.hasNonTextContent ? '(image only)' : candidate.preview
+  const tag = candidate.hasNonTextContent ? '[attachment] ' : ''
+  const preview = candidate.preview === '' && candidate.hasNonTextContent ? '(attachment only)' : candidate.preview
   return {
     value: String(candidate.turnStartSeq),
     label: `turn ${candidate.turn} · ${tag}${preview}`,
     ...(candidate.hasNonTextContent
-      ? { description: 'attachments are not re-staged on rewind' }
+      ? { description: 'non-text content is not re-staged on rewind' }
       : {}),
   }
 }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -2982,9 +2982,10 @@ function markdownContent(blocks: readonly ContentBlock[]): string {
       flush()
       const attachment = block.attachment
       parts.push(`> ${escapeMarkdownInline(fileAttachmentSummary(attachment))} · attachment \`${attachment.attachmentId}\``)
-    } else if (block.type === 'reasoning' || block.type === 'tool-call' || block.type === 'tool-result') {
+    } else if (block.type === 'reasoning' || block.type === 'tool-call') {
       // These known process blocks have their existing dedicated transcript
-      // semantics; they do not belong in the plain content projection.
+      // semantics; a finalized tool-result has no separate assistant surface,
+      // so it uses the explicit bounded fallback below.
       continue
     } else {
       flush()

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -20,6 +20,7 @@ import { isReplacementSurfaceEvent } from '@deepseek-ai/dsh-session'
 import type { SessionEvent, SessionHeader } from '@deepseek-ai/dsh-session'
 import { expandAssistantStream, ToolCallId, type ContentBlock } from '@deepseek-ai/dsh-llm'
 import { contextIconSemantic, contextProvenance, contextSummary } from './context.ts'
+import { finalizedBlockFallbackText, fileAttachmentSummary, textWithAttachmentMarkers, userBlocksVisibleNow } from './content-block-presentation.ts'
 import { displayFailure, displayFailureText } from './failure-presentation.ts'
 import type { IconSemantic } from './icons.ts'
 import { firstLine, latestLine, type JsonValue } from './present.ts'
@@ -48,13 +49,15 @@ export type TranscriptMessage =
   /**
    * A direct human prompt. `text` is the flat text (search/title/queue
    * recall); `content` carries the FULL ordered blocks when the message had
-   * images — the image pipeline renders them in order (plan §15).
+   * non-text content — attachment and generic presentation renders it in
+   * order (plan §15).
    */
   | { kind: 'user'; turn: number; text: string; content?: readonly ContentBlock[] }
   /**
    * One step's model output. `text` is the flat markdown; `content` is the
-   * settled message's full blocks when the step carried any (role-neutral
-   * `ImageBlock`s render rather than crash, plan §15.3).
+   * settled message's full blocks when the step carried any role-neutral
+   * non-text content (attachments and future blocks render rather than crash,
+   * plan §15.3).
    */
   | {
     kind: 'assistant'
@@ -370,36 +373,17 @@ function assistantBlocksHaveInterruptionEvidence(blocks: readonly ContentBlock[]
   return false
 }
 
-/** Flat text with image positions preserved: text blocks verbatim, image
- * blocks as an inline `🖼️ name` marker AT their position (the queue-preview
- * format; U+FE0F keeps the marker 2 cells wide in emoji fonts). A marker
- * boundary always carries a single separating space — the /image insertion
- * leaves NO space before the placeholder, so `what is this [image…]` must
- * not read as `what is this 🖼️ shot.png` — while a space the user already
- * typed is never doubled. The structured `content` blocks stay the canonical form
- * for thumbnail rendering; this projection feeds the flat-text consumers
- * (transcript search, loader-less fallback rendering, the user bubble's
- * inline marker) so a mixed message never reads as if the image was not
- * there, and an image-only message is not empty. Identical to
- * {@link textOf} for text-only content. */
-export function textWithImageMarkers(blocks: readonly ContentBlock[]): string {
-  let text = ''
-  // A marker boundary: the previous block was an image and the next text
-  // block needs a separator unless it brings its own whitespace.
-  let boundary = false
-  for (const block of blocks) {
-    if (block.type === 'text') {
-      if (boundary && text !== '' && !/\s$/.test(text) && !/^\s/.test(block.text)) text += ' '
-      boundary = false
-      text += block.text
-    } else if (block.type === 'image') {
-      if (text !== '' && !/\s$/.test(text)) text += ' '
-      text += `🖼️ ${block.attachment.name ?? 'image'}`
-      boundary = true
-    }
-  }
-  return text
-}
+/**
+ * Flat text with known attachment positions preserved. The structured
+ * `content` blocks remain canonical for rich rendering; this lightweight
+ * projection feeds transcript search and loader-less user rendering. Unknown
+ * finalized blocks stay in `content` so their explicit fallback can render
+ * without polluting ordinary text previews.
+ */
+export { textWithAttachmentMarkers }
+
+/** Whether a user message has human-visible finalized content. */
+export { userBlocksVisibleNow }
 
 /** Key identifying one step's model output (turn + step). */
 function stepKey(turn: number, step: number): string {
@@ -2453,19 +2437,20 @@ export class TranscriptFolder {
       }
       case 'user/message': {
         const blocks = event.data.content
-        // User messages keep an inline `🖼️ name` marker at every image's
-        // position in the FLAT text too (textWithImageMarkers): the search
-        // and loader-less rendering paths consume `text`, and a mixed
-        // message must never read as if the image was not there. The
-        // ordered `content` blocks stay the canonical form for thumbnails.
-        const text = textWithImageMarkers(blocks)
-        if (text === '' && !blocks.some(block => block.type === 'image')) break
-        // Only direct human prompts are user messages; plugin-injected
-        // context (system reminders, skill content) folds into a collapsible
-        // system entry.
+        // User messages keep known attachment markers at their original
+        // positions in the FLAT text; the ordered `content` blocks stay the
+        // canonical form for rich rendering. A finalized non-text block is
+        // human-visible content for a direct user prompt even when the
+        // lightweight projection is empty, so a future block cannot disappear.
+        const text = textWithAttachmentMarkers(blocks)
+        // Only direct human prompts use the generalized finalized-content
+        // predicate. Injected context keeps its text-only empty gate: a
+        // process block must not turn into an empty system row.
         if (event.data.source.kind === 'user') {
+          if (!userBlocksVisibleNow(blocks)) break
           this.appendItem({ kind: 'user', turn: this.currentTurn, text, content: blocks })
         } else {
+          if (text === '') break
           // Injected context: name the producer the way the Web row does
           // (contextProvenance), plus a notice form's one-line account. The
           // fold stores the icon SEMANTIC (never the concrete glyph), so a
@@ -2952,12 +2937,31 @@ export function childOwnEvents(events: readonly SessionEvent[]): readonly Sessio
   return cut === 0 ? events : events.slice(cut)
 }
 
-/** Render one session's log as a readable markdown transcript for `/export md`. */
-/** The markdown projection of content blocks (review finding 4): text
- * blocks verbatim, image blocks as a compact `🖼️` line (U+FE0F marker,
- * same convention as the transcript and queue summaries) with the durable
- * attachment id — the binary is NEVER embedded, and an image-only message
- * still renders a User/Assistant section. */
+/** Build a markdown fence longer than any backtick run in the payload. */
+function markdownCodeFence(payload: string): string {
+  let longestRun = 0
+  let run = 0
+  for (const character of payload) {
+    if (character === '`') run += 1
+    else {
+      longestRun = Math.max(longestRun, run)
+      run = 0
+    }
+  }
+  longestRun = Math.max(longestRun, run)
+  const fence = '`'.repeat(Math.max(3, longestRun + 1))
+  return `${fence}json\n${payload}\n${fence}`
+}
+
+/** Escape inline presentation text without changing ordinary metadata text. */
+function escapeMarkdownInline(text: string): string {
+  return text.replace(/[\\`*_{}\[\]()!<>]/g, '\\$&')
+}
+
+/** The markdown projection of finalized content blocks: rich attachment
+ * metadata remains readable, opaque ids are labeled as attachment identities,
+ * and unknown block payloads use the same bounded explicit fallback as the
+ * ordinary TUI. Attachment bytes are never embedded. */
 function markdownContent(blocks: readonly ContentBlock[]): string {
   const parts: string[] = []
   let buffer = ''
@@ -2974,12 +2978,28 @@ function markdownContent(blocks: readonly ContentBlock[]): string {
       flush()
       const attachment = block.attachment
       parts.push(`> 🖼️ ${attachment.name ?? 'image'} · ${attachment.width}×${attachment.height} · attachment \`${attachment.attachmentId}\``)
+    } else if (block.type === 'file') {
+      flush()
+      const attachment = block.attachment
+      parts.push(`> ${escapeMarkdownInline(fileAttachmentSummary(attachment))} · attachment \`${attachment.attachmentId}\``)
+    } else if (block.type === 'reasoning' || block.type === 'tool-call' || block.type === 'tool-result') {
+      // These known process blocks have their existing dedicated transcript
+      // semantics; they do not belong in the plain content projection.
+      continue
+    } else {
+      flush()
+      const fallback = finalizedBlockFallbackText(block)
+      const newline = fallback.indexOf('\n')
+      const heading = newline === -1 ? fallback : fallback.slice(0, newline)
+      const payload = newline === -1 ? '' : fallback.slice(newline + 1)
+      parts.push(`> ${escapeMarkdownInline(heading)}${payload === '' ? '' : `\n\n${markdownCodeFence(payload)}`}`)
     }
   }
   flush()
   return parts.join('\n\n')
 }
 
+/** Render one session's log as a readable markdown transcript for `/export md`. */
 export function renderTranscriptMarkdown(session: {
   header: SessionHeader
   snapshotEvents(): readonly SessionEvent[]

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -53,6 +53,7 @@ import {
 } from '@xmoon76/pi-tui'
 import { claimProcessTuiSlot, releaseProcessTuiSlot } from './process-tui-slot.ts'
 import { ImageThumbnail } from './components/media/image-thumbnail.ts'
+import { FileAttachmentComponent } from './components/media/file-attachment.ts'
 import {
   detectThemeFromBackground,
   detectThemeFromColorFgBg,
@@ -128,7 +129,8 @@ import { HistoryPanel, historyOverlayGeometry } from './history-panel.ts'
 import type { HistorySearchSource } from './history-search.ts'
 import { QuestionFlow } from './question.ts'
 import { MentionProvider } from './mentions.ts'
-import { recentTurnThreshold, textWithImageMarkers, type TranscriptMessage, type TurnActivity } from './transcript.ts'
+import { recentTurnThreshold, textWithAttachmentMarkers, type TranscriptMessage, type TurnActivity } from './transcript.ts'
+import { finalizedBlockFallbackText, fileAttachmentSummary } from './content-block-presentation.ts'
 import type { TranscriptWindowState } from './transcript-window.ts'
 import { FocusActivityComponent, focusPreparingSummary, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
 import { WorkingIndicator, workingFramesFor } from './working.ts'
@@ -8574,94 +8576,138 @@ export class TuiApp {
   }
 
   /**
-   * Render one transcript message as a pi-tui component — the HOST
-   * renderer (M7: extensions are consulted by buildMessage, which owns
-   * the plugin chain + identity; renderMessage itself never re-runs a
-   * renderer, so a throwing renderer is invoked exactly once per build
-   * and the host fallback is single-path).
-   */
-  /**
-   * Render a message's content blocks IN ORDER (plan §15.2): text blocks
-   * fold into one text component per run, image blocks render as inline
-   * thumbnails between them — `[text, image, text]` stays `text → image →
-   * text` on screen. Other block kinds (reasoning/tool-call) are skipped
-   * exactly like the flat `textWithImageMarkers` path. Only reached when
-   * the loader and theme are wired.
+   * Render finalized message blocks IN ORDER (plan §15.2): text blocks fold
+   * into one text component per run, images use the existing thumbnail path
+   * when available (or their flat marker without a loader), files use their
+   * metadata-only row, and unknown blocks use the bounded explicit fallback.
+   * Reasoning and tool-call blocks retain their existing process ownership.
    */
   private renderBlockSequence(
     content: readonly import('@deepseek-ai/dsh-llm').ContentBlock[],
     makeText: (text: string) => Component,
     message: TranscriptMessage,
   ): Component {
-    if (this.imageLoader === undefined || this.imageTheme === undefined) {
-      // Loader-less hosts keep the image POSITION as an inline marker — a
-      // mixed message must never silently lose its images (the fold's flat
-      // text uses the same projection).
-      return makeText(textWithImageMarkers(content))
-    }
     const container = new Container()
-    let buffer = ''
-    const flush = (): void => {
-      if (buffer !== '') {
-        container.addChild(makeText(buffer))
-        buffer = ''
+    const canRenderImages = this.imageLoader !== undefined && this.imageTheme !== undefined
+    let textBlocks: import('@deepseek-ai/dsh-llm').ContentBlock[] = []
+    const flushText = (): void => {
+      if (textBlocks.length > 0) {
+        container.addChild(makeText(textWithAttachmentMarkers(textBlocks)))
+        textBlocks = []
       }
     }
     let imageIndex = 0
     for (const block of content) {
       if (block.type === 'text') {
-        buffer += block.text
+        textBlocks.push(block)
       } else if (block.type === 'image') {
-        flush()
-        container.addChild(new ImageThumbnail(
-          block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
-          this.imageLoader,
-          this.imageTheme,
-          this.occurrenceCollapsedRef(message, imageIndex),
-        ))
+        if (!canRenderImages) {
+          // Loader-less hosts keep the image position as an inline marker.
+          textBlocks.push(block)
+        } else {
+          flushText()
+          container.addChild(new ImageThumbnail(
+            block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
+            this.imageLoader!,
+            this.imageTheme!,
+            this.occurrenceCollapsedRef(message, imageIndex),
+          ))
+        }
         imageIndex += 1
+      } else if (block.type === 'file') {
+        flushText()
+        container.addChild(new FileAttachmentComponent(block.attachment, { fallbackColor: color.textDim }))
+      } else if (block.type === 'reasoning' || block.type === 'tool-call' || block.type === 'tool-result') {
+        // These blocks belong to the existing thinking/tool surfaces, not the
+        // assistant's ordinary markdown body.
+        continue
+      } else {
+        flushText()
+        container.addChild(new Text(color.textDim(finalizedBlockFallbackText(block)), 0, 0))
       }
     }
-    flush()
+    flushText()
     return container
   }
 
   /**
-   * A user message with images: ONE bubble whose text keeps an inline
-   * `🖼️ name` placeholder at every image's ORIGINAL position — the user's
-   * own words then read like the draft they submitted (`what is this 🖼️
-   * shot.png`), instead of a bubble with the image silently moved to its
-   * own row. The thumbnails follow as attachment rows in block order; the
-   * bubble marker carries the position, the thumbnail carries the picture.
+   * Render a user message with its flat marker plus rich attachment rows.
+   * Existing image-only/mixed-image UX keeps one submitted bubble followed by
+   * thumbnail rows. When a file or generic block is present, segments become
+   * ordered bubble/row children so `[text, file, text, unknown, image]` keeps
+   * its finalized block order without resolving bytes or paths.
    */
   private renderUserBlocks(
     content: readonly import('@deepseek-ai/dsh-llm').ContentBlock[],
     message: TranscriptMessage,
   ): Component {
     const container = new Container()
-    container.addChild(new UserBubbleComponent(
-      // The attachment marker is deliberately NOT style-swapped (the plan
-      // defers it): the flat text keeps the constant 🖼️ fact, so a
-      // user-typed 🖼️ in their own words is never rewritten.
-      new Text(textWithImageMarkers(content), 0, 0),
-      `${color.roleUser('❯')} `,
-      color.roleUserBg,
-    ))
-    let imageIndex = 0
-    for (const block of content) {
-      if (block.type === 'image') {
-        container.addChild(new ImageThumbnail(
-          block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
-          this.imageLoader!,
-          this.imageTheme!,
-          this.occurrenceCollapsedRef(message, imageIndex),
-        ))
-        imageIndex += 1
+    const marker = `${color.roleUser('❯')} `
+    const bubble = (child: Component): void => {
+      container.addChild(new UserBubbleComponent(child, marker, color.roleUserBg))
+    }
+    const hasOrderedRows = content.some(block => block.type === 'file' || (block.type !== 'text' && block.type !== 'image'))
+    if (!hasOrderedRows) {
+      bubble(new Text(textWithAttachmentMarkers(content), 0, 0))
+      let imageIndex = 0
+      for (const block of content) {
+        if (block.type === 'image') {
+          if (this.imageLoader !== undefined && this.imageTheme !== undefined) {
+            container.addChild(new ImageThumbnail(
+              block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
+              this.imageLoader,
+              this.imageTheme,
+              this.occurrenceCollapsedRef(message, imageIndex),
+            ))
+          }
+          imageIndex += 1
+        }
+      }
+      return container
+    }
+
+    let textBlocks: import('@deepseek-ai/dsh-llm').ContentBlock[] = []
+    const flushText = (): void => {
+      if (textBlocks.length > 0) {
+        bubble(new Text(textWithAttachmentMarkers(textBlocks), 0, 0))
+        textBlocks = []
       }
     }
+    let imageIndex = 0
+    for (const block of content) {
+      if (block.type === 'text') {
+        textBlocks.push(block)
+      } else if (block.type === 'image') {
+        textBlocks.push(block)
+        flushText()
+        if (this.imageLoader !== undefined && this.imageTheme !== undefined) {
+          container.addChild(new ImageThumbnail(
+            block.attachment as import('./image/admission.ts').ImageAttachmentRefLike,
+            this.imageLoader,
+            this.imageTheme,
+            this.occurrenceCollapsedRef(message, imageIndex),
+          ))
+        }
+        imageIndex += 1
+      } else if (block.type === 'file') {
+        flushText()
+        bubble(new FileAttachmentComponent(block.attachment, { fallbackColor: color.textDim }))
+      } else {
+        flushText()
+        bubble(new Text(color.textDim(finalizedBlockFallbackText(block)), 0, 0))
+      }
+    }
+    flushText()
     return container
   }
 
+  /**
+   * Render one transcript message as a pi-tui component — the HOST
+   * renderer (M7: extensions are consulted by buildMessage, which owns
+   * the plugin chain + identity; renderMessage itself never re-runs a
+   * renderer, so a throwing renderer is invoked exactly once per build
+   * and the host fallback is single-path).
+   */
   private renderMessage(message: TranscriptMessage, expanded: boolean, expandHint: ExpandHint, fullReveal: boolean, width: number): Component {
     if (message.kind === 'user') {
       // dsh-web parity: the user's own input is a floating BUBBLE (its
@@ -8670,7 +8716,7 @@ export class TuiApp {
       // blue. The ❯ leads the FIRST line; wrapped continuation lines keep
       // the background and indent under the marker, so multi-line input
       // stays aligned inside one block.
-      if (message.content !== undefined && this.imageLoader !== undefined && this.imageTheme !== undefined) {
+      if (message.content !== undefined && message.content.some(block => block.type !== 'text')) {
         return this.renderUserBlocks(message.content, message)
       }
       return new UserBubbleComponent(
@@ -8689,7 +8735,7 @@ export class TuiApp {
       // re-renders it at the new width, so tables reflow instead of
       // re-wrapping a frozen render (the 5a76526 regression).
       const bullet = color.primary(iconPrefix('assistant-bullet', this.iconStyle))
-      const body = message.content !== undefined && this.imageLoader !== undefined && this.imageTheme !== undefined
+      const body = message.content !== undefined && message.content.some(block => block.type !== 'text')
         ? this.renderBlockSequence(message.content, (text) =>
           new BulletedComponent(new Markdown(text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS), bullet), message)
         : new BulletedComponent(new Markdown(message.text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS), bullet)
@@ -9424,10 +9470,11 @@ export class TuiApp {
                     this.imageTheme,
                   ))
                 } else {
-                  // Non-text/non-image blocks keep the legacy JSON form,
-                  // interleaved in order (round-5 finding 4).
+                  // Known process blocks keep their legacy JSON form;
+                  // file and unknown blocks use their bounded presentation,
+                  // interleaved in order.
                   flush()
-                  card.addChild(new Text(color.textDim(JSON.stringify(block, null, 2)), 0, 0))
+                  card.addChild(new Text(color.textDim(this.blockDisplayText(block)), 0, 0))
                 }
               }
               flush()
@@ -9567,10 +9614,10 @@ export class TuiApp {
               this.imageTheme,
             ))
           } else {
-            // Non-text/non-image blocks keep the legacy JSON form, in order
-            // (round-5 finding 4).
+            // Known process blocks keep their legacy JSON form; file and
+            // unknown blocks use their bounded presentation, in order.
             flush()
-            card.addChild(new Text(color.textDim(JSON.stringify(block, null, 2)), 0, 0))
+            card.addChild(new Text(color.textDim(this.blockDisplayText(block)), 0, 0))
           }
         }
         flush()
@@ -9585,15 +9632,14 @@ export class TuiApp {
     }
   }
 
-  /**
-   * Display form for a non-text block WITHOUT the image pipeline: image
-   * blocks project to a compact placeholder — never a JSON dump (the
-   * read_image envelope rule, review finding); everything else keeps the
-   * legacy pretty-JSON form.
-   */
+  /** Display form for one non-text result block when no rich renderer owns it. */
   private blockDisplayText(block: import('@deepseek-ai/dsh-llm').ContentBlock): string {
     if (block.type === 'image') return '[image]'
-    return JSON.stringify(block, null, 2)
+    if (block.type === 'file') return fileAttachmentSummary(block.attachment)
+    if (block.type === 'reasoning' || block.type === 'tool-call' || block.type === 'tool-result') {
+      return JSON.stringify(block, null, 2)
+    }
+    return finalizedBlockFallbackText(block)
   }
 
   /** Append the result's IMAGE blocks as thumbnails (any tool card that

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -8617,9 +8617,11 @@ export class TuiApp {
       } else if (block.type === 'file') {
         flushText()
         container.addChild(new FileAttachmentComponent(block.attachment, { fallbackColor: color.textDim }))
-      } else if (block.type === 'reasoning' || block.type === 'tool-call' || block.type === 'tool-result') {
+      } else if (block.type === 'reasoning' || block.type === 'tool-call') {
         // These blocks belong to the existing thinking/tool surfaces, not the
-        // assistant's ordinary markdown body.
+        // assistant's ordinary markdown body. A finalized tool-result has no
+        // separate assistant surface, so it falls through to the explicit
+        // bounded fallback below.
         continue
       } else {
         flushText()

--- a/test/file-transcript.test.ts
+++ b/test/file-transcript.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Stage C1 coverage for finalized file and generic content presentation.
+ * @module @xmoon76/dsh-pi-tui/file-transcript.test
+ */
+
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import type { ContentBlock } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import {
+  finalizedBlockFallbackText,
+  fileAttachmentSummary,
+  textWithAttachmentMarkers,
+  userBlocksVisibleNow,
+} from '../src/content-block-presentation.ts'
+import { resultTextLines } from '../src/present.ts'
+import { collectRewindCandidates, rewindPickerItem } from '../src/rewind.ts'
+import { renderTranscriptMarkdown, TranscriptFolder } from '../src/transcript.ts'
+import { TuiApp } from '../src/tui-app.ts'
+import { stripTerminalSequences, visibleWidth } from '@xmoon76/pi-tui'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+const FILE_REF = {
+  attachmentId: 'att-file-1',
+  name: 'report.pdf',
+  bytes: 12_600,
+}
+const IMAGE_REF = {
+  attachmentId: 'att-image-1',
+  mediaType: 'image/png',
+  bytes: 4,
+  width: 800,
+  height: 600,
+  name: 'shot.png',
+}
+const fileBlock = (): ContentBlock => ({ type: 'file', attachment: FILE_REF } as never)
+const imageBlock = (): ContentBlock => ({ type: 'image', attachment: IMAGE_REF } as never)
+
+function userEvent(content: readonly ContentBlock[], seq: number, time = seq): SessionEvent {
+  return {
+    type: 'user/message',
+    seq,
+    time,
+    data: { content, source: { kind: 'user' } },
+  } as never
+}
+
+function turnEvent(type: 'turn/start' | 'turn/end', seq: number, turn: number): SessionEvent {
+  return {
+    type,
+    seq,
+    time: seq,
+    data: type === 'turn/start' ? { turn } : { turn, reason: { kind: 'completed' } },
+  } as never
+}
+
+function genericBlock(payload: string): ContentBlock {
+  return { type: 'future-test-block', payload } as never
+}
+
+function typedGenericBlock(type: string, payload: string): ContentBlock {
+  return { type, payload } as never
+}
+
+const startedApps = new Set<TuiApp>()
+afterEach(() => {
+  for (const app of [...startedApps]) {
+    startedApps.delete(app)
+    if (!app.isDisposed()) app.dispose()
+  }
+})
+
+async function viewport(vt: VirtualTerminal): Promise<string> {
+  await vt.waitForRender()
+  return vt.getViewport().join('\n')
+}
+
+test('file summaries and ordered attachment markers use durable metadata only', () => {
+  assert.equal(fileAttachmentSummary({ name: 'report.pdf', bytes: 0 }), '📄 report.pdf · 0 B')
+  assert.equal(fileAttachmentSummary({ name: 'report.pdf', bytes: 1_023 }), '📄 report.pdf · 1023 B')
+  assert.equal(fileAttachmentSummary({ name: 'report.pdf', bytes: 1_024 }), '📄 report.pdf · 1.0 KiB')
+  assert.equal(fileAttachmentSummary({ name: 'report.pdf', bytes: 1_048_576 }), '📄 report.pdf · 1.0 MiB')
+  assert.equal(
+    textWithAttachmentMarkers([
+      { type: 'text', text: '分析' },
+      fileBlock(),
+      { type: 'text', text: '然后' },
+      imageBlock(),
+    ]),
+    '分析 📄 report.pdf 然后 🖼️ shot.png',
+  )
+  assert.equal(textWithAttachmentMarkers([{ type: 'text', text: '先' }, fileBlock()]), '先 📄 report.pdf')
+  assert.equal(textWithAttachmentMarkers([fileBlock(), { type: 'text', text: '后' }]), '📄 report.pdf 后')
+  assert.equal(textWithAttachmentMarkers([fileBlock(), imageBlock()]), '📄 report.pdf 🖼️ shot.png')
+  assert.equal(textWithAttachmentMarkers([imageBlock(), fileBlock()]), '🖼️ shot.png 📄 report.pdf')
+})
+
+test('file-only and unknown finalized user blocks survive folding and search', () => {
+  const unknown = genericBlock('x'.repeat(21_000))
+  const folder = new TranscriptFolder()
+  folder.apply([userEvent([fileBlock()], 1), userEvent([unknown], 2)])
+
+  const messages = folder.messages()
+  assert.equal(messages.length, 2)
+  assert.equal(messages[0]?.kind, 'user')
+  assert.equal(messages[0]?.text, '📄 report.pdf')
+  assert.equal(messages[1]?.kind, 'user')
+  assert.equal(messages[1]?.text, '')
+  assert.equal(userBlocksVisibleNow([]), false)
+  assert.equal(userBlocksVisibleNow([{ type: 'text', text: '   ' }]), false)
+  assert.equal(userBlocksVisibleNow([unknown]), true)
+  assert.equal(folder.search('report.pdf').length, 1)
+
+  const injected = new TranscriptFolder()
+  injected.apply([{
+    type: 'user/message',
+    seq: 3,
+    time: 3,
+    data: { content: [unknown], source: { kind: 'plugin' } },
+  } as never])
+  assert.deepEqual(injected.messages(), [], 'an empty injected context row must stay dropped')
+
+  const fallback = finalizedBlockFallbackText(unknown)
+  assert.ok(fallback.startsWith('Unknown block: future-test-block'))
+  assert.ok(fallback.includes('block payload truncated'))
+  assert.ok(fallback.length < 21_000)
+
+  const hostileTypeFallback = finalizedBlockFallbackText(typedGenericBlock(`future\n\u001b[2J${'x'.repeat(200)}`, 'payload'))
+  assert.ok(!hostileTypeFallback.includes('\u001b'))
+  const hostileHeading = hostileTypeFallback.split('\n', 1)[0]!
+  assert.ok(!hostileHeading.includes('\n'))
+  assert.ok(hostileHeading.length <= 'Unknown block: '.length + 120)
+})
+
+test('rewind recognizes file-only turns and generalizes the warning label', () => {
+  const candidates = collectRewindCandidates([
+    turnEvent('turn/start', 1, 1),
+    userEvent([fileBlock()], 2),
+    turnEvent('turn/end', 3, 1),
+  ])
+  assert.equal(candidates.length, 1)
+  assert.equal(candidates[0]?.editorText, '')
+  assert.equal(candidates[0]?.hasNonTextContent, true)
+  assert.equal(rewindPickerItem(candidates[0]!).label, 'turn 1 · [attachment] (attachment only)')
+})
+
+test('result and markdown projections retain files and bound unknown blocks', () => {
+  const unknown = genericBlock('payload')
+  const lines = resultTextLines([
+    { type: 'text', text: 'before' },
+    fileBlock(),
+    { type: 'text', text: 'after' },
+    unknown,
+  ])
+  assert.ok(lines.includes('📄 report.pdf · 12.3 KiB'))
+  assert.ok(lines.some(line => line.includes('Unknown block: future-test-block')))
+  assert.ok(!lines.some(line => line.includes('att-file-1')))
+
+  const markdownUnknown = genericBlock('x'.repeat(21_000))
+  const md = renderTranscriptMarkdown({
+    header: { id: 'session-c1' as never, cwd: '/ws', version: 1, createdAt: 0 },
+    snapshotEvents: () => [userEvent([
+      { type: 'text', text: 'before' },
+      fileBlock(),
+      { type: 'text', text: 'after' },
+      markdownUnknown,
+    ], 1), {
+      type: 'assistant/message',
+      seq: 2,
+      time: 2,
+      data: {
+        turn: 0,
+        step: 0,
+        message: { content: [{ type: 'text', text: 'assistant before' }, fileBlock(), { type: 'text', text: 'assistant after' }] },
+      },
+    } as never, {
+      type: 'tool/result',
+      seq: 3,
+      time: 3,
+      data: {
+        turn: 0,
+        step: 0,
+        callId: 'call-c1',
+        message: {
+          content: [{
+            type: 'tool-result',
+            toolCallId: 'call-c1',
+            content: [{ type: 'text', text: 'tool before' }, fileBlock(), { type: 'text', text: 'tool after' }],
+          }],
+        },
+      },
+    } as never],
+  } as never)
+  assert.ok(md.indexOf('before') < md.indexOf('📄 report.pdf · 12.3 KiB'))
+  assert.ok(md.indexOf('📄 report.pdf · 12.3 KiB') < md.indexOf('after'))
+  assert.ok(md.includes('attachment `att-file-1`'))
+  assert.ok(md.includes('Unknown block: future-test-block'))
+  assert.ok(md.includes('block payload truncated'))
+  assert.ok(!md.includes('x'.repeat(21_000)), 'the fallback must not dump an unbounded payload')
+  assert.equal((md.match(/📄 report\.pdf · 12\.3 KiB/g) ?? []).length, 3, 'user, assistant, and nested tool-result files must export')
+  assert.ok(md.includes('assistant before'))
+  assert.ok(md.includes('assistant after'))
+  assert.ok(md.indexOf('tool before') < md.lastIndexOf('📄 report.pdf · 12.3 KiB'))
+  assert.ok(md.lastIndexOf('📄 report.pdf · 12.3 KiB') < md.indexOf('tool after'))
+
+  const unsafeName = { type: 'file', attachment: { ...FILE_REF, name: '![x](https://example.invalid)' } } as never
+  const unsafeMd = renderTranscriptMarkdown({
+    header: { id: 'session-c1-unsafe' as never, cwd: '/ws', version: 1, createdAt: 0 },
+    snapshotEvents: () => [userEvent([unsafeName], 4)],
+  } as never)
+  assert.ok(unsafeMd.includes('\\!\\[x\\]\\(https://example.invalid\\)'))
+  assert.ok(!unsafeMd.includes('![x](https://example.invalid)'))
+})
+
+test('user and assistant file presentation is visible and width-safe', async () => {
+  const vt = new VirtualTerminal(40, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([{
+    kind: 'user',
+    turn: 0,
+    text: '📄 report.pdf',
+    content: [fileBlock()],
+  }])
+  const view = await viewport(vt)
+  assert.ok(view.includes('📄 report.pdf · 12.3 KiB'), `file row missing:\n${view}`)
+  for (const line of view.split('\n')) {
+    assert.ok(visibleWidth(stripTerminalSequences(line)) <= 40, `line exceeds terminal width: ${line}`)
+  }
+
+  vt.resize(100, 24)
+  app.setTranscript([{
+    kind: 'user',
+    turn: 0,
+    text: 'before 📄 report.pdf after 🖼️ shot.png',
+    content: [
+      { type: 'text', text: 'before' },
+      fileBlock(),
+      { type: 'text', text: 'after' },
+      genericBlock('payload'),
+      imageBlock(),
+    ],
+  }])
+  const orderedUserView = await viewport(vt)
+  const orderedUserFileAt = orderedUserView.indexOf('📄 report.pdf · 12.3 KiB')
+  assert.ok(orderedUserView.indexOf('before') < orderedUserFileAt)
+  assert.ok(orderedUserFileAt < orderedUserView.indexOf('after'))
+  assert.ok(orderedUserView.indexOf('after') < orderedUserView.indexOf('Unknown block: future-test-block'))
+  assert.ok(orderedUserView.indexOf('Unknown block: future-test-block') < orderedUserView.indexOf('🖼️ shot.png'))
+
+  app.setTranscript([{
+    kind: 'assistant',
+    turn: 0,
+    text: 'beforeafter',
+    content: [
+      { type: 'text', text: 'before' },
+      fileBlock(),
+      { type: 'text', text: 'after' },
+      genericBlock('payload'),
+    ],
+  }])
+  const assistantView = await viewport(vt)
+  const fileAt = assistantView.indexOf('📄 report.pdf · 12.3 KiB')
+  assert.ok(fileAt >= 0, `assistant file row missing:\n${assistantView}`)
+  assert.ok(assistantView.indexOf('before') < fileAt)
+  assert.ok(fileAt < assistantView.indexOf('after'))
+  assert.ok(assistantView.includes('Unknown block: future-test-block'))
+})
+
+test('generic tool-result content presents file and unknown blocks in order', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setToolOutputExpanded(true)
+  app.setTranscript([{
+    kind: 'tool',
+    turn: 0,
+    name: 'custom_tool',
+    args: '{}',
+    result: 'before after',
+    status: 'ok',
+    resultBlocks: [
+      { type: 'text', text: 'before' },
+      fileBlock(),
+      { type: 'text', text: 'after' },
+      genericBlock('payload'),
+    ],
+  }])
+  const view = await viewport(vt)
+  const fileAt = view.indexOf('📄 report.pdf · 12.3 KiB')
+  assert.ok(fileAt >= 0, `tool file row missing:\n${view}`)
+  assert.ok(view.indexOf('before') < fileAt)
+  assert.ok(fileAt < view.indexOf('after'))
+  assert.ok(view.includes('Unknown block: future-test-block'))
+  assert.ok(!view.includes('att-file-1'))
+})

--- a/test/file-transcript.test.ts
+++ b/test/file-transcript.test.ts
@@ -62,6 +62,14 @@ function typedGenericBlock(type: string, payload: string): ContentBlock {
   return { type, payload } as never
 }
 
+function assistantToolResultBlock(): ContentBlock {
+  return {
+    type: 'tool-result',
+    toolCallId: 'call-assistant-c1',
+    content: [{ type: 'text', text: 'assistant tool result' }],
+  } as never
+}
+
 const startedApps = new Set<TuiApp>()
 afterEach(() => {
   for (const app of [...startedApps]) {
@@ -130,6 +138,37 @@ test('file-only and unknown finalized user blocks survive folding and search', (
   const hostileHeading = hostileTypeFallback.split('\n', 1)[0]!
   assert.ok(!hostileHeading.includes('\n'))
   assert.ok(hostileHeading.length <= 'Unknown block: '.length + 120)
+})
+
+test('assistant finalized tool-result content uses an explicit fallback everywhere', async () => {
+  const block = assistantToolResultBlock()
+  const event: SessionEvent = {
+    type: 'assistant/message',
+    seq: 1,
+    time: 1,
+    data: { turn: 0, step: 0, message: { content: [block] } },
+  } as never
+  const folder = new TranscriptFolder()
+  folder.apply([event])
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined, 'the finalized assistant entry remains visible')
+  assert.equal(assistant?.text, '')
+  assert.deepEqual(assistant?.kind === 'assistant' ? assistant.content?.map(item => item.type) : [], ['tool-result'])
+
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript(folder.messages())
+  const view = await viewport(vt)
+  assert.ok(view.includes('Unknown block: tool-result'), `assistant tool-result fallback missing:\n${view}`)
+
+  const md = renderTranscriptMarkdown({
+    header: { id: 'session-c1-tool-result' as never, cwd: '/ws', version: 1, createdAt: 0 },
+    snapshotEvents: () => [event],
+  } as never)
+  assert.ok(md.includes('Unknown block: tool-result'))
+  assert.ok(md.includes('assistant tool result'))
 })
 
 test('rewind recognizes file-only turns and generalizes the warning label', () => {

--- a/test/rewind.test.ts
+++ b/test/rewind.test.ts
@@ -225,7 +225,7 @@ test('R08: a multimodal prompt sets hasNonTextContent and restores text only', (
   assert.equal(candidate.hasNonTextContent, true)
   assert.equal(candidate.editorText, 'analyse this screenshot', 'text blocks only')
   const item = rewindPickerItem(candidate)
-  assert.ok(item.label.startsWith('turn 1 · [image] '), `image marker missing: ${item.label}`)
+  assert.ok(item.label.startsWith('turn 1 · [attachment] '), `attachment marker missing: ${item.label}`)
 })
 
 test('R08: an image-only prompt is still a candidate with an explicit marker', () => {
@@ -243,7 +243,7 @@ test('R08: an image-only prompt is still a candidate with an explicit marker', (
   assert.equal(candidates.length, 1)
   assert.equal(candidates[0]!.hasNonTextContent, true)
   assert.equal(candidates[0]!.editorText, '')
-  assert.ok(rewindPickerItem(candidates[0]!).label.includes('(image only)'))
+  assert.ok(rewindPickerItem(candidates[0]!).label.includes('(attachment only)'))
 })
 
 test('R09: malformed spans are skipped, never thrown to the UI', () => {


### PR DESCRIPTION
## Summary
- Present finalized FileBlocks with metadata-only file rows and ordered attachment markers.
- Keep finalized unknown blocks visible through bounded, explicit fallbacks across transcript, TUI, tool results, rewind, and Markdown export.
- Preserve existing image, process-block, stream, persistence, and Direct backend semantics.

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm test:product` (3527 passed)
- `pnpm test` (passed)
- `pnpm gate:boundary`
- `pnpm gate:raw-persistence`
- `node scripts/check-no-session-events.mjs`

## Scope
- Finalized-only presentation; no attachment byte/path resolution, upload/download/open API, or queue/steer/dequeue changes.
- Review-loop completed with no remaining Stage C1 blocker.