### PR TITLE
fix: show full file-completion paths and marquee selected rows

### DIFF
--- a/packages/pi-tui/DIVERGENCES.md
+++ b/packages/pi-tui/DIVERGENCES.md
@@ -3540,31 +3540,33 @@ Fullscreen host routing must register before the viewport listener so raw captur
 - Category: `HARD_HOST_API`
 - Risk: `HIGH`
 - Files: `src/components/editor.ts`
-- Last audited: `2026-09-03`
+- Last audited: `2026-09-06`
 - Baseline compared: `earendil-works/pi@b79e4cc834970cca69daebffab7df1da7d1e52c4`
 
 #### Why it exists
 
-The host TuiEditor subclass needs to drive explicit/context-gated completion and stale-dropdown cancellation through a supported protected seam rather than unsafe casts to private methods.
+The host TuiEditor subclass needs to drive explicit/context-gated completion, stale-dropdown cancellation, and context-specific SelectList layout through supported protected seams rather than unsafe casts to private methods or private autocomplete state.
 
 #### Changed surface
 
 - requestAutocomplete visibility private -> protected
 - cancelAutocomplete visibility private -> protected
+- getAutocompleteSelectListLayout protected layout decision hook
 
 #### Dependency map
 
 **Vendor internal**
-- Editor completion state, request/cancel methods, provider callbacks, and dropdown lifecycle are coupled.
-- Audit note: Visibility is the only local code change; behavior remains vendor-owned.
+- Editor completion state, request/cancel methods, provider callbacks, dropdown lifecycle, and SelectList construction are coupled.
+- Audit note: Visibility and the layout decision hook are the only local code changes; behavior remains vendor-owned.
 
 **Inheritance / structural**
-- src/tui-editor.ts subclass calls requestAutocomplete/cancelAutocomplete through protected access.
+- src/tui-editor.ts subclass calls requestAutocomplete/cancelAutocomplete/getAutocompleteSelectListLayout through protected access.
 - Audit note: This is the explicit structural audit target.
 
 **Host**
-- src/tui-editor.ts eight former cast sites for completion gating and cancellation
-- Audit note: The host no longer depends on a private implementation cast.
+- src/tui-editor.ts explicit/context-gated completion and file-completion layout selection
+- host active-screen repaint route for SelectedMarquee timer callbacks
+- Audit note: The host no longer depends on private implementation casts or private autocomplete state.
 
 **Public / extension**
 - Host editor adapter and subclass compatibility surface.
@@ -3573,14 +3575,17 @@ The host TuiEditor subclass needs to drive explicit/context-gated completion and
 **Behavioral coupling**
 - explicit completion uses the same request state
 - stale dropdown cancellation stays synchronized with Editor input
+- default slash-command layout remains unchanged
+- file contexts use a single full-path layout with selected-row marquee while other autocomplete contexts keep their existing layout
 - upstream signature changes fail at typecheck instead of silently at runtime
-- Audit note: A public wrapper or cast would change the supported structural contract.
+- Audit note: A public wrapper, private-state adapter, or inline host layout decision would change the supported structural contract.
 
 #### Guarding tests
 
 - packages/pi-tui/test/protected-autocomplete-compile.ts: compile-only host subclass contract
 - packages/pi-tui/test/editor.test.ts: no-provider protected seam
 - test/advanced-editor.test.ts and editor autocomplete integration
+- test/autocomplete-marquee-active-screen.test.ts: file marquee context and active-screen timer routing
 
 #### Upstream comparison
 
@@ -3591,12 +3596,12 @@ The host TuiEditor subclass needs to drive explicit/context-gated completion and
 - packages/tui/src/components/editor.ts
 - Relevant issues/PRs:
 - None recorded; issue/PR state was not used as semantic proof.
-- Remaining semantic delta: Both the pinned baseline and the audited upstream reference keep both methods private; the host subclass cannot express its supported completion control without the visibility divergence.
+- Remaining semantic delta: The pinned baseline and audited upstream reference keep requestAutocomplete and cancelAutocomplete private. Neither upstream version exposes getAutocompleteSelectListLayout; the slash layout decision remains inline in createAutocompleteList, so the host needs an additive protected layout hook alongside the visibility divergence.
 
 #### Retirement conditions
 
-- Upstream must expose a protected or equivalent subclass-safe completion seam with compatible request/cancel lifecycle.
-- Run subclass typecheck and stale-dropdown/autocomplete tests before changing visibility.
+- Upstream must expose protected or equivalent subclass-safe completion request/cancel lifecycle and context-specific layout decision seams with compatible semantics.
+- Run subclass typecheck, stale-dropdown/autocomplete, and layout-hook tests before changing visibility or retiring this record.
 
 #### Replacement mapping
 
@@ -3609,7 +3614,7 @@ The host TuiEditor subclass needs to drive explicit/context-gated completion and
 #### Audit record
 
 - Scope: `vendor-internal`, `inheritance-structural`, `host`, `public-extension`, `behavioral`, `tests`
-- Notes: Confirmed the subclass edge and kept the seam; audited upstream reference private visibility is not semantically equivalent.
+- Notes: Confirmed the subclass edge and kept the request/cancel and layout seams; audited upstream reference has private request/cancel methods and no layout hook (inline slash layout), so it is not semantically equivalent.
 
 ### X045 — Editor expanded-cursor mapping getExpandedCursor
 

--- a/packages/pi-tui/src/components/editor.ts
+++ b/packages/pi-tui/src/components/editor.ts
@@ -2452,11 +2452,20 @@ export class Editor implements Component, Focusable {
 		return firstPrefixIndex;
 	}
 
+	/**
+	 * Select the layout for an autocomplete list. PROTECTED (dsh-pi-tui
+	 * divergence X044): host editor subclasses can provide a context-specific
+	 * layout without reaching private autocomplete state.
+	 */
+	protected getAutocompleteSelectListLayout(prefix: string): SelectListLayoutOptions | undefined {
+		return prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
+	}
+
 	private createAutocompleteList(
 		prefix: string,
 		items: Array<{ value: string; label: string; description?: string }>,
 	): SelectList {
-		const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
+		const layout = this.getAutocompleteSelectListLayout(prefix);
 		return new SelectList(items, this.autocompleteMaxVisible, this.theme.selectList, layout);
 	}
 

--- a/packages/pi-tui/test/editor.test.ts
+++ b/packages/pi-tui/test/editor.test.ts
@@ -4899,12 +4899,20 @@ describe("protected autocomplete seam (X044)", () => {
 			exposedRequest(): void {
 				this.requestAutocomplete({ force: true, explicitTab: true });
 			}
+			exposedLayout(prefix: string) {
+				return this.getAutocompleteSelectListLayout(prefix);
+			}
 		}
 		const sub = new SubEditor(createTestTUI(), defaultEditorTheme);
 		// No provider: request must be a safe no-op, cancel must not throw
 		sub.exposedRequest();
 		sub.exposedCancel();
 		assert.strictEqual(sub.isShowingAutocomplete(), false);
+		assert.deepStrictEqual(sub.exposedLayout('/im'), {
+			minPrimaryColumnWidth: 12,
+			maxPrimaryColumnWidth: 32,
+		}, 'slash-command layout remains the default hook behavior');
+		assert.strictEqual(sub.exposedLayout('@path'), undefined, 'non-slash prefixes keep the default layout');
 		assert.ok(editor instanceof Editor);
 	});
 });

--- a/packages/pi-tui/test/protected-autocomplete-compile.ts
+++ b/packages/pi-tui/test/protected-autocomplete-compile.ts
@@ -1,4 +1,5 @@
 import { Editor } from "../src/components/editor.ts";
+import type { SelectListLayoutOptions } from "../src/components/select-list.ts";
 
 /** Compile-only contract fixture for host editor subclasses (X044). */
 class HostEditor extends Editor {
@@ -8,6 +9,10 @@ class HostEditor extends Editor {
 
 	requestFromHost(): void {
 		this.requestAutocomplete({ force: true, explicitTab: true });
+	}
+
+	layoutFromHost(prefix: string): SelectListLayoutOptions | undefined {
+		return this.getAutocompleteSelectListLayout(prefix);
 	}
 }
 

--- a/packages/pi-tui/vendor-divergences.json
+++ b/packages/pi-tui/vendor-divergences.json
@@ -1563,32 +1563,32 @@
       "category": ["HARD_HOST_API"],
       "risk": "HIGH",
       "files": ["src/components/editor.ts"],
-      "why": "The host TuiEditor subclass needs to drive explicit/context-gated completion and stale-dropdown cancellation through a supported protected seam rather than unsafe casts to private methods.",
-      "changedSurface": ["requestAutocomplete visibility private -> protected", "cancelAutocomplete visibility private -> protected"],
+      "why": "The host TuiEditor subclass needs to drive explicit/context-gated completion, stale-dropdown cancellation, and context-specific SelectList layout through supported protected seams rather than unsafe casts to private methods or private autocomplete state.",
+      "changedSurface": ["requestAutocomplete visibility private -> protected", "cancelAutocomplete visibility private -> protected", "getAutocompleteSelectListLayout protected layout decision hook"],
       "dependencies": {
-        "vendorInternal": {"audited": true, "items": ["Editor completion state, request/cancel methods, provider callbacks, and dropdown lifecycle are coupled."], "notes": "Visibility is the only local code change; behavior remains vendor-owned."},
-        "inheritanceStructural": {"audited": true, "items": ["src/tui-editor.ts subclass calls requestAutocomplete/cancelAutocomplete through protected access."], "notes": "This is the explicit structural audit target."},
-        "host": {"audited": true, "items": ["src/tui-editor.ts eight former cast sites for completion gating and cancellation"], "notes": "The host no longer depends on a private implementation cast."},
+        "vendorInternal": {"audited": true, "items": ["Editor completion state, request/cancel methods, provider callbacks, dropdown lifecycle, and SelectList construction are coupled."], "notes": "Visibility and the layout decision hook are the only local code changes; behavior remains vendor-owned."},
+        "inheritanceStructural": {"audited": true, "items": ["src/tui-editor.ts subclass calls requestAutocomplete/cancelAutocomplete/getAutocompleteSelectListLayout through protected access."], "notes": "This is the explicit structural audit target."},
+        "host": {"audited": true, "items": ["src/tui-editor.ts explicit/context-gated completion and file-completion layout selection", "host active-screen repaint route for SelectedMarquee timer callbacks"], "notes": "The host no longer depends on private implementation casts or private autocomplete state."},
         "publicExtension": {"audited": true, "items": ["Host editor adapter and subclass compatibility surface."], "notes": "Protected is intentionally not a root public method for unrelated consumers."},
-        "behavioral": {"audited": true, "items": ["explicit completion uses the same request state", "stale dropdown cancellation stays synchronized with Editor input", "upstream signature changes fail at typecheck instead of silently at runtime"], "notes": "A public wrapper or cast would change the supported structural contract."}
+        "behavioral": {"audited": true, "items": ["explicit completion uses the same request state", "stale dropdown cancellation stays synchronized with Editor input", "default slash-command layout remains unchanged", "file contexts use a single full-path layout with selected-row marquee while other autocomplete contexts keep their existing layout", "upstream signature changes fail at typecheck instead of silently at runtime"], "notes": "A public wrapper, private-state adapter, or inline host layout decision would change the supported structural contract."}
       },
-      "tests": ["packages/pi-tui/test/protected-autocomplete-compile.ts: compile-only host subclass contract", "packages/pi-tui/test/editor.test.ts: no-provider protected seam", "test/advanced-editor.test.ts and editor autocomplete integration"],
+      "tests": ["packages/pi-tui/test/protected-autocomplete-compile.ts: compile-only host subclass contract", "packages/pi-tui/test/editor.test.ts: no-provider protected seam", "test/advanced-editor.test.ts and editor autocomplete integration", "test/autocomplete-marquee-active-screen.test.ts: file marquee context and active-screen timer routing"],
       "upstream": {
         "equivalence": "NO",
         "checkedAgainst": {"repo": "earendil-works/pi", "baselineRef": "b79e4cc834970cca69daebffab7df1da7d1e52c4", "referenceRef": "b8b873b9872db04a938fb4357b5e8e824ddc051c"},
         "relevantFiles": ["packages/tui/src/components/editor.ts"],
         "relevantIssues": [],
-        "semanticDelta": "Both the pinned baseline and the audited upstream reference keep both methods private; the host subclass cannot express its supported completion control without the visibility divergence."
+        "semanticDelta": "The pinned baseline and audited upstream reference keep requestAutocomplete and cancelAutocomplete private. Neither upstream version exposes getAutocompleteSelectListLayout; the slash layout decision remains inline in createAutocompleteList, so the host needs an additive protected layout hook alongside the visibility divergence."
       },
       "retirement": {
-        "conditions": ["Upstream must expose a protected or equivalent subclass-safe completion seam with compatible request/cancel lifecycle.", "Run subclass typecheck and stale-dropdown/autocomplete tests before changing visibility."],
+        "conditions": ["Upstream must expose protected or equivalent subclass-safe completion request/cancel lifecycle and context-specific layout decision seams with compatible semantics.", "Run subclass typecheck, stale-dropdown/autocomplete, and layout-hook tests before changing visibility or retiring this record."],
         "replacementMapping": [],
         "evidence": []
       },
       "audit": {
-        "lastAuditedAt": "2026-09-03",
+        "lastAuditedAt": "2026-09-06",
         "scope": ["vendor-internal", "inheritance-structural", "host", "public-extension", "behavioral", "tests"],
-        "notes": "Confirmed the subclass edge and kept the seam; audited upstream reference private visibility is not semantically equivalent."
+        "notes": "Confirmed the subclass edge and kept the request/cancel and layout seams; audited upstream reference has private request/cancel methods and no layout hook (inline slash layout), so it is not semantically equivalent."
       }
     },
     "X045": {

--- a/src/file-completion/presentation.ts
+++ b/src/file-completion/presentation.ts
@@ -1,9 +1,9 @@
 /**
  * The shared path presentation (plan §8): how one path-only candidate
- * becomes an `AutocompleteItem`. The `@` mention shape and the `/image`
- * argument shape differ ONLY in the value prefix (`@` + quoting vs bare)
- * — the path math (trailing `/` for continuation, quoting, labels,
- * descriptions) is shared.
+ * becomes an `AutocompleteItem`. The `@` mention shape and the `/attach` +
+ * `/image` argument shapes differ ONLY in the value prefix (`@` + quoting vs
+ * bare) — the path math (trailing `/` for continuation, quoting, and labels)
+ * is shared.
  *
  * The SOURCE is responsible for reattaching the query's display base
  * (see {@link displayPathOf}): candidates reach this layer as FINAL
@@ -13,7 +13,7 @@
  */
 
 import type { AutocompleteItem } from '@xmoon76/pi-tui'
-import { basenameOfPath, type PathCandidate, type PathCompletionQuery } from './types.ts'
+import type { PathCandidate, PathCompletionQuery } from './types.ts'
 
 /** The joined display path for one candidate under a scoped query: the
  * display base (already in the user's own dialect, always ending with the
@@ -51,7 +51,7 @@ export function presentPathCandidate(
     // The vendored SelectList uses the slash marker to recognize a directory
     // item during apply. The accepted VALUE carries the user's actual
     // separator; keep this UI marker stable across path dialects.
-    label: `${basenameOfPath(candidate.path)}${candidate.kind === 'directory' ? '/' : ''}`,
-    description: displayPath,
+    label: `${displayPath}${candidate.kind === 'directory' ? '/' : ''}`,
+    description: undefined,
   }
 }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -3294,6 +3294,9 @@ export class TuiApp {
     // capability a plugin editor captured (replaceText, dispatch,
     // subscribe, invalidate) becomes inert; a late plugin callback can no
     // longer mutate the seat or dispatch a real submission.
+    // The seat holder is non-owning for the permanent host editor, so final
+    // surface teardown closes host-only resources explicitly here.
+    this.editor.disposeHostResources()
     this.editorSeatHolder.dispose()
     // Re-vendor lifecycle follow-up P3 (review-loop round 2): release the
     // process slot ONLY after the completed final teardown — the

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -202,6 +202,13 @@ export class TuiEditor extends Editor {
     return this.inputMode
   }
 
+  /** Dispose resources owned by the permanent host editor at final surface
+   * teardown. EditorSeatHolder is deliberately non-owning: plugin editor
+   * handoffs must never dispose this host editor. */
+  disposeHostResources(): void {
+    this.fileCompletionMarquee.dispose()
+  }
+
   /** Close any open autocomplete dropdown and abort any pending completion
    * request (the host-owned stale-context guard — the declined-key
    * fallback cancels when the staged document differs from the host's

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -4,8 +4,9 @@
  * stays pristine). After every handled key, if the cursor sits on an
  * `@dir/` mention with the autocomplete closed, re-trigger completion so
  * Tab-accepting a directory immediately shows its children (kimi's
- * reopenAutocompleteAfterInput). Esc while autocomplete is active closes
- * it WITHOUT re-triggering (kimi parity).
+ * reopenAutocompleteAfterInput). The same path-argument behavior covers
+ * `/attach` and `/image`. Esc while autocomplete is active closes it WITHOUT
+ * re-triggering (kimi parity).
  *
  * The editor also carries the terminal-prompt prefix: the fork's Editor is
  * constructed with `paddingX: 2` (kimi's CustomEditor reserves padding for
@@ -21,7 +22,8 @@
  * @module @xmoon76/dsh-pi-tui/tui-editor
  */
 
-import { decodePrintableKey, Editor, matchesKey, truncateToWidth, type EditorTheme, type TUI } from '@xmoon76/pi-tui'
+import { decodePrintableKey, Editor, matchesKey, truncateToWidth, type EditorTheme, type SelectListLayoutOptions, type TUI } from '@xmoon76/pi-tui'
+import { SelectedMarquee } from './marquee.ts'
 import { color } from './theme.ts'
 import { classifyFileCompletionContext, FILE_ARGUMENT_COMMANDS } from './file-completion/context.ts'
 import { editorModeFromHistoryEntry, type EditorInputMode } from './editor-input-mode.ts'
@@ -148,6 +150,8 @@ export class TuiEditor extends Editor {
   private placeholderText = ''
   /** The current input mode: `!` / `!!` are state, never document text. */
   private inputMode: EditorInputMode = 'prompt'
+  /** The selected file-completion row's horizontal marquee. */
+  private readonly fileCompletionMarquee: SelectedMarquee
   /** An in-flight bracketed paste captured at the RAW layer: whether it
    * began in an EMPTY PROMPT (the normalization gate) and the content
    * accumulated so far. While set, every input chunk belongs to the
@@ -167,6 +171,9 @@ export class TuiEditor extends Editor {
     // state repaints, incl. async autocomplete commits) at the host's
     // active screen — see TuiEditorOptions.requestRender.
     super(routeEditorRenders(tui, options.requestRender), theme, { paddingX: PROMPT_WIDTH })
+    this.fileCompletionMarquee = new SelectedMarquee({
+      requestRender: () => this.tui.requestRender(),
+    })
     // Dynamic border: shell modes use the shellMode token, the prompt the
     // normal border. The function reads the LIVE color helpers on every
     // call, so a theme switch repaints correctly (never a cached Chalk
@@ -246,8 +253,44 @@ export class TuiEditor extends Editor {
     return this.inputMode
   }
 
+  protected override getAutocompleteSelectListLayout(
+    prefix: string,
+  ): SelectListLayoutOptions | undefined {
+    if (this.inputMode !== 'prompt') {
+      this.fileCompletionMarquee.reset()
+      return super.getAutocompleteSelectListLayout(prefix)
+    }
+
+    const lines = this.getLines()
+    const cursor = this.getCursor()
+    const currentLine = lines[cursor.line] ?? ''
+    const textBeforeCursor = currentLine.slice(0, cursor.col)
+    const context = classifyFileCompletionContext(
+      textBeforeCursor,
+      FILE_ARGUMENT_COMMANDS,
+    )
+
+    if (context.kind === 'none') {
+      this.fileCompletionMarquee.reset()
+      return super.getAutocompleteSelectListLayout(prefix)
+    }
+
+    return {
+      truncatePrimary: ({ text, maxWidth, item, isSelected }) =>
+        this.fileCompletionMarquee.render({
+          key: item.value,
+          text,
+          maxWidth,
+          selected: isSelected,
+        }),
+    }
+  }
+
   override render(width: number): string[] {
     const lines = super.render(width)
+    if (!this.isShowingAutocomplete()) {
+      this.fileCompletionMarquee.reset()
+    }
     if (this.inputMode === 'prompt' && this.placeholderText !== '' && this.getText().trim() === '') {
       return injectEditorPlaceholder(lines, this.placeholderText, width)
     }

--- a/test/autocomplete-marquee-active-screen.test.ts
+++ b/test/autocomplete-marquee-active-screen.test.ts
@@ -260,3 +260,33 @@ test('fullscreen: selected /image rows marquee on the active alt screen', async 
   await vt.waitForRender()
   assert.equal(marqueeDeadline(app), -1, '/image close must reset the file marquee')
 })
+
+test('final app disposal disposes the host file-completion marquee', async (t) => {
+  const life = testLifecycle(t)
+  const root = marqueeFixture(life)
+  const marqueeNow = { value: 0 }
+  const { vt, app, screen } = await startFullscreen(life, root, 'image', marqueeNow)
+
+  app.setEditorText('/image src/file-completion/very-long-file-completion-path-')
+  vt.sendInput('\t')
+  await pollImmediate(() => isAutocompleteActive(app), 'dispose: dropdown must open')
+  resetFileMarqueeForTest(app)
+  const timers = captureMarqueeTimers(() => screen.renderNow(true))
+  const timer = timers.find(candidate => candidate.delay === 800)
+  await flushTerminal(vt)
+  if (timer === undefined) assert.fail('dispose: initial marquee timer must be armed')
+  assert.notEqual(marqueeDeadline(app), -1, 'dispose: marquee timer must be armed before final teardown')
+
+  app.dispose()
+  assert.equal(marqueeDeadline(app), -1, 'final app disposal must clear the host marquee timer')
+
+  let repaintRequests = 0
+  const host = app as unknown as { requestRender(force?: boolean): void }
+  const requestRender = host.requestRender.bind(app)
+  host.requestRender = (force?: boolean) => {
+    repaintRequests += 1
+    requestRender(force)
+  }
+  timer.fire()
+  assert.equal(repaintRequests, 0, 'a captured timer callback must not request a repaint after disposal')
+})

--- a/test/autocomplete-marquee-active-screen.test.ts
+++ b/test/autocomplete-marquee-active-screen.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Active-screen regressions for the file-completion marquee. The host editor
+ * must render selected overflowing `@`, `/attach`, and `/image` paths through
+ * the routed TUI, so a timer repaint reaches fullscreen's visible screen rather
+ * than the stopped screen captured at editor construction time.
+ * @module @xmoon76/dsh-pi-tui/autocomplete-marquee-active-screen.test
+ */
+
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { startImageApp } from './support/app-harness.ts'
+import { testLifecycle, type TestLifecycle } from './support/temp-lifecycle.ts'
+import type { TuiApp } from '../src/tui-app.ts'
+import type { VirtualTerminal } from './virtual-terminal.ts'
+
+const startedApps = new Set<TuiApp>()
+afterEach(() => {
+  for (const app of [...startedApps]) {
+    startedApps.delete(app)
+    if (app.isDisposed()) continue
+    try { app.dispose() } catch {}
+  }
+})
+
+/** Two long candidates make explicit Tab open the list instead of applying a
+ * single result, while their full display paths overflow the editor row. */
+function marqueeFixture(life: TestLifecycle): string {
+  const root = life.tempDir('dsh-ac-marquee-')
+  mkdirSync(join(root, 'src', 'file-completion'), { recursive: true })
+  const stem = 'very-long-file-completion-path-'.repeat(4)
+  writeFileSync(join(root, 'src', 'file-completion', `${stem}alpha.ts`), 'x')
+  writeFileSync(join(root, 'src', 'file-completion', `${stem}beta.ts`), 'x')
+  return root
+}
+
+function isAutocompleteActive(app: TuiApp): boolean {
+  return app.seatEditorForTest().isShowingAutocomplete?.() === true
+}
+
+/** Clear the current cycle before the synchronous render probe below. The
+ * production path resets this through render lifecycle; the test only uses the
+ * private instance to avoid waiting for the provider's already-rendered frame. */
+function resetFileMarqueeForTest(app: TuiApp): void {
+  const host = app as unknown as { editor: { fileCompletionMarquee: { reset(): void } } }
+  host.editor.fileCompletionMarquee.reset()
+}
+
+async function flushTerminal(vt: VirtualTerminal): Promise<void> {
+  await new Promise<void>(resolve => process.nextTick(resolve))
+  await vt.flush()
+}
+
+async function pollImmediate(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 3_000
+  for (;;) {
+    if (predicate()) return
+    if (Date.now() > deadline) assert.fail(`${label}: condition never became true`)
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+}
+
+function selectedAutocompleteRow(view: string, label: string): string {
+  const row = view.split('\n').find(line => line.includes('→ '))
+  if (row === undefined) assert.fail(`${label}: selected autocomplete row missing:\n${view}`)
+  return row
+}
+
+type CapturedTimer = {
+  readonly delay: number
+  cancelled: boolean
+  fire(): void
+  unref(): void
+}
+
+/** Capture only the marquee's phase timers for one synchronous render pass.
+ * The real scheduler remains in place for every other timer, so this fake is
+ * local to the render call and cannot interfere with parallel test files. */
+function captureMarqueeTimers(run: () => void): CapturedTimer[] {
+  const timers: CapturedTimer[] = []
+  const captured = new Set<CapturedTimer>()
+  const realSetTimeout = globalThis.setTimeout
+  const realClearTimeout = globalThis.clearTimeout
+  const replacementSetTimeout = ((handler: unknown, delay?: number, ...args: unknown[]) => {
+    if ((delay === 800 || delay === 250) && typeof handler === 'function') {
+      const timer: CapturedTimer = {
+        delay,
+        cancelled: false,
+        fire: () => {
+          if (timer.cancelled) return
+          timer.cancelled = true
+          Reflect.apply(handler as (...callbackArgs: unknown[]) => void, undefined, args)
+        },
+        unref: () => {},
+      }
+      timers.push(timer)
+      captured.add(timer)
+      return timer as unknown as ReturnType<typeof setTimeout>
+    }
+    return Reflect.apply(realSetTimeout, globalThis, [handler, delay, ...args]) as ReturnType<typeof setTimeout>
+  }) as unknown as typeof setTimeout
+  const replacementClearTimeout = ((handle: unknown) => {
+    const timer = handle as CapturedTimer
+    if (captured.has(timer)) {
+      timer.cancelled = true
+      return
+    }
+    Reflect.apply(realClearTimeout, globalThis, [handle])
+  }) as unknown as typeof clearTimeout
+
+  globalThis.setTimeout = replacementSetTimeout
+  globalThis.clearTimeout = replacementClearTimeout
+  try {
+    run()
+  } finally {
+    globalThis.setTimeout = realSetTimeout
+    globalThis.clearTimeout = realClearTimeout
+  }
+  return timers
+}
+
+interface TestScreen {
+  readonly fullRedraws: number
+  renderNow(force?: boolean): void
+}
+
+function activeScreenForTest(app: TuiApp): TestScreen {
+  const host = app as unknown as { fullscreen?: TestScreen; tui: TestScreen }
+  return host.fullscreen ?? host.tui
+}
+
+async function assertMarqueeShift(
+  vt: VirtualTerminal,
+  app: TuiApp,
+  screen: TestScreen,
+  draft: string,
+  marqueeNow: { value: number },
+  label: string,
+): Promise<void> {
+  app.setEditorText(draft)
+  vt.sendInput('\t')
+  await pollImmediate(() => isAutocompleteActive(app), `${label}: dropdown must open`)
+  resetFileMarqueeForTest(app)
+
+  const initialTimers = captureMarqueeTimers(() => screen.renderNow(true))
+  const initialTimer = initialTimers.find(timer => timer.delay === 800)
+  await flushTerminal(vt)
+  assert.ok(initialTimer !== undefined, `${label}: initial marquee timer must be armed`)
+  const initial = selectedAutocompleteRow(vt.getViewport().join('\n'), `${label} initial`)
+  assert.ok(initial.includes('src/file-completion'), `${label}: the full path must be the primary row`)
+  assert.ok(!initial.includes('…'), `${label}: selected overflow must use the marquee window, not ellipsis`)
+
+  // Move the injected marquee clock past the initial pause and invoke the
+  // captured phase timer. The timer callback alone requests a repaint; the
+  // active screen's normal render cycle must produce the shifted row.
+  marqueeNow.value += 1_050
+  initialTimer.fire()
+  await vt.waitForRender()
+  const shifted = selectedAutocompleteRow(vt.getViewport().join('\n'), `${label} shifted`)
+  assert.notEqual(shifted, initial, `${label}: the selected row must move after the first step`)
+}
+
+type MarqueeSurface = {
+  vt: VirtualTerminal
+  app: TuiApp
+  screen: TestScreen
+}
+
+async function startFullscreen(
+  life: TestLifecycle,
+  root: string,
+  commandName: 'image' | 'attach',
+  marqueeNow: { value: number },
+): Promise<MarqueeSurface> {
+  // SelectedMarquee captures Date.now during editor construction. Keep that
+  // captured clock independently controllable while the rest of the app uses
+  // the real clock; the fake scheduler below invokes the captured callbacks.
+  const realDateNow = Date.now
+  Date.now = () => marqueeNow.value
+  let surface: ReturnType<typeof startImageApp>
+  try {
+    surface = startImageApp(root, commandName)
+  } finally {
+    Date.now = realDateNow
+  }
+  const { vt, app } = surface
+  startedApps.add(app)
+  life.defer(() => app.stop())
+  await vt.waitForRender()
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  return { vt, app, screen: activeScreenForTest(app) }
+}
+
+function marqueeDeadline(app: TuiApp): number {
+  const host = app as unknown as { editor: { fileCompletionMarquee: { pendingTimerDeadlineForTest(): number } } }
+  return host.editor.fileCompletionMarquee.pendingTimerDeadlineForTest()
+}
+
+test('fullscreen: selected @ file rows marquee on the active alt screen', async (t) => {
+  const life = testLifecycle(t)
+  const root = marqueeFixture(life)
+  const marqueeNow = { value: 0 }
+  const { vt, app, screen } = await startFullscreen(life, root, 'image', marqueeNow)
+  const mainScreen = (app as unknown as { tui: TestScreen }).tui
+  const mainRedrawsBefore = mainScreen.fullRedraws
+
+  await assertMarqueeShift(
+    vt,
+    app,
+    screen,
+    '@src/file-completion/very-long-file-completion-path-',
+    marqueeNow,
+    '@ mention',
+  )
+  vt.sendInput('\x1b')
+  await pollImmediate(() => !isAutocompleteActive(app), '@ mention: dropdown must close')
+  await vt.waitForRender()
+  assert.equal(marqueeDeadline(app), -1, 'closing the dropdown must reset the file marquee')
+  assert.equal(mainScreen.fullRedraws, mainRedrawsBefore, 'the stopped main screen must not receive the timer repaint')
+})
+
+test('fullscreen: selected /attach rows marquee on the active alt screen', async (t) => {
+  const life = testLifecycle(t)
+  const root = marqueeFixture(life)
+  const marqueeNow = { value: 0 }
+  const { vt, app, screen } = await startFullscreen(life, root, 'attach', marqueeNow)
+
+  await assertMarqueeShift(
+    vt,
+    app,
+    screen,
+    '/attach src/file-completion/very-long-file-completion-path-',
+    marqueeNow,
+    '/attach path argument',
+  )
+  vt.sendInput('\x1b')
+  await pollImmediate(() => !isAutocompleteActive(app), '/attach: dropdown must close')
+  await vt.waitForRender()
+  assert.equal(marqueeDeadline(app), -1, '/attach close must reset the file marquee')
+})
+
+test('fullscreen: selected /image rows marquee on the active alt screen', async (t) => {
+  const life = testLifecycle(t)
+  const root = marqueeFixture(life)
+  const marqueeNow = { value: 0 }
+  const { vt, app, screen } = await startFullscreen(life, root, 'image', marqueeNow)
+
+  await assertMarqueeShift(
+    vt,
+    app,
+    screen,
+    '/image src/file-completion/very-long-file-completion-path-',
+    marqueeNow,
+    '/image path argument',
+  )
+  vt.sendInput('\x1b')
+  await pollImmediate(() => !isAutocompleteActive(app), '/image: dropdown must close')
+  await vt.waitForRender()
+  assert.equal(marqueeDeadline(app), -1, '/image close must reset the file marquee')
+})

--- a/test/file-completion-convergence.test.ts
+++ b/test/file-completion-convergence.test.ts
@@ -2,8 +2,8 @@
  * The file-completion convergence regression suite (the 2026-08-27 plan):
  * P1.1–P1.5, the §23 matrix, and the §24 headless A–E integration flows.
  * These tests pin the CONVERGED contract — file completion ONLY on `@...`
- * and `/image ...`, scoped `@` paths, shared fuzzy ranking, directory
- * continuation, fd/fdfind detection, stale-apply fencing, and the sessionless
+ * and attachment arguments (`/attach ...` + `/image ...`), scoped `@` paths,
+ * shared fuzzy ranking, directory continuation, fd/fdfind detection, stale-apply fencing, and the sessionless
  * scope walk. The engine modules are pure; the provider/port/app layers are
  * exercised through the real chain (TuiApp + VirtualTerminal + MentionProvider
  * + DirectHostFilePort).
@@ -196,7 +196,7 @@ test('P1.2 absolute: @/tmp/ searches the absolute scope', async (t) => {
   assert.ok(result.items.some(item => item.value.startsWith(`@${target}`)))
 })
 
-test('§23 matrix: /image shares the scoped forms (../, ~/, absolute, directory continuation)', async (t) => {
+test('§23 matrix: attachment commands share the scoped forms (../, ~/, absolute, directory continuation)', async (t) => {
   const life = testLifecycle(t)
   // ../../ fixture for /image: workspace = /root/alpha/beta/workspace;
   // ../../alpha targets /root/alpha/alpha/pics.
@@ -466,22 +466,33 @@ test('§23 matrix: Windows drive and UNC tokens keep their dialect (pure)', () =
   assert.equal(unc.winAbsolute, true)
 })
 
-test('Windows candidates rank and present basename labels independently of host path dialect', () => {
+test('candidates present one full display path independently of host path dialect', () => {
   assert.equal(scorePathCandidate({ path: 'C:\\Users\\Foo.txt', kind: 'file' }, 'foo.txt'), 100)
   assert.equal(scorePathCandidate({ path: 'C:\\Users\\deep\\Foo.txt', kind: 'file' }, 'foo.txt'), 100)
+  const rootFile = presentPathCandidate({ path: 'package.json', kind: 'file' }, { at: false, quoted: false })
+  assert.equal(rootFile.label, 'package.json')
+  assert.equal(rootFile.description, undefined)
+  const nestedFile = presentPathCandidate(
+    { path: 'src/file-completion/presentation.ts', kind: 'file' },
+    { at: false, quoted: false },
+  )
+  assert.equal(nestedFile.label, 'src/file-completion/presentation.ts')
+  assert.equal(nestedFile.description, undefined)
   const directory = presentPathCandidate(
     { path: 'C:\\Users\\Pictures', kind: 'directory' },
     { at: false, quoted: false, sep: '\\' },
   )
   assert.equal(directory.value, 'C:\\Users\\Pictures\\')
-  assert.equal(directory.label, 'Pictures/')
-  assert.equal(directory.description, 'C:\\Users\\Pictures')
+  assert.equal(directory.label, 'C:\\Users\\Pictures/')
+  assert.ok(directory.label.endsWith('/'))
+  assert.equal(directory.description, undefined)
   const mixed = presentPathCandidate(
     { path: 'C:/Users\\Pictures', kind: 'directory' },
     { at: true, quoted: false, sep: '\\' },
   )
   assert.equal(mixed.value, '@C:/Users\\Pictures\\')
-  assert.equal(mixed.label, 'Pictures/')
+  assert.equal(mixed.label, 'C:/Users\\Pictures/')
+  assert.equal(mixed.description, undefined)
 })
 
 test('the presentation layer quotes spaced values for /image and keeps @ quoting', () => {

--- a/test/image-arg-completion.test.ts
+++ b/test/image-arg-completion.test.ts
@@ -1,6 +1,6 @@
 /**
- * Headless tests for the REAL /image argument-completion wiring: the
- * registerTuiCommands → installCompletions → MentionProvider chain must end
+ * Headless tests for the REAL /image + /attach argument-completion wiring:
+ * the registerTuiCommands → installCompletions → MentionProvider chain must end
  * with a working completion menu down in the editor (the natural-typing and
  * Tab flows), exactly like the @ mention menu. The unit tests in
  * mentions.test.ts cover suggestPathArgument in isolation; this file drives
@@ -169,9 +169,10 @@ test('the installed /image completion answers natural typing with a menu', async
   await vt.waitForRender()
   vt.sendInput('/image sh')
   const view = await waitForDropdownRow(vt, 'shot.png', 'natural typing')
-  // The menu row renders exactly like the @ mention menu: item + absolute
-  // path description.
+  // The menu row renders exactly like the @ mention menu: one full display
+  // path, with no duplicated basename + path description column.
   assert.ok(view.includes('shot.png'), 'the candidate row is visible')
+  assert.equal(view.split('shot.png').length - 1, 1, 'the candidate path must appear once')
   assert.ok(!app.getDraft().includes('shot.png'), 'typing alone must not apply anything')
 })
 
@@ -182,6 +183,7 @@ test('the installed /attach completion shares the local path chain', async (t) =
   vt.sendInput('/attach no')
   const view = await waitForDropdownRow(vt, 'notes.txt', 'attach natural typing')
   assert.ok(view.includes('notes.txt'), 'generic files are offered by /attach')
+  assert.equal(view.split('notes.txt').length - 1, 1, 'the /attach candidate path must appear once')
   assert.ok(!app.getDraft().includes('notes.txt'), 'typing alone must not apply anything')
 })
 

--- a/test/support/app-harness.ts
+++ b/test/support/app-harness.ts
@@ -22,9 +22,9 @@ export function startApp(cwd: string): { vt: VirtualTerminal; app: TuiApp } {
   return { vt, app }
 }
 
-/** Start the app with the /image path-argument command (the same shape
- * commands.ts installs — the convergence headless B/E flows drive it). */
-export function startImageApp(cwd: string): { vt: VirtualTerminal; app: TuiApp } {
+/** Start the app with one path-argument command (the same shape commands.ts
+ * installs — the convergence headless flows drive both /image and /attach). */
+export function startImageApp(cwd: string, commandName: 'image' | 'attach' = 'image'): { vt: VirtualTerminal; app: TuiApp } {
   const vt = new VirtualTerminal(100, 24)
   const app = new TuiApp(vt, {
     onSubmit: () => {},
@@ -32,7 +32,7 @@ export function startImageApp(cwd: string): { vt: VirtualTerminal; app: TuiApp }
     onCancel: () => {},
   })
   app.setCommandCompletions(
-    [{ name: 'image', description: 'Attach an image file', getArgumentCompletions: (arg) => suggestPathArgument(arg, cwd) }],
+    [{ name: commandName, description: commandName === 'attach' ? 'Attach a file' : 'Attach an image file', getArgumentCompletions: (arg: string) => suggestPathArgument(arg, cwd) }],
     cwd,
     new DirectHostFilePort(() => undefined, null),
   )


### PR DESCRIPTION
## Summary

- Render full display paths for @, /attach, and /image file completion while preserving values, quoting, separators, directory markers, ranking, and locality.
- Add the minimal X044 protected layout seam and route SelectedMarquee timer repaints through the active TUI screen.
- Add convergence, active-screen, and lifecycle regression coverage; regenerate the divergence report.

## Validation

- pnpm build
- pnpm typecheck
- pnpm test:fork (1052/1052)
- pnpm test:product (3548/3548)
- Targeted completion/marquee tests (60/60)
- pnpm gate:pi-surface-compat
- pnpm gate:pi-divergence-ledger
- pnpm gate:pi-vendor-diff --strict

## Note

- pnpm verify:prepush reaches the existing temp-hygiene gate, which currently reports four pre-existing direct mkdtemp usages in test/attachment-intake.test.ts and test/attachment-submit.test.ts; unrelated files were not changed.