### PR TITLE
feat: render open opaque assistant blocks immediately

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,11 @@ in that worktree before using a profile.
   replace `next`'s newer DSH target/policy with `main`'s released one.
 * Do not modify the real-use `pi-tui` profile during development.
 * `compat:dsh:source` is a full distribution-boundary verification, not a
-  routine test after ordinary TUI changes.
+  routine test after ordinary TUI changes. Run it only when the DSH source or
+  distribution boundary changes (source pin, target metadata, distribution
+  infrastructure, source/npm discrepancy, or an unpublished DSH commit), or
+  when explicitly requested; skip it for TUI-only changes when DSH is
+  unchanged.
 
 Read `docs/local-development.md` before changing DSH mode, worktree/bootstrap
 behavior, or promoting `main`/`next`. Read `docs/dsh-compatibility.md` for

--- a/docs/client-server-migration.md
+++ b/docs/client-server-migration.md
@@ -85,6 +85,19 @@ Connection transport, or Remote upload state is implemented here.
 Locality is explicit: `/attach` and `/image` use the Client-local cwd, while
 `@` mentions remain Host/session-scoped.
 
+### Open/opaque Assistant block presentation timing (Stage C3 / pre-M2)
+
+Stage C3 aligns the TUI's transient and durable-attempt presentation with
+the pinned DSH client projection. A non-incremental/unknown block-start is
+visible immediately as an opaque null-payload presentation row, while
+text/reasoning/tool-call retain their existing lane-specific visibility.
+The first block-end remains authoritative and replaces the open
+presentation with the finalized ContentBlock. No synthetic ContentBlock is
+persisted or exposed through semantic text/search state.
+
+Stage C is complete after this change; M2 remains NOT STARTED and Direct
+remains the production backend.
+
 ## Target
 
 A DSH-native client: the TUI keeps terminal/editor/overlays/keybindings/

--- a/src/content-block-presentation.ts
+++ b/src/content-block-presentation.ts
@@ -54,14 +54,18 @@ export function textWithAttachmentMarkers(blocks: readonly ContentBlock[]): stri
   return text
 }
 
-/** Read and bound the type tag for the explicit unknown-block heading. */
-function blockType(block: unknown): string {
-  if (typeof block !== 'object' || block === null) return 'unknown'
-  const type = (block as { readonly type?: unknown }).type
+/** Sanitize and bound a provider-supplied block type for a heading. */
+function safeBlockTypeLabel(type: unknown): string {
   if (typeof type !== 'string') return 'unknown'
   const safeType = type.replace(/[\u0000-\u001f\u007f-\u009f]/g, '')
   if (safeType === '') return 'unknown'
   return safeType.length <= 120 ? safeType : `${safeType.slice(0, 119)}…`
+}
+
+/** Read and bound the type tag for the explicit unknown-block heading. */
+function blockType(block: unknown): string {
+  if (typeof block !== 'object' || block === null) return 'unknown'
+  return safeBlockTypeLabel((block as { readonly type?: unknown }).type)
 }
 
 /** Serialize one finalized block and keep its payload bounded. */
@@ -78,6 +82,11 @@ function boundedSerializedBlock(block: unknown): string {
  */
 export function finalizedBlockFallbackText(block: unknown): string {
   return `Unknown block: ${blockType(block)}\n${boundedSerializedBlock(block)}`
+}
+
+/** Render an open opaque block without inventing an unfinished payload. */
+export function openOpaqueBlockFallbackText(blockType: string): string {
+  return `Unknown block: ${safeBlockTypeLabel(blockType)}\nnull`
 }
 
 /** Whether a user message contains content the transcript should retain. */

--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -26,7 +26,7 @@ import { color } from './theme.ts'
 import { formatTokens } from './token-usage.ts'
 import { iconFor, type IconSemantic, type IconStyle } from './icons.ts'
 import { toolTitle } from './present.ts'
-import { assistantBlocksVisibleNow, type TurnActivity, type TranscriptMessage } from './transcript.ts'
+import { assistantEntryVisibleNow, type TurnActivity, type TranscriptMessage } from './transcript.ts'
 import { displayFailureText } from './failure-presentation.ts'
 
 /** The max tool-type names the header stats show before the `+N` tail
@@ -506,7 +506,7 @@ function initialPromptBoundary(group: readonly TranscriptMessage[]): number {
  * an empty authoritative entry may remain internal without becoming a final
  * answer, while generic finalized blocks retain their Stage A identity. */
 function assistantRenderable(assistant: Extract<TranscriptMessage, { kind: 'assistant' }>): boolean {
-  return assistantBlocksVisibleNow(assistant.content ?? [{ type: 'text', text: assistant.text }])
+  return assistantEntryVisibleNow(assistant)
 }
 
 /** The turn's final assistant selection: only after the authoritative

--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -26,7 +26,7 @@ import { color } from './theme.ts'
 import { formatTokens } from './token-usage.ts'
 import { iconFor, type IconSemantic, type IconStyle } from './icons.ts'
 import { toolTitle } from './present.ts'
-import { assistantEntryVisibleNow, type TurnActivity, type TranscriptMessage } from './transcript.ts'
+import { assistantBlocksVisibleNow, assistantLatestStepOf, assistantStepOf, type TurnActivity, type TranscriptMessage } from './transcript.ts'
 import { displayFailureText } from './failure-presentation.ts'
 
 /** The max tool-type names the header stats show before the `+N` tail
@@ -473,15 +473,16 @@ export function projectFocus(
   return out
 }
 
-/** The EXACT last assistant message of a turn (by position — an empty or
- * image-only step still owns the final slot; there is NEVER a fallback to
- * an earlier assistant, review fix). */
-function lastAssistant(
+/** Find the Assistant entry that owns the structural latest step. A late
+ * durable message can append after newer process evidence, so physical array
+ * order is not a reliable final-answer identity. */
+function assistantForStep(
   group: readonly TranscriptMessage[],
+  step: number,
 ): Extract<TranscriptMessage, { kind: 'assistant' }> | undefined {
   for (let index = group.length - 1; index >= 0; index -= 1) {
     const member = group[index]
-    if (member?.kind === 'assistant') return member
+    if (member?.kind === 'assistant' && assistantStepOf(member) === step) return member
   }
   return undefined
 }
@@ -501,19 +502,21 @@ function initialPromptBoundary(group: readonly TranscriptMessage[]): number {
   return firstInitialUserIndex < 0 ? 0 : firstInitialUserIndex + 1
 }
 
-/** Whether one assistant message has visible Assistant content. Keep final
- * selection on the same block predicate as the transcript row projection;
- * an empty authoritative entry may remain internal without becoming a final
- * answer, while generic finalized blocks retain their Stage A identity. */
+/** Whether one Assistant entry has semantic/finalized content. Pending
+ * display-only open-opaque rows remain transcript evidence but cannot become a
+ * completed/max-token final; finalized generic blocks stay eligible. */
 function assistantRenderable(assistant: Extract<TranscriptMessage, { kind: 'assistant' }>): boolean {
-  return assistantEntryVisibleNow(assistant)
+  if (assistant.displayBlocks?.some(block => block.kind === 'open-opaque') === true) return false
+  if (assistant.content !== undefined) return assistantBlocksVisibleNow(assistant.content)
+  return assistant.text.trim() !== ''
 }
 
 /** The turn's final assistant selection: only after the authoritative
  * turn/end, only for a reason the system presents output (completed /
- * max-tokens), and only when the EXACT last assistant renders rows. An
- * empty last step yields NO final — never an earlier assistant (review
- * fix). The max-tokens final carries the truncated marker (plan §13.8). */
+ * max-tokens), and only when the Assistant owning the structural latest step
+ * has semantic/finalized content. An empty or pending latest step yields NO
+ * final — never an earlier assistant (review fix). The max-tokens final carries
+ * the truncated marker (plan §13.8). */
 function finalAssistantSelection(
   activity: TurnActivity | undefined,
   group: readonly TranscriptMessage[],
@@ -523,10 +526,12 @@ function finalAssistantSelection(
   if (reason !== 'completed' && reason !== 'max-tokens') return undefined
   // The exact authoritative assistant may be retained internally but hidden
   // from the normal transcript projection; never fall back to an earlier row.
-  if (activity.lastAssistantVisible === false) return undefined
-  const last = lastAssistant(group)
-  // Interrupted prefixes are process evidence, never a completed/max-token
-  // final answer, even when a malformed log reports a successful reason.
+  const latestStep = assistantLatestStepOf(activity)
+  if (activity.lastAssistantVisible === false || latestStep === undefined) return undefined
+  const last = assistantForStep(group, latestStep)
+  // Interrupted prefixes and display-only pending rows are process evidence,
+  // never a completed/max-token final answer, even when a malformed log reports
+  // a successful reason.
   if (last === undefined || last.interrupted === true || !assistantRenderable(last)) return undefined
   return { message: last, truncated: reason === 'max-tokens' }
 }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -102,8 +102,9 @@ export const RECENT_PERFORMANCE_SAMPLE_LIMIT = 5
  * valid, letting the next-older retained candidate rejoin. Twice the
  * window covers the worst case of every derived sample being
  * invalidated; a duplicate older than the candidate buffer is a replay
- * artifact beyond the recent contract. TTFT needs no candidates — its
- * samples have no invalidation path. */
+ * artifact beyond the recent contract. TTFT has no candidate buffer because
+ * late evidence can only fill a previously missing sample, never invalidate
+ * an existing first-token sample. */
 const RECENT_PERFORMANCE_CANDIDATE_LIMIT = RECENT_PERFORMANCE_SAMPLE_LIMIT * 2
 
 /** Key identifying one step's model output (turn + step). */
@@ -295,8 +296,8 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
   const stats: SessionStats = { ...EMPTY }
   const perStep = new Map<string, StepTiming>()
   // Keep settled samples only until their turn closes, so a late duplicate
-  // assistant/message can replace its output-token sample without retaining
-  // timing state for the full session.
+  // assistant/message or assistant/attempt can replace its output-token sample
+  // without retaining timing state for the full session.
   const settledPerStep = new Map<string, StepTiming>()
   // Step boundaries are idempotent within the active turn; older boundaries
   // are stale once the timing fence advances.
@@ -337,13 +338,23 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
     if (kind === 'assistant/attempt') {
       const failed = event.data as { turn: number; step: number; stream?: readonly unknown[] }
       const stream = failed.stream ?? []
+      const key = stepKey(failed.turn, failed.step)
+      const attemptUsage = usageFromAssistantSettlement('attempt', undefined, stream)
+      const attemptFirstToken = firstTokenTimeFromAssistantStream(stream)
       const timing = settledTurn === failed.turn
-        ? perStep.get(stepKey(failed.turn, failed.step))
+        ? perStep.get(key) ?? settledPerStep.get(key)
         : undefined
-      if (timing !== undefined && timing.firstDelta === undefined) {
-        timing.firstDelta = firstTokenTimeFromAssistantStream(stream)
+      if (timing !== undefined) {
+        if (timing.firstDelta === undefined && attemptFirstToken !== undefined) {
+          timing.firstDelta = attemptFirstToken
+          if (timing.settled === true) replaceRecentTtft(key, timing, attemptFirstToken, recent)
+        }
+        if (timing.settled === true && attemptUsage !== undefined) {
+          timing.usage = attemptUsage
+          replaceRecentThroughput(key, timing, attemptUsage, recent)
+        }
       }
-      usage.onAssistantAttempt(failed.turn, failed.step, usageFromAssistantSettlement('attempt', undefined, stream))
+      usage.onAssistantAttempt(failed.turn, failed.step, attemptUsage)
       // Keep the open logical-step timing: a retry reuses this (turn, step)
       // and the eventual assistant/message must settle its wall/TTFT sample.
       continue
@@ -399,8 +410,8 @@ export function computeStats(events: readonly SessionEvent[]): SessionStats {
         }
         usage.onStepEnd(event.data.turn, event.data.step)
         // The open timing entry is dropped at step/end, but retain its small
-        // settled sample until turn/end so a late authoritative message can
-        // replace output tokens without losing throughput parity.
+        // settled sample until turn/end so a late authoritative message or
+        // attempt can replace output tokens without losing throughput parity.
         const timing = currentTimingTurn ? perStep.get(key) : undefined
         if (timing?.settled === true) settledPerStep.set(key, timing)
         if (currentTimingTurn) perStep.delete(key)
@@ -505,10 +516,10 @@ function settleStep(
 }
 
 /** Replace the throughput sample of an already-settled step from a late
- * authoritative usage (assistant/message duplicate). The sample keeps its
- * original completion ordinal — it replaces, never appends; llmMs and
- * TTFB are never re-added; and a message belonging to a route the window
- * has moved past must not resurrect its sample into the current window.
+ * authoritative usage (assistant/message or assistant/attempt replay). The
+ * sample keeps its original completion ordinal — it replaces, never appends;
+ * llmMs and TTFB are never re-added; and an event belonging to a route the
+ * window has moved past must not resurrect its sample into the current window.
  * The EPOCH is the authoritative gate: A → B → A returns to an equal
  * route STRING while the window belongs to the second A lifecycle, so
  * only `timing.routeEpoch === recent.routeEpoch` admits the replacement.
@@ -535,6 +546,22 @@ function replaceRecentThroughput(
   recent.upsertThroughput(key, timing.completionOrdinal, wallMs, usage.outputTokens)
 }
 
+/** Fill the TTFT sample when a late attempt supplies the first token that the
+ * authoritative message did not embed. The sample keeps the settled step's
+ * ordinal and route lifecycle, just like a late usage replacement. */
+function replaceRecentTtft(
+  key: string,
+  timing: StepTiming,
+  firstDelta: number,
+  recent: RecentPerformanceWindow,
+): void {
+  if (timing.routeKey !== undefined && recent.routeKey !== undefined && timing.routeKey !== recent.routeKey) return
+  if (timing.routeEpoch !== undefined && timing.routeEpoch !== recent.routeEpoch) return
+  if (timing.completionOrdinal === undefined) return
+  if (timing.start === undefined) return
+  recent.upsertTtft(key, timing.completionOrdinal, Math.max(0, firstDelta - timing.start))
+}
+
 /** Token totals from one usage record (cache fields counted separately). */
 function addUsage(stats: SessionStats, usage: UsageLike): void {
   stats.inputTokens += usage.inputTokens
@@ -552,7 +579,7 @@ function addUsage(stats: SessionStats, usage: UsageLike): void {
 export class StatsFolder {
   private readonly stats: SessionStats = { ...EMPTY }
   private readonly perStep = new Map<string, StepTiming>()
-  // Retain only the current turn's settled samples for late message replay.
+  // Retain only the current turn's settled samples for late message/attempt replay.
   private readonly settledPerStep = new Map<string, StepTiming>()
   // Step boundaries are idempotent within the active turn; older boundaries
   // are stale once the timing fence advances.
@@ -694,16 +721,26 @@ export class StatsFolder {
     if (kind === 'assistant/attempt') {
       const data = event.data as { turn: number; step: number; stream?: readonly unknown[] }
       const stream = data.stream ?? []
+      const key = stepKey(data.turn, data.step)
+      const attemptUsage = usageFromAssistantSettlement('attempt', undefined, stream)
+      const attemptFirstToken = firstTokenTimeFromAssistantStream(stream)
       const timing = this.settledTurn === data.turn
-        ? this.perStep.get(stepKey(data.turn, data.step))
+        ? this.perStep.get(key) ?? this.settledPerStep.get(key)
         : undefined
-      if (timing !== undefined && timing.firstDelta === undefined) {
-        timing.firstDelta = firstTokenTimeFromAssistantStream(stream)
+      if (timing !== undefined) {
+        if (timing.firstDelta === undefined && attemptFirstToken !== undefined) {
+          timing.firstDelta = attemptFirstToken
+          if (timing.settled === true) replaceRecentTtft(key, timing, attemptFirstToken, this.recent)
+        }
+        if (timing.settled === true && attemptUsage !== undefined) {
+          timing.usage = attemptUsage
+          replaceRecentThroughput(key, timing, attemptUsage, this.recent)
+        }
       }
       // Keep timing open across the retry: assistant/attempt is evidence for
       // the failed attempt, not the logical step's final timing boundary.
       this.settleFailedAttempt(data.turn, data.step, true, false)
-      this.usage.onAssistantAttempt(data.turn, data.step, usageFromAssistantSettlement('attempt', undefined, stream))
+      this.usage.onAssistantAttempt(data.turn, data.step, attemptUsage)
       return
     }
     switch (event.type) {

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -271,6 +271,9 @@ export class StepUsageAccumulator {
     const key = stepKey(turn, step)
     const entry = this.perStep.get(key)
     if (entry !== undefined) {
+      // A usage-less late failed-attempt record must not erase an
+      // authoritative assistant/message value already held for this step.
+      if (usage === undefined && entry.authoritative === true) return
       if (entry.usage !== undefined) this.subtractPending(turn, entry.usage)
       this.perStep.delete(key)
     }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -2978,7 +2978,17 @@ export class TranscriptFolder {
         // last assistant step — the final-answer dedup depends on it
         // (review finding).
         activity.lastAssistantStep = Math.max(priorLast, event.data.step)
-        if (!staleForFocus) {
+        if (staleForFocus) {
+          // A stale durable settlement cannot reclaim candidate or final
+          // ownership. It may still update the confirmed slot when that exact
+          // step already owns the displayed intermediate message: the
+          // authoritative text must replace the streamed preview in place.
+          if (activity.messageConfirmedStep === event.data.step) {
+            activity.messageConfirmed = text === ''
+              ? undefined
+              : text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP)
+          }
+        } else {
           const prior = activity.messageCandidate
           // Only a message for a NEWER step confirms the open candidate
           // (plan §5.3 C); a message for an older step is stale and must

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -44,6 +44,14 @@ import type {} from '@deepseek-ai/dsh-tool-workflow/types'
 // Load the official retry event declarations.
 import type {} from '@deepseek-ai/dsh-llm-retry'
 
+/**
+ * Presentation-only Assistant blocks. An `open-opaque` item records that a
+ * block has started without inventing a finalized ContentBlock or payload.
+ */
+export type AssistantDisplayBlock =
+  | { readonly kind: 'content'; readonly block: ContentBlock }
+  | { readonly kind: 'open-opaque'; readonly blockType: string }
+
 /** One renderable message in the TUI transcript. */
 export type TranscriptMessage =
   /**
@@ -64,13 +72,16 @@ export type TranscriptMessage =
    * One step's model output. `text` is the flat markdown; `content` is the
    * settled message's full blocks when the step carried any role-neutral
    * non-text content (attachments and future blocks render rather than crash,
-   * plan §15.3).
+   * plan §15.3). `displayBlocks` is presentation-only evidence for an open
+   * opaque block and is never durable model content.
    */
   | {
     kind: 'assistant'
     turn: number
     text: string
     content?: readonly ContentBlock[]
+    /** Ordered presentation blocks while an opaque block is still open. */
+    displayBlocks?: readonly AssistantDisplayBlock[]
     /** Durable interruption evidence; presentation metadata, not body text. */
     interrupted?: true
   }
@@ -127,6 +138,17 @@ export type TranscriptMessage =
     /** Non-empty when compaction/end carried an error. */
     error?: string
   }
+
+const assistantPresentationRevisions = new WeakMap<Extract<TranscriptMessage, { kind: 'assistant' }>, number>()
+
+/** Return the mutation revision of an Assistant's live indexed projection. */
+export function assistantPresentationRevision(message: TranscriptMessage): number {
+  return message.kind === 'assistant' ? assistantPresentationRevisions.get(message) ?? 0 : 0
+}
+
+function bumpAssistantPresentationRevision(message: Extract<TranscriptMessage, { kind: 'assistant' }>): void {
+  assistantPresentationRevisions.set(message, assistantPresentationRevision(message) + 1)
+}
 
 /** One member row of a workflow run card. */
 export interface WorkflowMemberView {
@@ -411,6 +433,31 @@ type AssistantBlockChunk =
   | { readonly type: 'tool-call-delta'; readonly index: number; readonly id: string; readonly name?: string; readonly argumentsDelta: string }
   | { readonly type: 'block-end'; readonly index: number; readonly block: AssistantLiveContentBlock | ContentBlock }
 
+interface AssistantStreamProjection {
+  states: Map<number, AssistantBlockState>
+  blocks: ContentBlock[]
+  displayBlocks: AssistantDisplayBlock[]
+  firstLane: 'thinking' | 'assistant' | undefined
+}
+
+/**
+ * The live arrays are intentionally retained and updated in place: streaming
+ * projection must not copy the complete pending row for every indexed chunk.
+ * TranscriptFolder already mutates its message objects in place; the separate
+ * presentation revision is the cache identity for this live-only optimization.
+ * Durable stream projections remain fresh arrays.
+ */
+interface LiveAssistantProjection {
+  states: Map<number, AssistantBlockState>
+  blockIndexes: number[]
+  blocks: ContentBlock[]
+  displayIndexes: number[]
+  displayBlocks: AssistantDisplayBlock[]
+  assistantVisibleCount: number
+  thinkingVisibleCount: number
+  openOpaqueCount: number
+}
+
 /** Start one typed partial block without pretending it is a finalized block. */
 function emptyAssistantBlockState(blockType: string): AssistantBlockState {
   switch (blockType) {
@@ -427,50 +474,57 @@ function emptyAssistantBlockState(blockType: string): AssistantBlockState {
  * state at a time; its first block-end replaces the partial state
  * authoritatively and then freezes the completed block.
  */
-function applyAssistantBlockChunk(blocks: Map<number, AssistantBlockState>, chunk: AssistantBlockChunk): void {
+function applyAssistantBlockChunk(blocks: Map<number, AssistantBlockState>, chunk: AssistantBlockChunk): boolean {
   switch (chunk.type) {
     case 'block-start':
       // The first block-start owns the index; duplicate starts must not erase
       // deltas already accepted for that block.
-      if (!blocks.has(chunk.index)) blocks.set(chunk.index, emptyAssistantBlockState(chunk.blockType))
-      break
+      if (blocks.has(chunk.index)) return false
+      blocks.set(chunk.index, emptyAssistantBlockState(chunk.blockType))
+      return true
     case 'text-delta': {
       const previous = blocks.get(chunk.index)
-      if (previous?.kind === 'complete') break
+      if (previous?.kind === 'complete') return false
+      if (previous?.kind === 'text' && chunk.text === '') return false
       blocks.set(chunk.index, {
         kind: 'text',
         text: previous?.kind === 'text' ? previous.text + chunk.text : chunk.text,
       })
-      break
+      return true
     }
     case 'reasoning-delta': {
       const previous = blocks.get(chunk.index)
-      if (previous?.kind === 'complete') break
+      if (previous?.kind === 'complete') return false
+      if (previous?.kind === 'reasoning' && chunk.text === '') return false
       blocks.set(chunk.index, {
         kind: 'reasoning',
         text: previous?.kind === 'reasoning' ? previous.text + chunk.text : chunk.text,
       })
-      break
+      return true
     }
     case 'tool-call-delta': {
       const previous = blocks.get(chunk.index)
-      if (previous?.kind === 'complete') break
+      if (previous?.kind === 'complete') return false
       const base = previous?.kind === 'tool-call'
         ? previous
         : { kind: 'tool-call' as const, id: '', name: '', arguments: '' }
+      const id = base.id || chunk.id
+      const name = chunk.name ?? base.name
+      const args = base.arguments + chunk.argumentsDelta
+      if (previous?.kind === 'tool-call'
+        && previous.id === id && previous.name === name && previous.arguments === args) return false
       blocks.set(chunk.index, {
         kind: 'tool-call',
-        id: base.id || chunk.id,
-        name: chunk.name ?? base.name,
-        arguments: base.arguments + chunk.argumentsDelta,
+        id,
+        name,
+        arguments: args,
       })
-      break
+      return true
     }
     case 'block-end':
-      if (blocks.get(chunk.index)?.kind !== 'complete') {
-        blocks.set(chunk.index, { kind: 'complete', block: chunk.block })
-      }
-      break
+      if (blocks.get(chunk.index)?.kind === 'complete') return false
+      blocks.set(chunk.index, { kind: 'complete', block: chunk.block })
+      return true
   }
 }
 
@@ -501,6 +555,115 @@ function assistantContentFromBlocks(blocks: Map<number, AssistantBlockState>): C
     .sort(([left], [right]) => left - right)
     .map(([, state]) => assistantContentFromBlockState(state))
     .filter((block): block is ContentBlock => block !== undefined)
+}
+
+/** Project one block state for rendering without promoting open opaque state to content. */
+function assistantDisplayBlockFromState(state: AssistantBlockState): AssistantDisplayBlock | undefined {
+  switch (state.kind) {
+    case 'text': return { kind: 'content', block: { type: 'text', text: state.text } }
+    case 'reasoning': return { kind: 'content', block: { type: 'reasoning', text: state.text } }
+    case 'tool-call':
+      return state.id === ''
+        ? undefined
+        : { kind: 'content', block: { type: 'tool-call', id: ToolCallId(state.id), name: state.name, arguments: state.arguments } }
+    case 'complete': return { kind: 'content', block: authoritativeContentBlock(state.block) }
+    case 'opaque': return { kind: 'open-opaque', blockType: state.blockType }
+  }
+}
+
+/** Project all indexed states in upstream numeric order for Assistant display. */
+function assistantDisplayBlocksFromStates(blocks: Map<number, AssistantBlockState>): AssistantDisplayBlock[] {
+  return [...blocks.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, state]) => assistantDisplayBlockFromState(state))
+    .filter((block): block is AssistantDisplayBlock => block !== undefined)
+}
+
+interface AssistantBlockProjection {
+  content: ContentBlock | undefined
+  display: AssistantDisplayBlock | undefined
+  assistantVisible: boolean
+  thinkingVisible: boolean
+  opaque: boolean
+}
+
+function assistantBlockProjection(state: AssistantBlockState): AssistantBlockProjection {
+  const content = assistantContentFromBlockState(state)
+  const display = assistantDisplayBlockFromState(state)
+  return {
+    content,
+    display,
+    assistantVisible: state.kind === 'opaque'
+      || (content !== undefined && assistantBlocksVisibleNow([content])),
+    thinkingVisible: content !== undefined && content.type === 'reasoning' && content.text !== '',
+    opaque: state.kind === 'opaque',
+  }
+}
+
+function lowerBound(values: readonly number[], value: number): number {
+  let low = 0
+  let high = values.length
+  while (low < high) {
+    const middle = (low + high) >>> 1
+    if (values[middle]! < value) low = middle + 1
+    else high = middle
+  }
+  return low
+}
+
+/** Replace one indexed projection without rescanning the other indexes. */
+function updateIndexedProjection<T>(
+  indexes: number[],
+  values: T[],
+  index: number,
+  value: T | undefined,
+): void {
+  const position = lowerBound(indexes, index)
+  const ownsIndex = position < indexes.length && indexes[position] === index
+  if (value === undefined) {
+    if (!ownsIndex) return
+    indexes.splice(position, 1)
+    values.splice(position, 1)
+    return
+  }
+  if (ownsIndex) {
+    values[position] = value
+    return
+  }
+  indexes.splice(position, 0, index)
+  values.splice(position, 0, value)
+}
+
+/** Whether a display projection contains user-visible Assistant output. */
+function assistantDisplayBlocksVisibleNow(blocks: readonly AssistantDisplayBlock[]): boolean {
+  for (const block of blocks) {
+    if (block.kind === 'open-opaque') return true
+    if (assistantBlocksVisibleNow([block.block])) return true
+  }
+  return false
+}
+
+/** Whether a display projection retains evidence at a closed attempt boundary. */
+function assistantDisplayBlocksHaveInterruptionEvidence(blocks: readonly AssistantDisplayBlock[]): boolean {
+  for (const block of blocks) {
+    if (block.kind === 'open-opaque') return true
+    if (assistantBlocksHaveInterruptionEvidence([block.block])) return true
+  }
+  return false
+}
+
+/** Use the semantic or display-only projection for entry visibility. */
+export function assistantEntryVisibleNow(entry: Extract<TranscriptMessage, { kind: 'assistant' }>): boolean {
+  return entry.displayBlocks === undefined
+    ? assistantBlocksVisibleNow(assistantEntryBlocks(entry))
+    : assistantDisplayBlocksVisibleNow(entry.displayBlocks)
+}
+
+/** Use the semantic or display-only projection for attempt evidence. */
+function assistantEntryHasInterruptionEvidence(entry: Extract<TranscriptMessage, { kind: 'assistant' }>): boolean {
+  return entry.displayBlocks === undefined
+    ? assistantBlocksHaveInterruptionEvidence(assistantEntryBlocks(entry))
+    : assistantDisplayBlocksHaveInterruptionEvidence(entry.displayBlocks)
 }
 
 /**
@@ -664,7 +827,7 @@ export class TranscriptFolder {
   /** In-flight live block state keyed by logical step. This is required for
    * authoritative block-end replacement: deltas may be partial, while a
    * completed block replaces the entire indexed state without duplication. */
-  private readonly liveAssistantBlocks = new Map<string, Map<number, AssistantBlockState>>()
+  private readonly liveAssistantBlocks = new Map<string, LiveAssistantProjection>()
   /** Assistant entries created by the LIVE stream path and not yet taken
    * over by a durable settlement. Attempt evidence remains transient until
    * retry or turn end; abandoned attempts have no durable surface and are
@@ -836,6 +999,7 @@ export class TranscriptFolder {
 
   /** Restore one authoritative reasoning body into the bounded Focus preview. */
   private restoreThinkingPreview(activity: MutableTurnActivity, step: number, text: string): void {
+    if (step < (activity.lastAssistantStep ?? step)) return
     activity.thinkingStep = step
     activity.thinkingTail = text.slice(-TranscriptFolder.THINKING_TAIL_CAP)
     const line = latestLine(activity.thinkingTail).slice(0, TranscriptFolder.NARRATIVE_PREVIEW_CAP)
@@ -845,6 +1009,7 @@ export class TranscriptFolder {
 
   /** Clear the Focus reasoning preview owned by one authoritative step. */
   private clearThinkingPreview(activity: MutableTurnActivity, step: number): void {
+    if (step < (activity.lastAssistantStep ?? step)) return
     if (activity.thinkingStep !== step) return
     activity.thinkingStep = undefined
     if (activity.thinkingTail === '' && activity.think === undefined) return
@@ -860,7 +1025,7 @@ export class TranscriptFolder {
     // After turn/end the Think slot was settled: a late reasoning delta
     // (replay artifact) must not mutate it (review finding). The thinking
     // transcript entry still accumulates the delta.
-    if (activity.completed) return
+    if (activity.completed || step < (activity.lastAssistantStep ?? step)) return
     activity.thinkingStep = step
     activity.thinkingTail = (activity.thinkingTail + delta).slice(-TranscriptFolder.THINKING_TAIL_CAP)
     const line = latestLine(activity.thinkingTail).slice(0, TranscriptFolder.NARRATIVE_PREVIEW_CAP)
@@ -1177,7 +1342,7 @@ export class TranscriptFolder {
     if (item.kind === 'assistant') {
       if (this.hiddenAssistantEntries.has(item)) return false
       if (item.interrupted === true) return true
-      return assistantBlocksVisibleNow(assistantEntryBlocks(item))
+      return assistantEntryVisibleNow(item)
     }
     if (item.kind === 'thinking') return !this.hiddenThinkingEntries.has(item)
     return true
@@ -1533,7 +1698,16 @@ export class TranscriptFolder {
         // the failed one's. Reopen parity: the durable log restores the
         // step's reasoning from its LATEST source.
         const key = stepKey(input.turn, input.step)
-        this.liveAssistantBlocks.set(key, new Map())
+        this.liveAssistantBlocks.set(key, {
+          states: new Map(),
+          blockIndexes: [],
+          blocks: [],
+          displayIndexes: [],
+          displayBlocks: [],
+          assistantVisibleCount: 0,
+          thinkingVisibleCount: 0,
+          openOpaqueCount: 0,
+        })
         const thinking = this.thinkingEntries.get(key)
         if (thinking !== undefined && thinking.running === false) {
           thinking.text = ''
@@ -1577,27 +1751,34 @@ export class TranscriptFolder {
   /** Tombstone one transient assistant entry at a retry boundary. The
    * first-token timing and usage live in their separate folds and are not
    * touched here; only the presentation state is reset. */
-  private hideTransientAssistantEntry(turn: number, step: number): void {
+  private hideTransientAssistantEntry(turn: number, step: number): boolean {
     const key = stepKey(turn, step)
     const entry = this.assistantEntries.get(key)
-    if (entry === undefined || !this.transientAssistantEntries.has(entry)) return
+    if (entry === undefined || !this.transientAssistantEntries.has(entry)) return false
+    const activity = this.activityByTurn.get(turn)
+    const clearLatestVisibility = activity !== undefined
+      && activity.lastAssistantStep === step
+      && activity.lastAssistantVisible === true
+    if (clearLatestVisibility) activity.lastAssistantVisible = false
     const wasVisible = this.isVisible(entry)
     this.assistantEntries.delete(key)
     entry.text = ''
     entry.content = undefined
+    entry.displayBlocks = undefined
     entry.interrupted = undefined
     this.transientAssistantEntries.delete(entry)
     this.attemptAssistantEntries.delete(entry)
     this.hiddenAssistantEntries.add(entry)
     this.markStreamingEntryDirty(`assistant:${key}`)
     this.syncAssistantVisibility(turn, step, entry, wasVisible, false)
+    return clearLatestVisibility
   }
 
   /** A failed live attempt has no durable evidence and is therefore
    * tombstoned. A committed `assistant/attempt` is restored separately and
    * remains available as interruption evidence until retry/turn end. */
   private settleFailedAttempt(turn: number, step: number, abandoned = false, discardUsage = true): void {
-    if (abandoned) this.hideTransientAssistantEntry(turn, step)
+    const visibilityReset = abandoned ? this.hideTransientAssistantEntry(turn, step) : false
     if (abandoned) {
       // Tombstone abandoned reasoning too: the raw item remains index-stable
       // while every visible/search/grouped projection skips it.
@@ -1608,13 +1789,15 @@ export class TranscriptFolder {
     if (activity === undefined) return
     if (abandoned) this.clearThinkingPreview(activity, step)
     if (abandoned) {
+      let changed = visibilityReset
       const candidate = activity.messageCandidate
       if (candidate !== undefined && candidate.step === step
         && !activity.settledSteps.has(step) && !activity.confirmedSteps.has(step)) {
         activity.messageCandidate = undefined
         this.syncMessage(activity)
-        activity.revision += 1
+        changed = true
       }
+      if (changed) activity.revision += 1
     }
     this.syncUsage(activity)
   }
@@ -1654,16 +1837,31 @@ export class TranscriptFolder {
     }
     const existing = this.assistantEntries.get(key)
     if (existing !== undefined && this.attemptAssistantEntries.has(existing)) return
-    const blocks = this.liveBlocksFor(turn, step)
+    const reasoningFrame = chunk.type === 'reasoning-delta'
+      || (chunk.type === 'block-start' && chunk.blockType === 'reasoning')
+      || (chunk.type === 'block-end' && chunk.block.type === 'reasoning')
+    // Usage facts deliberately bypass the presentation-only stale fence so
+    // Focus accounting remains aligned with the independent stats fold.
+    if (chunk.type !== 'usage'
+      && existing === undefined && step < (activity.lastAssistantStep ?? -1) && !reasoningFrame) return
+    // An existing older row may still receive an interleaved late chunk; keep
+    // that semantic transcript evidence current. The no-entry fence above
+    // prevents replay from resurrecting a removed surface, while candidate and
+    // latest-step bookkeeping below keep Focus ownership on the newer step.
+    const projection = this.liveAssistantProjectionFor(turn, step)
     switch (chunk.type) {
       case 'block-start':
       case 'text-delta':
       case 'reasoning-delta':
       case 'tool-call-delta':
-      case 'block-end':
-        applyAssistantBlockChunk(blocks, chunk)
-        this.syncLiveAssistantPresentation(turn, step)
+      case 'block-end': {
+        const previous = projection.states.get(chunk.index)
+        if (applyAssistantBlockChunk(projection.states, chunk)) {
+          this.updateLiveAssistantProjection(projection, chunk.index, previous)
+          this.syncLiveAssistantPresentation(turn, step)
+        }
         break
+      }
       case 'usage':
         // Focus aggregation: per-turn token facts (the shared
         // accumulator — the footer and Focus can never drift).
@@ -1675,15 +1873,43 @@ export class TranscriptFolder {
     }
   }
 
-  /** Return the current live block state in stable upstream index order. */
-  private liveBlocksFor(turn: number, step: number): Map<number, AssistantBlockState> {
+  /** Return the mutable live projection for one logical step. */
+  private liveAssistantProjectionFor(turn: number, step: number): LiveAssistantProjection {
     const key = stepKey(turn, step)
-    let blocks = this.liveAssistantBlocks.get(key)
-    if (blocks === undefined) {
-      blocks = new Map()
-      this.liveAssistantBlocks.set(key, blocks)
+    let projection = this.liveAssistantBlocks.get(key)
+    if (projection === undefined) {
+      projection = {
+        states: new Map(),
+        blockIndexes: [],
+        blocks: [],
+        displayIndexes: [],
+        displayBlocks: [],
+        assistantVisibleCount: 0,
+        thinkingVisibleCount: 0,
+        openOpaqueCount: 0,
+      }
+      this.liveAssistantBlocks.set(key, projection)
     }
-    return blocks
+    return projection
+  }
+
+  /** Update only the indexed projection affected by one accepted chunk. */
+  private updateLiveAssistantProjection(
+    projection: LiveAssistantProjection,
+    index: number,
+    previous: AssistantBlockState | undefined,
+  ): void {
+    const previousProjection = previous === undefined ? undefined : assistantBlockProjection(previous)
+    const current = projection.states.get(index)
+    const currentProjection = current === undefined ? undefined : assistantBlockProjection(current)
+    if (previousProjection?.assistantVisible === true) projection.assistantVisibleCount -= 1
+    if (previousProjection?.thinkingVisible === true) projection.thinkingVisibleCount -= 1
+    if (previousProjection?.opaque === true) projection.openOpaqueCount -= 1
+    if (currentProjection?.assistantVisible === true) projection.assistantVisibleCount += 1
+    if (currentProjection?.thinkingVisible === true) projection.thinkingVisibleCount += 1
+    if (currentProjection?.opaque === true) projection.openOpaqueCount += 1
+    updateIndexedProjection(projection.blockIndexes, projection.blocks, index, currentProjection?.content)
+    updateIndexedProjection(projection.displayIndexes, projection.displayBlocks, index, currentProjection?.display)
   }
 
   /** Replace the Focus message candidate with authoritative assembled text. */
@@ -1703,16 +1929,37 @@ export class TranscriptFolder {
   /** Project the current live block map without duplicating block-end text. */
   private syncLiveAssistantPresentation(turn: number, step: number): void {
     const key = stepKey(turn, step)
-    const blocks = assistantContentFromBlocks(this.liveBlocksFor(turn, step))
+    const projection = this.liveAssistantProjectionFor(turn, step)
+    const { blocks, displayBlocks } = projection
+    const hasOpenOpaque = projection.openOpaqueCount > 0
+    const displayProjection = hasOpenOpaque ? displayBlocks : undefined
     const text = textOf(blocks)
     const activity = this.activityFor(turn)
-    const visibleNow = assistantBlocksVisibleNow(blocks)
-    if (step >= (activity.lastAssistantStep ?? -1)) activity.lastAssistantVisible = visibleNow
+    const visibleNow = projection.assistantVisibleCount > 0
+    const priorLastAssistantStep = activity.lastAssistantStep ?? -1
+    const priorLastAssistantVisible = activity.lastAssistantVisible
+    if (step >= priorLastAssistantStep) {
+      activity.lastAssistantVisible = visibleNow
+      // Any accepted indexed block state owns the latest-step fence, even
+      // when its current projection is hidden (empty text/reasoning/tool-call).
+      // This is structural state only; it never creates a Focus candidate.
+      if (projection.states.size > 0) activity.lastAssistantStep = Math.max(priorLastAssistantStep, step)
+    }
+    if (activity.lastAssistantStep !== priorLastAssistantStep
+      || activity.lastAssistantVisible !== priorLastAssistantVisible) {
+      activity.revision += 1
+    }
     const entry = this.assistantEntries.get(key)
     const wasVisible = entry !== undefined && this.isVisible(entry)
+    const staleStep = step < priorLastAssistantStep
     if (!visibleNow) {
-      if (entry !== undefined && this.transientAssistantEntries.has(entry)) this.hideTransientAssistantEntry(turn, step)
-      this.replaceMessageCandidate(activity, step, '')
+      // A late reasoning frame may reopen an empty block map after a committed
+      // step was closed. Preserve that step's existing transcript rows; only
+      // the diagnostic Thinking text below may be refreshed.
+      if (!staleStep) {
+        if (entry !== undefined && this.transientAssistantEntries.has(entry)) this.hideTransientAssistantEntry(turn, step)
+        this.replaceMessageCandidate(activity, step, '')
+      }
     } else {
       const target = entry ?? this.assistantEntry(turn, step)
       this.transientAssistantEntries.add(target)
@@ -1720,20 +1967,43 @@ export class TranscriptFolder {
       this.hiddenAssistantEntries.delete(target)
       target.text = text
       target.content = blocks.some(block => block.type !== 'text') ? blocks : undefined
+      target.displayBlocks = displayProjection
       target.interrupted = undefined
+      bumpAssistantPresentationRevision(target)
       this.markStreamingEntryDirty(`assistant:${key}`)
-      this.replaceMessageCandidate(activity, step, text)
+      if (text.trim() !== '') {
+        this.replaceMessageCandidate(activity, step, text)
+      } else if (!hasOpenOpaque) {
+        this.replaceMessageCandidate(activity, step, '')
+      } else {
+        // A new opaque step confirms an older real-text candidate, but never
+        // creates a candidate from the pending fallback itself. If this same
+        // step's semantic text was replaced by an empty block, clear its old
+        // candidate instead of leaving stale Focus text behind.
+        const candidate = activity.messageCandidate
+        if (candidate !== undefined && candidate.step === step) {
+          this.replaceMessageCandidate(activity, step, '')
+        } else if (candidate !== undefined && candidate.step < step) {
+          this.confirmMessageCandidate(activity)
+          this.syncMessage(activity)
+          activity.revision += 1
+        }
+      }
       this.syncAssistantVisibility(turn, step, target, wasVisible, false)
     }
 
-    const reasoning = blocks
-      .filter((block): block is Extract<ContentBlock, { type: 'reasoning' }> => block.type === 'reasoning')
-      .map(block => block.text)
-      .join('')
+    const reasoning = projection.thinkingVisibleCount === 0
+      ? ''
+      : blocks
+        .filter((block): block is Extract<ContentBlock, { type: 'reasoning' }> => block.type === 'reasoning')
+        .map(block => block.text)
+        .join('')
     const thinkingKey = `thinking:${key}`
     if (reasoning === '') {
-      this.hideThinkingEntry(turn, step)
-      this.clearThinkingPreview(this.activityFor(turn), step)
+      if (!staleStep) {
+        this.hideThinkingEntry(turn, step)
+        this.clearThinkingPreview(this.activityFor(turn), step)
+      }
       return
     }
     const thinking = this.thinkingEntry(turn, step)
@@ -1744,44 +2014,79 @@ export class TranscriptFolder {
     this.restoreThinkingPreview(this.activityFor(turn), step, reasoning)
   }
 
-  /** Reconstruct the authoritative assistant blocks from one compact stream.
-   * The durable path intentionally uses the same indexed state accumulator as
-   * live input, so partial attempt evidence and block-end replacement cannot
-   * drift between live and cold replay. */
-  private assistantBlocksFromStream(stream: readonly unknown[]): ContentBlock[] {
-    const blocks = new Map<number, AssistantBlockState>()
-    for (const member of expandAssistantStream(stream as Parameters<typeof expandAssistantStream>[0])) {
-      const chunk = member.chunk
-      switch (chunk.type) {
-        case 'block-start':
-        case 'text-delta':
-        case 'reasoning-delta':
-        case 'tool-call-delta':
-        case 'block-end':
-          applyAssistantBlockChunk(blocks, chunk)
-          break
-        case 'usage':
-        case 'finish':
-          break
+  /** Fold one durable assistant stream once for both presentation order and
+   * restored content. The indexed state is updated in O(1) per accepted chunk;
+   * only the final projections sort the retained indexes. */
+  private assistantStreamProjection(stream: readonly unknown[]): AssistantStreamProjection {
+    const states = new Map<number, AssistantBlockState>()
+    const rowOrder: Array<'thinking' | 'assistant'> = []
+    let assistantVisibleCount = 0
+    let thinkingVisibleCount = 0
+    let assistantPresent = false
+    let thinkingPresent = false
+
+    const adjustVisibility = (state: AssistantBlockState, amount: number): void => {
+      const projection = assistantBlockProjection(state)
+      if (projection.assistantVisible) assistantVisibleCount += amount
+      if (projection.thinkingVisible) thinkingVisibleCount += amount
+    }
+
+    for (const { chunk } of expandAssistantStream(stream as Parameters<typeof expandAssistantStream>[0])) {
+      if (chunk.type === 'usage' || chunk.type === 'finish') continue
+      const previous = states.get(chunk.index)
+      if (!applyAssistantBlockChunk(states, chunk)) continue
+      if (previous !== undefined) adjustVisibility(previous, -1)
+      const current = states.get(chunk.index)
+      if (current !== undefined) adjustVisibility(current, 1)
+
+      const visibleNow = assistantVisibleCount > 0
+      const nextThinking = thinkingVisibleCount > 0
+      // Match live step-level materialization: a hidden aggregate lane is
+      // removed, and a later recreation is appended after surviving rows.
+      if (visibleNow !== assistantPresent) {
+        if (visibleNow) rowOrder.push('assistant')
+        else {
+          const index = rowOrder.indexOf('assistant')
+          if (index >= 0) rowOrder.splice(index, 1)
+        }
+        assistantPresent = visibleNow
+      }
+      if (nextThinking !== thinkingPresent) {
+        if (nextThinking) rowOrder.push('thinking')
+        else {
+          const index = rowOrder.indexOf('thinking')
+          if (index >= 0) rowOrder.splice(index, 1)
+        }
+        thinkingPresent = nextThinking
       }
     }
-    return assistantContentFromBlocks(blocks)
+
+    return {
+      states,
+      blocks: assistantContentFromBlocks(states),
+      displayBlocks: assistantDisplayBlocksFromStates(states),
+      firstLane: rowOrder[0],
+    }
   }
 
-  /** Restore a SETTLED thinking entry from a durable embedded stream
-   * (Session v2 cold replay — `assistant/message.stream` /
-   * `assistant/attempt.stream`). The canonical DSH decoder expands every
-   * compact representation, and block-end remains authoritative. */
-  private restoreThinkingFromStream(turn: number, step: number, stream: readonly unknown[]): void {
-    const text = this.assistantBlocksFromStream(stream)
+  private restoreThinkingFromProjection(turn: number, step: number, projection: AssistantStreamProjection): void {
+    const activity = this.activityByTurn.get(turn)
+    const staleStep = activity !== undefined && step < (activity.lastAssistantStep ?? step)
+    const key = stepKey(turn, step)
+    // A late replay may supply the first diagnostic row for an older step, but
+    // it must not replace reasoning already restored from that step's earlier
+    // authoritative attempt.
+    if (staleStep && this.thinkingEntries.has(key)) return
+    const text = projection.blocks
       .filter((block): block is Extract<ContentBlock, { type: 'reasoning' }> => block.type === 'reasoning')
       .map(block => block.text)
       .join('')
-    const key = stepKey(turn, step)
     if (text === '') {
-      this.hideThinkingEntry(turn, step)
-      const activity = this.activityByTurn.get(turn)
-      if (activity !== undefined) this.clearThinkingPreview(activity, step)
+      if (!staleStep) {
+        this.hideThinkingEntry(turn, step)
+        const activity = this.activityByTurn.get(turn)
+        if (activity !== undefined) this.clearThinkingPreview(activity, step)
+      }
       return
     }
     const entry = this.thinkingEntry(turn, step)
@@ -1795,22 +2100,51 @@ export class TranscriptFolder {
   /** Restore assistant interruption evidence from a durable attempt. Text and
    * finalized non-text blocks are retained; reasoning remains in the Think
    * entry. Tool-call-only content is retained as hidden evidence until the
-   * closed boundary. The attempt entry is still transient so `llm/retry` can
-   * reset it. */
-  private restoreAssistantAttempt(turn: number, step: number, stream: readonly unknown[]): void {
-    const blocks = this.assistantBlocksFromStream(stream)
-    const visibleNow = assistantBlocksVisibleNow(blocks)
-    const hasEvidence = assistantBlocksHaveInterruptionEvidence(blocks)
+   * closed boundary. An open opaque block keeps display-only evidence while
+   * the attempt is live. The attempt entry is still transient so `llm/retry`
+   * can reset it. */
+  private restoreAssistantAttempt(turn: number, step: number, projection: AssistantStreamProjection): void {
+    const { states, blocks, displayBlocks } = projection
+    const hasOpenOpaque = displayBlocks.some(block => block.kind === 'open-opaque')
+    const displayProjection = hasOpenOpaque ? displayBlocks : undefined
+    const visibleNow = displayProjection === undefined
+      ? assistantBlocksVisibleNow(blocks)
+      : assistantDisplayBlocksVisibleNow(displayProjection)
+    const hasEvidence = displayProjection === undefined
+      ? assistantBlocksHaveInterruptionEvidence(blocks)
+      : assistantDisplayBlocksHaveInterruptionEvidence(displayProjection)
+    // An explicitly decoded block state is authoritative even when it has no
+    // visible Assistant row (reasoning/tool-call/empty text). Only an entirely
+    // empty stream may preserve a live prefix as attempt evidence.
+    const hasAuthoritativeBlockState = states.size > 0
     const text = textOf(blocks)
     const key = stepKey(turn, step)
+    const activity = this.activityFor(turn)
     const existing = this.assistantEntries.get(key)
+    if (existing === undefined && step < (activity.lastAssistantStep ?? -1)) return
+    if (hasAuthoritativeBlockState && step >= (activity.lastAssistantStep ?? -1)) {
+      // Durable attempt evidence owns the same structural stale-event fence
+      // as live opaque presentation. Hidden authoritative state clears the
+      // latest-visible bit while preserving the monotonic step fence.
+      activity.lastAssistantVisible = visibleNow
+      // Hidden authoritative state is still the latest structural output and
+      // must fence late older steps without creating a Message candidate.
+      activity.lastAssistantStep = Math.max(activity.lastAssistantStep ?? -1, step)
+    }
+    if (hasAuthoritativeBlockState && text.trim() === '' && activity.messageCandidate?.step === step) {
+      // A hidden authoritative state replaces semantic text for this step; do
+      // not leave the earlier live candidate visible in Focus.
+      this.replaceMessageCandidate(activity, step, '')
+    }
     const wasVisible = existing !== undefined && this.isVisible(existing)
-    if (!visibleNow && !hasEvidence) {
+    if (!visibleNow && !hasEvidence && !hasAuthoritativeBlockState) {
       // A live prefix may be the only evidence when the compact settlement
-      // carries no visible blocks. Keep that prefix as attempt evidence
-      // instead of promoting it to a normal settled message.
+      // carries no block state. Keep that prefix as attempt evidence instead
+      // of promoting it to a normal settled message.
       if (existing !== undefined && this.transientAssistantEntries.has(existing)) {
-        this.attemptAssistantEntries.add(existing)
+        const hasOpenOpaque = existing.displayBlocks?.some(block => block.kind === 'open-opaque') === true
+        if (hasOpenOpaque) this.hideTransientAssistantEntry(turn, step)
+        else this.attemptAssistantEntries.add(existing)
       }
       return
     }
@@ -1820,6 +2154,7 @@ export class TranscriptFolder {
     this.attemptAssistantEntries.add(entry)
     entry.text = text
     entry.content = blocks.some(block => block.type !== 'text') ? blocks : undefined
+    entry.displayBlocks = displayProjection
     entry.interrupted = undefined
     this.markStreamingEntryDirty(`assistant:${key}`)
     this.syncAssistantVisibility(turn, step, entry, wasVisible, false)
@@ -1833,7 +2168,7 @@ export class TranscriptFolder {
       if (item.turn !== turn || !this.attemptAssistantEntries.has(item)) continue
       const itemStep = Number(key.slice(key.indexOf('/') + 1))
       if (step !== undefined && itemStep !== step) continue
-      if (!assistantBlocksHaveInterruptionEvidence(assistantEntryBlocks(item))) continue
+      if (!assistantEntryHasInterruptionEvidence(item)) continue
       if (this.hiddenAssistantEntries.has(item)) continue
       const wasVisible = this.isVisible(item)
       item.interrupted = true
@@ -2407,17 +2742,27 @@ export class TranscriptFolder {
     // turn closes. Usage is folded independently from the stream.
     if (kind === 'assistant/attempt') {
       const data = event.data as { turn: number; step: number; stream?: readonly unknown[] }
-      if (this.activityByTurn.get(data.turn)?.completed === true) return
+      const existingActivity = this.activityByTurn.get(data.turn)
+      if (existingActivity?.completed === true) return
+      // An authoritative assistant/message owns this step permanently; a
+      // later attempt replay must not turn the settled row back into a
+      // transient/open presentation. Its usage is still folded independently
+      // below so Focus and Stats keep the same late-fact policy.
+      const alreadySettled = existingActivity?.settledSteps.has(data.step) === true
       const stream = data.stream ?? []
       this.liveAssistantBlocks.delete(stepKey(data.turn, data.step))
-      this.restoreAssistantAttempt(data.turn, data.step, stream)
+      const projection = alreadySettled ? undefined : this.assistantStreamProjection(stream)
+      // The durable embedded stream is COMPLETE and authoritative for
+      // reasoning; restore the first lane before the other one so cold replay
+      // preserves the live Thinking → Assistant / Assistant → Thinking order.
+      if (projection?.firstLane === 'thinking') this.restoreThinkingFromProjection(data.turn, data.step, projection)
+      if (projection !== undefined) this.restoreAssistantAttempt(data.turn, data.step, projection)
       this.usage.onAssistantAttempt(data.turn, data.step, usageFromAssistantSettlement('attempt', undefined, stream))
       const activity = this.activityFor(data.turn)
       const key = stepKey(data.turn, data.step)
-      // The durable embedded stream is COMPLETE and authoritative for
-      // reasoning; overwrite any live partial so cold replay matches the
-      // settled attempt. A later retry resets this evidence at llm/retry.
-      this.restoreThinkingFromStream(data.turn, data.step, stream)
+      if (projection !== undefined && projection.firstLane !== 'thinking') {
+        this.restoreThinkingFromProjection(data.turn, data.step, projection)
+      }
       this.syncUsage(activity)
       const thinking = this.thinkingEntries.get(key)
       if (thinking !== undefined && thinking.running) this.closeThinking(thinking)
@@ -2537,19 +2882,27 @@ export class TranscriptFolder {
         const activity = this.activityFor(event.data.turn)
         if (activity.completed) break
         const key = stepKey(event.data.turn, event.data.step)
+        const priorLast = activity.lastAssistantStep ?? -1
+        const entry = this.assistantEntries.get(key)
+        // A replayed older message with no existing row must not be appended
+        // after a newer open presentation; otherwise it can become the
+        // exact-last assistant selected at turn end. Its accounting and
+        // settlement facts still fold below, independently of presentation.
+        const staleWithoutEntry = entry === undefined && event.data.step < priorLast
         this.liveAssistantBlocks.delete(key)
         const messageUsage = usageFromAssistantSettlement('message', event.data.usage, event.data.stream)
         const alreadySettled = activity.settledSteps.has(event.data.step)
         const messageBlocks = event.data.message.content
         const text = textOf(messageBlocks)
-        const entry = this.assistantEntries.get(key)
-        const wasVisible = entry !== undefined && this.isVisible(entry)
-        if (entry !== undefined) {
+        if (!staleWithoutEntry) {
+          const wasVisible = entry !== undefined && this.isVisible(entry)
+          if (entry !== undefined) {
           entry.text = text
           // The durable message takes over the live/attempt entry: it is no
           // longer transient, so retry cleanup can never remove settled text.
           this.transientAssistantEntries.delete(entry)
           this.attemptAssistantEntries.delete(entry)
+          entry.displayBlocks = undefined
           entry.interrupted = event.data.interrupted === true ? true : undefined
           // The settled full blocks replace any earlier attempt evidence;
           // text-only messages must also clear stale non-text content.
@@ -2577,9 +2930,10 @@ export class TranscriptFolder {
           // and must be able to refresh its searchable entry (review
           // finding — the streaming-created path already registers).
           this.searchIndexByStepKey.set(`assistant:${key}`, this.appendItem(created))
+          }
+          const settledEntry = this.assistantEntries.get(key)
+          if (settledEntry !== undefined) this.syncAssistantVisibility(event.data.turn, event.data.step, settledEntry, wasVisible, false)
         }
-        const settledEntry = this.assistantEntries.get(key)
-        if (settledEntry !== undefined) this.syncAssistantVisibility(event.data.turn, event.data.step, settledEntry, wasVisible, false)
         // The step is complete: its thinking entry stops streaming and leaves
         // the open-lifecycle index, so a later turn/end never revisits it.
         // On a COLD replay no live reasoning deltas ever arrived — the
@@ -2599,11 +2953,11 @@ export class TranscriptFolder {
         // it is a replay artifact and must never resurrect a preview
         // (review finding).
         activity.settledSteps.add(event.data.step)
-        // A message of a DIFFERENT step than the open candidate proves the
-        // earlier step's output was intermediate: confirm it first (plan
-        // §5.3 C — a later step's output confirms the earlier candidate).
-        const priorLast = activity.lastAssistantStep ?? -1
-        if (event.data.step >= priorLast) {
+        if (!staleWithoutEntry) {
+          // A message of a DIFFERENT step than the open candidate proves the
+          // earlier step's output was intermediate: confirm it first (plan
+          // §5.3 C — a later step's output confirms the earlier candidate).
+          if (event.data.step >= priorLast) {
           activity.lastAssistantVisible = event.data.interrupted === true || assistantBlocksVisibleNow(messageBlocks)
         }
         const prior = activity.messageCandidate
@@ -2652,7 +3006,8 @@ export class TranscriptFolder {
             tail: text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP),
           }
         }
-        this.syncMessage(activity)
+          this.syncMessage(activity)
+        }
         this.usage.onAssistantMessage(event.data.turn, event.data.step, messageUsage)
         // Settled Assistant visibility was synchronized above without deleting its authoritative entry.
         this.syncUsage(activity)

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -140,10 +140,26 @@ export type TranscriptMessage =
   }
 
 const assistantPresentationRevisions = new WeakMap<Extract<TranscriptMessage, { kind: 'assistant' }>, number>()
+const assistantStepIdentities = new WeakMap<Extract<TranscriptMessage, { kind: 'assistant' }>, number>()
 
 /** Return the mutation revision of an Assistant's live indexed projection. */
 export function assistantPresentationRevision(message: TranscriptMessage): number {
   return message.kind === 'assistant' ? assistantPresentationRevisions.get(message) ?? 0 : 0
+}
+
+/** Return the internal step identity used to protect Focus final ownership. */
+export function assistantStepOf(message: TranscriptMessage): number | undefined {
+  return message.kind === 'assistant' ? assistantStepIdentities.get(message) : undefined
+}
+
+/** Read the private latest-step fence without exposing it on the public
+ * TurnActivity shape. Focus uses this only to select the structural owner. */
+export function assistantLatestStepOf(activity: TurnActivity): number | undefined {
+  return (activity as MutableTurnActivity).lastAssistantStep
+}
+
+function rememberAssistantStep(message: Extract<TranscriptMessage, { kind: 'assistant' }>, step: number): void {
+  assistantStepIdentities.set(message, step)
 }
 
 function bumpAssistantPresentationRevision(message: Extract<TranscriptMessage, { kind: 'assistant' }>): void {
@@ -2616,6 +2632,7 @@ export class TranscriptFolder {
     let entry = this.assistantEntries.get(key)
     if (entry === undefined) {
       entry = { kind: 'assistant', turn, text: '' }
+      rememberAssistantStep(entry, step)
       this.assistantEntries.set(key, entry)
       this.searchIndexByStepKey.set(`assistant:${key}`, this.appendItem(entry))
     }
@@ -2884,19 +2901,17 @@ export class TranscriptFolder {
         const key = stepKey(event.data.turn, event.data.step)
         const priorLast = activity.lastAssistantStep ?? -1
         const entry = this.assistantEntries.get(key)
-        // A replayed older message with no existing row must not be appended
-        // after a newer open presentation; otherwise it can become the
-        // exact-last assistant selected at turn end. Its accounting and
-        // settlement facts still fold below, independently of presentation.
-        const staleWithoutEntry = entry === undefined && event.data.step < priorLast
+        // A durable assistant/message is always a transcript surface fact.
+        // A stale step may not own Focus final selection, but it must remain
+        // available in the ordinary transcript and search projections.
         this.liveAssistantBlocks.delete(key)
         const messageUsage = usageFromAssistantSettlement('message', event.data.usage, event.data.stream)
         const alreadySettled = activity.settledSteps.has(event.data.step)
         const messageBlocks = event.data.message.content
         const text = textOf(messageBlocks)
-        if (!staleWithoutEntry) {
-          const wasVisible = entry !== undefined && this.isVisible(entry)
-          if (entry !== undefined) {
+        const wasVisible = entry !== undefined && this.isVisible(entry)
+        if (entry !== undefined) {
+          rememberAssistantStep(entry, event.data.step)
           entry.text = text
           // The durable message takes over the live/attempt entry: it is no
           // longer transient, so retry cleanup can never remove settled text.
@@ -2913,27 +2928,26 @@ export class TranscriptFolder {
           const searchIndex = this.searchIndexByStepKey.get(`assistant:${key}`)
           if (searchIndex !== undefined) this.markSearchEntryDirty(searchIndex)
         } else {
-          // ALWAYS preserve the entry — an empty settled message with no
-          // preceding chunk (replay edge) must still own the exact-last
-          // assistant slot, so the final selection never falls back to an
-          // earlier answer (review finding).
-          const created: TranscriptMessage = {
+          // ALWAYS preserve the durable entry — including an empty message
+          // and an older step with no preceding chunk. Focus ownership is
+          // fenced separately below; it must never delete a real settlement.
+          const created: Extract<TranscriptMessage, { kind: 'assistant' }> = {
             kind: 'assistant',
             turn: event.data.turn,
             text,
             ...(messageBlocks.some(block => block.type !== 'text') ? { content: messageBlocks } : {}),
             ...(event.data.interrupted === true ? { interrupted: true as const } : {}),
           }
+          rememberAssistantStep(created, event.data.step)
           this.assistantEntries.set(key, created)
           // The created entry must register its search index too: a later
           // replay replacement or text delta mutates this entry in place
           // and must be able to refresh its searchable entry (review
           // finding — the streaming-created path already registers).
           this.searchIndexByStepKey.set(`assistant:${key}`, this.appendItem(created))
-          }
-          const settledEntry = this.assistantEntries.get(key)
-          if (settledEntry !== undefined) this.syncAssistantVisibility(event.data.turn, event.data.step, settledEntry, wasVisible, false)
         }
+        const settledEntry = this.assistantEntries.get(key)
+        if (settledEntry !== undefined) this.syncAssistantVisibility(event.data.turn, event.data.step, settledEntry, wasVisible, false)
         // The step is complete: its thinking entry stops streaming and leaves
         // the open-lifecycle index, so a later turn/end never revisits it.
         // On a COLD replay no live reasoning deltas ever arrived — the
@@ -2953,61 +2967,59 @@ export class TranscriptFolder {
         // it is a replay artifact and must never resurrect a preview
         // (review finding).
         activity.settledSteps.add(event.data.step)
-        if (!staleWithoutEntry) {
+        const staleForFocus = event.data.step < priorLast
+        if (!staleForFocus) {
           // A message of a DIFFERENT step than the open candidate proves the
           // earlier step's output was intermediate: confirm it first (plan
           // §5.3 C — a later step's output confirms the earlier candidate).
-          if (event.data.step >= priorLast) {
           activity.lastAssistantVisible = event.data.interrupted === true || assistantBlocksVisibleNow(messageBlocks)
-        }
-        const prior = activity.messageCandidate
-        // Only a message for a NEWER step confirms the open candidate
-        // (plan §5.3 C); a message for an older step is stale and must
-        // never confirm a still-streaming candidate (review finding).
-        if (prior !== undefined && prior.step < event.data.step) {
-          this.confirmMessageCandidate(activity)
         }
         // Monotonic: a late event for an older step never regresses the
         // last assistant step — the final-answer dedup depends on it
         // (review finding).
         activity.lastAssistantStep = Math.max(priorLast, event.data.step)
-        const candidate = activity.messageCandidate
-        if (candidate !== undefined && candidate.step === event.data.step) {
-          // The authoritative text replaces the streaming tail — bounded
-          // to the tail cap, never a second full copy of the assistant
-          // output (plan §34 — the transcript entry owns the full text).
-          candidate.tail = text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP)
-        } else if (activity.messageConfirmedStep === event.data.step) {
-          // The step's candidate was already confirmed (a tool/call
-          // followed the text) and it is still the LATEST confirmed: the
-          // authoritative message updates the confirmed text IN PLACE —
-          // never a stale streamed fragment, never a resurrected
-          // candidate (review finding). An EMPTY authoritative text
-          // clears the confirmed text (the slot shows nothing — the stale
-          // streamed fragment must not survive).
-          activity.messageConfirmed = text === ''
-            ? undefined
-            : text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP)
-        } else if (activity.confirmedSteps.has(event.data.step)) {
-          // A late message for an OLDER confirmed step: the slot already
-          // shows a newer intermediate — ignore it entirely.
-        } else if (event.data.step < priorLast) {
-          // A late message for an older step that was never a candidate:
-          // stale — ignore it entirely (review finding).
-        } else if (text !== '' && !activity.completed) {
-          // A settled message without a prior candidate (replay edge): the
-          // authoritative text IS the step's output — it becomes the
-          // candidate so a later continuation still confirms it as an
-          // intermediate message (the LATEST intermediate wins, plan §5.6).
-          // After turn/end the final was already resolved: a late message
-          // must never resurrect a candidate (review finding).
-          activity.messageCandidate = {
-            step: event.data.step,
-            tail: text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP),
+        if (!staleForFocus) {
+          const prior = activity.messageCandidate
+          // Only a message for a NEWER step confirms the open candidate
+          // (plan §5.3 C); a message for an older step is stale and must
+          // never confirm a still-streaming candidate (review finding).
+          if (prior !== undefined && prior.step < event.data.step) {
+            this.confirmMessageCandidate(activity)
+          }
+          const candidate = activity.messageCandidate
+          if (candidate !== undefined && candidate.step === event.data.step) {
+            // The authoritative text replaces the streaming tail — bounded
+            // to the tail cap, never a second full copy of the assistant
+            // output (plan §34 — the transcript entry owns the full text).
+            candidate.tail = text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP)
+          } else if (activity.messageConfirmedStep === event.data.step) {
+            // The step's candidate was already confirmed (a tool/call
+            // followed the text) and it is still the LATEST confirmed: the
+            // authoritative message updates the confirmed text IN PLACE —
+            // never a stale streamed fragment, never a resurrected
+            // candidate (review finding). An EMPTY authoritative text
+            // clears the confirmed text (the slot shows nothing — the stale
+            // streamed fragment must not survive).
+            activity.messageConfirmed = text === ''
+              ? undefined
+              : text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP)
+          } else if (activity.confirmedSteps.has(event.data.step)) {
+            // A late message for an OLDER confirmed step: the slot already
+            // shows a newer intermediate — ignore it entirely.
+          } else if (text !== '' && !activity.completed) {
+            // A settled message without a prior candidate (replay edge): the
+            // authoritative text IS the step's output — it becomes the
+            // candidate so a later continuation still confirms it as an
+            // intermediate message (the LATEST intermediate wins, plan §5.6).
+            // After turn/end the final was already resolved: a late message
+            // must never resurrect a candidate (review finding).
+            activity.messageCandidate = {
+              step: event.data.step,
+              tail: text.slice(-TranscriptFolder.MESSAGE_TAIL_CAP),
+            }
           }
         }
-          this.syncMessage(activity)
-        }
+        this.syncMessage(activity)
         this.usage.onAssistantMessage(event.data.turn, event.data.step, messageUsage)
         // Settled Assistant visibility was synchronized above without deleting its authoritative entry.
         this.syncUsage(activity)

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -129,8 +129,8 @@ import { HistoryPanel, historyOverlayGeometry } from './history-panel.ts'
 import type { HistorySearchSource } from './history-search.ts'
 import { QuestionFlow } from './question.ts'
 import { MentionProvider } from './mentions.ts'
-import { recentTurnThreshold, textWithAttachmentMarkers, type TranscriptMessage, type TurnActivity } from './transcript.ts'
-import { finalizedBlockFallbackText, fileAttachmentSummary } from './content-block-presentation.ts'
+import { assistantPresentationRevision, recentTurnThreshold, textWithAttachmentMarkers, type AssistantDisplayBlock, type TranscriptMessage, type TurnActivity } from './transcript.ts'
+import { finalizedBlockFallbackText, fileAttachmentSummary, openOpaqueBlockFallbackText } from './content-block-presentation.ts'
 import type { TranscriptWindowState } from './transcript-window.ts'
 import { FocusActivityComponent, focusPreparingSummary, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
 import { WorkingIndicator, workingFramesFor } from './working.ts'
@@ -1965,6 +1965,12 @@ interface MessageComponentEntry {
    * from — an immutable array identity, so a settled image block landing
    * on a text-only component marks it stale (round-1 finding 2). */
   content?: unknown
+  /** The ordered Assistant display-only projection; its array identity plus
+   * presentation revision ensures live opaque rows invalidate the cache. */
+  displayBlocks?: unknown
+  /** Live indexed Assistant mutations can retain the projection array in
+   * place; this revision remains part of the cache identity. */
+  presentationRevision?: number
   /** Durable assistant interruption metadata; the marker is rendered outside
    * the assistant body so searchable/model-facing text stays unchanged. */
   interrupted?: boolean
@@ -8490,7 +8496,15 @@ export class TuiApp {
     width: number,
   ): MessageComponentEntry {
     const registry = this.renderers
-    const rendered = registry === undefined ? undefined : this.renderThroughExtensions(message, state.expanded)
+    // An open opaque Assistant item is a transient display contract, not part
+    // of the semantic renderer snapshot. Host rendering must own this frame so
+    // an extension renderer cannot hide the immediate pending row; once the
+    // block closes, the normal extension path resumes.
+    const hasOpenOpaque = message.kind === 'assistant'
+      && message.displayBlocks?.some(block => block.kind === 'open-opaque') === true
+    const rendered = registry === undefined || hasOpenOpaque
+      ? undefined
+      : this.renderThroughExtensions(message, state.expanded)
     // The width-baking flag is a HOST-build property: plugin components
     // never bake width (compiled views wrap at render time), so a resize
     // must not invalidate them — the renderer-cache contract (renderers
@@ -8528,6 +8542,8 @@ export class TuiApp {
       case 'system':
         entry.text = message.text
         entry.content = message.kind === 'user' || message.kind === 'assistant' ? message.content : undefined
+        entry.displayBlocks = message.kind === 'assistant' ? message.displayBlocks : undefined
+        entry.presentationRevision = message.kind === 'assistant' ? assistantPresentationRevision(message) : undefined
         entry.interrupted = message.kind === 'assistant' ? message.interrupted === true : undefined
         entry.running = message.kind === 'thinking' ? message.running : undefined
         entry.label = message.kind === 'system' ? message.label : undefined
@@ -8561,6 +8577,8 @@ export class TuiApp {
         return entry.text !== message.text || entry.content !== message.content
       case 'assistant':
         return entry.text !== message.text || entry.content !== message.content
+          || entry.displayBlocks !== message.displayBlocks
+          || entry.presentationRevision !== assistantPresentationRevision(message)
           || entry.interrupted !== (message.interrupted === true)
       case 'thinking':
         return entry.text !== message.text || entry.running !== message.running
@@ -8579,15 +8597,10 @@ export class TuiApp {
     }
   }
 
-  /**
-   * Render finalized message blocks IN ORDER (plan §15.2): text blocks fold
-   * into one text component per run, images use the existing thumbnail path
-   * when available (or their flat marker without a loader), files use their
-   * metadata-only row, and unknown blocks use the bounded explicit fallback.
-   * Reasoning and tool-call blocks retain their existing process ownership.
-   */
-  private renderBlockSequence(
-    content: readonly import('@deepseek-ai/dsh-llm').ContentBlock[],
+  /** Render an ordered Assistant display projection. Open opaque items are
+   * independent dim rows; content items reuse the finalized block renderer. */
+  private renderAssistantDisplaySequence(
+    displayBlocks: readonly AssistantDisplayBlock[],
     makeText: (text: string) => Component,
     message: TranscriptMessage,
   ): Component {
@@ -8601,7 +8614,13 @@ export class TuiApp {
       }
     }
     let imageIndex = 0
-    for (const block of content) {
+    for (const displayBlock of displayBlocks) {
+      if (displayBlock.kind === 'open-opaque') {
+        flushText()
+        container.addChild(new Text(color.textDim(openOpaqueBlockFallbackText(displayBlock.blockType)), 0, 0))
+        continue
+      }
+      const block = displayBlock.block
       if (block.type === 'text') {
         textBlocks.push(block)
       } else if (block.type === 'image') {
@@ -8634,6 +8653,25 @@ export class TuiApp {
     }
     flushText()
     return container
+  }
+
+  /**
+   * Render finalized message blocks IN ORDER (plan §15.2): text blocks fold
+   * into one text component per run, images use the existing thumbnail path
+   * when available (or their flat marker without a loader), files use their
+   * metadata-only row, and unknown blocks use the bounded explicit fallback.
+   * Reasoning and tool-call blocks retain their existing process ownership.
+   */
+  private renderBlockSequence(
+    content: readonly import('@deepseek-ai/dsh-llm').ContentBlock[],
+    makeText: (text: string) => Component,
+    message: TranscriptMessage,
+  ): Component {
+    return this.renderAssistantDisplaySequence(
+      content.map(block => ({ kind: 'content' as const, block })),
+      makeText,
+      message,
+    )
   }
 
   /**
@@ -8741,10 +8779,13 @@ export class TuiApp {
       // re-renders it at the new width, so tables reflow instead of
       // re-wrapping a frozen render (the 5a76526 regression).
       const bullet = color.primary(iconPrefix('assistant-bullet', this.iconStyle))
-      const body = message.content !== undefined && message.content.some(block => block.type !== 'text')
-        ? this.renderBlockSequence(message.content, (text) =>
-          new BulletedComponent(new Markdown(text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS), bullet), message)
-        : new BulletedComponent(new Markdown(message.text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS), bullet)
+      const makeAssistantText = (text: string): Component =>
+        new BulletedComponent(new Markdown(text, 0, 0, markdownTheme, undefined, HOST_MARKDOWN_OPTIONS), bullet)
+      const body = message.displayBlocks !== undefined
+        ? this.renderAssistantDisplaySequence(message.displayBlocks, makeAssistantText, message)
+        : message.content !== undefined && message.content.some(block => block.type !== 'text')
+          ? this.renderBlockSequence(message.content, makeAssistantText, message)
+          : makeAssistantText(message.text)
       if (!message.interrupted) return body
       const interrupted = new Container()
       interrupted.addChild(body)

--- a/test/file-transcript.test.ts
+++ b/test/file-transcript.test.ts
@@ -7,9 +7,11 @@ import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import type { ContentBlock } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import type { AssistantLiveChunk } from '../src/runtime/assistant-stream-port.ts'
 import {
   finalizedBlockFallbackText,
   fileAttachmentSummary,
+  openOpaqueBlockFallbackText,
   textWithAttachmentMarkers,
   userBlocksVisibleNow,
 } from '../src/content-block-presentation.ts'
@@ -138,6 +140,52 @@ test('file-only and unknown finalized user blocks survive folding and search', (
   const hostileHeading = hostileTypeFallback.split('\n', 1)[0]!
   assert.ok(!hostileHeading.includes('\n'))
   assert.ok(hostileHeading.length <= 'Unknown block: '.length + 120)
+  assert.equal(openOpaqueBlockFallbackText('future-test-block'), 'Unknown block: future-test-block\nnull')
+  const hostileOpen = openOpaqueBlockFallbackText(`future\n\u001b[2J${'x'.repeat(200)}`)
+  assert.ok(!hostileOpen.includes('\u001b'))
+  const hostileOpenHeading = hostileOpen.split('\n', 1)[0]!
+  assert.ok(hostileOpenHeading.length <= 'Unknown block: '.length + 120)
+  assert.ok(hostileOpen.endsWith('\nnull'))
+})
+
+test('open file and image blocks replace their pending rows with C1 renderers', async () => {
+  const folder = new TranscriptFolder()
+  const send = (chunk: AssistantLiveChunk, time: number): void => {
+    folder.applyLiveInput({
+      kind: 'chunk', sessionId: 'test', attemptId: 'attempt', turn: 0, step: 0, time, chunk,
+    })
+  }
+  send({ type: 'block-start', index: 0, blockType: 'file' }, 1)
+  const pendingFile = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(pendingFile !== undefined && pendingFile.kind === 'assistant')
+  assert.deepEqual(pendingFile.displayBlocks, [{ kind: 'open-opaque', blockType: 'file' }])
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript(folder.messages())
+  const pendingView = await viewport(vt)
+  assert.ok(pendingView.includes('Unknown block: file'), `pending file row missing:\n${pendingView}`)
+  const cache = (app as unknown as { messageComponents: Map<object, { component: object }> }).messageComponents
+  const pendingComponent = cache.get(pendingFile)?.component
+  assert.ok(pendingComponent !== undefined)
+  send({ type: 'block-end', index: 0, block: fileBlock() as never }, 2)
+  send({ type: 'block-start', index: 1, blockType: 'image' }, 3)
+  send({ type: 'block-end', index: 1, block: imageBlock() as never }, 4)
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.displayBlocks, undefined)
+  assert.deepEqual(assistant.content?.map(block => block.type), ['file', 'image'])
+
+  app.setTranscript(folder.messages())
+  const finalComponent = cache.get(assistant)?.component
+  assert.ok(finalComponent !== undefined)
+  assert.notStrictEqual(finalComponent, pendingComponent, 'block-end must replace the pending component')
+  const view = await viewport(vt)
+  assert.ok(view.includes('report.pdf'), `finalized file presentation missing:\n${view}`)
+  assert.ok(view.includes('shot.png'), `finalized image presentation missing:\n${view}`)
+  assert.ok(!view.includes('Unknown block: file'), `pending file fallback leaked after block-end:\n${view}`)
+  assert.ok(!view.includes('Unknown block: image'), `pending image fallback leaked after block-end:\n${view}`)
 })
 
 test('assistant finalized tool-result content uses an explicit fallback everywhere', async () => {

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2164,6 +2164,112 @@ function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionE
   ]
 }
 
+test('completed open opaque output remains the exact Assistant final in Focus', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [eventAt('turn/start', { turn: 0 }, 1000, 0)])
+  folder.applyLiveInput(liveChunk(0, 0, {
+    type: 'block-start', index: 0, blockType: 'future-final',
+  } as never, 1001))
+  applyMixed(folder, [eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1002, 2)])
+
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, '')
+  assert.deepEqual(assistant.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-final' }])
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['activity', 'assistant'])
+  const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
+  assert.deepEqual(blockKinds(expanded), ['activity', 'assistant'])
+})
+
+test('durable open opaque attempt remains the exact Focus final in both modes', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('step/start', { turn: 0, step: 0 }, 1001, 1),
+    eventAt('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: 1002, chunk: { type: 'block-start', index: 0, blockType: 'future-attempt' } }],
+    }, 1002, 2),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1003, 3),
+  ])
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.deepEqual(assistant.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-attempt' }])
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
+  assert.deepEqual(blockKinds(collapsed), ['activity'], 'interrupted attempt evidence stays hidden in collapsed Focus')
+  assert.deepEqual(blockKinds(expanded), ['activity', 'assistant'])
+  const expandedAssistant = expanded.at(-1)
+  assert.ok(expandedAssistant?.kind === 'message' && expandedAssistant.message.kind === 'assistant')
+  assert.deepEqual(expandedAssistant.message.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-attempt' }])
+})
+
+test('completed Focus chooses the latest open opaque Assistant over an earlier answer', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('step/start', { turn: 0, step: 0 }, 1001, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'earlier answer' }, 1002))
+  applyMixed(folder, [eventAt('step/start', { turn: 0, step: 1 }, 1003, 3)])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'text-delta', index: 0, text: '   ' }, 1004))
+  folder.applyLiveInput(liveChunk(0, 1, {
+    type: 'block-start', index: 1, blockType: 'future-final',
+  } as never, 1005))
+  applyMixed(folder, [eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1006, 6)])
+
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  const collapsedAssistants = collapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message] : [])
+  assert.deepEqual(collapsedAssistants.map(message => message.text), ['   '])
+  assert.deepEqual(collapsedAssistants[0]?.displayBlocks, [
+    { kind: 'content', block: { type: 'text', text: '   ' } },
+    { kind: 'open-opaque', blockType: 'future-final' },
+  ])
+
+  const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
+  const expandedAssistants = expanded.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message] : [])
+  assert.deepEqual(expandedAssistants.map(message => message.text), ['earlier answer', '   '])
+  assert.deepEqual(expandedAssistants[1]?.displayBlocks, [
+    { kind: 'content', block: { type: 'text', text: '   ' } },
+    { kind: 'open-opaque', blockType: 'future-final' },
+  ])
+})
+
+test('open opaque process rows preserve same-turn steer ordering in collapsed and expanded Focus', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('user/message', {
+      id: MessageId('opaque-initial'), role: 'user',
+      content: [{ type: 'text', text: 'initial prompt' }],
+      source: { kind: 'user' },
+    }, 1001, 1),
+    eventAt('assistant/chunk', {
+      turn: 0, step: 0,
+      chunk: { type: 'reasoning-delta', index: 0, text: 'thinking before steer' },
+    }, 1002, 2),
+    ...claimedSteer('opaque-steer', 'same-turn steer', 1003, 3),
+  ])
+  folder.applyLiveInput(liveChunk(0, 1, {
+    type: 'block-start', index: 0, blockType: 'future',
+  } as never, 1005))
+
+  const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
+  assert.deepEqual(blockKinds(expanded), ['user', 'activity', 'thinking', 'user', 'assistant'])
+  const expandedAssistant = expanded.at(-1)
+  assert.ok(expandedAssistant?.kind === 'message' && expandedAssistant.message.kind === 'assistant')
+  assert.deepEqual(expandedAssistant.message.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  const expandedUsers = expanded.flatMap(block => block.kind === 'message' && block.message.kind === 'user' ? [block.message.text] : [])
+  assert.deepEqual(expandedUsers, ['initial prompt', 'same-turn steer'])
+
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'user', 'activity'])
+  assert.ok(!collapsed.some(block => block.kind === 'message' && block.message.kind === 'assistant'),
+    'collapsed Focus must retain its existing hidden process policy')
+})
+
 test('expanded: the initial user stays before the Thought; a mid-turn steer returns to its chronological position', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, steeredTurn(0, 0, 1000))

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -644,7 +644,7 @@ test('an empty candidate confirmed after a prior intermediate clears the slot', 
   assert.equal(activity.message, undefined, 'the empty intermediate must clear the slot, never leave the stale earlier preview')
 })
 
-test('a late message for an older step never regresses the final-answer dedup', () => {
+test('a late message for an older step updates its confirmed preview without regressing final ownership', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, [
     eventAt('turn/start', { turn: 0 }, 1000, 0),
@@ -663,12 +663,20 @@ test('a late message for an older step never regresses the final-answer dedup', 
     eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1006, 6),
   ])
   const activity = folder.turnActivity(0)!
-  // The durable row is still updated, but the stale step cannot rewrite the
-  // already-confirmed Focus slot or regress the latest-step fence.
+  // The durable row is still updated, and the stale step may update the
+  // confirmed Focus preview it already owns, but it cannot regress the
+  // latest-step fence or final ownership.
   assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [
     '第一步权威', '最终答案',
   ])
-  assert.equal(activity.message?.text, '第一步')
+  assert.equal(activity.message?.text, '第一步权威')
+  assert.equal((activity as { lastAssistantStep?: number }).lastAssistantStep, 1)
+  const projected = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  const final = projected.find(block => block.kind === 'message' && block.message.kind === 'assistant')
+  assert.ok(final !== undefined && final.kind === 'message' && final.message.kind === 'assistant')
+  if (final !== undefined && final.kind === 'message' && final.message.kind === 'assistant') {
+    assert.equal(final.message.text, '最终答案')
+  }
 })
 
 test('a late assistant event after turn/end never changes the exact final answer', () => {

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -663,10 +663,12 @@ test('a late message for an older step never regresses the final-answer dedup', 
     eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1006, 6),
   ])
   const activity = folder.turnActivity(0)!
-  // The final (step 1) must be dropped from the slot; the confirmed
-  // intermediate (step 0's authoritative text) shows instead — the late
-  // message must not regress lastAssistantStep and duplicate the final.
-  assert.equal(activity.message?.text, '第一步权威')
+  // The durable row is still updated, but the stale step cannot rewrite the
+  // already-confirmed Focus slot or regress the latest-step fence.
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [
+    '第一步权威', '最终答案',
+  ])
+  assert.equal(activity.message?.text, '第一步')
 })
 
 test('a late assistant event after turn/end never changes the exact final answer', () => {
@@ -2164,7 +2166,7 @@ function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionE
   ]
 }
 
-test('completed open opaque output remains the exact Assistant final in Focus', () => {
+test('completed open opaque output remains process evidence, not a final Assistant', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, [eventAt('turn/start', { turn: 0 }, 1000, 0)])
   folder.applyLiveInput(liveChunk(0, 0, {
@@ -2177,12 +2179,36 @@ test('completed open opaque output remains the exact Assistant final in Focus', 
   assert.equal(assistant.text, '')
   assert.deepEqual(assistant.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-final' }])
   const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
-  assert.deepEqual(blockKinds(collapsed), ['activity', 'assistant'])
+  assert.deepEqual(blockKinds(collapsed), ['activity'], 'pending process evidence is not a collapsed final')
+  const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
+  assert.deepEqual(blockKinds(expanded), ['activity', 'assistant'], 'expanded Focus still shows pending process evidence')
+})
+
+test('open opaque after semantic text is still not a completed final', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [eventAt('turn/start', { turn: 0 }, 1000, 0)])
+  folder.applyLiveInput(liveChunk(0, 0, {
+    type: 'text-delta', index: 0, text: 'semantic prefix',
+  }, 1001))
+  folder.applyLiveInput(liveChunk(0, 0, {
+    type: 'block-start', index: 1, blockType: 'future-final',
+  } as never, 1002))
+  applyMixed(folder, [eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1003, 3)])
+
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, 'semantic prefix')
+  assert.deepEqual(assistant.displayBlocks, [
+    { kind: 'content', block: { type: 'text', text: 'semantic prefix' } },
+    { kind: 'open-opaque', blockType: 'future-final' },
+  ])
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['activity'], 'pending open opaque blocks final selection')
   const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
   assert.deepEqual(blockKinds(expanded), ['activity', 'assistant'])
 })
 
-test('durable open opaque attempt remains the exact Focus final in both modes', () => {
+test('durable open opaque attempt remains process evidence, not a final', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, [
     eventAt('turn/start', { turn: 0 }, 1000, 0),
@@ -2206,7 +2232,7 @@ test('durable open opaque attempt remains the exact Focus final in both modes', 
   assert.deepEqual(expandedAssistant.message.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-attempt' }])
 })
 
-test('completed Focus chooses the latest open opaque Assistant over an earlier answer', () => {
+test('completed Focus does not fall back to an earlier answer when latest Assistant is open opaque', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, [
     eventAt('turn/start', { turn: 0 }, 1000, 0),
@@ -2222,11 +2248,8 @@ test('completed Focus chooses the latest open opaque Assistant over an earlier a
 
   const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
   const collapsedAssistants = collapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message] : [])
-  assert.deepEqual(collapsedAssistants.map(message => message.text), ['   '])
-  assert.deepEqual(collapsedAssistants[0]?.displayBlocks, [
-    { kind: 'content', block: { type: 'text', text: '   ' } },
-    { kind: 'open-opaque', blockType: 'future-final' },
-  ])
+  assert.deepEqual(blockKinds(collapsed), ['activity'], 'latest pending Assistant blocks an earlier final but is not itself final')
+  assert.deepEqual(collapsedAssistants, [])
 
   const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
   const expandedAssistants = expanded.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message] : [])

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -7,13 +7,15 @@
 
 import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { MessageId } from '@deepseek-ai/dsh-llm'
+import { MessageId, ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import type { AssistantLiveChunk } from '../src/runtime/assistant-stream-port.ts'
 import { isDiffResult, renderDiffLine } from '../src/diff.ts'
 import {
   foldedCallPreview, genericRawInputLines, parseReadEnvelopes, parseSkillEnvelope, resultTextLines, subagentModelDisplay, systemContextBody, toolPresenterFrom, webCardLines,
 } from '../src/present.ts'
 import { parseUserKeybindings } from '../src/keybindings/config.ts'
+import { RendererRegistry } from '../src/renderer-registry.ts'
 import { color, currentPalette, darkColors, lightColors, setTheme } from '../src/theme.ts'
 import { iconFor } from '../src/icons.ts'
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent, type TranscriptViewportAnchor } from '../src/tui-app.ts'
@@ -1196,6 +1198,251 @@ test('the message component cache is pruned to the live transcript', () => {
   app.setTranscript([{ kind: 'user', turn: 100, text: 'fresh' }])
   assert.equal(cache.size, 1, 'entries from the previous window must be disposed')
   app.stop()
+})
+
+test('open opaque display changes invalidate the assistant cache and render in order', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    {
+      type: 'turn/start',
+      seq: 0,
+      time: 1_700_000_000_000,
+      data: { turn: 0 },
+    } as SessionEvent,
+    {
+      type: 'step/start',
+      seq: 1,
+      time: 1_700_000_000_001,
+      data: { turn: 0, step: 0 },
+    } as SessionEvent,
+  ])
+  const input = (chunk: AssistantLiveChunk, time: number) => folder.applyLiveInput({
+    kind: 'chunk', sessionId: 'test', attemptId: 'attempt', turn: 0, step: 0, time, chunk,
+  })
+  input({ type: 'text-delta', index: 0, text: 'before' }, 2)
+  const message = folder.messages()[0]
+  assert.ok(message !== undefined && message.kind === 'assistant')
+
+  const { vt, app } = startApp()
+  app.setTranscript([message])
+  await viewport(vt)
+  const cache = (app as unknown as { messageComponents: Map<object, { component: object }> }).messageComponents
+  const before = cache.get(message)?.component
+  assert.ok(before !== undefined)
+
+  input({ type: 'block-start', index: 1, blockType: 'future-test-block' }, 3)
+  const projected = folder.messages()[0]
+  assert.strictEqual(projected, message, 'live folding updates the cached message object in place')
+  assert.equal(message.text, 'before', 'semantic text must remain unchanged')
+  assert.equal(message.content, undefined, 'open opaque display must not become semantic content')
+  app.setTranscript([projected])
+  const after = cache.get(projected)?.component
+  assert.ok(after !== undefined)
+  assert.notStrictEqual(after, before, 'displayBlocks must be part of the component cache identity')
+
+  const pendingView = await viewport(vt)
+  const beforeIndex = pendingView.indexOf('before')
+  const pendingIndex = pendingView.indexOf('Unknown block: future-test-block')
+  assert.ok(beforeIndex >= 0 && pendingIndex > beforeIndex,
+    `ordered open projection missing:\n${pendingView}`)
+  assert.ok(pendingView.includes('\nnull'), `open opaque rows must use a null payload:\n${pendingView}`)
+
+  input({ type: 'block-start', index: 1, blockType: 'future-test-block' }, 4)
+  app.setTranscript([projected])
+  assert.strictEqual(cache.get(projected)?.component, after, 'duplicate block-start must not invalidate the unchanged display projection')
+
+  input({
+    type: 'block-end', index: 1,
+    block: { type: 'future-test-block', payload: { value: 'done' } },
+  } as never, 5)
+  app.setTranscript([projected])
+  const finalized = cache.get(projected)?.component
+  assert.ok(finalized !== undefined)
+  assert.notStrictEqual(finalized, after, 'authoritative block-end must replace the pending component')
+
+  input({
+    type: 'block-end', index: 1,
+    block: { type: 'future-test-block', payload: { value: 'duplicate' } },
+  } as never, 6)
+  input({ type: 'text-delta', index: 1, text: 'ignored after freeze' }, 7)
+  app.setTranscript([projected])
+  assert.strictEqual(cache.get(projected)?.component, finalized, 'frozen duplicates and deltas must not invalidate the unchanged projection')
+
+})
+
+test('empty same-lane deltas preserve component identity while first ownership remains effective', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    {
+      type: 'turn/start', seq: 0, time: 1_700_000_000_000,
+      data: { turn: 0 },
+    } as SessionEvent,
+    {
+      type: 'step/start', seq: 1, time: 1_700_000_000_001,
+      data: { turn: 0, step: 0 },
+    } as SessionEvent,
+  ])
+  const input = (chunk: AssistantLiveChunk, time: number) => folder.applyLiveInput({
+    kind: 'chunk', sessionId: 'test', attemptId: 'attempt', turn: 0, step: 0, time, chunk,
+  })
+  input({ type: 'text-delta', index: 0, text: 'stable' }, 2)
+  const { app } = startApp()
+  app.setTranscript(folder.messages())
+  const cache = (app as unknown as { messageComponents: Map<object, { component: object }> }).messageComponents
+  const firstAssistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(firstAssistant !== undefined && firstAssistant.kind === 'assistant')
+  const textComponent = cache.get(firstAssistant)?.component
+  assert.ok(textComponent !== undefined)
+
+  input({ type: 'text-delta', index: 0, text: '' }, 3)
+  app.setTranscript(folder.messages())
+  assert.strictEqual(cache.get(firstAssistant)?.component, textComponent, 'empty text delta must not churn an existing text lane')
+
+  input({ type: 'reasoning-delta', index: 1, text: 'thinking' }, 4)
+  app.setTranscript(folder.messages())
+  const thinking = folder.messages().find(message => message.kind === 'thinking')
+  assert.ok(thinking !== undefined && thinking.kind === 'thinking')
+  const thinkingComponent = cache.get(thinking)?.component
+  assert.ok(thinkingComponent !== undefined)
+  input({ type: 'reasoning-delta', index: 1, text: '' }, 5)
+  app.setTranscript(folder.messages())
+  assert.strictEqual(cache.get(thinking)?.component, thinkingComponent, 'empty reasoning delta must not churn an existing reasoning lane')
+
+  input({ type: 'tool-call-delta', index: 2, id: ToolCallId('empty-delta-call'), name: 'bash', argumentsDelta: '{}' }, 6)
+  app.setTranscript(folder.messages())
+  const assistantAfterTool = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistantAfterTool !== undefined && assistantAfterTool.kind === 'assistant')
+  const toolComponent = cache.get(assistantAfterTool)?.component
+  assert.ok(toolComponent !== undefined)
+  input({ type: 'tool-call-delta', index: 2, id: ToolCallId('renamed-delta-call'), name: 'bash', argumentsDelta: '' }, 7)
+  app.setTranscript(folder.messages())
+  assert.strictEqual(cache.get(assistantAfterTool)?.component, toolComponent,
+    'a changed tool-call id must not override the first owner of the indexed block')
+  input({ type: 'tool-call-delta', index: 2, id: ToolCallId('empty-delta-call'), name: 'zsh', argumentsDelta: '' }, 8)
+  app.setTranscript(folder.messages())
+  const renamedNameComponent = cache.get(assistantAfterTool)?.component
+  assert.ok(renamedNameComponent !== undefined)
+  assert.notStrictEqual(renamedNameComponent, toolComponent, 'a changed tool-call name must invalidate the component')
+  input({ type: 'tool-call-delta', index: 2, id: ToolCallId('empty-delta-call'), name: 'zsh', argumentsDelta: '' }, 9)
+  app.setTranscript(folder.messages())
+  assert.strictEqual(cache.get(assistantAfterTool)?.component, renamedNameComponent, 'an empty unchanged tool-call delta must not churn the component')
+
+  input({ type: 'block-start', index: 4, blockType: 'future-empty-transition' }, 10)
+  app.setTranscript(folder.messages())
+  const opaqueComponent = cache.get(assistantAfterTool)?.component
+  assert.ok(opaqueComponent !== undefined)
+  input({ type: 'text-delta', index: 4, text: '' }, 11)
+  app.setTranscript(folder.messages())
+  const emptyTransitionComponent = cache.get(assistantAfterTool)?.component
+  assert.ok(emptyTransitionComponent !== undefined)
+  assert.notStrictEqual(emptyTransitionComponent, opaqueComponent, 'opaque to empty known state must invalidate the component')
+  assert.equal(assistantAfterTool.displayBlocks?.some(block => block.kind === 'open-opaque') ?? false, false,
+    'opaque to empty known state must remove the display-only row')
+
+  input({ type: 'text-delta', index: 3, text: '' }, 12)
+  input({ type: 'block-start', index: 3, blockType: 'future-claimed' }, 9)
+  const claimed = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(claimed !== undefined && claimed.kind === 'assistant')
+  assert.equal(claimed.displayBlocks?.some(block => block.kind === 'open-opaque' && block.blockType === 'future-claimed') ?? false, false,
+    'an empty first delta still owns its index against a later block-start')
+})
+
+test('mixed assistant text and open opaque rows render in display order', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([{
+    kind: 'assistant',
+    turn: 0,
+    text: 'beforeafter',
+    displayBlocks: [
+      { kind: 'content', block: { type: 'text', text: 'before' } },
+      { kind: 'open-opaque', blockType: 'future-test-block' },
+      { kind: 'content', block: { type: 'text', text: 'after' } },
+    ],
+  } as never])
+  const view = await viewport(vt)
+  const beforeIndex = view.indexOf('before')
+  const pendingIndex = view.indexOf('Unknown block: future-test-block')
+  const afterIndex = view.indexOf('after')
+  assert.ok(beforeIndex >= 0 && pendingIndex > beforeIndex && afterIndex > pendingIndex,
+    `mixed display order broken:\n${view}`)
+
+  app.setTranscript([{
+    kind: 'assistant',
+    turn: 0,
+    text: 'beforeafter',
+    displayBlocks: [
+      { kind: 'content', block: { type: 'text', text: 'before' } },
+      { kind: 'content', block: { type: 'future-test-block', payload: { value: 'done' } } },
+      { kind: 'content', block: { type: 'text', text: 'after' } },
+    ],
+  } as never])
+  const finalizedView = await viewport(vt)
+  const finalizedBeforeIndex = finalizedView.indexOf('before')
+  const finalizedBlockIndex = finalizedView.indexOf('Unknown block: future-test-block')
+  const finalizedAfterIndex = finalizedView.indexOf('after')
+  assert.ok(finalizedBeforeIndex >= 0 && finalizedBlockIndex > finalizedBeforeIndex && finalizedAfterIndex > finalizedBlockIndex,
+    `finalized display order broken:\n${finalizedView}`)
+  assert.ok(finalizedView.includes('"value": "done"'), `finalized payload missing:\n${finalizedView}`)
+  assert.ok(!finalizedView.includes('\nnull'), `pending null row survived finalization:\n${finalizedView}`)
+})
+
+test('open opaque rows remain width-safe on a narrow viewport', async () => {
+  const { vt, app } = startApp(24, 12)
+  app.setTranscript([{
+    kind: 'assistant',
+    turn: 0,
+    text: '',
+    displayBlocks: [{ kind: 'open-opaque', blockType: 'future-test-block' }],
+  } as never])
+  const view = await viewport(vt)
+  assert.ok(view.includes('Unknown block:'), `narrow pending row missing:\n${view}`)
+  assert.ok(view.includes('null'), `narrow pending null payload missing:\n${view}`)
+  for (const line of view.split('\n')) {
+    assert.ok(visibleWidth(stripTerminalSequences(line)) <= 24, `line exceeds narrow width: ${line}`)
+  }
+})
+
+test('open opaque assistant rows bypass semantic plugin renderers', async () => {
+  const registry = new RendererRegistry()
+  registry.registerMessageRenderer({
+    id: 'assistant-plugin',
+    render: () => ({ kind: 'text', spans: [{ text: 'PLUGIN' }] }),
+  }, 'test-owner')
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { renderers: registry })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([{
+    kind: 'assistant',
+    turn: 0,
+    text: '',
+    displayBlocks: [{ kind: 'open-opaque', blockType: 'future-test-block' }],
+  } as never])
+  const view = await viewport(vt)
+  assert.ok(view.includes('Unknown block: future-test-block'), `host pending row missing:\n${view}`)
+  assert.ok(view.includes('\nnull'), `host pending payload missing:\n${view}`)
+  assert.ok(!view.includes('PLUGIN'), `semantic plugin renderer swallowed the pending row:\n${view}`)
+
+  app.setTranscript([{ kind: 'assistant', turn: 0, text: 'settled' } as never])
+  const settledView = await viewport(vt)
+  assert.ok(settledView.includes('PLUGIN'), `semantic plugin renderer did not recover after finalization:\n${settledView}`)
+  assert.ok(!settledView.includes('Unknown block: future-test-block'),
+    `pending opaque fallback survived finalization:\n${settledView}`)
+  assert.ok(!settledView.includes('\nnull'), `pending null payload survived finalization:\n${settledView}`)
+})
+
+test('interrupted open opaque rows retain the stopped marker', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([{
+    kind: 'assistant',
+    turn: 0,
+    text: '',
+    displayBlocks: [{ kind: 'open-opaque', blockType: 'future-test-block' }],
+    interrupted: true,
+  } as never])
+  const view = await viewport(vt)
+  assert.ok(view.includes('Unknown block: future-test-block'), `interrupted pending row missing:\n${view}`)
+  assert.ok(view.includes('(interrupted)'), `interrupted marker missing:\n${view}`)
 })
 
 test('local card push/replace/clear prune the component cache too', () => {

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -155,6 +155,25 @@ test('a step without an assistant message contributes no timing (Web parity)', (
   assert.equal(stats.tokensPerSec, 0)
 })
 
+test('open opaque block starts do not create token, usage, or TTFT facts', () => {
+  const t = 1_700_000_000_000
+  const folder = new StatsFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t + 100),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, {
+    type: 'block-start', index: 0, blockType: 'future',
+  } as never, t + 500))
+  const stats = folder.snapshot()
+  assert.equal(stats.firstTokenMsAvg, 0, 'presentation-only open state is not TTFT')
+  assert.equal(stats.llmMs, 0, 'presentation-only open state is not LLM wall time')
+  assert.equal(stats.outputTokens, 0, 'presentation-only open state is not output usage')
+  assert.equal(stats.inputTokens, 0)
+  assert.equal(stats.cacheReadTokens, 0)
+  assert.equal(stats.cacheWriteTokens, 0)
+})
+
 test('first-token semantics match the Web isTokenDelta: reasoning deltas start the decode window', () => {
   const t = 1_700_000_000_000
   // Step 0: reasoning delta arrives first, text delta later. The decode
@@ -1045,6 +1064,7 @@ test('a retry accumulates attempts while settling logical-step timing once', () 
   assert.equal(stats.outputTokens, 14)
   assert.equal(stats.llmMs, 700, 'the retry reuses the original step start for wall time')
   assert.equal(stats.firstTokenMsAvg, 100, 'the first token of the logical step survives the failed attempt')
+  assert.equal(stats.tokensPerSec, Math.round((9 * 1000) / 700), 'throughput samples the final retry message, not the additive attempt total')
   const cold = computeStats(events.filter(item => (item.type as string) !== 'assistant/chunk'))
   assert.equal(cold.inputTokens, 300, 'cold replay keeps both attempt totals')
   assert.equal(cold.outputTokens, 14)
@@ -1112,6 +1132,203 @@ test('without llm/retry-started, a later same-step settlement replaces the slot'
   const stats = computeStats(events)
   assert.equal(stats.inputTokens, 200)
   assert.equal(stats.outputTokens, 9)
+})
+
+test('a late assistant/attempt replaces a settled message usage in both folds', () => {
+  const topLevelUsage = { inputTokens: 10, outputTokens: 100 }
+  const embeddedUsage = { inputTokens: 20, outputTokens: 200 }
+  const events = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: { id: MessageId('m-settled-before-attempt'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+      usage: topLevelUsage,
+      stream: [],
+    }, 2),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: 3, chunk: { type: 'usage', usage: embeddedUsage } }],
+    }, 3),
+    event('step/end', { turn: 0, step: 0 }, 4),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5),
+  ]
+  const transcript = new TranscriptFolder()
+  transcript.apply(events)
+  const activity = transcript.turnActivity(0)
+  assert.deepEqual(activity?.usage, { inputTokens: 20, outputTokens: 200, cacheReadTokens: 0, cacheWriteTokens: 0 })
+  assert.equal(activity?.totalTokens, 220)
+  assert.equal(activity?.assistantMessages, 1)
+  const stats = foldStats(events)
+  assert.equal(stats.inputTokens, 20)
+  assert.equal(stats.outputTokens, 200)
+  const cold = computeStats(events)
+  assert.equal(cold.inputTokens, 20)
+  assert.equal(cold.outputTokens, 200)
+})
+
+test('a usage-less late attempt preserves authoritative message usage in both folds', () => {
+  const usage = { inputTokens: 10, outputTokens: 100 }
+  const events = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: { id: MessageId('m-authoritative-usage'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+      usage,
+      stream: [],
+    }, 2),
+    event('assistant/attempt', { turn: 0, step: 0, stream: [] }, 3),
+    event('step/end', { turn: 0, step: 0 }, 4),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5),
+  ]
+  const transcript = new TranscriptFolder()
+  transcript.apply(events)
+  assert.equal(transcript.turnActivity(0)?.usage?.inputTokens, 10)
+  assert.equal(transcript.turnActivity(0)?.usage?.outputTokens, 100)
+  const stats = foldStats(events)
+  assert.equal(stats.inputTokens, 10)
+  assert.equal(stats.outputTokens, 100)
+  const cold = computeStats(events)
+  assert.equal(cold.inputTokens, 10)
+  assert.equal(cold.outputTokens, 100)
+})
+
+test('a late assistant/attempt replacement updates recent throughput and TTFT', () => {
+  const t = 1_700_000_000_000
+  const usageA = { inputTokens: 10, outputTokens: 100 }
+  const usageB = { inputTokens: 20, outputTokens: 200 }
+  const events = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t + 100),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: { id: MessageId('m-performance-replacement'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+      usage: usageA,
+      stream: [],
+    }, 2, t + 110),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [
+        { type: 'chunk', time: t + 105, chunk: { type: 'text-delta', index: 0, text: 'late token' } },
+        { type: 'chunk', time: t + 106, chunk: { type: 'usage', usage: usageB } },
+      ],
+    }, 3, t + 120),
+    event('step/end', { turn: 0, step: 0 }, 4, t + 130),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5, t + 140),
+  ]
+  const oneShot = computeStats(events)
+  const incremental = foldStats(events)
+  for (const stats of [oneShot, incremental]) {
+    assert.equal(stats.inputTokens, 20)
+    assert.equal(stats.outputTokens, 200)
+    assert.equal(stats.firstTokenMsAvg, 5, 'late attempt first-token evidence fills the missing TTFT sample')
+    assert.equal(stats.tokensPerSec, 20_000, 'late authoritative usage replaces the throughput sample')
+  }
+})
+
+test('a first-token-only late attempt fills TTFT without changing usage throughput', () => {
+  const t = 1_700_000_000_000
+  const events = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t + 100),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: { id: MessageId('m-first-token-only'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+      usage: { inputTokens: 10, outputTokens: 100 },
+      stream: [],
+    }, 2, t + 110),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: t + 105, chunk: { type: 'text-delta', index: 0, text: 'late token' } }],
+    }, 3, t + 120),
+    event('step/end', { turn: 0, step: 0 }, 4, t + 130),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5, t + 140),
+  ]
+  const oneShot = computeStats(events)
+  const incremental = foldStats(events)
+  for (const stats of [oneShot, incremental]) {
+    assert.equal(stats.inputTokens, 10)
+    assert.equal(stats.outputTokens, 100)
+    assert.equal(stats.firstTokenMsAvg, 5)
+    assert.equal(stats.tokensPerSec, 10_000)
+  }
+  assert.deepEqual(incremental, oneShot)
+})
+
+test('a late assistant/attempt after step/end replaces the retained throughput sample', () => {
+  const t = 1_700_000_000_000
+  const events = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t + 100),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: { id: MessageId('m-post-step-performance'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+      usage: { inputTokens: 10, outputTokens: 100 },
+      stream: [],
+    }, 2, t + 110),
+    event('step/end', { turn: 0, step: 0 }, 3, t + 120),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: t + 115, chunk: { type: 'usage', usage: { inputTokens: 20, outputTokens: 200 } } }],
+    }, 4, t + 130),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5, t + 140),
+  ]
+  const oneShot = computeStats(events)
+  const incremental = foldStats(events)
+  assert.equal(oneShot.tokensPerSec, 20_000)
+  assert.equal(incremental.tokensPerSec, 20_000)
+  assert.deepEqual(incremental, oneShot)
+})
+
+test('duplicate late attempts replace and can invalidate the throughput sample', () => {
+  const t = 1_700_000_000_000
+  const prefix = [
+    event('turn/start', { turn: 0 }, 0, t),
+    event('step/start', { turn: 0, step: 0 }, 1, t + 100),
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: { id: MessageId('m-duplicate-attempt-performance'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+      usage: { inputTokens: 10, outputTokens: 100 },
+      stream: [],
+    }, 2, t + 110),
+  ]
+  const replacement = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: t + 105, chunk: { type: 'usage', usage: { inputTokens: 20, outputTokens: 200 } } }],
+  }, 3, t + 120)
+  const invalidation = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: t + 106, chunk: { type: 'usage', usage: { inputTokens: 30, outputTokens: 0 } } }],
+  }, 4, t + 130)
+  const suffix = [
+    invalidation,
+    event('step/end', { turn: 0, step: 0 }, 5, t + 140),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 6, t + 150),
+  ]
+  const oneShot = computeStats([...prefix, replacement, ...suffix])
+  const folder = new StatsFolder()
+  folder.apply(prefix)
+  folder.apply([replacement])
+  assert.equal(folder.snapshot().outputTokens, 200)
+  assert.equal(folder.snapshot().tokensPerSec, 20_000)
+  folder.apply(suffix)
+  assert.equal(folder.snapshot().inputTokens, 30)
+  assert.equal(folder.snapshot().outputTokens, 0)
+  assert.equal(folder.snapshot().tokensPerSec, 0)
+  assert.deepEqual(folder.snapshot(), oneShot)
 })
 
 test('a duplicate step/start never leaks the open step pending usage', () => {
@@ -1378,6 +1595,61 @@ test('recent TTFB averages the latest five first-token steps', () => {
   assert.deepEqual(folder.snapshot(), oneShot)
 })
 
+test('late attempt TTFT keeps its completion ordinal and recent-five membership', () => {
+  const t = 1_700_000_000_000
+  const log: SessionEvent[] = []
+  let seq = 0
+  const first = completedStep(0, 0, seq, t, { firstDeltaMs: undefined })
+  log.push(...first)
+  seq += first.length
+  for (let step = 1; step <= 4; step += 1) {
+    const events = completedStep(0, step, seq, t + step * 10_000, { firstDeltaMs: step * 100 })
+    log.push(...events)
+    seq += events.length
+  }
+  const folder = new StatsFolder()
+  applyMixed(folder, log)
+  const late = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: t + 50, chunk: { type: 'text-delta', index: 0, text: 'late first token' } }],
+  }, seq++, t + 50)
+  applyMixed(folder, [late])
+  const internals = folder as unknown as { recent: { ttft: Array<{ key: string; ordinal: number; ttftMs: number }> } }
+  const repaired = internals.recent.ttft.find(sample => sample.key === '0/0')
+  assert.ok(repaired !== undefined)
+  assert.equal(repaired.ordinal, 0, 'late evidence must retain the original completion ordinal')
+  assert.equal(repaired.ttftMs, 50)
+
+  const newest = completedStep(0, 5, seq, t + 50_000, { firstDeltaMs: 500 })
+  applyMixed(folder, newest)
+  // The late step 0 sample is now outside the latest-five window; an
+  // incorrectly appended late sample would evict step 1 instead and change
+  // this average.
+  assert.equal(folder.snapshot().firstTokenMsAvg, 300)
+})
+
+test('late attempt TTFT cannot resurrect a sample across A → B → A route epochs', () => {
+  const t = 1_700_000_000_000
+  const stepA0 = completedStep(0, 0, 0, t, { provider: 'a', model: 'm' })
+  const stepB = completedStep(0, 1, stepA0.length, t + 10_000, {
+    provider: 'b', model: 'm', firstDeltaMs: 100,
+  })
+  const stepA1 = completedStep(0, 2, stepA0.length + stepB.length, t + 20_000, {
+    provider: 'a', model: 'm', firstDeltaMs: 200,
+  })
+  const late = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: t + 30_000, chunk: { type: 'text-delta', index: 0, text: 'old route token' } }],
+  }, stepA0.length + stepB.length + stepA1.length, t + 30_000)
+  const folder = new StatsFolder()
+  applyMixed(folder, [...stepA0, ...stepB, ...stepA1, late])
+  // Only the second A lifecycle's 200ms sample belongs to the current
+  // performance window; the old A step remains an accounting fact only.
+  assert.equal(folder.snapshot().firstTokenMsAvg, 200)
+})
+
 test('a model/provider route change resets the recent performance window', () => {
   const t = 1_700_000_000_000
   const log: SessionEvent[] = []
@@ -1455,6 +1727,25 @@ test('a late usage replacement cannot resurrect a sample after a route reset', (
   applyMixed(folder, log)
   assert.equal(oneShot.tokensPerSec, 100, 'only route B\'s sample remains')
   assert.equal(oneShot.outputTokens, 10_099, 'the token ACCOUNTING still applies the authoritative replacement')
+  assert.deepEqual(folder.snapshot(), oneShot)
+})
+
+test('a late attempt cannot resurrect a sample across A → B → A route epochs', () => {
+  const t = 1_700_000_000_000
+  const stepA0 = completedStep(0, 0, 0, t, { provider: 'a', model: 'm', outputTokens: 100, wallMs: 1_000 })
+  const stepB = completedStep(0, 1, stepA0.length, t + 10_000, { provider: 'b', model: 'm', outputTokens: 100, wallMs: 1_000 })
+  const stepA1 = completedStep(0, 2, stepA0.length + stepB.length, t + 20_000, { provider: 'a', model: 'm', outputTokens: 100, wallMs: 1_000 })
+  const late = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: t + 30_000, chunk: { type: 'usage', usage: { inputTokens: 20, outputTokens: 9_999 } } }],
+  }, stepA0.length + stepB.length + stepA1.length, t + 30_000)
+  const log = [...stepA0, ...stepB, ...stepA1, late]
+  const oneShot = computeStats(log)
+  const folder = new StatsFolder()
+  applyMixed(folder, log)
+  assert.equal(oneShot.tokensPerSec, 100)
+  assert.equal(oneShot.outputTokens, 10_199)
   assert.deepEqual(folder.snapshot(), oneShot)
 })
 

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -6,12 +6,15 @@
  */
 
 import assert from 'node:assert/strict'
+import { performance } from 'node:perf_hooks'
 import test from 'node:test'
-import { BlockAssembler, ToolCallId, MessageId, type AssistantStreamRecord, type ContentBlock, type StreamChunk } from '@deepseek-ai/dsh-llm'
+import { BlockAssembler, expandAssistantStream, ToolCallId, MessageId, type AssistantStreamRecord, type ContentBlock, type StreamChunk } from '@deepseek-ai/dsh-llm'
 import { CommandId } from '@deepseek-ai/dsh-commands'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { RetryId } from '@deepseek-ai/dsh-llm-retry'
-import { foldTranscript, TranscriptFolder, windowMessages, type TranscriptMessage } from '../src/transcript.ts'
+import { foldTranscript, renderTranscriptMarkdown, TranscriptFolder, windowMessages, type TranscriptMessage } from '../src/transcript.ts'
+import { projectFocus } from '../src/focus-activity.ts'
+import { computeStats, StatsFolder } from '../src/stats.ts'
 import { TranscriptWindowController } from '../src/transcript-window.ts'
 import type { AssistantLiveChunk, AssistantLiveContentBlock, AssistantLiveInput } from '../src/runtime/assistant-stream-port.ts'
 
@@ -2261,6 +2264,25 @@ test('settled Assistant rows follow block visibility while retaining empty autho
   assert.equal(interrupted[0]?.interrupted, true)
 })
 
+test('an empty durable attempt tombstones a live-only open opaque prefix for cold parity', () => {
+  const prefix = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ]
+  const attempt = event('assistant/attempt', { turn: 0, step: 0, stream: [] }, 3)
+  const end = event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, 4)
+
+  const live = new TranscriptFolder()
+  live.apply(prefix)
+  live.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future-open' } as never, 2))
+  live.apply([attempt, end])
+
+  const cold = new TranscriptFolder()
+  cold.hydrate([...prefix, attempt, end])
+  assert.deepEqual(live.messages(), cold.messages())
+  assert.equal(live.messages().some(message => message.kind === 'assistant'), false)
+})
+
 test('partial text attempt evidence has no undefined prefix and matches cold replay', () => {
   const prefix = [
     event('turn/start', { turn: 0 }, 0),
@@ -2392,6 +2414,368 @@ test('image-only assistant attempts preserve live/cold parity and interruption e
   assert.deepEqual(assistantImage.attachment, image.attachment)
 })
 
+test('durable hidden attempt state takes over a live opaque prefix', () => {
+  const hiddenStreams = [
+    [{ type: 'chunk' as const, time: 2, chunk: { type: 'block-end' as const, index: 0, block: { type: 'reasoning' as const, text: 'closed thought' } } }],
+    [{ type: 'chunk' as const, time: 2, chunk: { type: 'block-end' as const, index: 0, block: { type: 'text' as const, text: '' } } }],
+  ]
+  for (const stream of hiddenStreams) {
+    const prefix = [
+      event('turn/start', { turn: 0 }, 0),
+      event('step/start', { turn: 0, step: 0 }, 1),
+    ]
+    const attempt = event('assistant/attempt', { turn: 0, step: 0, stream }, 3)
+    const live = new TranscriptFolder()
+    live.apply(prefix)
+    live.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future' }, 2))
+    live.apply([attempt])
+    const cold = new TranscriptFolder()
+    cold.hydrate([...prefix, attempt])
+    assert.deepEqual(live.messages(), cold.messages())
+    assert.equal(live.messages().some(message => message.kind === 'assistant'), false)
+  }
+})
+
+test('hidden durable takeover clears latest Focus visibility without regressing its step fence', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'older answer' }, 2))
+  folder.apply([event('step/start', { turn: 0, step: 1 }, 3)])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' }, 4))
+  folder.apply([event('assistant/attempt', {
+    turn: 0,
+    step: 1,
+    stream: [{ type: 'chunk', time: 5, chunk: { type: 'block-end', index: 0, block: { type: 'text', text: '' } } }],
+  }, 5), event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 6)])
+  const activity = folder.turnActivity(0)
+  assert.equal(activity?.lastAssistantVisible, false)
+  const internalActivity = (folder as unknown as { activityByTurn: Map<number, { lastAssistantStep?: number }> }).activityByTurn.get(0)
+  assert.equal(internalActivity?.lastAssistantStep, 1)
+  const projected = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  assert.equal(projected.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false,
+    'hidden durable takeover must not fall back to the older Assistant in Focus')
+})
+
+test('hidden latest block state fences late older Assistant events in live and durable folds', () => {
+  const oldMessage = event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId('hidden-fence-old'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'old answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stream: [],
+  }, 7)
+  const lateMessage = event('assistant/message', {
+    turn: 0,
+    step: 0,
+    message: {
+      id: MessageId('hidden-fence-late'),
+      role: 'assistant',
+      content: [{ type: 'text', text: 'late old answer' }],
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stream: [],
+  }, 8)
+  const assertFenced = (folder: TranscriptFolder): void => {
+    assert.equal(folder.turnActivity(0)?.lastAssistantVisible, false)
+    const internalActivity = (folder as unknown as { activityByTurn: Map<number, { lastAssistantStep?: number }> }).activityByTurn.get(0)
+    assert.equal(internalActivity?.lastAssistantStep, 1)
+    const projected = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+    assert.equal(projected.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false)
+  }
+
+  const live = new TranscriptFolder()
+  live.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  live.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'old answer' }, 2))
+  live.apply([event('step/start', { turn: 0, step: 1 }, 3)])
+  live.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'text' }, 4))
+  live.apply([lateMessage, event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 9)])
+  assertFenced(live)
+
+  const durable = new TranscriptFolder()
+  durable.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    oldMessage,
+    event('step/start', { turn: 0, step: 1 }, 3),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 1,
+      stream: [{ type: 'chunk', time: 4, chunk: { type: 'block-end', index: 0, block: { type: 'text', text: '' } } }],
+    }, 5),
+    lateMessage,
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 9),
+  ])
+  assertFenced(durable)
+})
+
+test('assistant block transition matrix preserves raw live/cold parity', () => {
+  const cases = [
+    {
+      name: 'tool-call id and name replacement',
+      chunks: [
+        { type: 'chunk' as const, time: 2, chunk: { type: 'tool-call-delta', index: 0, id: ToolCallId('old-call'), name: 'bash', argumentsDelta: '{}' } },
+        { type: 'chunk' as const, time: 3, chunk: { type: 'tool-call-delta', index: 0, id: ToolCallId('new-call'), name: 'zsh', argumentsDelta: '' } },
+        { type: 'chunk' as const, time: 4, chunk: { type: 'block-end', index: 0, block: { type: 'tool-call', id: ToolCallId('new-call'), name: 'zsh', arguments: '{}' } } },
+      ],
+    },
+    {
+      name: 'opaque to empty known text',
+      chunks: [
+        { type: 'chunk' as const, time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never },
+        { type: 'chunk' as const, time: 3, chunk: { type: 'text-delta', index: 0, text: '' } },
+      ],
+    },
+    {
+      name: 'block-end before duplicate block-start',
+      chunks: [
+        { type: 'chunk' as const, time: 2, chunk: { type: 'block-end', index: 0, block: { type: 'text', text: 'authoritative first' } } },
+        { type: 'chunk' as const, time: 3, chunk: { type: 'block-start', index: 0, blockType: 'future-ignored' } as never },
+      ],
+    },
+  ]
+  for (const [caseIndex, scenario] of cases.entries()) {
+    const prefix = [
+      event('turn/start', { turn: 0 }, caseIndex * 10),
+      event('step/start', { turn: 0, step: 0 }, caseIndex * 10 + 1),
+    ]
+    const attempt = event('assistant/attempt', { turn: 0, step: 0, stream: scenario.chunks as AssistantStreamRecord[] }, caseIndex * 10 + 5)
+    const end = event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, caseIndex * 10 + 6)
+    const live = new TranscriptFolder()
+    live.apply(prefix)
+    for (const member of scenario.chunks) live.applyLiveInput(liveChunk(0, 0, member.chunk as never, member.time))
+    live.apply([attempt, end])
+    const cold = new TranscriptFolder()
+    cold.hydrate([...prefix, attempt, end])
+    assert.deepEqual(live.messages(), cold.messages(), `${scenario.name}: live/cold parity`)
+    if (scenario.name === 'tool-call id and name replacement') {
+      const assistant = cold.messages().find(message => message.kind === 'assistant')
+      assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+      assert.deepEqual(assistant.content, [{ type: 'tool-call', id: ToolCallId('new-call'), name: 'zsh', arguments: '{}' }])
+    }
+    if (scenario.name === 'opaque to empty known text') {
+      assert.equal(cold.messages().some(message => message.kind === 'assistant'), false)
+    }
+    if (scenario.name === 'block-end before duplicate block-start') {
+      const assistant = cold.messages().find(message => message.kind === 'assistant')
+      assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+      assert.equal(assistant.text, 'authoritative first')
+    }
+  }
+})
+
+test('large durable assistant streams do not rescan the accumulated projection per chunk', () => {
+  const blockCount = 5_000
+  const stream: AssistantStreamRecord[] = Array.from({ length: blockCount }, (_, index) => ({
+    type: 'chunk' as const,
+    time: index + 2,
+    chunk: { type: 'block-start' as const, index, blockType: 'future' } as never,
+  }))
+  const started = performance.now()
+  const folder = new TranscriptFolder()
+  folder.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('assistant/attempt', { turn: 0, step: 0, stream }, 2),
+  ])
+  const elapsed = performance.now() - started
+  assert.equal(folder.messages().length, 1)
+  assert.ok(elapsed < 1_000, `large durable stream took ${elapsed.toFixed(1)}ms`)
+})
+
+test('large live assistant streams update indexed display projection incrementally', () => {
+  const blockCount = 5_000
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  const started = performance.now()
+  for (let index = 0; index < blockCount; index += 1) {
+    folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index, blockType: 'future' }, index + 2))
+  }
+  const elapsed = performance.now() - started
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.displayBlocks?.length, blockCount)
+  assert.ok(elapsed < 1_000, `large live stream took ${elapsed.toFixed(1)}ms`)
+})
+
+test('durable attempt replay preserves reasoning/opaque first-lane order', () => {
+  const cases = [
+    {
+      name: 'reasoning then opaque',
+      expected: ['thinking', 'assistant'],
+      chunks: [
+        { type: 'block-start' as const, index: 0, blockType: 'reasoning' as const },
+        { type: 'reasoning-delta' as const, index: 0, text: 'thought first' },
+        { type: 'block-start' as const, index: 1, blockType: 'future' },
+      ],
+    },
+    {
+      name: 'opaque then reasoning',
+      expected: ['assistant', 'thinking'],
+      chunks: [
+        { type: 'block-start' as const, index: 0, blockType: 'future' },
+        { type: 'block-start' as const, index: 1, blockType: 'reasoning' as const },
+        { type: 'reasoning-delta' as const, index: 1, text: 'thought second' },
+      ],
+    },
+  ]
+  for (const [caseIndex, scenario] of cases.entries()) {
+    const stream = scenario.chunks.map((chunk, index) => ({
+      type: 'chunk' as const, time: index + 2, chunk: chunk as never,
+    }))
+    const prefix = [
+      event('turn/start', { turn: 0 }, caseIndex * 10),
+      event('step/start', { turn: 0, step: 0 }, caseIndex * 10 + 1),
+    ]
+    const attempt = event('assistant/attempt', { turn: 0, step: 0, stream }, caseIndex * 10 + 4)
+    const end = event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, caseIndex * 10 + 5)
+    const live = new TranscriptFolder()
+    live.apply(prefix)
+    for (const member of stream) live.applyLiveInput(liveChunk(0, 0, member.chunk as never, member.time))
+    live.apply([attempt, end])
+    const cold = new TranscriptFolder()
+    cold.hydrate([...prefix, attempt, end])
+
+    assert.deepEqual(live.messages(), cold.messages(), `${scenario.name}: live/cold transcript parity`)
+    assert.deepEqual(live.messages().slice(0, 2).map(message => message.kind), scenario.expected, `${scenario.name}: lane order`)
+  }
+})
+
+test('compact assistant stream records preserve first-lane parity across representations', () => {
+  const compactCases: Array<{
+    name: string
+    stream: readonly AssistantStreamRecord[]
+    expected: readonly string[]
+  }> = [
+    {
+      name: 'reasoning-chunks then raw opaque start',
+      stream: [
+        { type: 'reasoning-chunks', time0: 2, index: 7, dt: [], texts: ['packed thought'] },
+        { type: 'chunk', time: 3, chunk: { type: 'block-start', index: 11, blockType: 'future' } as never },
+      ],
+      expected: ['thinking', 'assistant'],
+    },
+    {
+      name: 'raw opaque start then reasoning-chunks',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-start', index: 11, blockType: 'future' } as never },
+        { type: 'reasoning-chunks', time0: 3, index: 7, dt: [], texts: ['packed thought'] },
+      ],
+      expected: ['assistant', 'thinking'],
+    },
+    {
+      name: 'tool-call-chunks then reasoning and opaque',
+      stream: [
+        { type: 'tool-call-chunks', time0: 2, index: 4, dt: [], id: ToolCallId('compact-call'), name: 'bash', args: ['{"x":'] },
+        { type: 'reasoning-chunks', time0: 3, index: 7, dt: [], texts: ['packed thought'] },
+        { type: 'chunk', time: 4, chunk: { type: 'block-start', index: 11, blockType: 'future' } as never },
+      ],
+      expected: ['thinking', 'assistant'],
+    },
+    {
+      name: 'block-end reasoning then opaque',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-end', index: 7, block: { type: 'reasoning', text: 'closed thought' } } },
+        { type: 'chunk', time: 3, chunk: { type: 'block-end', index: 11, block: { type: 'future', payload: 'closed opaque' } } as never },
+      ],
+      expected: ['thinking', 'assistant'],
+    },
+    {
+      name: 'reasoning replaced by opaque end before later reasoning',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'reasoning' as const } },
+        { type: 'reasoning-chunks', time0: 3, index: 0, dt: [], texts: ['stale thought'] },
+        { type: 'chunk', time: 4, chunk: { type: 'block-end', index: 0, block: { type: 'future', payload: 'opaque replacement' } } as never },
+        { type: 'reasoning-chunks', time0: 5, index: 1, dt: [], texts: ['later thought'] },
+      ],
+      expected: ['assistant', 'thinking'],
+    },
+    {
+      name: 'opaque start replaced by reasoning end before later text',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never },
+        { type: 'chunk', time: 3, chunk: { type: 'block-end', index: 0, block: { type: 'reasoning', text: 'closed thought' } } },
+        { type: 'text-chunks', time0: 4, index: 3, dt: [], texts: ['later answer'] },
+      ],
+      expected: ['thinking', 'assistant'],
+    },
+    {
+      name: 'opaque partial text is replaced by reasoning before a later opaque row',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never },
+        { type: 'text-chunks', time0: 3, index: 0, dt: [], texts: ['partial'] },
+        { type: 'chunk', time: 4, chunk: { type: 'block-end', index: 0, block: { type: 'reasoning', text: 'closed thought' } } },
+        { type: 'chunk', time: 5, chunk: { type: 'block-start', index: 7, blockType: 'future-later' } as never },
+      ],
+      expected: ['thinking', 'assistant'],
+    },
+    {
+      name: 'opaque empty text end freezes before duplicate opaque end',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never },
+        { type: 'chunk', time: 3, chunk: { type: 'block-end', index: 0, block: { type: 'text', text: '' } } },
+        { type: 'chunk', time: 4, chunk: { type: 'block-end', index: 0, block: { type: 'future-duplicate', payload: 'ignored' } } as never },
+        { type: 'reasoning-chunks', time0: 5, index: 3, dt: [], texts: ['packed thought'] },
+        { type: 'text-chunks', time0: 6, index: 7, dt: [], texts: ['later answer'] },
+      ],
+      expected: ['thinking', 'assistant'],
+    },
+    {
+      name: 'opaque tool-call end freezes before duplicate opaque end',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never },
+        { type: 'chunk', time: 3, chunk: { type: 'block-end', index: 0, block: { type: 'tool-call', id: ToolCallId('frozen-call'), name: 'bash', arguments: '{}' } } },
+        { type: 'chunk', time: 4, chunk: { type: 'block-end', index: 0, block: { type: 'future-duplicate', payload: 'ignored' } } as never },
+        { type: 'reasoning-chunks', time0: 5, index: 3, dt: [], texts: ['packed thought'] },
+        { type: 'text-chunks', time0: 6, index: 7, dt: [], texts: ['later answer'] },
+      ],
+      expected: ['thinking', 'assistant'],
+    },
+    {
+      name: 'duplicate sparse opaque then whitespace/text mix',
+      stream: [
+        { type: 'chunk', time: 2, chunk: { type: 'block-start', index: 9, blockType: 'future' } as never },
+        { type: 'chunk', time: 3, chunk: { type: 'block-start', index: 9, blockType: 'future-duplicate' } as never },
+        { type: 'text-chunks', time0: 4, index: 2, dt: [], texts: ['   '] },
+        { type: 'reasoning-chunks', time0: 5, index: 7, dt: [], texts: ['packed thought'] },
+      ],
+      expected: ['assistant', 'thinking'],
+    },
+  ]
+  for (const [caseIndex, scenario] of compactCases.entries()) {
+    const prefix = [
+      event('turn/start', { turn: 0 }, caseIndex * 10),
+      event('step/start', { turn: 0, step: 0 }, caseIndex * 10 + 1),
+    ]
+    const attempt = event('assistant/attempt', { turn: 0, step: 0, stream: [...scenario.stream] }, caseIndex * 10 + 4)
+    const end = event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, caseIndex * 10 + 5)
+    const live = new TranscriptFolder()
+    live.apply(prefix)
+    for (const member of expandAssistantStream(scenario.stream)) {
+      live.applyLiveInput(liveChunk(0, 0, member.chunk as never, member.time))
+    }
+    live.apply([attempt, end])
+    const cold = new TranscriptFolder()
+    cold.hydrate([...prefix, attempt, end])
+    assert.deepEqual(live.messages(), cold.messages(), `${scenario.name}: live/cold parity`)
+    assert.deepEqual(live.messages().slice(0, 2).map(message => message.kind), scenario.expected, `${scenario.name}: first-lane order`)
+  }
+})
+
 test('tool-call-only assistant attempts stay hidden until the closed boundary', () => {
   const callId = ToolCallId('call-delayed')
   const stream = [
@@ -2472,6 +2856,746 @@ test('a durable assistant/attempt with only block-end evidence reopens as interr
   assert.equal(interrupted[0]?.interrupted, true)
 })
 
+test('open opaque live starts are visible without semantic content', () => {
+  for (const blockType of ['future-test-block', 'file', 'image', 'tool-result']) {
+    const folder = new TranscriptFolder()
+    folder.apply([
+      event('turn/start', { turn: 0 }, 0),
+      event('step/start', { turn: 0, step: 0 }, 1),
+    ])
+    folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType }, 2))
+    const assistant = folder.messages().find(message => message.kind === 'assistant')
+    assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+    assert.equal(assistant.text, '')
+    assert.equal(assistant.content, undefined)
+    assert.deepEqual(assistant.displayBlocks, [{ kind: 'open-opaque', blockType }])
+    assert.deepEqual(folder.search(blockType), [], 'pending blockType is display-only, never searchable')
+    assert.equal(folder.turnActivity(0)?.lastAssistantVisible, true)
+    assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 0)
+  }
+})
+
+test('open opaque display projection keeps sparse and duplicate indexes ordered', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 3, blockType: 'future-A' }, 2))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 3, blockType: 'future-B' }, 3))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 7, text: 'later' }, 4))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 1, text: 'first' }, 5))
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.deepEqual(assistant.displayBlocks, [
+    { kind: 'content', block: { type: 'text', text: 'first' } },
+    { kind: 'open-opaque', blockType: 'future-A' },
+    { kind: 'content', block: { type: 'text', text: 'later' } },
+  ])
+})
+
+test('open opaque advances the latest-step fence without creating a Focus candidate', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'old' }, 2))
+  folder.apply([event('step/start', { turn: 0, step: 1 }, 3)])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' }, 4))
+  const beforeLate = folder.turnActivity(0)
+  assert.equal((beforeLate as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(beforeLate?.lastAssistantVisible, true)
+  assert.deepEqual(beforeLate?.message, { text: 'old' })
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: '-late-old' }, 5))
+  const afterLate = folder.turnActivity(0)
+  assert.equal((afterLate as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(afterLate?.lastAssistantVisible, true)
+  assert.deepEqual(afterLate?.message, { text: 'old' })
+  assert.doesNotMatch(afterLate?.message?.text ?? '', /Unknown block|future/)
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), ['old-late-old', ''])
+})
+
+test('stale live usage bypasses the presentation fence and matches stats', () => {
+  const events = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 1,
+      chunk: { type: 'block-start', index: 0, blockType: 'future' },
+    }, 3),
+    event('assistant/chunk', {
+      turn: 0,
+      step: 0,
+      chunk: { type: 'usage', usage: { inputTokens: 10, outputTokens: 5 } },
+    }, 4),
+    event('step/end', { turn: 0, step: 0 }, 5),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 6),
+  ]
+  const transcript = new TranscriptFolder()
+  const stats = new StatsFolder()
+  for (const item of events) {
+    if ((item.type as string) === 'assistant/chunk') {
+      const data = item.data as { turn: number; step: number; chunk: AssistantLiveChunk }
+      const input = liveChunk(data.turn, data.step, data.chunk, item.time)
+      transcript.applyLiveInput(input)
+      stats.applyLiveInput(input)
+    } else {
+      transcript.apply([item])
+      stats.apply([item])
+    }
+  }
+  assert.equal(transcript.turnActivity(0)?.totalTokens, 15)
+  assert.equal(stats.snapshot().inputTokens, 10)
+  assert.equal(stats.snapshot().outputTokens, 5)
+})
+
+test('stale durable attempt usage stays in parity with and without an older row', () => {
+  for (const withOlderRow of [false, true]) {
+    const events = [
+      event('turn/start', { turn: 0 }, 0),
+      event('step/start', { turn: 0, step: 0 }, 1),
+      ...(withOlderRow ? [event('assistant/chunk', {
+        turn: 0,
+        step: 0,
+        chunk: { type: 'text-delta', index: 0, text: 'older row' },
+      }, 2)] : []),
+      event('step/start', { turn: 0, step: 1 }, 3),
+      event('assistant/chunk', {
+        turn: 0,
+        step: 1,
+        chunk: { type: 'block-start', index: 0, blockType: 'future' },
+      }, 4),
+      event('assistant/attempt', {
+        turn: 0,
+        step: 0,
+        stream: [{ type: 'chunk', time: 1_700_000_000_005, chunk: { type: 'usage', usage: { inputTokens: 10, outputTokens: 5 } } }],
+      }, 5),
+      event('step/end', { turn: 0, step: 0 }, 6),
+      event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 7),
+    ]
+    const transcript = new TranscriptFolder()
+    const stats = new StatsFolder()
+    for (const item of events) {
+      if ((item.type as string) === 'assistant/chunk') {
+        const data = item.data as { turn: number; step: number; chunk: AssistantLiveChunk }
+        const input = liveChunk(data.turn, data.step, data.chunk, item.time)
+        transcript.applyLiveInput(input)
+        stats.applyLiveInput(input)
+      } else {
+        transcript.apply([item])
+        stats.apply([item])
+      }
+    }
+    const cold = computeStats(events.filter(item => (item.type as string) !== 'assistant/chunk'))
+    assert.equal(transcript.turnActivity(0)?.totalTokens, 15, `Focus usage missing (${withOlderRow ? 'with' : 'without'} older row)`)
+    assert.equal(stats.snapshot().inputTokens, 10)
+    assert.equal(stats.snapshot().outputTokens, 5)
+    assert.equal(cold.inputTokens, 10)
+    assert.equal(cold.outputTokens, 5)
+    if (withOlderRow) {
+      assert.ok(transcript.messages().some(message => message.kind === 'assistant' && message.text === 'older row'))
+    }
+  }
+})
+
+test('a stale reasoning block-start preserves closed Assistant and Thinking rows', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'old answer' }, 2))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'reasoning-delta', index: 1, text: 'old thought' }, 3))
+  folder.applyLiveInput(liveAttemptEnd(0, 0, 'committed'))
+  folder.apply([event('step/start', { turn: 0, step: 1 }, 4)])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' } as never, 5))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 2, blockType: 'reasoning' }, 6))
+
+  const assistants = folder.messages().filter(message => message.kind === 'assistant')
+  assert.deepEqual(assistants.map(message => message.text), ['old answer', ''])
+  assert.deepEqual(assistants[1]?.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'thinking').map(message => message.text), ['old thought'])
+  assert.equal(folder.turnActivity(0)?.think?.text, 'old thought')
+})
+
+test('an empty semantic block-end clears a same-step Focus candidate beside opaque output', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'hello' }, 2))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 1, blockType: 'future' } as never, 3))
+  folder.applyLiveInput(liveChunk(0, 0, {
+    type: 'block-end', index: 0, block: { type: 'text', text: '' },
+  }, 4))
+
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, '')
+  assert.deepEqual(assistant.displayBlocks, [
+    { kind: 'content', block: { type: 'text', text: '' } },
+    { kind: 'open-opaque', blockType: 'future' },
+  ])
+})
+
+test('durable hidden opaque takeover clears a same-step live Focus candidate', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'hello' }, 2))
+  const stream: AssistantStreamRecord[] = [
+    { type: 'chunk', time: 3, chunk: { type: 'text-delta', index: 0, text: 'ignored live prefix' } },
+    { type: 'chunk', time: 4, chunk: { type: 'block-start', index: 1, blockType: 'future' } as never },
+    { type: 'chunk', time: 5, chunk: { type: 'block-end', index: 0, block: { type: 'text', text: '' } } },
+  ]
+  folder.apply([event('assistant/attempt', { turn: 0, step: 0, stream }, 6)])
+
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, '')
+  assert.deepEqual(assistant.displayBlocks, [
+    { kind: 'content', block: { type: 'text', text: '' } },
+    { kind: 'open-opaque', blockType: 'future' },
+  ])
+})
+
+test('whitespace text beside open opaque never creates a Focus Message candidate', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'real intermediate' }, 2))
+  folder.apply([event('step/start', { turn: 0, step: 1 }, 3)])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'text-delta', index: 0, text: '   ' }, 4))
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 1, blockType: 'future' } as never, 5))
+  const activity = folder.turnActivity(0)
+  assert.deepEqual(activity?.message, { text: 'real intermediate' })
+  assert.equal((activity as { messageCandidate?: unknown } | undefined)?.messageCandidate, undefined)
+  const assistant = folder.messages().find(message => message.kind === 'assistant' && message.displayBlocks !== undefined)
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, '   ')
+  assert.deepEqual(assistant.displayBlocks, [
+    { kind: 'content', block: { type: 'text', text: '   ' } },
+    { kind: 'open-opaque', blockType: 'future' },
+  ])
+})
+
+test('whitespace open opaque output advances the fence and abandons without fallback', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+  ])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'text-delta', index: 0, text: '   ' }, 3))
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 1, blockType: 'future' } as never, 4))
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'late-old' }, 5))
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), ['   '])
+
+  folder.applyLiveInput(liveAttemptEnd(0, 1, 'abandoned'))
+  assert.equal((folder.turnActivity(0) as { lastAssistantVisible?: boolean } | undefined)?.lastAssistantVisible, false)
+  folder.apply([event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 6)])
+  const projected = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  assert.equal(projected.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false,
+    'an abandoned whitespace/opaque step must not promote a stale text replay')
+})
+
+test('a late live surface for an older step cannot append without a prior entry', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+  ])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' } as never, 3))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'late-old' }, 4))
+  const assistants = folder.messages().filter(message => message.kind === 'assistant')
+  assert.deepEqual(assistants.map(message => message.text), [''])
+  assert.deepEqual(assistants[0]?.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+})
+
+test('durable opaque latest-step fences reject late text from an older attempt', () => {
+  const folder = new TranscriptFolder()
+  const oldAttempt = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'text-chunks', time0: 2, index: 0, dt: [], texts: ['old'] }],
+  }, 2)
+  const opaqueAttempt = event('assistant/attempt', {
+    turn: 0,
+    step: 1,
+    stream: [{ type: 'chunk', time: 4, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+  }, 4)
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    oldAttempt,
+    event('step/start', { turn: 0, step: 1 }, 3),
+    opaqueAttempt,
+  ])
+  const beforeLate = folder.messages().filter(message => message.kind === 'assistant')
+  assert.deepEqual(beforeLate.map(message => message.text), ['old', ''])
+  assert.deepEqual(beforeLate[1]?.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: '-late-old' }, 5))
+  const afterLate = folder.messages().filter(message => message.kind === 'assistant')
+  assert.deepEqual(afterLate.map(message => message.text), ['old', ''])
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+})
+
+test('stale durable reasoning remains diagnostic beside a newer live opaque fence', () => {
+  const prefix = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+  ]
+  const staleAttempt = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: 3, chunk: { type: 'reasoning-delta', index: 0, text: 'late diagnostic reasoning' } }],
+  }, 3)
+
+  const live = new TranscriptFolder()
+  live.apply(prefix)
+  live.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' } as never, 4))
+  live.apply([staleAttempt])
+
+  const cold = new TranscriptFolder()
+  cold.hydrate([...prefix, staleAttempt])
+  assert.deepEqual(
+    live.messages().filter(message => message.kind === 'thinking').map(message => message.text),
+    cold.messages().filter(message => message.kind === 'thinking').map(message => message.text),
+  )
+  assert.deepEqual(live.messages().filter(message => message.kind === 'thinking').map(message => message.text), [
+    'late diagnostic reasoning',
+  ])
+  assert.equal(live.turnActivity(0)?.think, undefined, 'stale diagnostic reasoning cannot retake the latest Focus preview')
+})
+
+test('late older reasoning cannot regress the latest Focus preview', () => {
+  const live = new TranscriptFolder()
+  live.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  live.applyLiveInput(liveChunk(0, 0, { type: 'reasoning-delta', index: 0, text: 'old reasoning' }, 2))
+  live.apply([event('step/start', { turn: 0, step: 1 }, 3)])
+  live.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' } as never, 4))
+  live.applyLiveInput(liveChunk(0, 0, { type: 'reasoning-delta', index: 0, text: ' late replay' }, 5))
+  assert.equal(live.turnActivity(0)?.think?.text, 'old reasoning')
+  assert.deepEqual(live.messages().filter(message => message.kind === 'thinking').map(message => message.text), ['old reasoning late replay'])
+
+  const durable = new TranscriptFolder()
+  durable.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: 2, chunk: { type: 'reasoning-delta', index: 0, text: 'old reasoning' } }],
+    }, 2),
+    event('step/start', { turn: 0, step: 1 }, 3),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 1,
+      stream: [{ type: 'chunk', time: 4, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+    }, 4),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: 5, chunk: { type: 'reasoning-delta', index: 0, text: ' late replay' } }],
+    }, 5),
+  ])
+  assert.equal(durable.turnActivity(0)?.think?.text, 'old reasoning')
+  assert.deepEqual(durable.messages().filter(message => message.kind === 'thinking').map(message => message.text), ['old reasoning'])
+
+  const durableEmpty = new TranscriptFolder()
+  durableEmpty.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: 2, chunk: { type: 'reasoning-delta', index: 0, text: 'old reasoning' } }],
+    }, 2),
+    event('step/start', { turn: 0, step: 1 }, 3),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 1,
+      stream: [{ type: 'chunk', time: 4, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+    }, 4),
+    event('assistant/attempt', { turn: 0, step: 0, stream: [] }, 5),
+  ])
+  assert.equal(durableEmpty.turnActivity(0)?.think?.text, 'old reasoning')
+  assert.deepEqual(durableEmpty.messages().filter(message => message.kind === 'thinking').map(message => message.text), ['old reasoning'])
+})
+
+test('a late durable attempt for an older step cannot append without a prior entry', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 1,
+      stream: [{ type: 'chunk', time: 3, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+    }, 3),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'text-chunks', time0: 4, index: 0, dt: [], texts: ['late-old'] }],
+    }, 4),
+  ])
+  const assistants = folder.messages().filter(message => message.kind === 'assistant')
+  assert.deepEqual(assistants.map(message => message.text), [''])
+  assert.deepEqual(assistants[0]?.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+})
+
+test('an older accepted message restores its reasoning row without regressing Focus', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    assistantMessageWithBlocks(2, [
+      { type: 'reasoning', text: 'first reasoning' },
+      { type: 'text', text: 'first answer' },
+    ]),
+    event('step/start', { turn: 0, step: 1 }, 3),
+  ])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' } as never, 4))
+  folder.apply([assistantMessageWithBlocks(5, [
+    { type: 'reasoning', text: 'late settled reasoning' },
+    { type: 'text', text: 'updated old answer' },
+  ], { step: 0 })])
+
+  const assistant = folder.messages().find(message => message.kind === 'assistant' && message.text === 'updated old answer')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  const thinking = folder.messages().find(message => message.kind === 'thinking')
+  assert.ok(thinking !== undefined && thinking.kind === 'thinking')
+  assert.equal(thinking.text, 'late settled reasoning', 'accepted durable content still owns its diagnostic row')
+  assert.equal(folder.turnActivity(0)?.think?.text, 'first reasoning', 'older reasoning cannot retake the latest Focus preview')
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+})
+
+test('a stale message keeps settlement accounting while skipping presentation', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+    event('step/start', { turn: 0, step: 2 }, 3),
+  ])
+  folder.applyLiveInput(liveChunk(0, 2, { type: 'block-start', index: 0, blockType: 'future' } as never, 4))
+  folder.apply([
+    event('assistant/message', {
+      turn: 0,
+      step: 0,
+      message: { id: MessageId('stale-top'), role: 'assistant', content: [], source: { kind: 'model', provider: 'p', model: 'm' } },
+      usage: { inputTokens: 10, outputTokens: 100, cacheReadTokens: 1, cacheWriteTokens: 2 },
+      stream: [],
+    }, 5),
+    event('assistant/message', {
+      turn: 0,
+      step: 1,
+      message: { id: MessageId('stale-stream'), role: 'assistant', content: [], source: { kind: 'model', provider: 'p', model: 'm' } },
+      stream: [{ type: 'chunk', time: 6, chunk: { type: 'usage', usage: { inputTokens: 20, outputTokens: 200 } } }],
+    }, 6),
+  ])
+
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [''])
+  assert.deepEqual(activity.usage, { inputTokens: 30, outputTokens: 300, cacheReadTokens: 1, cacheWriteTokens: 2 })
+  assert.equal(activity.totalTokens, 333)
+  assert.equal(activity.assistantMessages, 2)
+  assert.deepEqual([...((activity as { settledSteps?: Set<number> }).settledSteps ?? [])], [0, 1])
+  assert.equal(activity.message, undefined)
+  assert.equal((activity as { lastAssistantStep?: number }).lastAssistantStep, 2)
+})
+
+test('stale empty, image, and unknown settlements keep accounting without rows', () => {
+  const contents = [
+    [],
+    [{
+      type: 'image' as const,
+      attachment: { attachmentId: 'stale-image', mediaType: 'image/png', bytes: 1 },
+    } as unknown as ContentBlock],
+    [{ type: 'future-settled', payload: 'opaque' } as unknown as ContentBlock],
+  ]
+  for (const [index, content] of contents.entries()) {
+    const folder = new TranscriptFolder()
+    folder.apply([
+      event('turn/start', { turn: 0 }, 0),
+      event('step/start', { turn: 0, step: 0 }, 1),
+      event('step/start', { turn: 0, step: 1 }, 2),
+    ])
+    folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: `future-${index}` } as never, 3))
+    folder.apply([assistantMessageWithBlocks(4, content, { step: 0 })])
+    const activity = folder.turnActivity(0)
+    assert.ok(activity !== undefined)
+    assert.equal(activity.assistantMessages, 1)
+    assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [''])
+    assert.equal((activity as { lastAssistantStep?: number }).lastAssistantStep, 1)
+    assert.equal(activity.message, undefined)
+  }
+})
+
+test('late older assistant messages cannot append after a newer opaque step', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 1,
+      stream: [{ type: 'chunk', time: 3, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+    }, 3),
+    assistantMessage(4, 'late-old', { step: 0 }),
+  ])
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [''])
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+
+  folder.apply([event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5)])
+  const projected = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  assert.equal(projected.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false,
+    'a stale older message must not become the exact-last completed answer')
+})
+
+test('durable open opaque attempts are visible before close and retain interruption evidence', () => {
+  const prefix = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 1 }, 1),
+  ]
+  const attempt = event('assistant/attempt', {
+    turn: 0,
+    step: 1,
+    stream: [{ type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+  }, 3)
+  const end = event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, 4)
+  const folder = new TranscriptFolder()
+  folder.apply(prefix)
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' }, 2))
+  const open = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(open !== undefined && open.kind === 'assistant')
+  assert.deepEqual(open.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  assert.equal(open.interrupted, undefined)
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(folder.turnActivity(0)?.lastAssistantVisible, true)
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+
+  folder.apply([attempt])
+  const durableOpen = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(durableOpen !== undefined && durableOpen.kind === 'assistant')
+  assert.deepEqual(durableOpen.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  folder.apply([end])
+  const interrupted = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(interrupted !== undefined && interrupted.kind === 'assistant')
+  assert.equal(interrupted.interrupted, true)
+  assert.deepEqual(interrupted.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+
+  const reopened = new TranscriptFolder()
+  reopened.hydrate([...prefix, attempt, end])
+  assert.deepEqual(reopened.messages(), folder.messages())
+  assert.equal((reopened.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.equal(reopened.turnActivity(0)?.lastAssistantVisible, true)
+})
+
+test('opaque block-end replaces the pending row with finalized content', () => {
+  const finalized = { type: 'future-test-block', payload: { value: 'done' } } as unknown as AssistantLiveContentBlock
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future-test-block' }, 2))
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-end', index: 0, block: finalized }, 3))
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.displayBlocks, undefined)
+  assert.deepEqual(assistant.content, [finalized])
+  assert.equal(assistant.text, '')
+})
+
+test('opaque finalization keeps empty text and tool-call lanes hidden', () => {
+  const emptyText = new TranscriptFolder()
+  emptyText.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future' }, 1))
+  emptyText.applyLiveInput(liveChunk(0, 0, {
+    type: 'block-end', index: 0, block: { type: 'text', text: '' },
+  }, 2))
+  assert.equal(emptyText.messages().some(message => message.kind === 'assistant'), false)
+
+  const toolCall = new TranscriptFolder()
+  toolCall.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future' }, 1))
+  toolCall.applyLiveInput(liveChunk(0, 0, {
+    type: 'block-end',
+    index: 0,
+    block: { type: 'tool-call', id: ToolCallId('call-hidden'), name: 'bash', arguments: '{}' },
+  }, 2))
+  assert.equal(toolCall.messages().some(message => message.kind === 'assistant'), false)
+})
+
+test('abandoning the latest opaque step clears stale final visibility without fallback', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'text-delta', index: 0, text: 'intermediate' }, 2))
+  folder.apply([event('step/start', { turn: 0, step: 1 }, 3)])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' } as never, 4))
+  folder.applyLiveInput(liveAttemptEnd(0, 1, 'abandoned'))
+  assert.equal((folder.turnActivity(0) as { lastAssistantVisible?: boolean } | undefined)?.lastAssistantVisible, false)
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), ['intermediate'])
+
+  folder.apply([event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5)])
+  const projected = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  assert.equal(projected.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false,
+    'an abandoned latest step must not promote an earlier assistant as the final')
+})
+
+test('retry and abandoned live endings clear open opaque presentation', () => {
+  const abandoned = new TranscriptFolder()
+  abandoned.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  abandoned.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future-A' }, 2))
+  abandoned.applyLiveInput(liveAttemptEnd(0, 0, 'abandoned'))
+  assert.equal(abandoned.messages().some(message => message.kind === 'assistant'), false)
+  const reopened = new TranscriptFolder()
+  reopened.hydrate([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, 2),
+  ])
+  assert.equal(reopened.messages().some(message => message.kind === 'assistant'), false,
+    'cold reopen without durable attempt evidence must not resurrect the abandoned row')
+
+  const retried = new TranscriptFolder()
+  retried.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  retried.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future-A' }, 2))
+  retried.apply([rawEvent('llm/retry', {
+    retryId: 'retry-open', turn: 0, step: 0, provider: 'p', mode: 'normal',
+    policyKey: 'test', retry: 1, maxRetries: 2, delayMs: 0,
+    failure: { message: 'failed', code: 'TEST' },
+  }, 3)])
+  assert.equal(retried.messages().some(message => message.kind === 'assistant'), false)
+  retried.applyLiveInput({ kind: 'start', sessionId: 'test', attemptId: 'attempt-y', turn: 0, step: 0 })
+  retried.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future-B' }, 4))
+  const assistant = retried.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.deepEqual(assistant.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-B' }])
+})
+
+test('authoritative assistant messages clear open opaque display state', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'file' }, 2))
+  folder.apply([assistantMessage(3, 'final text')])
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, 'final text')
+  assert.equal(assistant.displayBlocks, undefined)
+  assert.equal(assistant.content, undefined)
+})
+
+test('a durable attempt with open opaque state survives a committed attempt end', () => {
+  const folder = new TranscriptFolder()
+  const attempt = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+  }, 3)
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    attempt,
+  ])
+  folder.applyLiveInput(liveAttemptEnd(0, 0, 'committed', 'attempt'))
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.deepEqual(assistant.displayBlocks, [{ kind: 'open-opaque', blockType: 'future' }])
+  assert.equal(assistant.interrupted, undefined)
+})
+
+test('late durable attempts cannot overwrite an authoritative assistant message', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    assistantMessage(2, 'FINAL'),
+    event('assistant/attempt', {
+      turn: 0,
+      step: 0,
+      stream: [{ type: 'chunk', time: 3, chunk: { type: 'block-start', index: 0, blockType: 'future' } as never }],
+    }, 3),
+  ])
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.text, 'FINAL')
+  assert.equal(assistant.displayBlocks, undefined)
+  assert.equal(assistant.interrupted, undefined)
+  assert.equal(folder.turnActivity(0)?.assistantMessages, 1)
+  assert.deepEqual(folder.turnActivity(0)?.message, { text: 'FINAL' })
+})
+
+test('authoritative FileBlock messages replace an open file display row', () => {
+  const file = {
+    type: 'file',
+    attachment: { attachmentId: 'att-final-file', name: 'final.txt', bytes: 12 },
+  } as unknown as ContentBlock
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'file' }, 2))
+  folder.apply([assistantMessageWithBlocks(3, [file])])
+  const assistant = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(assistant !== undefined && assistant.kind === 'assistant')
+  assert.equal(assistant.displayBlocks, undefined)
+  assert.deepEqual(assistant.content, [file])
+  assert.equal(assistant.text, '')
+})
+
+test('an open opaque start does not create usage facts', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ])
+  folder.applyLiveInput(liveChunk(0, 0, { type: 'block-start', index: 0, blockType: 'future' }, 2))
+  assert.equal(folder.turnActivity(0)?.usage, undefined)
+  assert.equal(folder.turnActivity(0)?.totalTokens, undefined)
+})
+
 test('a durable assistant/attempt remains interruption evidence until turn end (live == reopen)', () => {
   const folder = new TranscriptFolder()
   folder.apply([
@@ -2530,6 +3654,43 @@ test('an ABANDONED live end removes the transient text (no durable settlement ex
   assert.equal(activity?.think, undefined)
   assert.equal(activity?.usage, undefined)
   assert.equal(activity?.totalTokens, undefined)
+})
+
+test('durable retry replaces open opaque display state without inheriting it', () => {
+  const prefix = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+  ]
+  const attemptA = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: 2, chunk: { type: 'block-start', index: 0, blockType: 'future-A' } as never }],
+  }, 3)
+  const retry = rawEvent('llm/retry', {
+    retryId: 'retry-open-opaque', turn: 0, step: 0, provider: 'p', mode: 'normal',
+    policyKey: 'test', retry: 1, maxRetries: 2, delayMs: 0,
+    failure: { message: 'failed', code: 'TEST' },
+  }, 4)
+  const attemptB = event('assistant/attempt', {
+    turn: 0,
+    step: 0,
+    stream: [{ type: 'chunk', time: 5, chunk: { type: 'block-start', index: 0, blockType: 'future-B' } as never }],
+  }, 6)
+  const folder = new TranscriptFolder()
+  folder.apply([...prefix, attemptA])
+  const first = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(first !== undefined && first.kind === 'assistant')
+  assert.deepEqual(first.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-A' }])
+  folder.apply([retry])
+  assert.equal(folder.messages().some(message => message.kind === 'assistant'), false)
+  folder.apply([attemptB])
+  const second = folder.messages().find(message => message.kind === 'assistant')
+  assert.ok(second !== undefined && second.kind === 'assistant')
+  assert.deepEqual(second.displayBlocks, [{ kind: 'open-opaque', blockType: 'future-B' }])
+
+  const cold = new TranscriptFolder()
+  cold.hydrate([...prefix, attemptA, retry, attemptB])
+  assert.deepEqual(cold.messages(), folder.messages())
 })
 
 test('a retry never concatenates: the durable message carries only the retry text', () => {
@@ -2626,6 +3787,23 @@ test('a committed MESSAGE settlement never removes text — the durable message 
   assert.equal(messages.length, 1)
   assert.ok(messages[0] !== undefined && messages[0].kind === 'assistant')
   assert.equal(messages[0].text, 'authoritative', 'the settled message text survives the end frame')
+})
+
+test('open opaque attempt state is excluded from markdown export', () => {
+  const finalized = { type: 'future-final', payload: { value: 'kept' } } as unknown as ContentBlock
+  const markdown = renderTranscriptMarkdown({
+    header: { id: 'session-export' as never, cwd: '/workspace' },
+    snapshotEvents: () => [
+      event('assistant/attempt', {
+        turn: 0,
+        step: 0,
+        stream: [{ type: 'chunk', time: 1, chunk: { type: 'block-start', index: 0, blockType: 'future-open' } as never }],
+      }, 1),
+      assistantMessageWithBlocks(2, [finalized]),
+    ],
+  } as never)
+  assert.doesNotMatch(markdown, /future-open|Unknown block: future-open/)
+  assert.match(markdown, /Unknown block: future-final/)
 })
 
 test('failed-attempt reasoning resets on retry and matches a cold replay', () => {

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -3331,7 +3331,7 @@ test('a stale message keeps settlement accounting while skipping presentation', 
   assert.equal((activity as { lastAssistantStep?: number }).lastAssistantStep, 2)
 })
 
-test('stale empty, image, and unknown settlements keep accounting without rows', () => {
+test('stale empty, image, and unknown settlements keep accounting and durable facts', () => {
   const contents = [
     [],
     [{
@@ -3352,13 +3352,37 @@ test('stale empty, image, and unknown settlements keep accounting without rows',
     const activity = folder.turnActivity(0)
     assert.ok(activity !== undefined)
     assert.equal(activity.assistantMessages, 1)
-    assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [''])
+    const assistants = folder.messages().filter(message => message.kind === 'assistant')
+    assert.equal(assistants.length, index === 0 ? 1 : 2)
+    if (index > 0) {
+      assert.deepEqual(assistants[1]?.content, content)
+    }
     assert.equal((activity as { lastAssistantStep?: number }).lastAssistantStep, 1)
     assert.equal(activity.message, undefined)
   }
 })
 
-test('late older assistant messages cannot append after a newer opaque step', () => {
+test('stale empty durable message remains available for later authoritative replacement', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    event('step/start', { turn: 0, step: 1 }, 2),
+  ])
+  folder.applyLiveInput(liveChunk(0, 1, { type: 'block-start', index: 0, blockType: 'future' } as never, 3))
+  folder.apply([assistantMessageWithBlocks(4, [], { step: 0 })])
+  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [''])
+
+  folder.apply([assistantMessage(5, 'late empty replacement', { step: 0 })])
+  assert.deepEqual(
+    folder.messages().filter(message => message.kind === 'assistant').map(message => message.text),
+    ['', 'late empty replacement'],
+  )
+  assert.equal(folder.turnActivity(0)?.message, undefined)
+  assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
+})
+
+test('late older durable assistant messages remain without retaking Focus ownership', () => {
   const folder = new TranscriptFolder()
   folder.apply([
     event('turn/start', { turn: 0 }, 0),
@@ -3371,14 +3395,21 @@ test('late older assistant messages cannot append after a newer opaque step', ()
     }, 3),
     assistantMessage(4, 'late-old', { step: 0 }),
   ])
-  assert.deepEqual(folder.messages().filter(message => message.kind === 'assistant').map(message => message.text), [''])
+  const assistants = folder.messages().filter(message => message.kind === 'assistant')
+  assert.deepEqual(assistants.map(message => message.text), ['', 'late-old'])
   assert.equal(folder.turnActivity(0)?.message, undefined)
   assert.equal((folder.turnActivity(0) as { lastAssistantStep?: number } | undefined)?.lastAssistantStep, 1)
 
   folder.apply([event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 5)])
-  const projected = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
-  assert.equal(projected.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false,
-    'a stale older message must not become the exact-last completed answer')
+  const collapsed = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  assert.equal(collapsed.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false,
+    'latest open opaque evidence is not a completed final and blocks stale fallback')
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  assert.deepEqual(
+    expanded.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message.text] : []),
+    ['', 'late-old'],
+    'expanded Focus retains both process evidence rows',
+  )
 })
 
 test('durable open opaque attempts are visible before close and retain interruption evidence', () => {


### PR DESCRIPTION
## Summary
- Render open opaque/non-incremental Assistant blocks immediately as display-only presentation rows without fabricating semantic ContentBlock values.
- Centralize assistant block assembly and preserve freeze, duplicate, empty-delta, stale-event, retry, tombstone, takeover, and interruption semantics.
- Keep live and durable projections aligned while preserving Focus ordering, cache identity, search/export, usage, TTFT, throughput, stats, and extension boundaries.
- Document the Stage C PR3 timing contract and add focused regression/performance coverage.

## Validation
- Focused changed suites: 502 passed, 0 failed.
- `pnpm test`: passed.
- `pnpm typecheck`: passed.
- `pnpm build`: passed.
- `pnpm gate:boundary`: passed.
- `node scripts/check-no-session-events.mjs`: passed.
- `pnpm gate:pi-vendor-diff --strict`: passed.
- `git diff --check`: passed.

## Review
- Holistic read-only review completed by the continuous reviewer.
- Verdict: `accepted`.
- Findings: none.

## Notes
- No changes were made under the protected `packages/pi-tui/**` fork.
- The branch remains based on the latest `next` commit.
