### PR TITLE
feat: enhance streaming tool preparing UX

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -969,6 +969,7 @@ function applyStreamingToolPreviewInput(
       step: input.step,
       index: chunk.index,
       name: chunk.name,
+      argumentsDelta: chunk.argumentsDelta,
     })
     return
   }

--- a/src/present.ts
+++ b/src/present.ts
@@ -583,6 +583,12 @@ const SUMMARY_KEYS: Record<string, string[]> = {
   others: [],
 }
 
+/** Return the formal Tool card's preferred argument summary keys. Preparing
+ * extraction treats this order as the best available choice at extraction time. */
+export function toolSummaryKeys(name: string): readonly string[] {
+  return SUMMARY_KEYS[classifyTool(name)] ?? []
+}
+
 /** The first line of a text (the Web's ReasoningRow summary for settled rows). */
 export function firstLine(text: string): string {
   const newline = text.indexOf('\n')
@@ -630,11 +636,11 @@ function pickString(args: Record<string, unknown>, keys: readonly string[]): str
 
 /** The summary key preference for one row variant, falling back to the first
  * string arg value, then to the raw args text (Web deriveSummary). */
-function deriveSummary(variant: ToolVariant, argsRaw: string): string {
+function deriveSummary(name: string, argsRaw: string): string {
   const parsed = parseArgs(argsRaw)
   if (typeof parsed !== 'object' || parsed === null) return firstLine(argsRaw)
   const args = parsed as Record<string, unknown>
-  const picked = pickString(args, SUMMARY_KEYS[variant] ?? [])
+  const picked = pickString(args, toolSummaryKeys(name))
   if (picked !== undefined) return firstLine(picked)
   for (const value of Object.values(args)) {
     if (typeof value === 'string' && value !== '') return firstLine(value)
@@ -1091,7 +1097,7 @@ export function toolCardHeader(name: string, argsRaw: string, cwd?: string): Too
   // generic derivation (Web TodoRow parity: `todo_write` reads
   // `2/3 done` instead of a raw args dump).
   const toolSummary = summarizeToolArgs(name, argsRaw)
-  const base = argsRaw === '' ? '' : toolSummary ?? relativizeToCwd(deriveSummary(variant, argsRaw), cwd)
+  const base = argsRaw === '' ? '' : toolSummary ?? relativizeToCwd(deriveSummary(name, argsRaw), cwd)
   const summary = variant === 'others' && toolTitle === undefined
     ? base === '' ? '' : name + ' · ' + base
     : base

--- a/src/streaming-tool-preparing.ts
+++ b/src/streaming-tool-preparing.ts
@@ -1,6 +1,10 @@
 /** Pure local operations for the live tool-call preparing projection. */
 
 import type { StreamingToolPreview } from './tui-app.ts'
+import { toolSummaryKeys } from './present.ts'
+
+/** Hard cap for the partial argument prefix retained for summary extraction. */
+export const PREPARING_SCAN_MAX_CHARS = 4096
 
 function fallbackPreviewKey(turn: number, step: number, index: number): string {
   return `\u0000streaming-tool-preview:${turn}:${step}:${index}`
@@ -18,23 +22,120 @@ function previewAt(
   return undefined
 }
 
-/** Upsert one local preview, preserving a delayed name and stable position. */
+/** Extract one complete, non-empty JSON string field from a partial object. */
+export function extractPartialStringField(
+  raw: string,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const encodedKey = JSON.stringify(key)
+    let searchFrom = 0
+    while (searchFrom < raw.length) {
+      const keyStart = raw.indexOf(encodedKey, searchFrom)
+      if (keyStart === -1) break
+      let cursor = keyStart + encodedKey.length
+      while (/\s/.test(raw[cursor] ?? '')) cursor += 1
+      if (raw[cursor] !== ':') {
+        searchFrom = cursor
+        continue
+      }
+      cursor += 1
+      while (/\s/.test(raw[cursor] ?? '')) cursor += 1
+      if (raw[cursor] !== '"') {
+        searchFrom = cursor
+        continue
+      }
+      const valueStart = cursor
+      cursor += 1
+      while (cursor < raw.length) {
+        if (raw[cursor] === '\\') {
+          cursor += 2
+          continue
+        }
+        if (raw[cursor] === '"') {
+          try {
+            const value: unknown = JSON.parse(raw.slice(valueStart, cursor + 1))
+            if (typeof value === 'string' && value !== '') return value
+          } catch {
+            // The value is not a valid complete JSON string yet.
+          }
+          break
+        }
+        cursor += 1
+      }
+      searchFrom = keyStart + encodedKey.length
+    }
+  }
+  return undefined
+}
+
+export interface StreamingToolPreviewInput {
+  readonly callId: string
+  readonly turn: number
+  readonly step: number
+  readonly index: number
+  readonly name?: string
+  /** One decoded argumentsDelta from the live assistant stream. */
+  readonly argumentsDelta?: string
+}
+
+/** Upsert one local preview, preserving streamed state across identity/name delays. */
 export function upsertStreamingToolPreview(
   previews: Map<string, StreamingToolPreview>,
-  preview: StreamingToolPreview,
+  input: StreamingToolPreviewInput,
 ): void {
-  const previous = previewAt(previews, preview.turn, preview.step, preview.index)
-  const key = preview.callId === ''
-    ? previous?.[0] ?? fallbackPreviewKey(preview.turn, preview.step, preview.index)
-    : preview.callId
+  const previous = previewAt(previews, input.turn, input.step, input.index)
+  const key = input.callId === ''
+    ? previous?.[0] ?? fallbackPreviewKey(input.turn, input.step, input.index)
+    : input.callId
   if (previous !== undefined && previous[0] !== key) previews.delete(previous[0])
   const existing = previews.get(key)
+  const prior = existing ?? previous?.[1]
+  const name = input.name ?? prior?.name
+  const previousArgumentBytes = prior?.argumentBytes ?? 0
+  const argumentBytes = previousArgumentBytes
+    + (input.argumentsDelta === undefined ? 0 : Buffer.byteLength(input.argumentsDelta, 'utf8'))
+  let summary = prior?.summary
+  let scanPrefix = prior?.scanPrefix
+
+  // `scanPrefix === undefined` with received bytes and no summary means a
+  // known-name scan already hit its cap. An unknown name keeps its capped
+  // prefix so a later name can perform one final extraction attempt.
+  const canScan = summary === undefined && (scanPrefix !== undefined || previousArgumentBytes === 0)
+  if (canScan) {
+    const boundedPrefix = scanPrefix?.slice(0, PREPARING_SCAN_MAX_CHARS)
+    const candidate = input.argumentsDelta === undefined
+      ? boundedPrefix
+      : `${boundedPrefix ?? ''}${input.argumentsDelta.slice(
+        0,
+        Math.max(0, PREPARING_SCAN_MAX_CHARS - (boundedPrefix?.length ?? 0)),
+      )}`
+    if (candidate !== undefined) {
+      // The formal key order is a preference among fields complete at this
+      // extraction point; partial streams do not promise a later re-selection.
+      const extracted = name === undefined
+        ? undefined
+        : extractPartialStringField(candidate, toolSummaryKeys(name))
+      if (extracted !== undefined) {
+        summary = extracted
+        scanPrefix = undefined
+      } else if (candidate.length >= PREPARING_SCAN_MAX_CHARS) {
+        scanPrefix = name === undefined ? candidate : undefined
+      } else {
+        scanPrefix = candidate
+      }
+    }
+  }
+
   previews.set(key, {
-    callId: preview.callId === '' ? existing?.callId ?? previous?.[1].callId ?? preview.callId : preview.callId,
-    turn: preview.turn,
-    step: preview.step,
-    index: preview.index,
-    name: preview.name ?? existing?.name ?? previous?.[1].name,
+    callId: input.callId === '' ? prior?.callId ?? input.callId : input.callId,
+    turn: input.turn,
+    step: input.step,
+    index: input.index,
+    ...(name === undefined ? {} : { name }),
+    argumentBytes,
+    ...(summary === undefined ? {} : { summary }),
+    ...(scanPrefix === undefined ? {} : { scanPrefix }),
   })
 }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -155,6 +155,7 @@ import {
   RUNNING_PREVIEW_LINES,
   SETTLED_PREVIEW_VISUAL_ROWS,
 } from './local-shell-card.ts'
+import { formatBytes } from './bounded-output.ts'
 import type { RendererRegistry } from './renderer-registry.ts'
 import { OverlayBroker } from './overlay-broker.ts'
 import { EditorSeatMount } from './editor-seat.ts'
@@ -250,6 +251,12 @@ export interface StreamingToolPreview {
   readonly step: number
   readonly index: number
   readonly name?: string
+  /** Total UTF-8 bytes received through argumentsDelta. */
+  readonly argumentBytes: number
+  /** Early human identity extracted from bounded partial args. */
+  readonly summary?: string
+  /** Bounded partial args retained until summary is found or a known-name scan reaches the cap. */
+  readonly scanPrefix?: string
 }
 
 /** The indeterminate progress-bar frames shown while a compaction runs:
@@ -5680,14 +5687,33 @@ export class TuiApp {
       : undefined
   }
 
-  /** Render the live preparing rows with the current semantic tool icon and
-   * title mappings. The arguments stream is intentionally not retained or
-   * parsed; only the tool identity is shown. */
-  private streamingToolPreviewComponent(previews: readonly StreamingToolPreview[]): Component {
+  /** Render live Preparing rows with the formal tool identity, early summary
+   * and exact UTF-8 argument bytes. The bounded scan prefix never reaches the
+   * presentation layer. */
+  private streamingToolPreviewComponent(
+    previews: readonly StreamingToolPreview[],
+    width: number,
+  ): Component {
+    const safeWidth = Math.max(1, Math.floor(width))
     const lines = previews.map(preview => {
       const name = preview.name ?? ''
-      const prefix = iconPrefix(toolIconSemantic(name), this.iconStyle)
-      return color.textDim(`${prefix}Preparing ${toolTitle(name)}...`)
+      const head = `${iconPrefix(toolIconSemantic(name), this.iconStyle)}Preparing ${toolTitle(name)}`
+      const summary = preview.summary === undefined
+        ? ''
+        : relativizeToCwd(preview.summary, this.workspaceRoot).replace(/\r\n|\r|\n/g, ' ')
+      const tail = `... · ${formatBytes(preview.argumentBytes)}`
+      const tailShown = truncateToWidth(tail, Math.min(safeWidth, visibleWidth(tail)), '…')
+      let remaining = Math.max(0, safeWidth - visibleWidth(tailShown))
+      const headShown = remaining === 0
+        ? ''
+        : remaining >= visibleWidth(head)
+          ? head
+          : truncateToWidth(head, remaining, '…')
+      remaining = Math.max(0, remaining - visibleWidth(headShown))
+      const summaryShown = summary === '' || remaining < 2
+        ? ''
+        : truncateToWidth(` ${summary}`, remaining, '…')
+      return color.textDim(`${headShown}${summaryShown}${tailShown}`)
     })
     return new Text(lines.join('\n'), 0, 0)
   }
@@ -5800,7 +5826,7 @@ export class TuiApp {
         rendered = component.render(width)
       } else if (block.kind === 'streaming-tool-previews') {
         // Live-only preview block
-        component = this.streamingToolPreviewComponent(block.previews)
+        component = this.streamingToolPreviewComponent(block.previews, width)
         rendered = component.render(width)
       } else {
         // Persistent per-message components (stage J): unchanged messages
@@ -6000,7 +6026,7 @@ export class TuiApp {
         )
         rendered = component.render(width)
       } else if (block.kind === 'streaming-tool-previews') {
-        component = this.streamingToolPreviewComponent(block.previews)
+        component = this.streamingToolPreviewComponent(block.previews, width)
         rendered = component.render(width)
       } else {
         component = this.componentForMessage(block.message, boundary, width)

--- a/test/focus-ui.test.ts
+++ b/test/focus-ui.test.ts
@@ -213,8 +213,8 @@ test('Focus collapsed Preparing uses the Tool slot and temporarily overrides the
   applyMixed(folder, runningTurn(0))
   app.setFocusMode(true)
   show(app, folder, [
-    { callId: 'p-edit', turn: 1, step: 0, index: 0, name: 'edit' },
-    { callId: 'p-bash', turn: 1, step: 0, index: 1, name: 'bash' },
+    { callId: 'p-edit', turn: 1, step: 0, index: 0, name: 'edit', argumentBytes: 0 },
+    { callId: 'p-bash', turn: 1, step: 0, index: 1, name: 'bash', argumentBytes: 0 },
   ])
   app.setFullscreen(true)
   await vt.waitForRender()
@@ -224,7 +224,7 @@ test('Focus collapsed Preparing uses the Tool slot and temporarily overrides the
   assert.ok(!joined.includes('Tool:    Read src/transcript.ts'), `the formal Tool slot must be overridden:\n${joined}`)
   assert.ok(!joined.includes('Preparing Edit...'), `collapsed Focus must not append a standalone preview row:\n${joined}`)
 
-  show(app, folder, [{ callId: 'p-read', turn: 1, step: 0, index: 0, name: 'read' }])
+  show(app, folder, [{ callId: 'p-read', turn: 1, step: 0, index: 0, name: 'read', argumentBytes: 0 }])
   await vt.waitForRender()
   joined = vt.getViewport().join('\n')
   assert.ok(joined.includes('Tool:    Preparing Read…'), `the live Tool-slot summary must refresh:\n${joined}`)
@@ -246,8 +246,8 @@ test('Focus expanded places Preparing rows after the process tail and before the
   applyMixed(folder, [...runningTurn(0), ...settleEvents(0)])
   app.setFocusMode(true)
   show(app, folder, [
-    { callId: 'p-bash', turn: 1, step: 0, index: 1, name: 'bash' },
-    { callId: 'p-edit', turn: 1, step: 0, index: 0, name: 'edit' },
+    { callId: 'p-bash', turn: 1, step: 0, index: 1, name: 'bash', argumentBytes: 0 },
+    { callId: 'p-edit', turn: 1, step: 0, index: 0, name: 'edit', argumentBytes: 0 },
   ])
   app.setFullscreen(true)
   await vt.waitForRender()

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -1939,15 +1939,21 @@ test('the parent Preparing projection and child viewer lifecycle rollover stay l
     const tui = (app as unknown as { tui: { handleTerminalInput(data: string): void } }).tui
     tui.handleTerminalInput(data)
   }
+  const parentArguments = '{"path":"parent.ts"}'
+  const childArguments = '{"command":"child"}'
 
   // The main session owns the first preview before the viewer opens.
   context.emit('session/event', parent as never, event('turn/start', { turn: 1 }, 10))
   const parentAgent = liveAgentOf(harness, parent.id)
   emitLiveStream(context, parentAgent, liveStart('p1', 1, 0))
-  emitLiveStream(context, parentAgent, liveChunkFrame('p1', 0, { type: 'tool-call-delta', index: 0, id: '', name: 'edit', argumentsDelta: '{' }))
+  emitLiveStream(context, parentAgent, liveChunkFrame('p1', 0, {
+    type: 'tool-call-delta', index: 0, id: '', name: 'edit', argumentsDelta: parentArguments,
+  }))
   await new Promise(resolve => setTimeout(resolve, 70))
   await vt.waitForRender()
-  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => preview.callId), [''])
+  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => [
+    preview.callId, preview.name, preview.argumentBytes, preview.summary,
+  ]), [['', 'edit', Buffer.byteLength(parentArguments, 'utf8'), 'parent.ts']])
 
   // The child Agent is already live, but its viewer has not mounted yet. Its
   // active prefix must remain available for the later exact-Agent replay.
@@ -1959,7 +1965,9 @@ test('the parent Preparing projection and child viewer lifecycle rollover stay l
   })
   emitLiveStream(context, childAgent, {
     type: 'chunk', attemptId: 'c1', revision: 3, index: 1,
-    time: 1_700_000_000_101, chunk: { type: 'tool-call-delta', index: 1, id: 'child-call', name: 'bash', argumentsDelta: '{' },
+    time: 1_700_000_000_101, chunk: {
+      type: 'tool-call-delta', index: 1, id: 'child-call', name: 'bash', argumentsDelta: childArguments,
+    },
   })
 
   // /tasks opens the real runner browser, and Enter mounts the child viewer.
@@ -1974,7 +1982,9 @@ test('the parent Preparing projection and child viewer lifecycle rollover stay l
   assert.notEqual(app.getViewerGeneration(), 0, 'the child viewer must be mounted')
   assert.ok(probe.capturedMessages?.some(message => message.kind === 'assistant' && message.text === 'late child answer'),
     'a late child viewer must replay the exact Agent baseline after durable hydration')
-  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => [preview.callId, preview.name]), [['child-call', 'bash']])
+  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => [
+    preview.callId, preview.name, preview.argumentBytes, preview.summary,
+  ]), [['child-call', 'bash', Buffer.byteLength(childArguments, 'utf8'), 'child']])
 
   // The same continuable child can roll from Activation A to a new Agent B
   // without closing the viewer. A's delayed frame must stay fenced while B's
@@ -2062,9 +2072,11 @@ test('the parent Preparing projection and child viewer lifecycle rollover stay l
   input('\x1b')
   await settle()
   await vt.waitForRender()
-  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => [preview.callId, preview.name]), [
-    ['parent-call-a', 'write'],
-    ['parent-call-b', 'read'],
+  assert.deepEqual(probe.capturedStreamingToolPreviews?.map(preview => [
+    preview.callId, preview.name, preview.argumentBytes, preview.summary,
+  ]), [
+    ['parent-call-a', 'write', Buffer.byteLength(parentArguments + '}', 'utf8'), 'parent.ts'],
+    ['parent-call-b', 'read', Buffer.byteLength('{', 'utf8'), undefined],
   ])
 
   // A parent call that materializes while the child remains visible must be

--- a/test/streaming-tool-preparing.test.ts
+++ b/test/streaming-tool-preparing.test.ts
@@ -6,13 +6,15 @@ import type { ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { RetryId } from '@deepseek-ai/dsh-llm-retry'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import {
+  PREPARING_SCAN_MAX_CHARS,
   clearStreamingToolPreviewsForStep,
   clearStreamingToolPreviewsForTurn,
+  extractPartialStringField,
   removeStreamingToolPreview,
   streamingToolPreviewSnapshot,
   upsertStreamingToolPreview,
 } from '../src/streaming-tool-preparing.ts'
-import { toolIconSemantic, toolTitle } from '../src/present.ts'
+import { toolIconSemantic, toolSummaryKeys, toolTitle } from '../src/present.ts'
 import { TuiApp, type StreamingToolPreview } from '../src/tui-app.ts'
 import type { TranscriptMessage, TurnActivity } from '../src/transcript.ts'
 import type { AssistantLiveChunk, AssistantLiveInput } from '../src/runtime/assistant-stream-port.ts'
@@ -68,6 +70,7 @@ function applyPreviewInput(previews: Map<string, StreamingToolPreview>, input: A
       step: input.step,
       index: chunk.index,
       name: chunk.name,
+      argumentsDelta: chunk.argumentsDelta,
     })
     return
   }
@@ -127,7 +130,130 @@ test('tracks one preview per call, preserves delayed names, and sorts by index',
     { callId: 'call-b', turn: 1, step: 0, index: 1, name: 'write' },
   ])
   assert.deepEqual(Object.keys(previews.get('call-b' as ToolCallId)!), [
-    'callId', 'turn', 'step', 'index', 'name',
+    'callId', 'turn', 'step', 'index', 'name', 'argumentBytes', 'summary',
+  ])
+})
+
+test('extracts only complete JSON string fields and decodes escapes', () => {
+  const encoded = JSON.stringify({ command: 'printf "hello"' })
+  assert.equal(extractPartialStringField('{"command":"printf', ['command']), undefined)
+  assert.equal(extractPartialStringField(encoded, ['command']), 'printf "hello"')
+  assert.equal(extractPartialStringField('{"command":42}', ['command']), undefined)
+})
+
+test('preparing summary extraction uses formal keys as best available at extraction time', () => {
+  // The shared order defines preference only among fields complete when the
+  // partial scan runs; it is not a promise of final-card re-selection.
+  assert.deepEqual(toolSummaryKeys('bash'), ['description', 'command'])
+  assert.deepEqual(toolSummaryKeys('pwsh'), ['description', 'command'])
+  assert.deepEqual(toolSummaryKeys('read'), ['path', 'file_path', 'url'])
+  assert.deepEqual(toolSummaryKeys('web_search'), ['query', 'pattern', 'url'])
+  assert.deepEqual(toolSummaryKeys('grep'), ['query', 'pattern', 'url'])
+  assert.deepEqual(toolSummaryKeys('write'), ['path', 'file_path'])
+  assert.deepEqual(toolSummaryKeys('edit'), ['path', 'file_path'])
+})
+
+test('accumulates exact UTF-8 argument bytes across deltas', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewInput(previews, delta(5, 0, 0, 'bytes', 'abc', 'edit'))
+  applyPreviewInput(previews, delta(5, 0, 0, 'bytes', '你好'))
+  assert.equal(previews.get('bytes')?.argumentBytes, Buffer.byteLength('abc你好', 'utf8'))
+  assert.equal(previews.get('bytes')?.summary, undefined)
+})
+
+test('extracts a summary only after a JSON string value closes across chunks', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewInput(previews, delta(6, 0, 0, 'path', '{"pa', 'edit'))
+  assert.equal(previews.get('path')?.summary, undefined)
+  applyPreviewInput(previews, delta(6, 0, 0, 'path', 'th":"src/foo.ts"}'))
+  assert.equal(previews.get('path')?.summary, 'src/foo.ts')
+  assert.equal(previews.get('path')?.scanPrefix, undefined)
+})
+
+test('delayed names extract from the existing bounded prefix', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewInput(previews, delta(7, 0, 0, 'delayed', '{"path":"src/foo.ts"}'))
+  assert.equal(previews.get('delayed')?.summary, undefined)
+  applyPreviewInput(previews, delta(7, 0, 0, 'delayed', '', 'edit'))
+  assert.equal(previews.get('delayed')?.summary, 'src/foo.ts')
+  assert.equal(previews.get('delayed')?.argumentBytes, Buffer.byteLength('{"path":"src/foo.ts"}', 'utf8'))
+})
+
+test('delayed names retain a capped prefix for final extraction', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  const path = '{"path":"src/foo.ts"}'
+  const first = path + 'x'.repeat(PREPARING_SCAN_MAX_CHARS - path.length)
+  applyPreviewInput(previews, delta(12, 0, 0, 'delayed-cap', first))
+  assert.equal(previews.get('delayed-cap')?.summary, undefined)
+  assert.equal(previews.get('delayed-cap')?.scanPrefix, first)
+
+  applyPreviewInput(previews, delta(12, 0, 0, 'delayed-cap', '', 'edit'))
+  assert.equal(previews.get('delayed-cap')?.summary, 'src/foo.ts')
+  assert.equal(previews.get('delayed-cap')?.scanPrefix, undefined)
+  assert.equal(previews.get('delayed-cap')?.argumentBytes, Buffer.byteLength(first, 'utf8'))
+})
+
+test('empty-to-real call ids preserve bytes and summary', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewInput(previews, delta(8, 0, 0, '', '{"path":"src/foo.ts"}', 'edit'))
+  applyPreviewInput(previews, delta(8, 0, 0, 'real-edit', '', 'edit'))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => ({
+    callId: preview.callId,
+    argumentBytes: preview.argumentBytes,
+    summary: preview.summary,
+  })), [{
+    callId: 'real-edit',
+    argumentBytes: Buffer.byteLength('{"path":"src/foo.ts"}', 'utf8'),
+    summary: 'src/foo.ts',
+  }])
+})
+
+test('bounded scans release the prefix but continue counting bytes', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  const first = 'x'.repeat(PREPARING_SCAN_MAX_CHARS)
+  applyPreviewInput(previews, delta(9, 0, 0, 'capped', first, 'edit'))
+  assert.equal(previews.get('capped')?.argumentBytes, Buffer.byteLength(first, 'utf8'))
+  assert.equal(previews.get('capped')?.scanPrefix, undefined)
+  applyPreviewInput(previews, delta(9, 0, 0, 'capped', '{"path":"late"}'))
+  assert.equal(previews.get('capped')?.summary, undefined)
+  assert.equal(previews.get('capped')?.argumentBytes, Buffer.byteLength(first + '{"path":"late"}', 'utf8'))
+})
+
+test('one oversized delta cannot reveal a field beyond the scan cap', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  const overCap = 'x'.repeat(PREPARING_SCAN_MAX_CHARS + 10) + '{"path":"late"}'
+  applyPreviewInput(previews, delta(9, 0, 0, 'oversized', overCap, 'edit'))
+  const preview = previews.get('oversized')!
+  assert.equal(preview.summary, undefined)
+  assert.equal(preview.scanPrefix, undefined)
+  assert.equal(preview.argumentBytes, Buffer.byteLength(overCap, 'utf8'))
+})
+
+test('summary success releases the prefix before large later arguments', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  const path = '{"path":"src/foo.ts"}'
+  const content = 'x'.repeat(PREPARING_SCAN_MAX_CHARS * 2)
+  applyPreviewInput(previews, delta(10, 0, 0, 'released', path, 'write'))
+  applyPreviewInput(previews, delta(10, 0, 0, 'released', content))
+  const preview = previews.get('released')!
+  assert.equal(preview.summary, 'src/foo.ts')
+  assert.equal(preview.scanPrefix, undefined)
+  assert.equal(preview.argumentBytes, Buffer.byteLength(path + content, 'utf8'))
+})
+
+test('parallel previews keep independent bytes and summaries', () => {
+  const previews = new Map<string, StreamingToolPreview>()
+  applyPreviewInput(previews, delta(11, 0, 1, 'write', '{"path":"src/b.ts"}', 'write'))
+  applyPreviewInput(previews, delta(11, 0, 0, 'edit', '{"path":"src/a.ts"}', 'edit'))
+  applyPreviewInput(previews, delta(11, 0, 0, 'edit', 'x'.repeat(10)))
+  assert.deepEqual(streamingToolPreviewSnapshot(previews).map(preview => ({
+    callId: preview.callId,
+    index: preview.index,
+    summary: preview.summary,
+    argumentBytes: preview.argumentBytes,
+  })), [
+    { callId: 'edit', index: 0, summary: 'src/a.ts', argumentBytes: Buffer.byteLength('{"path":"src/a.ts"}' + 'x'.repeat(10), 'utf8') },
+    { callId: 'write', index: 1, summary: 'src/b.ts', argumentBytes: Buffer.byteLength('{"path":"src/b.ts"}', 'utf8') },
   ])
 })
 
@@ -283,6 +409,7 @@ test('preparing rows are inert in the fullscreen hit map', async () => {
   }
   app.setTranscript([{ kind: 'assistant', turn: 1, text: 'answer' }], new Map([[1, activity]]), undefined, [{
     callId: 'preview-call',
+     argumentBytes: 0,
     turn: 1,
     step: 0,
     index: 0,
@@ -309,14 +436,17 @@ test('renders preparing rows with the selected icon style and no spinner state',
   app.start()
   const preview: StreamingToolPreview = {
     callId: 'call-a',
+    argumentBytes: 1234,
     turn: 1,
     step: 0,
     index: 0,
     name: 'edit',
+    summary: 'src/foo.ts',
   }
 
   const unnamedPreview: StreamingToolPreview = {
     callId: 'call-b',
+    argumentBytes: 0,
     turn: 1,
     step: 0,
     index: 1,
@@ -325,20 +455,20 @@ test('renders preparing rows with the selected icon style and no spinner state',
   app.setTranscript([], undefined, undefined, [preview, unnamedPreview])
   await vt.waitForRender()
   let view = vt.getViewport().join('\n')
-  assert.ok(view.includes('✏️  Preparing Edit...'), `emoji preview missing:\n${view}`)
-  assert.ok(view.includes('🛠️  Preparing tool...'), `unnamed preview missing:\n${view}`)
+  assert.ok(view.includes('✏️  Preparing Edit src/foo.ts... · 1.2 KiB'), `emoji preview missing:\n${view}`)
+  assert.ok(view.includes('🛠️  Preparing tool... · 0 B'), `unnamed preview missing:\n${view}`)
   assert.ok(view.includes('Working...'), `preview must not replace the working indicator:\n${view}`)
 
   app.setIconStyle('symbols')
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
-  assert.ok(view.includes('~  Preparing Edit...'), `symbol preview missing:\n${view}`)
+  assert.ok(view.includes('~  Preparing Edit src/foo.ts... · 1.2 KiB'), `symbol preview missing:\n${view}`)
 
   app.setIconStyle('minimal')
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
-  assert.ok(view.includes('Preparing Edit...'), `minimal preview missing:\n${view}`)
-  assert.ok(!view.includes('~  Preparing Edit...'), `minimal preview kept a symbol prefix:\n${view}`)
+  assert.ok(view.includes('Preparing Edit src/foo.ts... · 1.2 KiB'), `minimal preview missing:\n${view}`)
+  assert.ok(!view.includes('~  Preparing Edit src/foo.ts...'), `minimal preview kept a symbol prefix:\n${view}`)
 
   app.setFocusMode(true)
   const focusActivity: TurnActivity = {
@@ -355,9 +485,33 @@ test('renders preparing rows with the selected icon style and no spinner state',
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('Tool:    Preparing Edit…'), `Focus collapsed Tool slot missing:\n${view}`)
-  assert.ok(!view.includes('Preparing Edit...'), `Focus collapsed must not render a standalone row:\n${view}`)
+  assert.ok(!view.includes('src/foo.ts'), `Focus collapsed must not show the live path:\n${view}`)
+  assert.ok(!view.includes('1.2 KiB'), `Focus collapsed must not show live argument bytes:\n${view}`)
+  assert.ok(!view.includes('Preparing Edit src/foo.ts...'), `Focus collapsed must not render a standalone row:\n${view}`)
 
   app.setTranscript(focusMessages, new Map([[1, focusActivity]]))
   await vt.waitForRender()
   assert.ok(!vt.getViewport().join('\n').includes('Preparing'), 'omitting the preview snapshot must clear old rows')
+})
+
+test('narrow Preparing rows stay single-line while preserving the byte tail', async () => {
+  const vt = new VirtualTerminal(45, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  startedApps.add(app)
+  app.start()
+  app.setIconStyle('minimal')
+  app.setTranscript([], undefined, undefined, [{
+    callId: 'narrow',
+    turn: 1,
+    step: 0,
+    index: 0,
+    name: 'edit',
+    summary: 'really/long\npath',
+    argumentBytes: 123456,
+  }])
+  await vt.waitForRender()
+  const rows = vt.getViewport().filter(line => line.includes('Preparing Edit'))
+  assert.equal(rows.length, 1, `narrow Preparing row wrapped:\n${vt.getViewport().join('\n')}`)
+  assert.ok(rows[0]!.includes('... · 120.6 KiB'), `byte tail missing:\n${vt.getViewport().join('\n')}`)
+  assert.ok(rows[0]!.includes('…'), `summary should truncate with the existing marker:\n${rows[0]}`)
 })


### PR DESCRIPTION
## Summary
- Show early tool argument summaries in live Preparing rows using the formal Tool-card summary keys.
- Track and render exact UTF-8 argument bytes with bounded partial-field scanning.
- Preserve bytes and summaries across delayed names, call-id migration, concurrent calls, and parent/child viewers.

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `node scripts/client-boundary-gate.mjs`
- `git diff --check`
- Targeted Preparing/Focus/viewer tests: 110 passing

## Review
- Completed review-fix-loop; final holistic review verdict: accepted with no remaining findings.