### PR TITLE
fix: keep steers after Focus thought for non-user turns

### DIFF
--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -338,10 +338,11 @@ export class FocusActivityComponent {
 /**
  * The Focus presentation projection over one windowed transcript (plan
  * §12/§33): a turn with an initial prompt is grouped as
- * `user(s) → FocusActivity`; a steer-only turn starts with `FocusActivity`
- * and keeps steers in process order. Expanded process/final and compaction
- * rows follow, so the raw TranscriptMessage union is never polluted with a
- * fake `focus-activity` kind and the session data stays lossless.
+ * `user(s) → FocusActivity`; a turn with only same-turn steers starts with
+ * `FocusActivity` and keeps those steers in process order. Expanded
+ * process/final and compaction rows follow, so the raw TranscriptMessage
+ * union is never polluted with a fake `focus-activity` kind and the session
+ * data stays lossless.
  *
  * Collapsed turns HIDE thinking/tool/system/intermediate-assistant rows
  * entirely — they cannot leak through Ctrl+O/Alt+T because they are not in
@@ -445,8 +446,8 @@ export function projectFocus(
       continue
     }
     // Collapsed: preserve the existing users-before-Thought summary when
-    // an initial prompt exists. A steer-only turn has no opening user row,
-    // so its Thought must lead and the claimed steer follows it.
+    // an initial prompt exists. A turn with no same-turn opening user row
+    // has its Thought lead, followed by the claimed mid-turn steers.
     const hasInitialPrompt = initialPromptBoundary(group) > 0
     if (hasInitialPrompt) {
       for (const member of group) {
@@ -486,12 +487,13 @@ function lastAssistant(
 }
 
 /** The initial-prompt boundary of one turn group: the index AFTER the
- * turn's FIRST non-steer user row. Rows before it (injected/system context)
+ * turn's FIRST unmarked user row. Rows before it (injected/system context)
  * and the initial user itself stay above the Thought; every later row
- * (steers included) returns to its chronological position. A steer-only turn
- * has no boundary, so the Thought leads with chronology intact. Without steer
- * metadata, the first non-steer user remains the initial-prompt fallback;
- * consecutive users are queue/steer input, not a multi-row initial prompt. */
+ * (same-turn steers included) returns to its chronological position. A turn
+ * whose user rows are all marked same-turn steers has no boundary, so the
+ * Thought leads with chronology intact. Without steer metadata, the first
+ * user remains the initial-prompt fallback; consecutive users are queue/steer
+ * input, not a multi-row initial prompt. */
 function initialPromptBoundary(group: readonly TranscriptMessage[]): number {
   const firstInitialUserIndex = group.findIndex(
     member => member.kind === 'user' && member.steer !== true,

--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -337,10 +337,11 @@ export class FocusActivityComponent {
 
 /**
  * The Focus presentation projection over one windowed transcript (plan
- * §12/§33): messages are grouped per turn into `user(s) → FocusActivity →
- * (process when expanded | final when settled) → compaction cards`, so the
- * raw TranscriptMessage union is never polluted with a fake `focus-activity`
- * kind and the session data stays lossless.
+ * §12/§33): a turn with an initial prompt is grouped as
+ * `user(s) → FocusActivity`; a steer-only turn starts with `FocusActivity`
+ * and keeps steers in process order. Expanded process/final and compaction
+ * rows follow, so the raw TranscriptMessage union is never polluted with a
+ * fake `focus-activity` kind and the session data stays lossless.
  *
  * Collapsed turns HIDE thinking/tool/system/intermediate-assistant rows
  * entirely — they cannot leak through Ctrl+O/Alt+T because they are not in
@@ -414,14 +415,15 @@ export function projectFocus(
       // turn's `max tokens reached` system row must never land after the
       // final: the settled order is User → Thought → process → final).
       // The INITIAL-PROMPT boundary precedes the Thought: rows before the
-      // turn's FIRST direct user (injected/system context) stay in place
-      // and the initial user itself stays above the Thought; every later
+      // turn's FIRST non-steer user (injected/system context) stay in place
+      // and that initial user itself stays above the Thought; every later
       // user/steer returns to its chronological position in the process
       // (plan: expanded chronology — the projection reorders, never the
-      // session events). Only the FIRST direct user is the initial
-      // prompt — consecutive users are queue/steer input, never a
-      // multi-row initial prompt (plan: no adjacency guessing). Every
-      // revealed process row carries the owner-turn collapse mark; the
+      // session events). With a non-steer user, the first such row is the
+      // compatibility boundary; when every user is a steer, the boundary is 0.
+      // Consecutive users after the boundary stay in chronological
+      // order; they are not a multi-row initial prompt (plan: no adjacency guessing).
+      // Every revealed process row carries the owner-turn collapse mark; the
       // user's rows and the FINAL assistant stay unmarked (clicking them
       // must not collapse the Thought — review P2).
       const boundary = initialPromptBoundary(group)
@@ -442,13 +444,21 @@ export function projectFocus(
       }
       continue
     }
-    // Collapsed: the user's own messages stay visible (steers included)
-    // and ALL of them precede the Thought (summary semantics unchanged).
-    for (const member of group) {
-      if (member.kind === 'user') out.push({ kind: 'message', message: member })
+    // Collapsed: preserve the existing users-before-Thought summary when
+    // an initial prompt exists. A steer-only turn has no opening user row,
+    // so its Thought must lead and the claimed steer follows it.
+    const hasInitialPrompt = initialPromptBoundary(group) > 0
+    if (hasInitialPrompt) {
+      for (const member of group) {
+        if (member.kind === 'user') out.push({ kind: 'message', message: member })
+      }
     }
-    // The Thought disclosure follows the user rows.
     if (activity !== undefined) out.push({ kind: 'activity', activity })
+    if (!hasInitialPrompt) {
+      for (const member of group) {
+        if (member.kind === 'user') out.push({ kind: 'message', message: member })
+      }
+    }
     // Compaction cards keep their existing lifecycle in the collapsed
     // view (plan §12.3 v1 — never hidden into the Thought).
     for (const member of group) {
@@ -476,16 +486,17 @@ function lastAssistant(
 }
 
 /** The initial-prompt boundary of one turn group: the index AFTER the
- * turn's FIRST direct user row. Rows before it (injected/system context)
+ * turn's FIRST non-steer user row. Rows before it (injected/system context)
  * and the initial user itself stay above the Thought; every later row
- * (steers included) returns to its chronological position. 0 when the
- * turn has no user row — the Thought then leads with chronology intact
- * (never a synthetic user, never a crash). Only the FIRST direct user is
- * the initial prompt: consecutive users are queue/steer input, not a
- * multi-row initial prompt (plan: no adjacency guessing). */
+ * (steers included) returns to its chronological position. A steer-only turn
+ * has no boundary, so the Thought leads with chronology intact. Without steer
+ * metadata, the first non-steer user remains the initial-prompt fallback;
+ * consecutive users are queue/steer input, not a multi-row initial prompt. */
 function initialPromptBoundary(group: readonly TranscriptMessage[]): number {
-  const firstUserIndex = group.findIndex(member => member.kind === 'user')
-  return firstUserIndex < 0 ? 0 : firstUserIndex + 1
+  const firstInitialUserIndex = group.findIndex(
+    member => member.kind === 'user' && member.steer !== true,
+  )
+  return firstInitialUserIndex < 0 ? 0 : firstInitialUserIndex + 1
 }
 
 /** Whether one assistant message has visible Assistant content. Keep final

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -52,7 +52,7 @@ export type TranscriptMessage =
    * non-text content — attachment and generic presentation renders it in
    * order (plan §15).
    */
-  | { kind: 'user'; turn: number; text: string; content?: readonly ContentBlock[] }
+  | { kind: 'user'; turn: number; text: string; content?: readonly ContentBlock[]; steer?: true }
   /**
    * One step's model output. `text` is the flat markdown; `content` is the
    * settled message's full blocks when the step carried any role-neutral
@@ -642,6 +642,10 @@ interface TranscriptSearchEntry {
 
 export class TranscriptFolder {
   private readonly items: TranscriptMessage[] = []
+  /** Durable next-step inbox ids awaiting a claim or replacement. */
+  private readonly pendingNextStepIds: string[] = []
+  /** Message ids removed by a non-canceled next-step claim. */
+  private readonly claimedNextStepIds = new Set<string>()
   /** The assistant message object per (turn, step); streaming text lands in place. */
   private readonly assistantEntries = new Map<string, Extract<TranscriptMessage, { kind: 'assistant' }>>()
   /** In-flight live block state keyed by logical step. This is required for
@@ -2336,12 +2340,38 @@ export class TranscriptFolder {
     // Only an EXPLICIT replacement is filtered; unmarked legacy events
     // keep their current behavior (no surfaceOp = not a surface event at
     // all — the helper requires the event type AND the marker).
-    if (isReplacementSurfaceEvent(event)) return
+    if (isReplacementSurfaceEvent(event)) {
+      if (event.type === 'user/message') this.claimedNextStepIds.delete(event.data.id)
+      return
+    }
     // Compaction lifecycle events are typed STRUCTURALLY: dsh-compaction
     // is not a peer dependency, so its session-event augmentation never
     // enters our type graph (the same pattern as the structural service
     // types). An unknown event type is otherwise skipped by the switch.
     const kind = event.type as string
+    if (kind === 'agent/inbox/spliced') {
+      const data = event.data as {
+        target: 'next-turn' | 'next-step'
+        start: number
+        removedCount?: number
+        inserted: readonly { id: string }[]
+        outcome?: 'canceled'
+      }
+      const inserted = data.inserted.map(message => message.id)
+      let removed: string[] = []
+      if (data.target === 'next-step') {
+        removed = this.pendingNextStepIds.splice(
+          data.start,
+          data.removedCount ?? 0,
+          ...inserted,
+        )
+      }
+      for (const id of inserted) this.claimedNextStepIds.delete(id)
+      if (data.target === 'next-step' && data.outcome !== 'canceled') {
+        for (const id of removed) this.claimedNextStepIds.add(id)
+      }
+      return
+    }
     if (kind === 'compaction/start' || kind === 'compaction/summary' || kind === 'compaction/end' || kind === 'session/end-seed') {
       this.applyCompactionEvent(event as { type: string; data: Record<string, unknown> }, kind)
       return
@@ -2436,6 +2466,7 @@ export class TranscriptFolder {
         break
       }
       case 'user/message': {
+        const wasClaimedFromNextStep = this.claimedNextStepIds.delete(event.data.id)
         const blocks = event.data.content
         // User messages keep known attachment markers at their original
         // positions in the FLAT text; the ordered `content` blocks stay the
@@ -2448,7 +2479,13 @@ export class TranscriptFolder {
         // process block must not turn into an empty system row.
         if (event.data.source.kind === 'user') {
           if (!userBlocksVisibleNow(blocks)) break
-          this.appendItem({ kind: 'user', turn: this.currentTurn, text, content: blocks })
+          this.appendItem({
+            kind: 'user',
+            turn: this.currentTurn,
+            text,
+            content: blocks,
+            ...(wasClaimedFromNextStep ? { steer: true as const } : {}),
+          })
         } else {
           if (text === '') break
           // Injected context: name the producer the way the Web row does

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -52,7 +52,14 @@ export type TranscriptMessage =
    * non-text content — attachment and generic presentation renders it in
    * order (plan §15).
    */
-  | { kind: 'user'; turn: number; text: string; content?: readonly ContentBlock[]; steer?: true }
+  | {
+    kind: 'user'
+    turn: number
+    text: string
+    content?: readonly ContentBlock[]
+    /** Presentation-only marker for a next-step input inserted during this turn. */
+    steer?: true
+  }
   /**
    * One step's model output. `text` is the flat markdown; `content` is the
    * settled message's full blocks when the step carried any role-neutral
@@ -640,12 +647,18 @@ interface TranscriptSearchEntry {
   normalizedText: string
 }
 
+interface NextStepInboxIdentity {
+  id: string
+  /** The turn that was open when this identity entered next-step, if any. */
+  insertionTurn: number | undefined
+}
+
 export class TranscriptFolder {
   private readonly items: TranscriptMessage[] = []
-  /** Durable next-step inbox ids awaiting a claim or replacement. */
-  private readonly pendingNextStepIds: string[] = []
-  /** Message ids removed by a non-canceled next-step claim. */
-  private readonly claimedNextStepIds = new Set<string>()
+  /** Durable next-step identities awaiting a claim or replacement. */
+  private readonly pendingNextSteps: NextStepInboxIdentity[] = []
+  /** Claimed next-step ids and the turn that was open at insertion. */
+  private readonly claimedNextStepTurns = new Map<string, number | undefined>()
   /** The assistant message object per (turn, step); streaming text lands in place. */
   private readonly assistantEntries = new Map<string, Extract<TranscriptMessage, { kind: 'assistant' }>>()
   /** In-flight live block state keyed by logical step. This is required for
@@ -690,6 +703,8 @@ export class TranscriptFolder {
   private readonly compacting = new Map<string, number>()
   /** The turn most recently opened by turn/start. */
   private currentTurn = 0
+  /** The turn currently between its turn/start and turn/end boundaries. */
+  private openTurn: number | undefined
   /**
    * Incremental consecutive-read grouping (stage J): `groupOf` maps an item
    * index to its merged group card (only the FIRST member emits it in the
@@ -2341,7 +2356,7 @@ export class TranscriptFolder {
     // keep their current behavior (no surfaceOp = not a surface event at
     // all — the helper requires the event type AND the marker).
     if (isReplacementSurfaceEvent(event)) {
-      if (event.type === 'user/message') this.claimedNextStepIds.delete(event.data.id)
+      if (event.type === 'user/message') this.claimedNextStepTurns.delete(event.data.id)
       return
     }
     // Compaction lifecycle events are typed STRUCTURALLY: dsh-compaction
@@ -2357,18 +2372,18 @@ export class TranscriptFolder {
         inserted: readonly { id: string }[]
         outcome?: 'canceled'
       }
-      const inserted = data.inserted.map(message => message.id)
-      let removed: string[] = []
+      const inserted = data.inserted.map(message => ({ id: message.id, insertionTurn: this.openTurn }))
+      let removed: NextStepInboxIdentity[] = []
       if (data.target === 'next-step') {
-        removed = this.pendingNextStepIds.splice(
+        removed = this.pendingNextSteps.splice(
           data.start,
           data.removedCount ?? 0,
           ...inserted,
         )
       }
-      for (const id of inserted) this.claimedNextStepIds.delete(id)
+      for (const { id } of inserted) this.claimedNextStepTurns.delete(id)
       if (data.target === 'next-step' && data.outcome !== 'canceled') {
-        for (const id of removed) this.claimedNextStepIds.add(id)
+        for (const { id, insertionTurn } of removed) this.claimedNextStepTurns.set(id, insertionTurn)
       }
       return
     }
@@ -2462,11 +2477,17 @@ export class TranscriptFolder {
         activity.startedAt = event.time
         activity.completed = false
         activity.reason = undefined
+        if (event.data.turn === this.currentTurn) this.openTurn = event.data.turn
         activity.revision += 1
         break
       }
       case 'user/message': {
-        const wasClaimedFromNextStep = this.claimedNextStepIds.delete(event.data.id)
+        const claimedInsertionTurn = this.claimedNextStepTurns.get(event.data.id)
+        const wasClaimedFromNextStep = this.claimedNextStepTurns.delete(event.data.id)
+        // Only a next-step identity inserted during this admission turn is a
+        // mid-turn steer; an idle wake or a claim carried across turns is an
+        // ordinary opening/follow-up user message.
+        const isMidTurnSteer = wasClaimedFromNextStep && claimedInsertionTurn === this.currentTurn
         const blocks = event.data.content
         // User messages keep known attachment markers at their original
         // positions in the FLAT text; the ordered `content` blocks stay the
@@ -2484,7 +2505,7 @@ export class TranscriptFolder {
             turn: this.currentTurn,
             text,
             content: blocks,
-            ...(wasClaimedFromNextStep ? { steer: true as const } : {}),
+            ...(isMidTurnSteer ? { steer: true as const } : {}),
           })
         } else {
           if (text === '') break
@@ -2760,7 +2781,9 @@ export class TranscriptFolder {
       case 'turn/end': {
         // Idempotent: a replayed turn/end must not re-append the
         // synthetic cards or re-settle the activity (review finding).
-        const endActivity = this.activityFor(event.data.turn)
+        const endTurn = event.data.turn
+        if (this.openTurn === endTurn) this.openTurn = undefined
+        const endActivity = this.activityFor(endTurn)
         if (endActivity.completed) break
         // Every still-open thinking entry of THIS turn stops streaming when
         // the turn closes (interrupted steps never see their
@@ -2770,7 +2793,6 @@ export class TranscriptFolder {
         // The synthetic cards carry the EVENT's own turn — never
         // this.currentTurn: a turn-start-less fragment's end must land in
         // its own turn (review finding).
-        const endTurn = event.data.turn
         for (const key of this.liveAssistantBlocks.keys()) {
           if (key.startsWith(`${endTurn}/`)) this.liveAssistantBlocks.delete(key)
         }

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2099,6 +2099,21 @@ test('window summaries (turn-less entries) pass through the projection', () => {
 
 // ── expanded chronology (plan: steer rows return to their position) ─────
 
+/** Build the durable next-step insertion, claim, and admitted user message. */
+function claimedSteer(id: string, text: string, time: number, seq: number): SessionEvent[] {
+  const message = {
+    id: MessageId(id),
+    role: 'user',
+    content: [{ type: 'text', text }],
+    source: { kind: 'user' },
+  }
+  return [
+    eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, time, seq),
+    eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, time + 0.1, seq + 1),
+    eventAt('user/message', message, time + 1, seq + 2),
+  ]
+}
+
 /** A turn with an initial user, thinking, a tool, a MID-TURN steer, and a
  * final answer: user → thinking → tool → user(steer) → assistant → end. */
 function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionEvent[] {
@@ -2119,11 +2134,7 @@ function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionE
         source: { kind: 'tool', callId: ToolCallId(`c-${turn}-1`) },
       },
     }, startTime + 4, baseSeq + 4),
-    eventAt('user/message', {
-      id: MessageId(`msg-s-${turn}`), role: 'user',
-      content: [{ type: 'text', text: `steer ${turn}` }],
-      source: { kind: 'user' },
-    }, startTime + 5, baseSeq + 5),
+    ...claimedSteer(`msg-s-${turn}`, `steer ${turn}`, startTime + 5, baseSeq + 5),
     eventAt('assistant/message', {
       turn, step: 1,
       message: {
@@ -2131,8 +2142,8 @@ function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionE
         content: [{ type: 'text', text: `final answer ${turn}` }],
         source: { kind: 'model', provider: 'p', model: 'm' },
       },
-    }, startTime + 6, baseSeq + 6),
-    eventAt('turn/end', { turn, reason: { kind: 'completed' } }, startTime + 6000, baseSeq + 7),
+    }, startTime + 8, baseSeq + 8),
+    eventAt('turn/end', { turn, reason: { kind: 'completed' } }, startTime + 6000, baseSeq + 9),
   ]
 }
 
@@ -2284,28 +2295,113 @@ test('expanded: user rows never carry the owner collapse mark; process rows alwa
   }
 })
 
-test('expanded: rows before the first user stay in place; a late steer stays chronological', () => {
+test('expanded: a claimed steer in a non-user turn stays after the Thought', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1001, 1),
+    ...claimedSteer('late', 'late steer', 1002, 2),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1005, 5),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1006, 6),
+  ])
+  const blocks = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  // This user is a durable next-step claim, not an opening prompt. The
+  // Thought owns the turn root and the steer stays in its process position.
+  assert.deepEqual(blockKinds(blocks), ['activity', 'thinking', 'user', 'assistant'],
+    'a claimed steer must remain after the Thought in a non-user turn')
+})
+
+test('metadata-free logs keep the first user as the initial-prompt fallback', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, [
     eventAt('turn/start', { turn: 0 }, 1000, 0),
     eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1001, 1),
     eventAt('user/message', {
-      id: MessageId('late'), role: 'user',
-      content: [{ type: 'text', text: 'late steer' }],
+      id: MessageId('legacy-initial'),
+      role: 'user',
+      content: [{ type: 'text', text: 'legacy initial' }],
       source: { kind: 'user' },
     }, 1002, 2),
     eventAt('assistant/message', {
       turn: 0, step: 1,
-      message: { id: MessageId('a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+      message: { id: MessageId('legacy-answer'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
     }, 1003, 3),
     eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1004, 4),
   ])
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  assert.deepEqual(blockKinds(expanded), ['thinking', 'user', 'activity', 'assistant'])
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'activity', 'assistant'])
+})
+
+test('collapsed: a claimed steer in a non-user turn follows the Thought', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1001, 1),
+    ...claimedSteer('collapsed-late', 'late steer', 1002, 2),
+    eventAt('compaction/start', { compactionId: 'steer-only-compaction' }, 1005, 5),
+    eventAt('compaction/summary', {
+      compactionId: 'steer-only-compaction',
+      summary: [{ type: 'text', text: 'compacted context' }],
+      shadowedSeqs: [],
+      shadowedTokenCount: 3,
+    }, 1006, 6),
+    eventAt('compaction/end', { compactionId: 'steer-only-compaction' }, 1007, 7),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('collapsed-a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1008, 8),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1009, 9),
+  ])
+  const blocks = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(blocks), ['activity', 'user', 'compaction', 'assistant'],
+    'a non-user turn must put Thought, steer, compaction, and final in order when collapsed')
+})
+
+test('Focus keeps injected context and a claimed steer under the Thought root', () => {
+  const events: SessionEvent[] = [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('user/message', {
+      id: MessageId('injected-before-steer'),
+      role: 'user',
+      content: [{ type: 'text', text: 'system reminder' }],
+      source: { kind: 'plugin', plugin: 'agent-instructions' },
+    }, 1001, 1),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1002, 2),
+    ...claimedSteer('injected-steer', 'steer after inject', 1003, 3),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('injected-answer'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1006, 6),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1007, 7),
+  ]
+  const folder = new TranscriptFolder()
+  applyMixed(folder, events)
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  assert.deepEqual(blockKinds(expanded), ['activity', 'system', 'thinking', 'user', 'assistant'])
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['activity', 'user', 'assistant'])
+})
+
+test('a steer claimed before reasoning is still identified durably', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    ...claimedSteer('early-steer', 'early steer', 1001, 1),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1005, 5),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('early-answer'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1006, 6),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1007, 7),
+  ])
   const blocks = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
-  // The row BEFORE the first user (thinking) stays in place, the first
-  // user stays above the Thought, and the Thought follows — the steer
-  // never gets lifted above the Thought (plan: initial-prompt boundary).
-  assert.deepEqual(blockKinds(blocks), ['thinking', 'user', 'activity', 'assistant'],
-    'pre-user rows and the first user precede the Thought; the steer stays chronological')
+  assert.deepEqual(blockKinds(blocks), ['activity', 'user', 'thinking', 'assistant'],
+    'durable next-step identity must not depend on a prior visible process row')
 })
 
 test('fold → expand → fold projection is reversible (same collapsed output)', () => {

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2314,6 +2314,35 @@ test('expanded: a claimed steer in a non-user turn stays after the Thought', () 
     'a claimed steer must remain after the Thought in a non-user turn')
 })
 
+test('an idle steer that opens a turn remains before the Thought', () => {
+  const message = {
+    id: MessageId('idle-open-steer'),
+    role: 'user',
+    content: [{ type: 'text', text: 'idle opening input' }],
+    source: { kind: 'user' },
+  }
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, 1000, 0),
+    eventAt('turn/start', { turn: 0 }, 1001, 1),
+    eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 1002, 2),
+    eventAt('user/message', message, 1003, 3),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1004, 4),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('idle-open-answer'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1005, 5),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1006, 6),
+  ])
+  const user = folder.messages().find(message => message.kind === 'user')
+  assert.ok(user !== undefined && user.kind === 'user')
+  assert.equal(user.steer, undefined)
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  assert.deepEqual(blockKinds(expanded), ['user', 'activity', 'thinking', 'assistant'])
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'activity', 'assistant'])
+})
+
 test('metadata-free logs keep the first user as the initial-prompt fallback', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, [

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -154,6 +154,47 @@ test('next-step claims mark the matching human user message as steer', () => {
   assert.equal(message.steer, true)
 })
 
+test('an idle next-step wake is not a mid-turn steer', () => {
+  const message = {
+    id: MessageId('idle-steer'),
+    role: 'user',
+    content: [{ type: 'text', text: 'idle steer' }],
+    source: { kind: 'user' },
+  }
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, 0),
+    event('turn/start', { turn: 0 }, 1),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 2),
+    rawEvent('user/message', message, 3),
+  ])
+  const folded = folder.messages()[0]
+  assert.ok(folded !== undefined && folded.kind === 'user')
+  assert.equal(folded.steer, undefined)
+})
+
+test('a next-step claim carried across turns is not a steer in the later turn', () => {
+  const message = {
+    id: MessageId('cross-turn-steer'),
+    role: 'user',
+    content: [{ type: 'text', text: 'cross-turn steer' }],
+    source: { kind: 'user' },
+  }
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, 1),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 2),
+    event('turn/start', { turn: 1 }, 3),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 4),
+    rawEvent('user/message', message, 5),
+  ])
+  const folded = folder.messages()[0]
+  assert.ok(folded !== undefined && folded.kind === 'user')
+  assert.equal(folded.turn, 1)
+  assert.equal(folded.steer, undefined)
+})
+
 test('replacement user messages consume stale next-step claims', () => {
   const id = MessageId('replacement-steer')
   const folder = new TranscriptFolder()

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -131,6 +131,199 @@ test('folds a user message into a You message', () => {
   assert.equal(first.text, 'hello')
 })
 
+function claimedSteerEvents(id: string, text = 'steer'): SessionEvent[] {
+  const message = {
+    id: MessageId(id),
+    role: 'user',
+    content: [{ type: 'text', text }],
+    source: { kind: 'user' },
+  }
+  return [
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, 1),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 2),
+    rawEvent('user/message', message, 3),
+  ]
+}
+
+test('next-step claims mark the matching human user message as steer', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate(claimedSteerEvents('steer-a'))
+  const message = folder.messages()[0]
+  assert.ok(message !== undefined && message.kind === 'user')
+  assert.equal(message.steer, true)
+})
+
+test('replacement user messages consume stale next-step claims', () => {
+  const id = MessageId('replacement-steer')
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('agent/inbox/spliced', {
+      target: 'next-step', start: 0,
+      inserted: [{ id, role: 'user', content: [{ type: 'text', text: 'replacement' }], source: { kind: 'user' } }],
+    }, 1),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 2),
+    surfaceEvent('user/message', {
+      id,
+      role: 'user',
+      content: [{ type: 'text', text: 'replacement' }],
+      source: { kind: 'user' },
+    }, 3, { op: 'replace', start: 0, end: 0 }),
+    rawEvent('user/message', {
+      id,
+      role: 'user',
+      content: [{ type: 'text', text: 'replacement' }],
+      source: { kind: 'user' },
+    }, 4),
+  ])
+  const messages = folder.messages().filter((message): message is Extract<TranscriptMessage, { kind: 'user' }> => message.kind === 'user')
+  assert.equal(messages.length, 1)
+  assert.equal(messages[0]?.steer, undefined)
+})
+
+test('ordinary user messages do not carry steer metadata', () => {
+  const messages = foldTranscript([
+    rawEvent('user/message', {
+      id: MessageId('ordinary-user'),
+      role: 'user',
+      content: [{ type: 'text', text: 'ordinary' }],
+      source: { kind: 'user' },
+    }, 0),
+  ])
+  const message = messages[0]
+  assert.ok(message !== undefined && message.kind === 'user')
+  assert.equal(message.steer, undefined)
+})
+
+test('canceled next-step removals do not mark the matching user as steer', () => {
+  const message = {
+    id: MessageId('canceled-steer'),
+    role: 'user',
+    content: [{ type: 'text', text: 'canceled' }],
+    source: { kind: 'user' },
+  }
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, 1),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [], outcome: 'canceled' }, 2),
+    rawEvent('user/message', message, 3),
+  ])
+  const folded = folder.messages()[0]
+  assert.ok(folded !== undefined && folded.kind === 'user')
+  assert.equal(folded.steer, undefined)
+})
+
+test('reinserting a claimed id clears its stale steer claim', () => {
+  const message = {
+    id: MessageId('reinserted-steer'),
+    role: 'user',
+    content: [{ type: 'text', text: 'reinserted' }],
+    source: { kind: 'user' },
+  }
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, 1),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 2),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, 3),
+    rawEvent('user/message', message, 4),
+  ])
+  const folded = folder.messages()[0]
+  assert.ok(folded !== undefined && folded.kind === 'user')
+  assert.equal(folded.steer, undefined)
+})
+
+test('inbox splice positions and targets classify only claimed next-step ids', () => {
+  const first = {
+    id: MessageId('position-first'),
+    role: 'user',
+    content: [{ type: 'text', text: 'first' }],
+    source: { kind: 'user' },
+  }
+  const second = {
+    id: MessageId('position-second'),
+    role: 'user',
+    content: [{ type: 'text', text: 'second' }],
+    source: { kind: 'user' },
+  }
+  const replacement = {
+    id: MessageId('position-replacement'),
+    role: 'user',
+    content: [{ type: 'text', text: 'replacement' }],
+    source: { kind: 'user' },
+  }
+  const nextTurn = {
+    id: MessageId('next-turn-user'),
+    role: 'user',
+    content: [{ type: 'text', text: 'next turn' }],
+    source: { kind: 'user' },
+  }
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('agent/inbox/spliced', { target: 'next-turn', start: 0, inserted: [nextTurn] }, 1),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [first, second] }, 2),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 1, inserted: [replacement] }, 3),
+    rawEvent('agent/inbox/spliced', { target: 'next-turn', start: 0, removedCount: 1, inserted: [] }, 4),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 1, removedCount: 1, inserted: [] }, 5),
+    rawEvent('user/message', nextTurn, 6),
+    rawEvent('user/message', replacement, 7),
+    rawEvent('user/message', replacement, 8),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 1, removedCount: 1, inserted: [] }, 9),
+    rawEvent('user/message', second, 10),
+    rawEvent('user/message', first, 11),
+  ])
+  const userMessages = folder.messages().filter((message): message is Extract<TranscriptMessage, { kind: 'user' }> => message.kind === 'user')
+  const replacementMessages = userMessages.filter(message => message.text === 'replacement')
+  assert.deepEqual(replacementMessages.map(message => message.steer), [true, undefined])
+  assert.equal(userMessages.find(message => message.text === 'next turn')?.steer, undefined)
+  assert.equal(userMessages.find(message => message.text === 'second')?.steer, true,
+    'the sibling left after the positioned claim remains in the next-step inbox')
+  assert.equal(userMessages.find(message => message.text === 'first')?.steer, undefined)
+})
+
+test('claimed ids are consumed by non-user and empty user messages', () => {
+  const pluginMessage = {
+    id: MessageId('claimed-plugin'),
+    role: 'user',
+    content: [{ type: 'text', text: 'plugin message' }],
+    source: { kind: 'plugin', plugin: 'test' },
+  }
+  const emptyMessage = {
+    id: MessageId('claimed-empty'),
+    role: 'user',
+    content: [],
+    source: { kind: 'user' },
+  }
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [pluginMessage] }, 1),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 2),
+    rawEvent('user/message', pluginMessage, 3),
+    rawEvent('user/message', { ...pluginMessage, source: { kind: 'user' } }, 4),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [emptyMessage] }, 5),
+    rawEvent('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, 6),
+    rawEvent('user/message', emptyMessage, 7),
+    rawEvent('user/message', { ...emptyMessage, content: [{ type: 'text', text: 'later' }] }, 8),
+  ])
+  const userMessages = folder.messages().filter((message): message is Extract<TranscriptMessage, { kind: 'user' }> => message.kind === 'user')
+  assert.equal(userMessages.find(message => message.text === 'plugin message')?.steer, undefined)
+  assert.equal(userMessages.find(message => message.text === 'later')?.steer, undefined)
+  assert.equal(folder.messages().some(message => message.kind === 'system' && message.text === 'plugin message'), true)
+})
+
+test('hydrate and incremental apply preserve the same steer identity', () => {
+  const events = claimedSteerEvents('steer-replay', 'replay steer')
+  const hydrated = new TranscriptFolder()
+  hydrated.hydrate(events)
+  const incremental = new TranscriptFolder()
+  for (const event of events) incremental.apply([event])
+  assert.deepEqual(incremental.messages(), hydrated.messages())
+})
+
 test('accumulates streaming text deltas into one assistant message', () => {
   const messages = foldLive([
     event('turn/start', { turn: 0 }, 0),


### PR DESCRIPTION
## Summary

- Reconstruct durable `next-step` steer identity from inbox splice claims and matching MessageIds.
- Mark `steer: true` only when the next-step item was inserted during the same open turn; idle wakeups and keepInbox cross-turn claims remain opening/follow-up user input.
- Keep Thought at the root for true same-turn steer-only Focus turns while preserving initial-user collapsed summaries.
- Add transcript and Focus regression coverage for replay, cancellation, replacement, target separation, idle wakeups, cross-turn claims, and compaction ordering.

## Validation

- `node scripts/run-with-temp-root.mjs node --test test/transcript.test.ts test/focus-mode.test.ts` (225/225)
- `pnpm test:product` (3560/3560)
- `pnpm typecheck:bundle`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

The review-fix loop completed with accepted holistic reviews and no remaining findings.