### PR TITLE
fix: align Edit diff presentation

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -208,6 +208,36 @@ export function isAnchoredFileDiff(hunk: FileDiff): hunk is AnchoredFileDiff {
     && Number.isInteger(anchored.newStart) && (anchored.newStart as number) >= 1
 }
 
+/** Compute the exact render rows for one hunk. */
+function diffLinesForHunk(hunk: FileDiff): DiffLine[] {
+  const anchored = isAnchoredFileDiff(hunk)
+  const oldStart = anchored ? hunk.oldStart! : 1
+  const newStart = anchored ? hunk.newStart! : 1
+  const oldSide = hunk.oldText === null || hunk.oldText === '' ? [] : hunk.oldText.split('\n')
+  const newSide = hunk.newText === '' ? [] : hunk.newText.split('\n')
+  if (oldSide.length === 0) return newSide.map((code, index) => ({ kind: 'add', lineNum: newStart + index, code }))
+  if (newSide.length === 0) return oldSide.map((code, index) => ({ kind: 'delete', lineNum: oldStart + index, code }))
+  return computeDiffLines(hunk.oldText!, hunk.newText, oldStart, newStart)
+}
+
+/** Aggregate add/delete counts from the same rows rendered in a diff body. */
+export interface DiffStats {
+  added: number
+  removed: number
+}
+
+export function summarizeDiffs(diffs: readonly FileDiff[]): DiffStats {
+  let added = 0
+  let removed = 0
+  for (const hunk of diffs) {
+    for (const line of diffLinesForHunk(hunk)) {
+      if (line.kind === 'add') added++
+      else if (line.kind === 'delete') removed++
+    }
+  }
+  return { added, removed }
+}
+
 /** Options for {@link renderDiffView}. */
 export interface DiffViewOptions {
   /** Context rows around each change cluster (default 3). */
@@ -216,13 +246,16 @@ export interface DiffViewOptions {
   maxLines?: number
   /** Hint text for the truncation footer (default 'click to expand'). */
   expandHint?: string
+  /** Whether each hunk header includes its path and/or aggregate stats. */
+  headerMode?: 'full' | 'stats-only' | 'none'
 }
 
 /**
  * Render a result-side diff view (a `card: 'diff'` presentResult intent) as
- * colored lines: one `+N -M path` header per hunk (kimi parity; counts in
- * add/remove colors, path workspace-relative), then the LCS-aligned body
- * with context clustering — unchanged runs between clusters elide to a
+ * colored lines: by default (`headerMode: 'full'`), one `+N -M path` header per
+ * hunk (kimi parity; counts in add/remove colors, path workspace-relative);
+ * `stats-only` keeps only `+N -M`, and `none` omits hunk headers. Then the
+ * LCS-aligned body with context clustering — unchanged runs between clusters elide to a
  * `… N unchanged lines …` separator, and `maxLines` caps the body at a
  * cluster boundary with a `… N more changes hidden (hint)` footer. A hunk
  * with `oldText: null` (create) shows only new lines; an empty newText
@@ -232,7 +265,7 @@ export interface DiffViewOptions {
  * them no gutter renders (never a fake 1..N gutter).
  * @param diffs - the diff view's hunks.
  * @param cwd - workspace root for path relativization; optional.
- * @param options - context/cap/hint tuning.
+ * @param options - context/cap/hint/header-mode tuning.
  * @returns the colored render lines.
  */
 export function renderDiffView(diffs: readonly FileDiff[], cwd?: string, options: DiffViewOptions = {}): string[] {
@@ -247,22 +280,18 @@ export function renderDiffView(diffs: readonly FileDiff[], cwd?: string, options
     // no line numbers at all (never a fake 1..N gutter; plan: hide the
     // gutter, never guess it).
     const anchored = isAnchoredFileDiff(hunk)
-    const oldStart = anchored ? hunk.oldStart! : 1
-    const newStart = anchored ? hunk.newStart! : 1
-    const oldSide = hunk.oldText === null || hunk.oldText === '' ? [] : hunk.oldText.split('\n')
-    const newSide = hunk.newText === '' ? [] : hunk.newText.split('\n')
-    const diffLines: DiffLine[] = oldSide.length === 0
-      ? newSide.map((code, index) => ({ kind: 'add', lineNum: newStart + index, code }))
-      : newSide.length === 0
-        ? oldSide.map((code, index) => ({ kind: 'delete', lineNum: oldStart + index, code }))
-        : computeDiffLines(hunk.oldText!, hunk.newText, oldStart, newStart)
+    const diffLines = diffLinesForHunk(hunk)
     const { clusters, changedCount, addedCount, removedCount } = buildDiffClusters(diffLines, contextLines)
 
-    let header = ''
-    if (addedCount > 0) header += color.diffAdded(`+${addedCount} `)
-    if (removedCount > 0) header += color.diffRemoved(`-${removedCount} `)
-    header += relativizeToCwd(hunk.path, cwd)
-    out.push(header)
+    if ((options.headerMode ?? 'full') !== 'none') {
+      const stats: string[] = []
+      if (addedCount > 0) stats.push(color.diffAdded(`+${addedCount}`))
+      if (removedCount > 0) stats.push(color.diffRemoved(`-${removedCount}`))
+      const header = (options.headerMode ?? 'full') === 'full'
+        ? `${stats.join(' ')}${stats.length === 0 ? '' : ' '}${relativizeToCwd(hunk.path, cwd)}`
+        : stats.join(' ')
+      out.push(header)
+    }
     if (clusters.length === 0) continue
 
     // The elision/footer indent mirrors the gutter column when the gutter
@@ -306,12 +335,12 @@ export function renderDiffView(diffs: readonly FileDiff[], cwd?: string, options
     }
     if (truncated) {
       const hidden = changedCount - shownChanges
-      if (hidden > 0) {
-        const hint = options.expandHint ?? 'click to expand'
-        out.push(color.diffMeta(
-          `${elideIndent}… ${hidden} more change${hidden > 1 ? 's' : ''} hidden (${hint})`,
-        ))
-      }
+      const hint = options.expandHint ?? 'click to expand'
+      out.push(color.diffMeta(
+        hidden > 0
+          ? `${elideIndent}… ${hidden} more change${hidden > 1 ? 's' : ''} hidden (${hint})`
+          : `${elideIndent}… more diff lines hidden (${hint})`,
+      ))
     }
   }
   return out

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -293,6 +293,18 @@ export function renderDiffView(diffs: readonly FileDiff[], cwd?: string, options
   let sawHunk = false
 
   outer: for (const { hunk, anchored, diffLines, clusters, addedCount, removedCount } of hunkViews) {
+    const stats: string[] = []
+    if (addedCount > 0) stats.push(color.diffAdded(`+${addedCount}`))
+    if (removedCount > 0) stats.push(color.diffRemoved(`-${removedCount}`))
+    const header = headerMode === 'full'
+      ? `${stats.join(' ')}${stats.length === 0 ? '' : ' '}${relativizeToCwd(hunk.path, cwd)}`
+      : stats.join(' ')
+    // A no-op hunk has no body rows to consume or hide, so it must not turn
+    // an exactly-full budget into a false truncation marker.
+    if (clusters.length === 0) {
+      if (headerMode !== 'none') out.push(header)
+      continue
+    }
     // Keep later hunk headers from defeating the global folded body budget.
     // The first header remains visible even when maxLines is zero, matching
     // the single-hunk behavior and preserving the card's identity.
@@ -303,17 +315,7 @@ export function renderDiffView(diffs: readonly FileDiff[], cwd?: string, options
     const elideIndent = anchored ? '     ' : ''
     lastElideIndent = elideIndent
     sawHunk = true
-
-    if (headerMode !== 'none') {
-      const stats: string[] = []
-      if (addedCount > 0) stats.push(color.diffAdded(`+${addedCount}`))
-      if (removedCount > 0) stats.push(color.diffRemoved(`-${removedCount}`))
-      const header = headerMode === 'full'
-        ? `${stats.join(' ')}${stats.length === 0 ? '' : ' '}${relativizeToCwd(hunk.path, cwd)}`
-        : stats.join(' ')
-      out.push(header)
-    }
-    if (clusters.length === 0) continue
+    if (headerMode !== 'none') out.push(header)
 
     let prevEnd = -1
     for (const cluster of clusters) {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -242,7 +242,7 @@ export function summarizeDiffs(diffs: readonly FileDiff[]): DiffStats {
 export interface DiffViewOptions {
   /** Context rows around each change cluster (default 3). */
   contextLines?: number
-  /** Cap on rendered body rows; absent or negative renders everything. */
+  /** Cap on rendered body rows across all hunks; absent or negative renders everything. */
   maxLines?: number
   /** Hint text for the truncation footer (default 'click to expand'). */
   expandHint?: string
@@ -256,8 +256,9 @@ export interface DiffViewOptions {
  * hunk (kimi parity; counts in add/remove colors, path workspace-relative);
  * `stats-only` keeps only `+N -M`, and `none` omits hunk headers. Then the
  * LCS-aligned body with context clustering — unchanged runs between clusters elide to a
- * `… N unchanged lines …` separator, and `maxLines` caps the body at a
- * cluster boundary with a `… N more changes hidden (hint)` footer. A hunk
+ * `… N unchanged lines …` separator, and `maxLines` caps the body across all
+ * hunks at a cluster boundary with a `… N more changes hidden (hint)` footer.
+ * A hunk
  * with `oldText: null` (create) shows only new lines; an empty newText
  * (pure deletion) shows only old lines. The body renders a line-number
  * gutter ONLY when the hunk carries provable absolute anchors
@@ -273,45 +274,59 @@ export function renderDiffView(diffs: readonly FileDiff[], cwd?: string, options
   const cap = options.maxLines !== undefined && options.maxLines >= 0
     ? options.maxLines
     : Number.POSITIVE_INFINITY
-  const out: string[] = []
-  for (const hunk of diffs) {
+  const headerMode = options.headerMode ?? 'full'
+  const hunkViews = diffs.map(hunk => {
     // The absolute hunk anchors are an OPTIONAL additive capability: only
     // a provable anchor renders the gutter — without one the body shows
     // no line numbers at all (never a fake 1..N gutter; plan: hide the
     // gutter, never guess it).
     const anchored = isAnchoredFileDiff(hunk)
     const diffLines = diffLinesForHunk(hunk)
-    const { clusters, changedCount, addedCount, removedCount } = buildDiffClusters(diffLines, contextLines)
+    return { hunk, anchored, diffLines, ...buildDiffClusters(diffLines, contextLines) }
+  })
+  const totalChanged = hunkViews.reduce((total, view) => total + view.changedCount, 0)
+  const out: string[] = []
+  let body = 0
+  let truncated = false
+  let shownChanges = 0
+  let lastElideIndent = ''
+  let sawHunk = false
 
-    if ((options.headerMode ?? 'full') !== 'none') {
+  outer: for (const { hunk, anchored, diffLines, clusters, addedCount, removedCount } of hunkViews) {
+    // Keep later hunk headers from defeating the global folded body budget.
+    // The first header remains visible even when maxLines is zero, matching
+    // the single-hunk behavior and preserving the card's identity.
+    if (body >= cap && sawHunk) {
+      truncated = true
+      break
+    }
+    const elideIndent = anchored ? '     ' : ''
+    lastElideIndent = elideIndent
+    sawHunk = true
+
+    if (headerMode !== 'none') {
       const stats: string[] = []
       if (addedCount > 0) stats.push(color.diffAdded(`+${addedCount}`))
       if (removedCount > 0) stats.push(color.diffRemoved(`-${removedCount}`))
-      const header = (options.headerMode ?? 'full') === 'full'
+      const header = headerMode === 'full'
         ? `${stats.join(' ')}${stats.length === 0 ? '' : ' '}${relativizeToCwd(hunk.path, cwd)}`
         : stats.join(' ')
       out.push(header)
     }
     if (clusters.length === 0) continue
 
-    // The elision/footer indent mirrors the gutter column when the gutter
-    // renders; without a gutter the body starts at column 0.
-    const elideIndent = anchored ? '     ' : ''
-    let body = 0
     let prevEnd = -1
-    let truncated = false
-    let shownChanges = 0
-    outer: for (const cluster of clusters) {
+    for (const cluster of clusters) {
       if (body >= cap) {
         truncated = true
-        break
+        break outer
       }
       if (prevEnd >= 0) {
         const gap = cluster.start - prevEnd - 1
         if (gap > 0) {
           if (body + 1 > cap) {
             truncated = true
-            break
+            break outer
           }
           out.push(color.diffMeta(`${elideIndent}… ${gap} unchanged line${gap > 1 ? 's' : ''} …`))
           body++
@@ -333,15 +348,15 @@ export function renderDiffView(diffs: readonly FileDiff[], cwd?: string, options
         prevEnd = i
       }
     }
-    if (truncated) {
-      const hidden = changedCount - shownChanges
-      const hint = options.expandHint ?? 'click to expand'
-      out.push(color.diffMeta(
-        hidden > 0
-          ? `${elideIndent}… ${hidden} more change${hidden > 1 ? 's' : ''} hidden (${hint})`
-          : `${elideIndent}… more diff lines hidden (${hint})`,
-      ))
-    }
+  }
+  if (truncated) {
+    const hidden = totalChanged - shownChanges
+    const hint = options.expandHint ?? 'click to expand'
+    out.push(color.diffMeta(
+      hidden > 0
+        ? `${lastElideIndent}… ${hidden} more change${hidden > 1 ? 's' : ''} hidden (${hint})`
+        : `${lastElideIndent}… more diff lines hidden (${hint})`,
+    ))
   }
   return out
 }

--- a/src/present.ts
+++ b/src/present.ts
@@ -1500,10 +1500,7 @@ export function focusToolDisplay(
  * full multiline command (ghost-row fix). */
 function formatOwnedCallForCompactFocus(view: ToolCallView): string {
   if (view.card === 'terminal') return firstLine(view.title.replace(/\r\n|\r/g, '\n'))
-  if (view.card === 'diff') {
-    const path = view.diffs[0]?.path
-    return path === undefined ? view.title : `${view.title} ${path}`
-  }
+  if (view.card === 'diff') return firstLine(view.title.replace(/\r\n|\r/g, '\n'))
   const raw = typeof view.rawInput === 'string' ? view.rawInput.trim() : undefined
   if (raw === undefined || raw === '') return view.title
   return view.title.endsWith(raw) ? view.title : `${view.title} ${firstLine(raw)}`

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -66,7 +66,7 @@ import {
   themeOptOut,
   type ColorPalette,
 } from './theme.ts'
-import { isDiffResult, renderDiffLines, renderDiffView } from './diff.ts'
+import { isDiffResult, renderDiffLines, renderDiffView, summarizeDiffs } from './diff.ts'
 import { ENABLE_FOCUS_REPORTING, isFocusReport } from './notification/terminal-focus.ts'
 import { TaskBrowserPanel, type TaskBrowserViewState, type TaskPanelItem } from './task-panel.ts'
 import type { TaskBrowserSummary } from './task-browser-runtime.ts'
@@ -8870,6 +8870,35 @@ export class TuiApp {
       isError: message.status === 'error',
       ...(message.error === undefined ? {} : { error: message.error }),
     })
+    const callPreview = parseCallPreview(message.name, message.args)
+    // A settled Edit's structured result is the applied-diff source for both
+    // the folded preview and the expanded body. Other cards keep the existing
+    // result-presenter path below; running/error Edit cards use call preview.
+    const editResultView = message.name === 'edit' && message.status === 'ok'
+      ? this.toolResultView(message)
+      : undefined
+    const resultViewForEdit = editResultView?.card === 'diff' ? editResultView : undefined
+    const editDiffs = message.name === 'edit'
+      ? resultViewForEdit !== undefined
+        ? resultViewForEdit.diffs
+        : callPreview?.kind === 'diff'
+          ? callPreview.diffs
+          : undefined
+      : undefined
+    const diffBody = message.name === 'edit'
+      ? editDiffs
+      : callPreview?.kind === 'diff'
+        ? callPreview.diffs
+        : undefined
+    const statsDiffs = message.name === 'edit' && message.status !== 'error' ? editDiffs : undefined
+    const diffStats = statsDiffs === undefined ? undefined : summarizeDiffs(statsDiffs)
+    const diffStatsLabel = diffStats === undefined
+      ? ''
+      : [
+          diffStats.added > 0 ? `+${diffStats.added}` : '',
+          diffStats.removed > 0 ? `-${diffStats.removed}` : '',
+        ].filter(part => part !== '').join(' ')
+    const structuredEditDiff = message.name === 'edit' && message.status === 'ok' && resultViewForEdit?.card === 'diff'
     // Action identities use a dot separator (`Send message · child-1`) while
     // the existing Web-style rows retain their historical space separator.
     const summary = header.summary === '' ? '' : action !== undefined ? ` · ${header.summary}` : ` ${header.summary}`
@@ -8882,7 +8911,18 @@ export class TuiApp {
       : message.status === 'error'
         ? color.error('[error]')
         : color.textDim('[running]')
-    const head = `${color.textDim(`${icon}${header.title}${summary}`)} ${pill}`
+    const headIdentity = color.textDim(`${icon}${header.title}${summary}`)
+    const statusPart = ` ${pill}`
+    const statsPart = diffStatsLabel === '' ? '' : `  ${color.textDim(diffStatsLabel)}`
+    const head = `${headIdentity}${statusPart}${statsPart}`
+    const visibleStatus = truncateToWidth(statusPart, width, '…')
+    const identityBudget = Math.max(0, width - visibleWidth(visibleStatus))
+    const visibleIdentity = identityBudget === 0 ? '' : truncateToWidth(headIdentity, identityBudget, '…')
+    const headWithoutStats = `${visibleIdentity}${visibleStatus}`
+    const statsBudget = Math.max(0, width - visibleWidth(headWithoutStats))
+    const singleLineHead = statsPart === '' || statsBudget === 0
+      ? headWithoutStats
+      : `${headWithoutStats}${truncateToWidth(statsPart, statsBudget, '…')}`
     // LOCAL `!`/`!!` shell cards read the master expand switch (plan §5.3),
     // never the unbounded turn marker: collapsed by default so a long log
     // cannot fill the TUI, expanded only while the expand switch is on.
@@ -8890,13 +8930,15 @@ export class TuiApp {
     if (expanded) {
       // Action headers and payloads are live width-aware components; every
       // other host card keeps its existing Text path and cache behavior.
-      card.addChild(action === undefined ? new Text(head, 0, 0) : new CompactTextPreview(head, 1, ''))
+      card.addChild(action === undefined
+        ? new Text(singleLineHead, 0, 0)
+        : new CompactTextPreview(head, 1, ''))
       // An explicitly expanded card renders diff bodies in full; the
       // default recent-turn view caps them (kimi parity). The flag is
       // the FULL REVEAL: the per-card override (the fullscreen secondary
       // disclosure) or any REGULAR Focus expanded root — a capped diff in
       // regular mode would have no mouse affordance to open it.
-      this.renderToolBody(card, message, fullReveal)
+      this.renderToolBody(card, message, fullReveal, editResultView, editDiffs)
     } else {
       if (action !== undefined) {
         // Action cards deliberately keep the stable header separate from the
@@ -8927,7 +8969,6 @@ export class TuiApp {
         return card
       }
       const rows: string[] = []
-      const callPreview = parseCallPreview(message.name, message.args)
       // The header already carries friendly summaries (todo counts, web
       // query/url via SUMMARY_KEYS, skill name via the first string arg),
       // so the folded preview only adds a tool identity when the header
@@ -8992,8 +9033,9 @@ export class TuiApp {
           ? ''
           : ` — ${preview(message.result, RESULT_PREVIEW_LINES)}`
       }
+      if (structuredEditDiff) resultPreview = ''
       const callHead = foldedCall === '' ? '' : foldedCall
-      const headWithPreview = `${head}${callHead}${resultPreview}`
+      const headWithPreview = `${singleLineHead}${callHead}${resultPreview}`
       if (callPreview?.kind === 'bash' && callPreview.command !== '') {
         // The command row owns the result preview's separate line (kimi
         // ShellExecution layout), so the head row carries no result text.
@@ -9015,14 +9057,19 @@ export class TuiApp {
         if (resultPreview !== '') {
           rows.push(color.textDim(`  ${resultPreview}`))
         }
-      } else if (callPreview?.kind === 'diff' && callPreview.diffs.length > 0) {
+      } else if (diffBody !== undefined && diffBody.length > 0) {
         rows.push(truncateToWidth(`${headWithPreview}`, width, '…'))
-        for (const line of renderDiffView(callPreview.diffs, this.workspaceRoot, {
+        for (const line of renderDiffView(diffBody, this.workspaceRoot, {
           maxLines: FOLDED_DIFF_LINES,
           expandHint: `${this.expandHint(expandHint)} to expand`,
+          headerMode: message.name === 'edit'
+            ? diffBody.length === 1 ? 'none' : 'stats-only'
+            : 'full',
         })) {
           rows.push(`  ${line}`)
         }
+      } else if (structuredEditDiff) {
+        rows.push(truncateToWidth(`${headWithPreview}`, width, '…'))
       } else {
         rows.push(truncateToWidth(headWithPreview, width, '…'))
       }
@@ -9167,6 +9214,16 @@ export class TuiApp {
     card.addChild(new Text(rows.join('\n'), 0, 0))
   }
 
+  private toolResultView(
+    message: Extract<TranscriptMessage, { kind: 'tool' }>,
+  ): ReturnType<ToolPresenter['result']> {
+    return this.present?.result(message.name, message.args, {
+      content: message.resultBlocks ?? [],
+      isError: message.status === 'error',
+      ...message.meta === undefined ? {} : { meta: message.meta },
+    })
+  }
+
   /**
    * Render one expanded tool card's body. When the runner wired a presenter,
    * the body follows the tool's own render intent (presentResult): a read
@@ -9175,17 +9232,21 @@ export class TuiApp {
    * terminal card shows the output and exit status, and a diff card shows
    * the LCS-aligned, clustered diff (capped in the default view, full when
    * the card was explicitly expanded). Without a view the raw result text
-   * renders, diff-colored when it looks like one; a diff-card call whose
-   * result carried no view reuses the call-time diff so the block never
+   * renders, diff-colored when it looks like one; a parsed Edit call whose
+   * result carried no view reuses its call-time diff so the block never
    * collapses (kimi parity).
    * @param card - the card container to fill.
    * @param message - the tool message.
    * @param explicitlyExpanded - whether the user expanded this card by hand.
+   * @param editResultView - the already-resolved Edit result view, if any.
+   * @param editDiffs - the effective Edit diff selected by the outer card.
    */
   private renderToolBody(
     card: Container,
     message: Extract<TranscriptMessage, { kind: 'tool' }>,
     explicitlyExpanded: boolean,
+    editResultView: ReturnType<ToolPresenter['result']>,
+    editDiffs: readonly FileDiff[] | undefined,
   ): void {
     // LOCAL `!`/`!!` shell cards render their own expanded body (plan
     // §5.1): the `$ command` row (the card's `args` IS the raw command
@@ -9278,10 +9339,14 @@ export class TuiApp {
       // call carries no override — official subagent calls stay unchanged).
       const modelLine = subagentModelDisplay(message.name, message.args)
       if (modelLine !== undefined) card.addChild(new Text(color.textDim(modelLine), 0, 0))
-      const callView = this.present?.call(message.name, message.args)
+      if (message.name === 'edit' && editDiffs !== undefined && editDiffs.length > 0) {
+        this.renderDiffBody(card, editDiffs, explicitlyExpanded, message.name)
+        return
+      }
+      const callView = message.name === 'edit' ? undefined : this.present?.call(message.name, message.args)
       if (callView !== undefined) {
-        if (callView.card === 'diff' && callView.diffs.length > 0) {
-          this.renderDiffBody(card, callView.diffs, explicitlyExpanded)
+        if (message.name !== 'edit' && callView.card === 'diff' && callView.diffs.length > 0) {
+          this.renderDiffBody(card, callView.diffs, explicitlyExpanded, message.name)
           return
         }
         // A terminal call (bash/pwsh) shows its command row right away (the
@@ -9362,20 +9427,25 @@ export class TuiApp {
       }
       // Unparseable or failed: fall through to the generic presentation.
     }
-    if (message.result === '' && (message.resultBlocks?.length ?? 0) === 0) return
+    const emptyResult = message.result === '' && (message.resultBlocks?.length ?? 0) === 0
+    // Edit presentation metadata can carry the entire structured diff even
+    // when the model-facing result text is empty; resolve that view before
+    // falling through to the generic empty-result behavior.
+    if (emptyResult && message.name !== 'edit') return
     // A settled subagent-family call keeps its model/provider line above the
     // result (only when the call args carried an explicit override).
     const settledModelLine = subagentModelDisplay(message.name, message.args)
     if (settledModelLine !== undefined) card.addChild(new Text(color.textDim(settledModelLine), 0, 0))
-    const resultView = this.present?.result(message.name, message.args, {
-      content: message.resultBlocks ?? [],
-      isError: message.status === 'error',
-      ...message.meta === undefined ? {} : { meta: message.meta },
-    })
+    const resultView = message.name === 'edit' && message.status === 'ok'
+      ? editResultView?.card === 'diff' ? editResultView : undefined
+      : this.toolResultView(message)
     // A dedicated terminal presenter, when available, remains authoritative
-    // for output and exit status. Without one, the legacy raw-result fallback
-    // below keeps the expanded viewport/wait/session snapshot intact.
-    if (resultView !== undefined) {
+    // for output and exit status. An error Edit's diff is an attempted change,
+    // not an applied result, so it follows the call-time fallback below.
+    const ignoreEditErrorDiff = message.name === 'edit'
+      && message.status === 'error'
+      && resultView?.card === 'diff'
+    if (resultView !== undefined && !ignoreEditErrorDiff) {
       switch (resultView.card) {
         case 'read': {
           for (const line of resultView.lines) {
@@ -9425,7 +9495,7 @@ export class TuiApp {
           return
         }
         case 'diff': {
-          this.renderDiffBody(card, resultView.diffs, explicitlyExpanded)
+          this.renderDiffBody(card, resultView.diffs, explicitlyExpanded, message.name)
           return
         }
         case 'web': {
@@ -9494,16 +9564,24 @@ export class TuiApp {
           break
       }
     }
-    // No completed view (e.g. replay metadata absent): a diff-card call
-    // reuses its call-time diff, so the block shown while running stays put
-    // instead of collapsing to raw text (kimi parity).
-    if (resultView === undefined) {
-      const callView = this.present?.call(message.name, message.args)
-      if (callView !== undefined && callView.card === 'diff' && callView.diffs.length > 0) {
-        this.renderDiffBody(card, callView.diffs, explicitlyExpanded)
+    // No completed view (e.g. replay metadata absent): an Edit reuses its
+    // parsed call-time diff, so the block shown while running stays put
+    // instead of accepting a second presenter source or collapsing to raw
+    // text (kimi parity).
+    if (resultView === undefined || ignoreEditErrorDiff) {
+      if (message.name === 'edit' && editDiffs !== undefined && editDiffs.length > 0) {
+        this.renderDiffBody(card, editDiffs, explicitlyExpanded, message.name)
         return
       }
+      if (message.name !== 'edit') {
+        const callView = this.present?.call(message.name, message.args)
+        if (callView !== undefined && callView.card === 'diff' && callView.diffs.length > 0) {
+          this.renderDiffBody(card, callView.diffs, explicitlyExpanded, message.name)
+          return
+        }
+      }
     }
+    if (emptyResult) return
     // Generic fallback: the raw result text dimmed (diffs keep their own
     // + / − colors, which already distinguish them from assistant output).
     // A read card without a presenter still renders its envelope as numbered
@@ -9671,10 +9749,19 @@ export class TuiApp {
    * @param card - the card container to fill.
    * @param diffs - the diff hunks.
    * @param explicitlyExpanded - explicit expansion disables the cap.
+   * @param toolName - selects Edit's outer-card header ownership.
    */
-  private renderDiffBody(card: Container, diffs: readonly FileDiff[], explicitlyExpanded: boolean): void {
+  private renderDiffBody(
+    card: Container,
+    diffs: readonly FileDiff[],
+    explicitlyExpanded: boolean,
+    toolName: string,
+  ): void {
     for (const line of renderDiffView(diffs, this.workspaceRoot, {
       maxLines: explicitlyExpanded ? undefined : DIFF_PREVIEW_LINES,
+      headerMode: toolName === 'edit'
+        ? diffs.length === 1 ? 'none' : 'stats-only'
+        : 'full',
     })) {
       card.addChild(new Text(line, 0, 0))
     }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -8456,16 +8456,17 @@ export class TuiApp {
    * Whether a HOST build bakes width-dependent truncation into the
    * component at build time — the FOLDED system / compaction / legacy tool
    * cards (their preview rows truncate to the content width once, so a
-   * terminal resize must rebuild them at the new width). Render-time
-   * width-aware builds (assistant/user markdown and bubbles, Thinking
-   * compact with its per-width cache, expanded card bodies) re-derive
-   * every frame and are deliberately excluded: keying them by width
+   * terminal resize must rebuild them at the new width) and expanded Edit
+   * headers (their status-preserving single-line header is built at one
+   * width). Render-time width-aware builds (assistant/user markdown and
+   * bubbles, Thinking compact with its per-width cache, other expanded card
+   * bodies) re-derive every frame and are deliberately excluded: keying them by width
    * would invalidate the whole message cache on every resize and re-run
    * plugin renderers for unchanged content (the renderer-cache
    * contract, plan §23).
    */
   private bakesFoldedWidth(message: TranscriptMessage, expanded: boolean): boolean {
-    if (expanded) return false
+    if (expanded) return message.kind === 'tool' && message.name === 'edit'
     return message.kind === 'system' || message.kind === 'compaction'
       || (message.kind === 'tool' && !isCompactActionTool(message.name, message.args))
   }
@@ -9441,12 +9442,13 @@ export class TuiApp {
       ? editResultView?.card === 'diff' ? editResultView : undefined
       : this.toolResultView(message)
     // A dedicated terminal presenter, when available, remains authoritative
-    // for output and exit status. An error Edit's diff is an attempted change,
-    // not an applied result, so it follows the call-time fallback below.
-    const ignoreEditErrorDiff = message.name === 'edit'
+    // for output and exit status. An error Edit's result is an attempted
+    // change, not an applied result, so every result view follows the
+    // call-time fallback below.
+    const ignoreEditErrorResult = message.name === 'edit'
       && message.status === 'error'
-      && resultView?.card === 'diff'
-    if (resultView !== undefined && !ignoreEditErrorDiff) {
+      && resultView !== undefined
+    if (resultView !== undefined && !ignoreEditErrorResult) {
       switch (resultView.card) {
         case 'read': {
           for (const line of resultView.lines) {
@@ -9569,7 +9571,7 @@ export class TuiApp {
     // parsed call-time diff, so the block shown while running stays put
     // instead of accepting a second presenter source or collapsing to raw
     // text (kimi parity).
-    if (resultView === undefined || ignoreEditErrorDiff) {
+    if (resultView === undefined || ignoreEditErrorResult) {
       if (message.name === 'edit' && editDiffs !== undefined && editDiffs.length > 0) {
         this.renderDiffBody(card, editDiffs, explicitlyExpanded, message.name)
         return

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -8923,6 +8923,7 @@ export class TuiApp {
     const singleLineHead = statsPart === '' || statsBudget === 0
       ? headWithoutStats
       : `${headWithoutStats}${truncateToWidth(statsPart, statsBudget, '…')}`
+    const expandedHead = message.name === 'edit' ? singleLineHead : head
     // LOCAL `!`/`!!` shell cards read the master expand switch (plan §5.3),
     // never the unbounded turn marker: collapsed by default so a long log
     // cannot fill the TUI, expanded only while the expand switch is on.
@@ -8931,7 +8932,7 @@ export class TuiApp {
       // Action headers and payloads are live width-aware components; every
       // other host card keeps its existing Text path and cache behavior.
       card.addChild(action === undefined
-        ? new Text(singleLineHead, 0, 0)
+        ? new Text(expandedHead, 0, 0)
         : new CompactTextPreview(head, 1, ''))
       // An explicitly expanded card renders diff bodies in full; the
       // default recent-turn view caps them (kimi parity). The flag is
@@ -9035,7 +9036,7 @@ export class TuiApp {
       }
       if (structuredEditDiff) resultPreview = ''
       const callHead = foldedCall === '' ? '' : foldedCall
-      const headWithPreview = `${singleLineHead}${callHead}${resultPreview}`
+      const headWithPreview = `${expandedHead}${callHead}${resultPreview}`
       if (callPreview?.kind === 'bash' && callPreview.command !== '') {
         // The command row owns the result preview's separate line (kimi
         // ShellExecution layout), so the head row carries no result text.

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -84,6 +84,14 @@ test('renderDiffView does not add a marker when the body fits its cap', () => {
   assert.ok(!lines.some(line => line.includes('hidden')), `unexpected truncation marker:\n${lines.join('\n')}`)
 })
 
+test('renderDiffView ignores a trailing no-op hunk when the body cap is full', () => {
+  const lines = renderDiffView([
+    { path: 'changed.ts', oldText: 'old', newText: 'new' },
+    { path: 'same.ts', oldText: 'same', newText: 'same' },
+  ], undefined, { maxLines: 2 }).map(strip)
+  assert.ok(!lines.some(line => line.includes('hidden')), `a no-op hunk must not trigger truncation:\n${lines.join('\n')}`)
+})
+
 test('diff header modes and stats share the rendered diff rows', () => {
   const diffs = [
     { path: 'src/foo.ts', oldText: 'same\nold', newText: 'same\nnew\nadded' },

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -6,7 +6,7 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { computeDiffLines, renderDiffView, type AnchoredFileDiff } from '../src/diff.ts'
+import { computeDiffLines, renderDiffView, summarizeDiffs, type AnchoredFileDiff } from '../src/diff.ts'
 
 const strip = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, '')
 
@@ -69,6 +69,32 @@ test('renderDiffView caps the body and appends a hidden-changes footer', () => {
   const body = lines.slice(1)
   assert.ok(body.length <= 10 + 1, `capped body too tall:\n${lines.join('\n')}`)
   assert.ok(lines.some(line => line.includes('more changes hidden (click to expand)')), `footer missing:\n${lines.join('\n')}`)
+})
+
+test('renderDiffView marks a cap that hides context after all changes', () => {
+  const oldText = ['old', 'context 1', 'context 2', 'context 3', 'context 4', 'context 5'].join('\n')
+  const newText = ['new', 'context 1', 'context 2', 'context 3', 'context 4', 'context 5'].join('\n')
+  const lines = renderDiffView([{ path: 'f.ts', oldText, newText }], undefined, { maxLines: 2 }).map(strip)
+  assert.ok(lines.some(line => line.includes('more diff lines hidden (click to expand)')), `context marker missing:\n${lines.join('\n')}`)
+  assert.ok(!lines.some(line => line.includes('0 more changes hidden')), `must not report zero hidden changes:\n${lines.join('\n')}`)
+})
+
+test('renderDiffView does not add a marker when the body fits its cap', () => {
+  const lines = renderDiffView([{ path: 'f.ts', oldText: 'old', newText: 'new' }], undefined, { maxLines: 3 }).map(strip)
+  assert.ok(!lines.some(line => line.includes('hidden')), `unexpected truncation marker:\n${lines.join('\n')}`)
+})
+
+test('diff header modes and stats share the rendered diff rows', () => {
+  const diffs = [
+    { path: 'src/foo.ts', oldText: 'same\nold', newText: 'same\nnew\nadded' },
+    { path: 'src/foo.ts', oldText: 'before', newText: 'after' },
+  ]
+  assert.deepEqual(summarizeDiffs(diffs), { added: 3, removed: 2 })
+  const statsOnly = renderDiffView(diffs.slice(0, 1), undefined, { headerMode: 'stats-only' }).map(strip)
+  assert.equal(statsOnly[0], '+2 -1')
+  assert.ok(!statsOnly[0]!.includes('src/foo.ts'))
+  const noHeader = renderDiffView(diffs.slice(0, 1), undefined, { headerMode: 'none' }).map(strip)
+  assert.ok(!noHeader.some(line => line.includes('src/foo.ts')), `body must not repeat path:\n${noHeader.join('\n')}`)
 })
 
 test('renderDiffView shows only new lines for a create and only old lines for a deletion', () => {

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -1642,6 +1642,14 @@ test('the Tool display is presenter-first with a static fallback (plan §9/§43)
       if (name === 'bash') {
         return { card: 'terminal', title: 'pnpm test --filter provider' }
       }
+      if (name === 'edit') {
+        return {
+          card: 'diff',
+          title: 'Edit src/foo.ts',
+          diffs: [{ path: 'src/foo.ts', oldText: 'a', newText: 'b' }],
+          locations: [],
+        }
+      }
       return undefined
     },
     result() { return undefined },
@@ -1650,6 +1658,15 @@ test('the Tool display is presenter-first with a static fallback (plan §9/§43)
   assert.equal(focusToolDisplay({ name: 'skill', args: JSON.stringify({ name: 'session-review' }) }, { presenter }), 'Load skill session-review')
   assert.equal(focusToolDisplay({ name: 'vendor_probe', args: JSON.stringify({ host: 'cache-01' }) }, { presenter }), 'Probe Redis cache-01')
   assert.equal(focusToolDisplay({ name: 'bash', args: JSON.stringify({ command: 'pnpm test --filter provider' }) }, { presenter }), 'pnpm test --filter provider')
+  const editDisplay = focusToolDisplay({ name: 'edit', args: JSON.stringify({ file_path: 'src/foo.ts' }) }, { presenter })
+  assert.equal(editDisplay, 'Edit src/foo.ts')
+  assert.equal(editDisplay.split('src/foo.ts').length - 1, 1, 'the presenter-owned path must appear once')
+  for (const title of ['Edit src/foo.ts\r\ncontinued', 'Edit src/foo.ts\rcontinued']) {
+    const display = focusToolDisplay({ name: 'edit', args: '{}' }, {
+      presenter: { call: () => ({ card: 'diff' as const, title, diffs: [], locations: [] }), result: () => undefined },
+    })
+    assert.equal(display, 'Edit src/foo.ts', `diff title must remain one line: ${JSON.stringify(title)}`)
+  }
   // Fallback (replay / registry unavailable): the same semantic.
   assert.equal(focusToolDisplay({ name: 'skill', args: JSON.stringify({ name: 'session-review' }) }, {}), 'Load skill session-review')
   assert.equal(focusToolDisplay({ name: 'bash', args: JSON.stringify({ command: 'pnpm test --filter provider' }) }, {}), 'Bash pnpm test --filter provider')

--- a/test/focus-ui.test.ts
+++ b/test/focus-ui.test.ts
@@ -147,6 +147,42 @@ function show(app: TuiApp, folder: TranscriptFolder, previews?: readonly Streami
   app.setTranscript(folder.messages(), folder.turnActivities(), undefined, previews)
 }
 
+test('Focus collapsed Edit Tool slot keeps the presenter-owned path once', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: 'old', newText: 'new' }],
+        locations: [],
+      }),
+      result: () => undefined,
+    },
+  })
+  app.start()
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 1 }, T0, 0),
+    eventAt('user/message', {
+      id: MessageId('u-edit'), role: 'user',
+      content: [{ type: 'text', text: 'edit the file' }], source: { kind: 'user' },
+    }, T0 + 1, 1),
+    eventAt('tool/call', {
+      turn: 1, step: 0, callId: ToolCallId('edit-focus'), name: 'edit',
+      arguments: JSON.stringify({ file_path: 'src/foo.ts', old_string: 'old', new_string: 'new' }),
+    }, T0 + 2, 2),
+  ])
+  app.setFocusMode(true)
+  show(app, folder)
+  await vt.waitForRender()
+  const toolLine = vt.getViewport().find(line => line.includes('Tool:')) ?? ''
+  assert.ok(toolLine.includes('Edit src/foo.ts'), `presenter-owned Edit title missing:\n${vt.getViewport().join('\n')}`)
+  assert.equal(toolLine.split('src/foo.ts').length - 1, 1, `Focus Tool path duplicated:\n${toolLine}`)
+  app.stop()
+})
+
 test('Focus ON running: the Thought card is collapsed with previews, the process is hidden, the WorkingIndicator stays', async () => {
   const { vt, app } = startApp()
   const folder = new TranscriptFolder()
@@ -1053,12 +1089,13 @@ test('regular search reveal of a NON-recent root full-reveals its process (no de
 test('regular Focus expanded roots render large diffs in FULL (no mouse, no cap)', async () => {
   const vt = new VirtualTerminal(100, 40)
   const newLines = Array.from({ length: 30 }, (_, i) => `new ${i}`).join('\n')
+  const presenterLines = Array.from({ length: 30 }, (_, i) => `presenter ${i}`).join('\n')
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
     present: {
       call: () => ({
         card: 'diff' as const,
         title: 'Edit src/big.ts',
-        diffs: [{ path: 'src/big.ts', oldText: null, newText: newLines }],
+        diffs: [{ path: 'src/big.ts', oldText: null, newText: presenterLines }],
         locations: [],
       }),
       result: () => undefined,
@@ -1072,7 +1109,7 @@ test('regular Focus expanded roots render large diffs in FULL (no mouse, no cap)
     eventAt('tool/call', {
       turn: 1, step: 0, callId: ToolCallId('cdiff'),
       name: 'edit',
-      arguments: JSON.stringify({ file_path: 'src/big.ts', old_string: 'a\nb\nc', new_string: newLines }),
+      arguments: JSON.stringify({ file_path: 'src/big.ts', old_string: 'new 0', new_string: newLines }),
     }, T0 + 1, 1),
     eventAt('turn/end', { turn: 1, reason: { kind: 'completed' } }, T0 + 2, 2),
   ])
@@ -1088,8 +1125,9 @@ test('regular Focus expanded roots render large diffs in FULL (no mouse, no cap)
   await vt.waitForRender()
   joined = vt.getViewport().join('\n')
   assert.ok(joined.includes('🐳 Thought'), 'the derived root must expand')
-  assert.ok(joined.includes('new 15'), 'the regular Focus expanded root must render the diff in FULL')
-  assert.ok(!joined.includes('more changes hidden'), 'no cap footer in the regular Focus reveal')
+  assert.ok(joined.includes('new 15'), 'the regular Focus expanded root must render the call-time diff in FULL')
+  assert.ok(!joined.includes('presenter 15'), 'the expanded running Edit must not switch to presentCall data')
+   assert.ok(!joined.includes('more changes hidden'), 'no cap footer in the regular Focus reveal')
   app.stop()
 })
 
@@ -1112,7 +1150,7 @@ test('cache identity: Ctrl+O ON caps a large diff, then /focus on FULL-REVEALS t
   const folder = new TranscriptFolder()
   applyMixed(folder, [
     eventAt('turn/start', { turn: 1 }, T0, 0),
-    eventAt('tool/call', { turn: 1, step: 0, callId: ToolCallId('cdiff'), name: 'edit', arguments: JSON.stringify({ file_path: 'src/big.ts', old_string: 'a\nb\nc', new_string: newLines }) }, T0 + 1, 1),
+    eventAt('tool/call', { turn: 1, step: 0, callId: ToolCallId('cdiff'), name: 'edit', arguments: JSON.stringify({ file_path: 'src/big.ts', old_string: 'new 0', new_string: newLines }) }, T0 + 1, 1),
     eventAt('turn/end', { turn: 1, reason: { kind: 'completed' } }, T0 + 2, 2),
   ])
   // Focus OFF + Ctrl+O ON: the ordinary fold expands the card, the diff CAPS.
@@ -1151,7 +1189,7 @@ test('cache identity: /focus off restores the ordinary CAPPED diff presentation 
   const folder = new TranscriptFolder()
   applyMixed(folder, [
     eventAt('turn/start', { turn: 1 }, T0, 0),
-    eventAt('tool/call', { turn: 1, step: 0, callId: ToolCallId('cdiff'), name: 'edit', arguments: JSON.stringify({ file_path: 'src/big.ts', old_string: 'a\nb\nc', new_string: newLines }) }, T0 + 1, 1),
+    eventAt('tool/call', { turn: 1, step: 0, callId: ToolCallId('cdiff'), name: 'edit', arguments: JSON.stringify({ file_path: 'src/big.ts', old_string: 'new 0', new_string: newLines }) }, T0 + 1, 1),
     eventAt('turn/end', { turn: 1, reason: { kind: 'completed' } }, T0 + 2, 2),
   ])
   // Focus ON + Ctrl+O ON: the derived root full-reveals the diff.

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -1549,16 +1549,16 @@ function diffCallArgs(): string {
   return JSON.stringify({ file_path: 'src/foo.ts', old_string: 'a\nb\nc', new_string: 'a\nB\nc' })
 }
 
-function diffCallEvent(seq: number, callId: string): SessionEvent {
+function diffCallEvent(seq: number, callId: string, args = diffCallArgs()): SessionEvent {
   return {
     type: 'tool/call',
     seq: SessionSeq(seq),
     time: 1_700_000_000_000 + seq,
-    data: { turn: 0, step: 0, callId: ToolCallId(callId), name: 'edit', arguments: diffCallArgs() },
+    data: { turn: 0, step: 0, callId: ToolCallId(callId), name: 'edit', arguments: args },
   }
 }
 
-function diffResultEvent(seq: number, callId: string, text: string): SessionEvent {
+function diffResultEvent(seq: number, callId: string, text: string, isError = false): SessionEvent {
   return {
     type: 'tool/result',
     seq: SessionSeq(seq),
@@ -1566,7 +1566,20 @@ function diffResultEvent(seq: number, callId: string, text: string): SessionEven
     data: {
       turn: 0,
       step: 0,
-      message: createToolResultMessage({ callId: ToolCallId(callId), content: [{ type: 'text', text }], isError: false }),
+      message: createToolResultMessage({ callId: ToolCallId(callId), content: [{ type: 'text', text }], isError }),
+    },
+  }
+}
+
+function emptyResultEvent(seq: number, callId: string, isError = false): SessionEvent {
+  return {
+    type: 'tool/result',
+    seq: SessionSeq(seq),
+    time: 1_700_000_000_000 + seq,
+    data: {
+      turn: 0,
+      step: 0,
+      message: createToolResultMessage({ callId: ToolCallId(callId), content: [], isError }),
     },
   }
 }
@@ -1604,7 +1617,7 @@ test('a running edit card renders its call-time diff', async () => {
       call: () => ({
         card: 'diff' as const,
         title: 'Edit src/foo.ts',
-        diffs: [{ path: 'src/foo.ts', oldText: 'a\nb\nc', newText: 'a\nB\nc' }],
+        diffs: [{ path: 'src/foo.ts', oldText: 'PRESENTER_OLD', newText: 'PRESENTER_NEW' }],
         locations: [],
       }),
       result: () => undefined,
@@ -1619,9 +1632,11 @@ test('a running edit card renders its call-time diff', async () => {
   app.setTranscript(folder.messages())
   await vt.waitForRender()
   const view = vt.getViewport().join('\n')
-  assert.ok(view.includes('+1 -1 src/foo.ts'), `diff header missing:\n${view}`)
+  assert.ok(view.includes('Edit src/foo.ts [running]  +1 -1'), `diff stats missing from the card header:\n${view}`)
+  assert.ok(!view.includes('+1 -1 src/foo.ts'), `the Edit body must not repeat its path header:\n${view}`)
   assert.ok(view.includes('- b'), `delete row missing:\n${view}`)
   assert.ok(view.includes('+ B'), `add row missing:\n${view}`)
+  assert.ok(!view.includes('PRESENTER_OLD') && !view.includes('PRESENTER_NEW'), `running Edit must use call-time data:\n${view}`)
   app.stop()
 })
 
@@ -1692,9 +1707,304 @@ test('a completed diff card renders the applied result diffs', async () => {
   app.setTranscript(folder.messages())
   await vt.waitForRender()
   const view = vt.getViewport().join('\n')
-  assert.ok(view.includes('+2 -1 src/foo.ts'), `applied diff header missing:\n${view}`)
+  assert.ok(view.includes('Edit src/foo.ts [ok]  +2 -1'), `applied diff stats missing from the card header:\n${view}`)
+  assert.ok(!view.includes('+2 -1 src/foo.ts'), `the Edit body must not repeat its path header:\n${view}`)
   assert.ok(view.includes('+ Y'), `applied add row missing:\n${view}`)
   assert.ok(!view.includes('updated successfully'), `raw result text must not replace the diff:\n${view}`)
+  app.stop()
+})
+
+test('a settled Edit keeps folded and expanded views on the applied result diff', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const resultOld = ['context before', 'RESULT_OLD', 'context after 1', 'context after 2', 'context after 3'].join('\n')
+  const resultNew = ['context before', 'RESULT_NEW', 'context after 1', 'context after 2', 'context after 3'].join('\n')
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: 'CALL_OLD', newText: 'CALL_NEW' }],
+        locations: [],
+      }),
+      result: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: resultOld, newText: resultNew }],
+        locations: [],
+      }),
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-applied'), diffResultEvent(1, 'call-diff-applied', 'The file src/foo.ts has been updated successfully.')])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(folded.includes('Edit src/foo.ts [ok]  +1 -1'), `folded result stats missing:\n${folded}`)
+  assert.ok(folded.includes('RESULT_OLD') && folded.includes('RESULT_NEW'), `folded card must use applied diff:\n${folded}`)
+  assert.ok(!folded.includes('CALL_OLD') && !folded.includes('CALL_NEW'), `folded card used call-time diff:\n${folded}`)
+  assert.ok(!folded.includes('updated successfully'), `structured success must suppress raw result text:\n${folded}`)
+  assert.equal(folded.split('src/foo.ts').length - 1, 1, `Edit path must belong only to the card header:\n${folded}`)
+  assert.ok(folded.includes('more diff lines hidden'), `folded cap must explain hidden context:\n${folded}`)
+
+  app.setToolOutputExpanded(true)
+  await vt.waitForRender()
+  const expanded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(expanded.includes('Edit src/foo.ts [ok]  +1 -1'), `expanded result stats missing:\n${expanded}`)
+  assert.ok(expanded.includes('RESULT_OLD') && expanded.includes('RESULT_NEW') && expanded.includes('context after 3'), `expanded card must reveal the same applied diff:\n${expanded}`)
+  assert.ok(!expanded.includes('CALL_OLD') && !expanded.includes('CALL_NEW'), `expanded card switched to call-time diff:\n${expanded}`)
+  assert.equal(expanded.split('src/foo.ts').length - 1, 1, `expanded Edit path must appear once:\n${expanded}`)
+  app.stop()
+})
+
+test('a multi-hunk Edit keeps path ownership in the card header', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: 'call-old', newText: 'call-new' }],
+        locations: [],
+      }),
+      result: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [
+          { path: 'src/foo.ts', oldText: 'first-old', newText: 'first-new' },
+          { path: 'src/foo.ts', oldText: 'second-old', newText: 'second-new' },
+        ],
+        locations: [],
+      }),
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  app.setToolOutputExpanded(true)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-multi'), diffResultEvent(1, 'call-diff-multi', 'The file src/foo.ts has been updated successfully.')])
+  app.setTranscript(folder.messages())
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const view = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(view.includes('Edit src/foo.ts [ok]  +2 -2'), `aggregate stats missing:\n${view}`)
+  assert.ok((view.match(/\+1 -1/g) ?? []).length >= 2, `multi-hunk stats-only separators missing:\n${view}`)
+  assert.equal(view.split('src/foo.ts').length - 1, 1, `multi-hunk Edit path must appear once:\n${view}`)
+  assert.ok(!view.includes('+1 -1 src/foo.ts'), `multi-hunk body must not repeat the path:\n${view}`)
+  app.stop()
+})
+
+test('narrow Edit headers preserve status across running, success, and error states', async () => {
+  const vt = new VirtualTerminal(24, 24)
+  const args = JSON.stringify({
+    file_path: 'src/very-long-file-name.ts',
+    old_string: 'old',
+    new_string: 'new',
+  })
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/very-long-file-name.ts',
+        diffs: [{ path: 'src/very-long-file-name.ts', oldText: 'old', newText: 'new' }],
+        locations: [],
+      }),
+      result: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/very-long-file-name.ts',
+        diffs: [{ path: 'src/very-long-file-name.ts', oldText: 'old', newText: 'new' }],
+        locations: [],
+      }),
+    },
+  })
+  app.start()
+  startedApps.add(app)
+  app.setToolOutputExpanded(true)
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const assertHeaderStatus = async (expected: string, events: SessionEvent[]): Promise<void> => {
+    const folder = new TranscriptFolder()
+    folder.apply(events)
+    app.setTranscript(folder.messages())
+    await vt.waitForRender()
+    const rows = vt.getViewport().map(stripAnsi)
+    const header = rows.find(line => line.includes('Edit')) ?? ''
+    assert.ok(header.includes(expected), `operation/path/status must stay on one header row:\n${rows.join('\n')}`)
+    assert.equal(rows.filter(line => line.includes('Edit')).length, 1, `Edit header wrapped unexpectedly:\n${rows.join('\n')}`)
+  }
+
+  await assertHeaderStatus('[running]', [diffCallEvent(0, 'call-diff-narrow', args)])
+  await assertHeaderStatus('[ok]', [diffCallEvent(2, 'call-diff-narrow-ok', args), diffResultEvent(3, 'call-diff-narrow-ok', 'done')])
+  await assertHeaderStatus('[error]', [diffCallEvent(4, 'call-diff-narrow-error', args), diffResultEvent(5, 'call-diff-narrow-error', 'failed', true)])
+  app.stop()
+})
+
+test('a successful Edit with a non-diff result view falls back consistently', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const args = JSON.stringify({ file_path: 'src/foo.ts', old_string: 'CALL_OLD', new_string: 'CALL_NEW' })
+  const resultErrors: boolean[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: 'CALL_OLD', newText: 'CALL_NEW' }],
+        locations: [],
+      }),
+      result: (_name, _args, result) => {
+        resultErrors.push(result.isError)
+        return { card: 'generic' as const, title: 'Not an applied diff', content: [{ type: 'text', text: 'GENERIC_RESULT' }] }
+      },
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-generic', args), diffResultEvent(1, 'call-diff-generic', 'raw result')])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(folded.includes('CALL_OLD') && folded.includes('CALL_NEW'), `folded fallback diff missing:\n${folded}`)
+  assert.ok(!folded.includes('GENERIC_RESULT'), `folded card must not use a non-diff result view:\n${folded}`)
+
+  app.setToolOutputExpanded(true)
+  await vt.waitForRender()
+  const expanded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(expanded.includes('CALL_OLD') && expanded.includes('CALL_NEW'), `expanded fallback diff missing:\n${expanded}`)
+  assert.ok(!expanded.includes('GENERIC_RESULT'), `expanded card switched to a non-diff result view:\n${expanded}`)
+  assert.deepEqual(resultErrors, [false, false], 'each folded/expanded rebuild resolves the successful result without an error flag')
+  app.stop()
+})
+
+test('metadata-only successful Edit results render in folded and expanded views', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const args = JSON.stringify({ file_path: 'src/foo.ts', old_string: 'CALL_OLD', new_string: 'CALL_NEW' })
+  const resultErrors: boolean[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => undefined,
+      result: (_name, _args, result) => {
+        resultErrors.push(result.isError)
+        return {
+          card: 'diff' as const,
+          title: 'Edit src/foo.ts',
+          diffs: [{ path: 'src/foo.ts', oldText: 'RESULT_OLD', newText: 'RESULT_NEW' }],
+          locations: [],
+        }
+      },
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-empty-success', args), emptyResultEvent(1, 'call-diff-empty-success')])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(folded.includes('RESULT_OLD') && folded.includes('RESULT_NEW'), `folded metadata diff missing:\n${folded}`)
+  assert.ok(!folded.includes('CALL_OLD') && !folded.includes('CALL_NEW'), `folded view used call data over structured result:\n${folded}`)
+
+  app.setToolOutputExpanded(true)
+  await vt.waitForRender()
+  const expanded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(expanded.includes('RESULT_OLD') && expanded.includes('RESULT_NEW'), `expanded metadata diff missing:\n${expanded}`)
+  assert.ok(!expanded.includes('CALL_OLD') && !expanded.includes('CALL_NEW'), `expanded view lost the structured result diff:\n${expanded}`)
+  assert.deepEqual(resultErrors, [false, false], 'metadata-only success remains non-error in both views')
+  app.stop()
+})
+
+test('metadata-only error Edit results stay error and use the attempted call diff', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const args = JSON.stringify({ file_path: 'src/foo.ts', old_string: 'CALL_OLD', new_string: 'CALL_NEW' })
+  const resultErrors: boolean[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: 'CALL_OLD', newText: 'CALL_NEW' }],
+        locations: [],
+      }),
+      result: (_name, _args, result) => {
+        resultErrors.push(result.isError)
+        return {
+          card: 'diff' as const,
+          title: 'Edit src/foo.ts',
+          diffs: [{ path: 'src/foo.ts', oldText: 'RESULT_OLD', newText: 'RESULT_NEW' }],
+          locations: [],
+        }
+      },
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-empty-error', args), emptyResultEvent(1, 'call-diff-empty-error', true)])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(folded.includes('Edit src/foo.ts [error]'), `folded error identity missing:\n${folded}`)
+  assert.ok(folded.includes('CALL_OLD') && folded.includes('CALL_NEW'), `folded attempted diff missing:\n${folded}`)
+  assert.ok(!folded.includes('RESULT_OLD') && !folded.includes('RESULT_NEW'), `folded error used applied data:\n${folded}`)
+  assert.ok(!folded.includes('+1 -1'), `folded error fabricated success stats:\n${folded}`)
+
+  app.setToolOutputExpanded(true)
+  await vt.waitForRender()
+  const expanded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(expanded.includes('Edit src/foo.ts [error]'), `expanded error identity missing:\n${expanded}`)
+  assert.ok(expanded.includes('CALL_OLD') && expanded.includes('CALL_NEW'), `expanded attempted diff missing:\n${expanded}`)
+  assert.ok(!expanded.includes('RESULT_OLD') && !expanded.includes('RESULT_NEW'), `expanded error used applied data:\n${expanded}`)
+  assert.deepEqual(resultErrors, [true], 'expanded error forwards isError to the presenter')
+  app.stop()
+})
+
+test('malformed Edit args never substitute presenter call diffs', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  let callCount = 0
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => {
+        callCount += 1
+        return {
+          card: 'diff' as const,
+          title: 'Edit src/presenter-only.ts',
+          diffs: [{ path: 'src/presenter-only.ts', oldText: 'PRESENTER_OLD', newText: 'PRESENTER_NEW' }],
+          locations: [],
+        }
+      },
+      result: () => undefined,
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-malformed-edit', '{not-json'), diffResultEvent(1, 'call-malformed-edit', 'unstructured result')])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(!folded.includes('PRESENTER_OLD') && !folded.includes('PRESENTER_NEW'), `folded malformed Edit used presenter call data:\n${folded}`)
+
+  app.setToolOutputExpanded(true)
+  await vt.waitForRender()
+  const expanded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(!expanded.includes('PRESENTER_OLD') && !expanded.includes('PRESENTER_NEW'), `expanded malformed Edit used presenter call data:\n${expanded}`)
+  assert.equal(callCount, 0, 'malformed Edit args must not invoke a presenter call diff fallback')
   app.stop()
 })
 
@@ -1720,20 +2030,68 @@ test('a completed diff card without a result view falls back to the call-time di
   app.setTranscript(folder.messages())
   await vt.waitForRender()
   const view = vt.getViewport().join('\n')
-  assert.ok(view.includes('+1 -1 src/foo.ts'), `call diff header missing:\n${view}`)
+  assert.ok(view.includes('Edit src/foo.ts [ok]  +1 -1'), `call diff stats missing from the card header:\n${view}`)
+  assert.ok(!view.includes('+1 -1 src/foo.ts'), `the Edit body must not repeat its path header:\n${view}`)
   assert.ok(!view.includes('updated successfully'), `raw result text must not replace the diff:\n${view}`)
+  app.stop()
+})
+
+test('an error Edit stays an error and never renders an applied result diff', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const args = JSON.stringify({ file_path: 'src/foo.ts', old_string: 'CALL_OLD', new_string: 'CALL_NEW' })
+  const resultErrors: boolean[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: 'CALL_OLD', newText: 'CALL_NEW' }],
+        locations: [],
+      }),
+      result: (_name, _args, result) => {
+        resultErrors.push(result.isError)
+        return {
+          card: 'diff' as const,
+          title: 'Edit src/foo.ts',
+          diffs: [{ path: 'src/foo.ts', oldText: 'RESULT_OLD', newText: 'RESULT_NEW' }],
+          locations: [],
+        }
+      },
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-error', args), diffResultEvent(1, 'call-diff-error', 'edit failed', true)])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(folded.includes('Edit src/foo.ts [error]'), `error identity missing:\n${folded}`)
+  assert.ok(folded.includes('CALL_OLD') && folded.includes('CALL_NEW'), `error card should show the attempted call diff:\n${folded}`)
+  assert.ok(!folded.includes('RESULT_OLD') && !folded.includes('RESULT_NEW'), `error card must not show an applied result diff:\n${folded}`)
+  assert.ok(!folded.includes('+1 -1'), `error card must not fabricate success stats:\n${folded}`)
+
+  app.setToolOutputExpanded(true)
+  await vt.waitForRender()
+  const expanded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(expanded.includes('Edit src/foo.ts [error]'), `expanded error identity missing:\n${expanded}`)
+  assert.ok(expanded.includes('CALL_OLD') && expanded.includes('CALL_NEW'), `expanded error card switched diff source:\n${expanded}`)
+  assert.ok(!expanded.includes('RESULT_OLD') && !expanded.includes('RESULT_NEW'), `expanded error card rendered applied data:\n${expanded}`)
+  assert.deepEqual(resultErrors, [true], 'expanded error rendering preserves isError')
   app.stop()
 })
 
 test('a big diff card caps in the default view with an expand hint', async () => {
   const vt = new VirtualTerminal(100, 40)
-  const oldLines = Array.from({ length: 30 }, (_, i) => `old ${i}`).join('\n')
   const newLines = Array.from({ length: 30 }, (_, i) => `new ${i}`).join('\n')
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
     present: {
       call: () => ({
         card: 'diff' as const,
-        title: 'Write src/big.ts',
+        title: 'Edit src/big.ts',
         diffs: [{ path: 'src/big.ts', oldText: null, newText: newLines }],
         locations: [],
       }),
@@ -1745,11 +2103,23 @@ test('a big diff card caps in the default view with an expand hint', async () =>
   startedApps.add(app)
   app.setToolOutputExpanded(true)
   const folder = new TranscriptFolder()
-  folder.apply([diffCallEvent(0, 'call-diff-4')])
+  folder.apply([{
+    type: 'tool/call',
+    seq: SessionSeq(0),
+    time: 1_700_000_000_000,
+    data: {
+      turn: 0,
+      step: 0,
+      callId: ToolCallId('call-diff-4'),
+      name: 'edit',
+      arguments: JSON.stringify({ file_path: 'src/big.ts', old_string: '', new_string: newLines }),
+    },
+  }])
   app.setTranscript(folder.messages())
   await vt.waitForRender()
   const view = vt.getViewport().join('\n')
-  assert.ok(view.includes('+30 src/big.ts'), `create header missing:\n${view}`)
+  assert.ok(view.includes('Edit src/big.ts [running]  +30'), `create stats missing from the card header:\n${view}`)
+  assert.ok(!view.includes('+30 src/big.ts'), `the Edit body must not repeat its path header:\n${view}`)
   assert.ok(view.includes('more changes hidden (click to expand)'), `cap footer missing:\n${view}`)
   app.stop()
 })

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -1833,6 +1833,42 @@ test('a multi-hunk Edit keeps path ownership in the card header', async () => {
   app.stop()
 })
 
+test('expanded Edit headers reflow with terminal width changes', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const args = JSON.stringify({ file_path: 'src/very-long-file-name.ts', old_string: 'old', new_string: 'new' })
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => undefined,
+      result: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/very-long-file-name.ts',
+        diffs: [{ path: 'src/very-long-file-name.ts', oldText: 'old', newText: 'new' }],
+        locations: [],
+      }),
+    },
+  })
+  app.start()
+  startedApps.add(app)
+  app.setToolOutputExpanded(true)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-resize', args), diffResultEvent(1, 'call-diff-resize', 'done')])
+  app.setTranscript(folder.messages())
+  await vt.waitForRender()
+
+  vt.resize(24, 24)
+  await vt.waitForRender()
+  const narrowRows = vt.getViewport()
+  const narrowHeader = narrowRows.find(line => line.includes('Edit') && line.includes('[ok]')) ?? ''
+  assert.notEqual(narrowHeader, '', `expanded Edit header lost status after narrowing:\n${narrowRows.join('\\n')}`)
+
+  vt.resize(100, 24)
+  await vt.waitForRender()
+  const wideRows = vt.getViewport()
+  const wideHeader = wideRows.find(line => line.includes('Edit')) ?? ''
+  assert.ok(wideHeader.includes('src/very-long-file-name.ts') && wideHeader.includes('[ok]'), `expanded Edit header did not recover at wide width:\n${wideRows.join('\\n')}`)
+  app.stop()
+})
+
 test('narrow Edit headers preserve status across running, success, and error states', async () => {
   const vt = new VirtualTerminal(24, 24)
   const args = JSON.stringify({
@@ -2134,6 +2170,46 @@ test('an error Edit stays an error and never renders an applied result diff', as
   assert.ok(expanded.includes('CALL_OLD') && expanded.includes('CALL_NEW'), `expanded error card switched diff source:\n${expanded}`)
   assert.ok(!expanded.includes('RESULT_OLD') && !expanded.includes('RESULT_NEW'), `expanded error card rendered applied data:\n${expanded}`)
   assert.deepEqual(resultErrors, [true], 'expanded error rendering preserves isError')
+  app.stop()
+})
+
+test('an error Edit ignores non-diff result views and keeps the call diff', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const args = JSON.stringify({ file_path: 'src/foo.ts', old_string: 'CALL_OLD', new_string: 'CALL_NEW' })
+  const resultErrors: boolean[] = []
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: [{ path: 'src/foo.ts', oldText: 'CALL_OLD', newText: 'CALL_NEW' }],
+        locations: [],
+      }),
+      result: (_name, _args, result) => {
+        resultErrors.push(result.isError)
+        return { card: 'generic' as const, title: 'Failed Edit', content: [{ type: 'text', text: 'RESULT_GENERIC' }] }
+      },
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-error-generic', args), diffResultEvent(1, 'call-diff-error-generic', 'edit failed', true)])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(folded.includes('CALL_OLD') && folded.includes('CALL_NEW'), `folded attempted diff missing:\n${folded}`)
+  assert.ok(!folded.includes('RESULT_GENERIC'), `folded error should not show result content:\n${folded}`)
+
+  app.setToolOutputExpanded(true)
+  await vt.waitForRender()
+  const expanded = stripAnsi(vt.getViewport().join('\n'))
+  assert.ok(expanded.includes('CALL_OLD') && expanded.includes('CALL_NEW'), `expanded attempted diff missing:\n${expanded}`)
+  assert.ok(!expanded.includes('RESULT_GENERIC'), `expanded error must not use a non-diff result view:\n${expanded}`)
+  assert.deepEqual(resultErrors, [true], 'expanded error forwards isError to the presenter')
   app.stop()
 })
 

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -1761,6 +1761,40 @@ test('a settled Edit keeps folded and expanded views on the applied result diff'
   app.stop()
 })
 
+test('a folded settled Edit caps the result diff across all hunks', async () => {
+  const vt = new VirtualTerminal(100, 40)
+  const resultDiffs = Array.from({ length: 8 }, (_, index) => ({
+    path: 'src/foo.ts',
+    oldText: `old-${index}`,
+    newText: `new-${index}`,
+  }))
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
+    present: {
+      call: () => undefined,
+      result: () => ({
+        card: 'diff' as const,
+        title: 'Edit src/foo.ts',
+        diffs: resultDiffs,
+        locations: [],
+      }),
+    },
+  })
+  app.start()
+
+  startedApps.add(app)
+  const folder = new TranscriptFolder()
+  folder.apply([diffCallEvent(0, 'call-diff-folded-hunks'), diffResultEvent(1, 'call-diff-folded-hunks', 'updated')])
+  app.setTranscript(folder.messages())
+  app.setToolOutputExpanded(false)
+  await vt.waitForRender()
+  const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '')
+  const folded = stripAnsi(vt.getViewport().join('\n'))
+  const changedRows = folded.split('\n').filter(line => /(?:old|new)-\d+/.test(line))
+  assert.equal(changedRows.length, 4, `folded result body must share one global four-row budget:\n${folded}`)
+  assert.ok(folded.includes('more changes hidden'), `folded multi-hunk result must show an omission marker:\n${folded}`)
+  app.stop()
+})
+
 test('a multi-hunk Edit keeps path ownership in the card header', async () => {
   const vt = new VirtualTerminal(100, 24)
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, {
@@ -1840,6 +1874,25 @@ test('narrow Edit headers preserve status across running, success, and error sta
   await assertHeaderStatus('[running]', [diffCallEvent(0, 'call-diff-narrow', args)])
   await assertHeaderStatus('[ok]', [diffCallEvent(2, 'call-diff-narrow-ok', args), diffResultEvent(3, 'call-diff-narrow-ok', 'done')])
   await assertHeaderStatus('[error]', [diffCallEvent(4, 'call-diff-narrow-error', args), diffResultEvent(5, 'call-diff-narrow-error', 'failed', true)])
+  app.stop()
+})
+
+test('expanded non-Edit headers retain full wrapped descriptions', async () => {
+  const vt = new VirtualTerminal(28, 24)
+  const pattern = 'needle-that-must-wrap-12345'
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+
+  startedApps.add(app)
+  app.setToolOutputExpanded(true)
+  app.setTranscript([{
+    kind: 'tool', turn: 0, name: 'grep',
+    args: JSON.stringify({ pattern, path: 'src' }),
+    result: 'match', status: 'ok', resultBlocks: [],
+  }])
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.replace(/\n/g, '').includes(pattern), `non-Edit expanded header must wrap instead of truncating:\n${view}`)
   app.stop()
 })
 


### PR DESCRIPTION
## Summary
- Keep Focus Edit titles presenter-owned and avoid duplicate paths.
- Unify running, settled, replay, error, and metadata-only Edit diff sources across folded and expanded views.
- Add explicit diff header modes, shared stats, visible truncation markers, and narrow-header handling.

## Validation
- Targeted interaction tests: 295 passed
- `pnpm test:product`: 3557 passed
- `pnpm test`
- `pnpm typecheck:bundle`
- `pnpm build`
- `node scripts/client-boundary-gate.mjs`
- `git diff --check`
- review-fix-loop: accepted with no findings