### PR TITLE
fix: retire direct sessions during tui shutdown

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Direct sessions are now fully retired on exit.** Exiting the TUI now
+  retires the main Agent, its continuable subagents and Agent-scoped
+  background jobs in a fixed order: cancel the main Agent and await
+  quiescence → drain continuable descendants → final persistence flush →
+  release the AgentHandle. Previously the process could linger for ~5
+  minutes after exit while a continuable subagent stayed alive; exit now
+  completes within seconds, and the diagnostics distinguish surface close,
+  Host retirement and launcher exit. Session switches (/new, /fork, rewind,
+  /sessions) also retire the old owner's continuable descendants after the
+  commit.
+
 ## [0.4.1] - 2026-09-04
 
 ### Installation and version pairing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ## [Unreleased]
 
+### 修复
+
+- **退出时完整回收 Direct 会话。** 退出 TUI 时,主 Agent、continuable
+  subagent 与 Agent 作用域后台任务现在按固定顺序回收:取消主 Agent 并等待
+  静默 → 排空 continuable 后代 → 最终持久化 flush → 释放 AgentHandle。
+  此前退出后进程可能残留约 5 分钟(continuable subagent 仍存活);现在
+  退出在数秒内完成,且诊断日志能区分 surface 关闭、Host 回收与 launcher
+  退出三个阶段。会话切换(/new、/fork、rewind、/sessions)提交后也会
+  回收旧 owner 的 continuable 后代。
+
 ## [0.4.1] - 2026-09-04
 
 ### 安装与版本对应

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ fields.
 |---|---|---|
 | Layout, rendering, input routing, overlays | `src/tui-app.ts` (`TuiApp`) | messages, messageComponents render cache, themeRevision, expandedOverride, search overlay, status/todo/dock/queue state, working indicator |
 | Transcript folding / projection | `src/transcript.ts` | incremental read grouping, assistant/thinking entries, pending calls |
-| Exit contract | `src/exit.ts` | flushWithTimeout (pure, tested) |
+| Exit contract | `src/exit.ts` | latch → surface cleanup → hint → appExit (pure, tested); Direct owned-session retirement in `src/runtime/direct/owned-session-retirement.ts` |
 | Detached tasks | `src/detached.ts` | runDetached rejection classification (pure, tested) |
 | Diagnostics | `src/diag.ts` | file/stderr sinks |
 | Model menu | `src/model-menu.ts` | per-open disposed latch + AbortController |
@@ -29,12 +29,14 @@ fields.
 
 ## Target controllers (extraction order, one responsibility per commit)
 
-1. **RunnerLifecycle** — start, cleanup (idempotent), lifecycle abort, exit
-   order (block input → flush with timeout → record → cleanup → exit),
-   detached-task accounting. Already has its primitives (`exit.ts`,
-   `detached.ts`, the runner's `cleanup()`); extraction = moving the runner
-   closure's lifecycle block into a class with an explicit dependency
-   interface (`{ diag, app, signal }`).
+1. **RunnerLifecycle** — start, surface cleanup (idempotent), lifecycle
+   abort, exit order (latch → surface cleanup → resume hint → appExit; the
+   Direct owned-session retirement runs inside the appExit disposal under
+   the DSH process-shutdown watchdog), detached-task accounting. Already
+   has its primitives (`exit.ts`, `detached.ts`, the runner's
+   `disposeSurface()` / `retireOwnedSession()`); extraction = moving the
+   runner closure's lifecycle block into a class with an explicit
+   dependency interface (`{ diag, app, signal }`).
 2. **SessionController** — create/resume/switch, `sessionGeneration` bump +
    per-session teardown (callArgs, search, expansion overrides),
    write-fence wiring, event subscription. Depends on

--- a/docs/client-server-coupling.md
+++ b/docs/client-server-coupling.md
@@ -45,6 +45,16 @@
 | `CLIENT_LOCAL` | No Host coupling today; must stay that way | never |
 | `TEMPORARY_EXCEPTION` | Allowed by design, not migration debt | never (documented carve-outs) |
 
+The Direct owned-session retirement
+(`src/runtime/direct/owned-session-retirement.ts`) is a structural,
+callback-only helper: it imports no Host package and touches no `ctx`, so it
+adds ZERO baseline entries. The runner (`src/index.ts`, already the primary
+Direct coupling point) wires the live Agent / AgentHandle / sessions /
+subagents into it — the same Direct ownership escape the runner already
+owns. This is Direct ownership retirement, not a semantic-port or Remote
+capability (see `docs/client-server-migration.md` §Direct ownership
+retirement).
+
 ## Inventory (baseline, generated from the current tree)
 
 ### DIRECT_HOST_REQUIRED

--- a/docs/client-server-migration.md
+++ b/docs/client-server-migration.md
@@ -48,6 +48,21 @@ The semantic catalog names these operations explicitly as
 `selectSessionModel`, so a future Remote adapter can map them without moving
 Agent, Session, or Context objects across the boundary.
 
+### Direct ownership retirement (pre-M2)
+
+The current Direct backend owns the in-process top-level Agent and must
+quiesce/drain/dispose it during runner teardown (interactive exit, HMR
+unload, and post-commit session transitions). The retirement is a
+**Direct-only ownership escape** (`src/runtime/direct/owned-session-retirement.ts`,
+structural callbacks only — no semantic-port change, no new Host coupling)
+retained until M8 and is NOT a Remote session-close semantic. A future
+Remote client closes its client-side observation/connection state through
+official DSH client contracts; this fix does not invent a host
+session-destroy RPC, does not add `close()`/`dispose()`/`drainSubagents()`
+to the `SessionLifecycle` port, and does not expose
+`drainContinuableDescendants` as a cross-backend capability. M2 remains
+NOT STARTED and Direct remains the production backend.
+
 ### Lifecycle creation cancellation (Stage B / pre-M2)
 
 `CreateSessionRequest` and `ResumeSessionRequest` may carry a client-local,

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -122,7 +122,9 @@ is the whole point:
    session stays current and the user may retry.
 4. COMMIT — a synchronous critical section (generation bump, live
    handle/agent replacement) with no awaits between its steps.
-5. RETIRE — dispose the old handle; child surface/catalog work is
+5. RETIRE — retire the old Direct owner (cancel → idle → drain
+   continuable descendants → final flush → dispose — see the Direct
+   top-level Agent retirement section); child surface/catalog work is
    best-effort and the committed child always stands.
 
 A rejected `create`/`resume` is handled WITHOUT any publication-phase
@@ -169,6 +171,65 @@ refused (`TransitionInProgressError`).
   source identity captured when the picker opened must still own the
   surface, or the selection is rejected as `stale` (a stale selection
   never creates a child).
+
+## Direct top-level Agent retirement
+
+The Direct backend runs the TUI and the Host in one process and the TUI
+itself creates the top-level Agent, so closing the TUI surface must also
+retire that Direct ownership. This is a **Direct-only ownership escape**
+(`src/runtime/direct/owned-session-retirement.ts`), NOT a semantic port and
+NOT a future Remote `session.close` RPC — a future Remote client closes its
+client-side observation/connection state through official DSH client
+contracts and never destroys the Host Agent.
+
+The retirement order is fixed (mirroring the official DSH ACP session
+close):
+
+```text
+cancel → idle → descendants → flush → dispose
+```
+
+- `cancel` — `agent.cancel({ kind: 'user' })` stops new main-Agent work.
+- `idle` — `agent.whenIdle()` awaits the main Agent's quiescence.
+- `descendants` — `subagents.drainContinuableDescendants([agent])` closes
+  continuable admission below the exact parent, stops visible descendant
+  Activations, and releases their `AgentHandle`s child-first. This is the
+  piece that previously let a continuable subagent keep the process alive
+  for minutes after the TUI exited.
+- `flush` — the FINAL `sessions.flush` runs AFTER the descendant drain, so
+  the durability boundary includes every descendant settlement.
+- `dispose` — `AgentHandle.dispose()` releases the persistence writer and
+  stops Agent-scoped background jobs (the TUI never enumerates/kills jobs
+  itself — DSH jobs lifecycle is bound to the Agent scope).
+
+Every phase is individually contained: a failure is recorded and the next
+phase still runs, so one failure can never re-create a handle leak (a
+skipped dispose would pin the old session lease).
+
+Where it runs:
+
+- **Interactive exit** (`/exit`, Ctrl+C/D, plain `exit`): the exit
+  controller only latches, disposes the Client surface, prints the resume
+  hint and requests `appExit`. The retirement runs inside the
+  application-tree disposal that `appExit` starts, under the DSH
+  process-shutdown watchdog — the TUI never awaits a potentially long Host
+  teardown in front of `appExit`.
+- **HMR / runner fiber unload**: the fiber disposer is async (Cordis
+  unloads await it) and runs the SAME memoized retirement — one teardown
+  promise shared by every teardown path, never four copies.
+- **Successful session transition** (`/new`, `/fork`, rewind, `/sessions`
+  switch): the pre-commit quiesce (whenIdle + flush) is preserved; AFTER
+  the commit the old owner is retired with the same fixed order, so the old
+  Agent's continuable descendants are drained and its final flush lands
+  after the drain. A failed child create never drains or disposes the old
+  owner — the old session stays current (the transaction semantics are
+  unchanged).
+
+The process-local transition gate / operation barrier coordinate only the
+TUI's Client writers; they do not take over Host ownership. The retirement
+serializes against an in-flight transition through the same gate + barrier
+(a FIFO no-op task waits for a running transition to settle — the lifecycle
+abort already cancelled its create/resume), then retires the CURRENT owner.
 
 ## The submit path is guard-free (the decision)
 

--- a/docs/failure-model.md
+++ b/docs/failure-model.md
@@ -62,10 +62,11 @@ guarantee.
 ## Lifecycle roots are equally total
 
 Startup and exit (`src/index.ts` root catch, `src/exit.ts`) protect every
-step individually (session read, diag, cleanup, warn, hint, exit), so no
-throw can skip teardown or leak a rejection. `flushWithTimeout` returns a
-deterministic `failed` outcome for any hostile rejection (never a misreported
-`timed-out`), and the disabled-timeout path always settles.
+step individually (diag, cleanup, hint, exit), so no throw can skip
+teardown or leak a rejection. The Direct owned-session retirement
+(`src/runtime/direct/owned-session-retirement.ts`) is equally total: every
+phase failure is recorded and the remaining phases still run, so a hostile
+rejection can never skip the final flush or the handle dispose.
 
 ## Where the contract is wired in
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -363,9 +363,10 @@ export interface TuiCommandRunner {
    * (migration M1.11) — a runner assembly dependency, not a Host
    * capability. */
   readonly commandRegistry: CommandRegistryLike | undefined
-  /** The ONE exit orchestration (flush with a hard timeout, cleanup, warn,
-   * resume hint, process exit) — shared by Ctrl+C/Ctrl+D, /exit and /quit.
-   * Command handlers must NEVER stop the app, flush or exit themselves. */
+  /** The ONE exit orchestration (latch → surface cleanup → resume hint →
+   * appExit; the Direct owned-session retirement runs inside the appExit
+   * disposal) — shared by Ctrl+C/Ctrl+D, /exit and /quit. Command handlers
+   * must NEVER stop the app, flush or exit themselves. */
   requestExit(): void
   cwd: string
   /** The per-TUI draft image registry (image pipeline, plan M1). Shared by
@@ -1354,10 +1355,11 @@ export function registerTuiCommands(
   }
 
   // Shared by /exit and its /quit alias. The exit orchestration lives in
-  // the runner (createExitController): flush with a hard timeout, idempotent
-  // cleanup, warning, resume hint, process exit. Handlers never stop the app
-  // or flush themselves — that kept /exit diverging from Ctrl+C/Ctrl+D (no
-  // timeout, no catch, no warning) and could hang a stopped UI forever.
+  // the runner (createExitController): latch once, idempotent surface
+  // cleanup, resume hint, appExit (the Direct owned-session retirement runs
+  // inside the appExit disposal). Handlers never stop the app or flush
+  // themselves — that kept /exit diverging from Ctrl+C/Ctrl+D and could
+  // hang a stopped UI forever.
   const exitHandler = (): { kind: 'success' } => {
     runner.requestExit()
     return { kind: 'success' }

--- a/src/exit.ts
+++ b/src/exit.ts
@@ -1,97 +1,28 @@
 /**
- * The TUI exit contract: flush the live session with a HARD timeout, record
- * the outcome, then let the runner tear down. Pure and injectable so the
- * resolve/reject/hang paths are testable without a Cordis context.
+ * The TUI exit contract: latch the exit request, dispose/restore the Client
+ * surface, apply the resume-hint policy, then request the launcher's
+ * `appExit`. Pure and injectable so the resolve/reject/hang paths are
+ * testable without a Cordis context.
+ *
+ * Host-owned final durability is NOT this controller's job: the Direct
+ * owned-session retirement (cancel → idle → drain descendants → final flush
+ * → AgentHandle.dispose) runs inside the application-tree disposal that
+ * `appExit` starts, under the DSH process-shutdown watchdog — see
+ * `src/runtime/direct/owned-session-retirement.ts` and
+ * `docs/concurrency.md`. The exit controller only stops the Client surface
+ * and requests the exit; it never awaits a potentially long Host teardown
+ * in front of `appExit`. (The former flush-failure warning was removed
+ * with the flush: retirement failures are recorded by the retirement
+ * diagnostics, not by a user-facing exit warning.)
  *
  * Zero-unhandled guarantee: the exit root is a terminal lifecycle boundary
- * — every dependency read (`session()`), every step (flush, diagnostics,
- * cleanup, warn, hint, exit) and every error observation is individually
- * protected, so no throw can skip a later step, leak a rejection, or leave
- * the process running with a stopped TUI.
+ * — every step (cleanup, hint, exit) and every error observation is
+ * individually protected, so no throw can skip a later step, leak a
+ * rejection, or leave the process running with a stopped TUI.
  * @module @xmoon76/dsh-pi-tui/exit
  */
 
 import { safeErrorMessage } from './error-boundary.ts'
-
-export type FlushOutcome =
-  | { kind: 'ok'; tookMs: number }
-  | { kind: 'failed'; error: string; tookMs: number }
-  | { kind: 'timed-out'; tookMs: number }
-
-/** Elapsed time without ever throwing (an injectable hostile clock
- * degrades to 0 rather than breaking the flush state machine). */
-function elapsed(now: () => number, started: number): number {
-  try {
-    return now() - started
-  } catch {
-    return 0
-  }
-}
-
-/**
- * Flush the session but never wait forever: a flush that exceeds `timeoutMs`
- * resolves `timed-out` so the exit can proceed (a hung provider must not
- * trap the user in the TUI). The timer is unref'd and cleared on settle, so
- * it never holds the process open.
- *
- * The failure branch RETURNS a `FlushOutcome` (never a possibly-skipped
- * `finish()` side effect): a hostile thrown value yields a deterministic
- * `failed` outcome immediately, `timed-out` is never misreported for a real
- * failure, the disabled-timeout path always settles, and no internal chain
- * is ever left unobserved.
- * @param flush - the durable flush (e.g. `sessions.flush`).
- * @param timeoutMs - hard timeout; 0 or negative disables the timeout.
- * @param now - injectable clock.
- */
-export function flushWithTimeout(
-  flush: () => Promise<unknown>,
-  timeoutMs: number,
-  now: () => number = Date.now,
-): Promise<FlushOutcome> {
-  let started = 0
-  try {
-    started = now()
-  } catch {
-    // A hostile injectable clock degrades to 0; it must not break the
-    // flush state machine.
-  }
-  // The flush outcome is a REAL value the chain resolves with — its
-  // failure branch cannot throw (safe description + safe clock), so this
-  // promise never rejects and is always safe to observe.
-  const flushOutcome = Promise.resolve()
-    .then(flush)
-    .then(() => ({ kind: 'ok' as const, tookMs: elapsed(now, started) }))
-    .catch((error: unknown) => ({
-      kind: 'failed' as const,
-      error: safeErrorMessage(error),
-      tookMs: elapsed(now, started),
-    }))
-  return new Promise<FlushOutcome>((resolve) => {
-    let settled = false
-    let timer: NodeJS.Timeout | undefined
-    const finish = (outcome: FlushOutcome): void => {
-      if (settled) return
-      settled = true
-      if (timer !== undefined) clearTimeout(timer)
-      resolve(outcome)
-    }
-    if (timeoutMs > 0) {
-      timer = setTimeout(() => finish({ kind: 'timed-out', tookMs: elapsed(now, started) }), timeoutMs)
-      timer.unref?.()
-    }
-    // flushOutcome never rejects (see above), so this observation can
-    // never produce an unhandled rejection.
-    void flushOutcome.then(finish) // allowlist: exit-root terminal observation — see AGENTS.md
-  })
-}
-
-/** The live session the exit flush targets; undefined when none was created.
- * `seq` is the session's log offset (alpha.4's `Session.seq`) — the count
- * read for diagnostics without materializing the event log. */
-export interface ExitSessionLike {
-  readonly id: string
-  readonly seq: number
-}
 
 /** Diagnostics sink used by the exit controller (subset of Diag). */
 export interface ExitDiagLike {
@@ -101,18 +32,12 @@ export interface ExitDiagLike {
 
 /** Injectable dependencies of {@link createExitController}. */
 export interface ExitControllerDeps {
-  /** The session to flush, re-read at request time (never created lazily). */
-  session(): ExitSessionLike | undefined
-  /** The durable flush (e.g. `sessions.flush`). */
-  flush(session: ExitSessionLike): Promise<unknown>
-  /** Hard flush timeout; 0 or negative disables it. */
-  timeoutMs: number
   /** The runner diagnostics channel. */
   diag: ExitDiagLike
-  /** Idempotent teardown (abort lifecycle, stop TUI, close diag). */
+  /** Idempotent Client-surface teardown (abort lifecycle, stop TUI). The
+   * Direct owned-session retirement is NOT part of this step — it runs in
+   * the application-tree disposal after `exit` (see the module doc). */
   cleanup(): void
-  /** Print a user-visible warning to stderr (after the terminal restores). */
-  warn(message: string): void
   /** Print the resume hint to stdout (after the terminal restores). */
   hint(message: string): void
   /** The interactive-quit resume hint, or undefined without a session. */
@@ -134,18 +59,14 @@ function safeDiag(diag: ExitDiagLike, level: 'info' | 'error', message: string, 
 
 /**
  * The ONE exit orchestration shared by every exit entry (Ctrl+C, Ctrl+D,
- * `/exit`, `/quit`): invalidate nothing here (runner-owned state is the
- * runner's concern) — flush with a hard timeout → record → cleanup → warn on a
- * failed/timed-out flush → print the resume hint → exit. Idempotent: later
- * requests while one is in flight (or after it finished) are no-ops, so
- * double Ctrl+C or a command plus a key cannot double-flush or double-exit.
- * A flush that hangs can never trap the process; an unexpected internal
- * error still exits (code 1) instead of leaving the TUI stopped forever.
+ * `/exit`, `/quit`): latch once → dispose/restore the Client surface →
+ * resume-hint policy → request `appExit`. Idempotent: later requests while
+ * one is in flight (or after it finished) are no-ops, so double Ctrl+C or a
+ * command plus a key cannot double-cleanup or double-exit.
  *
- * TERMINAL ROOT: the whole body — including `session()`, which sits inside
- * the try — plus every later step (cleanup, warn, hint, exit) is
- * individually protected, so no throw can skip a later step or leak a
- * rejection, and cleanup/exit always run (exit exactly once, last).
+ * TERMINAL ROOT: every step (cleanup, hint, exit) is individually
+ * protected, so no throw can skip a later step or leak a rejection, and
+ * cleanup/exit always run (exit exactly once, last).
  * @param deps - the injectable surface.
  * @returns `requestExit()` — safe to call from any entry, any number of times.
  */
@@ -155,49 +76,15 @@ export function createExitController(deps: ExitControllerDeps): { requestExit():
     if (started) return
     started = true
     void (async () => { // allowlist: exit lifecycle root — see AGENTS.md
-      let flushOutcome: FlushOutcome | undefined
-      let failed = false
-      try {
-        // `session()` is INSIDE the protection: a throwing dependency read
-        // must not leak from the discarded IIFE (no cleanup, no exit).
-        const exitSession = deps.session()
-        if (exitSession !== undefined) {
-          flushOutcome = await flushWithTimeout(() => deps.flush(exitSession), deps.timeoutMs)
-          safeDiag(deps.diag, 'info', 'flush', {
-            session: exitSession.id,
-            outcome: flushOutcome.kind,
-            tookMs: flushOutcome.tookMs,
-            events: Number(exitSession.seq),
-            ...flushOutcome.kind === 'failed' ? { error: flushOutcome.error } : {},
-          })
-        }
-      } catch (error) {
-        // Defensive: an unexpected failure in the orchestration itself must
-        // not leave the process running with a stopped TUI.
-        failed = true
-        safeDiag(deps.diag, 'error', 'exit orchestration failed', { error: safeErrorMessage(error) })
-      }
-      // Terminal policy, OUTSIDE the try: each step is individually
-      // protected so a throw in one can never skip a later step; cleanup
-      // and exit are guaranteed (exit runs last, exactly once).
-      safeDiag(deps.diag, 'info', 'exit', { code: failed ? 1 : 0, flush: flushOutcome?.kind })
+      // Terminal policy: each step is individually protected so a throw in
+      // one can never skip a later step; cleanup and exit are guaranteed
+      // (exit runs last, exactly once). The Direct Host retirement runs
+      // inside the appExit disposal (see the module doc).
+      safeDiag(deps.diag, 'info', 'exit', { code: 0 })
       try {
         deps.cleanup()
       } catch (cleanupError) {
         safeDiag(deps.diag, 'error', 'cleanup failed', { error: safeErrorMessage(cleanupError) })
-      }
-      // A failed or timed-out flush is surfaced AFTER the terminal
-      // restores, where the user can actually read it. The process still
-      // exits.
-      if (!failed && flushOutcome !== undefined && flushOutcome.kind !== 'ok') {
-        const reason = flushOutcome.kind === 'timed-out'
-          ? 'timed out'
-          : `failed (${flushOutcome.error})`
-        try {
-          deps.warn(`session flush ${reason} — the latest events may not be persisted`)
-        } catch {
-          // A throwing warn cannot skip the exit.
-        }
       }
       // pi parity: after the terminal restores, print how to re-enter the
       // session (skipped when the deferred start never made one).
@@ -208,7 +95,7 @@ export function createExitController(deps: ExitControllerDeps): { requestExit():
         // A throwing hint cannot skip the exit.
       }
       try {
-        deps.exit(failed ? 1 : 0)
+        deps.exit(0)
       } catch {
         // The last step; there is no lower sink.
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,8 @@ import {
 } from './image/submit.ts'
 import { runReservedSubmit } from './image/submit-flow.ts'
 import { dshVersion } from './dsh-version.ts'
-import { createExitController, type ExitSessionLike } from './exit.ts'
+import { createExitController } from './exit.ts'
+import { retireDirectOwnedSession, type RetirementReport } from './runtime/direct/owned-session-retirement.ts'
 import { mergeDraft, refuseByTransitionFence, steerAll, steerHasPayload, sessionUnchanged, type SteerAgentLike } from './steer.ts'
 import {
   resolveSubagentSettleTarget,
@@ -1067,10 +1068,6 @@ const DANGER_PATTERNS: readonly RegExp[] = [
   /\bcurl\b[^\n|]*\|\s*(ba)?sh\b/,
 ]
 
-/** Hard cap for the /exit session flush: a hung provider must not trap the
- * user; after this the TUI exits and warns that the tail may be lost. */
-const EXIT_FLUSH_TIMEOUT_MS = 10_000
-
 /**
  * Whether a shell command matches a destructive pattern. `rm` is treated
  * specially: any spelling of recursive + force flags (`rm -rf`, `rm -r -f`,
@@ -1574,11 +1571,13 @@ export function apply(ctx: Context, config: Config): void {
   const lifecycleController = new AbortController()
   // Register cancellation before entering the fire-and-forget startup root:
   // loader/HMR disposal can happen before the full TUI cleanup effect exists.
-  // This disposer owns the runner lifetime signal and the diagnostics handle
-  // needed by a startup that exits before full cleanup is registered.
+  // This disposer owns the runner lifetime signal ONLY — diag stays open so
+  // the Direct owned-session retirement (which runs in the fiber disposer,
+  // in PARALLEL with this disposer under Cordis unload) can record its
+  // diagnostics; diag is closed by retireOwnedSession / the pre-mount abort
+  // path / the fatal catch (all idempotent).
   ctx.effect(() => () => {
     lifecycleController.abort()
-    diag.dispose()
   }, 'tui-runner lifecycle cancellation')
 
   // The guarded notification writer is hoisted to the RUNNER scope: both
@@ -1589,16 +1588,175 @@ export function apply(ctx: Context, config: Config): void {
   // errors; every use is additionally wrapped for synchronous throws.
   const notificationWriter = guardedStreamWriter(process.stdout)
 
+  // The Direct owner slots are hoisted to the RUNNER scope (outside the
+  // startup IIFE) so the terminal-total fatal catch can see whether a
+  // Direct owner exists; the memoized retirement coordinator itself stays
+  // inside the IIFE (it needs the transition gate / barrier / sessions)
+  // and is exposed to the fatal catch through a ref assigned once the
+  // coordinator is defined. The fatal catch treats an unassigned slot as
+  // "no owner".
+  let liveAgent: Agent | undefined
+  let liveHandle: AgentHandle | undefined
+  let retireOwnedSessionRef: (() => Promise<RetirementReport>) | undefined
+
   void (async () => { // allowlist: startup lifecycle root — see AGENTS.md
     // Loader siblings mount concurrently. Await the complete application before
     // creating an Agent so its scoped tools and adapters are not half-composed.
     await ctx.get('loader')?.await()
-    if (lifecycleController.signal.aborted) return
+    if (lifecycleController.signal.aborted) {
+      // Pre-mount unload before any Agent existed: nothing to retire; close
+      // the diagnostics handle (the early cancellation disposer no longer
+      // owns it — see the effect registration above).
+      diag.dispose()
+      return
+    }
     const agents = ctx.get('agents')
     const defaultModel = ctx.get('agentDefaultModel')
     const sessions = ctx.get('sessions')
     // Early process shutdown can dispose the tree while settlement is pending.
-    if (agents === undefined || defaultModel === undefined || sessions === undefined) return
+    if (agents === undefined || defaultModel === undefined || sessions === undefined) {
+      diag.dispose()
+      return
+    }
+    // The transition gate / operation barrier are declared BEFORE the
+    // first Agent can exist so the retirement coordinator below (and the
+    // fatal catch through retireOwnedSessionRef) is installed before any
+    // owner is created: a startup failure after the resume must join the
+    // SAME memoized retirement, never a second direct teardown that could
+    // race the DSH agent-loop owner disposer.
+    const transitionGate = new SessionTransitionGate()
+    const operationBarrier = new SessionOperationBarrier()
+    // The memoized Direct owned-session retirement: ONE teardown promise
+    // shared by every teardown path (the interactive exit via the appExit
+    // disposal, the fiber disposer / HMR unload, the pre-mount abort path
+    // and the fatal startup catch) — never four copies of the same
+    // teardown. It serializes against an in-flight session transition
+    // through the transition gate + operation barrier, then retires the
+    // CURRENT Direct owner in the fixed order cancel → idle → descendants →
+    // flush → dispose (see src/runtime/direct/owned-session-retirement.ts).
+    // diag stays open until the retirement diagnostics are recorded. The
+    // fatal catch reaches this coordinator through retireOwnedSessionRef.
+    let retirementPromise: Promise<RetirementReport> | undefined
+    const retireOwnedSession = (): Promise<RetirementReport> => {
+      if (retirementPromise !== undefined) return retirementPromise
+      retirementPromise = (async (): Promise<RetirementReport> => {
+        // If a session transition is queued or in flight, its pre-commit
+        // `whenIdle()` does not observe the lifecycle signal: cancel the
+        // CURRENT owner's work so the transition settles instead of waiting
+        // for the LLM (the appExit watchdog would otherwise force-exit
+        // without an ordered retirement). Keyed on `pending` (queued OR
+        // running), not `busy`: a queued-but-not-started transition is about
+        // to quiesce the old agent, and the pre-cancel must fire before the
+        // task starts. This pre-cancel is a DELIBERATE extra cancel on the
+        // transition path only: `agent.cancel` is idempotent (re-cancelling
+        // an already cancelled agent is a no-op), so the retirement's own
+        // cancel phase — the single cancel on the ordinary (no-transition)
+        // path — may run again on the same owner without changing the
+        // outcome. The tests assert the ordinary path cancels exactly once
+        // and the transition path cancels at least once.
+        if (transitionGate?.pending === true) {
+          liveAgent?.cancel({ kind: 'user' })
+        }
+        // The CURRENT Direct owner is read INSIDE the gate task, not at
+        // call time: an exit that lands while a session transition is
+        // committing must retire the NEW current owner (the old owner's
+        // retirement already ran inside the transition's post-commit
+        // phase), while an aborted transition leaves the old owner current
+        // and retires it. A deferred start never created an owner: nothing
+        // to retire, the surface teardown is complete.
+        const retire = async (): Promise<RetirementReport> => {
+          const agent = liveAgent
+          const handle = liveHandle
+          if (agent === undefined || handle === undefined) {
+            return { failures: [] }
+          }
+          diag.info('retire start', { session: agent.session.id })
+          const report = await retireDirectOwnedSession({
+            cancel: () => {
+              diag.info('retire cancel', { session: agent.session.id })
+              agent.cancel({ kind: 'user' })
+            },
+            whenIdle: async () => {
+              diag.info('retire idle', { session: agent.session.id })
+              await agent.whenIdle()
+            },
+            drainDescendants: async () => {
+              diag.info('retire descendants', { session: agent.session.id })
+              const subagents = ctx.get('subagents') as {
+                drainContinuableDescendants?(parents: readonly unknown[]): Promise<void>
+              } | undefined
+              await subagents?.drainContinuableDescendants?.([agent])
+            },
+            flush: async () => {
+              diag.info('retire flush', { session: agent.session.id })
+              await sessions.flush(agent.session)
+            },
+            disposeOwner: async () => {
+              diag.info('retire dispose', { session: agent.session.id })
+              await handle.dispose()
+            },
+          })
+          for (const failure of report.failures) {
+            diag.error('retire phase failed', {
+              session: agent.session.id,
+              phase: failure.phase,
+              error: failure.error,
+            })
+          }
+          diag.info('retire complete', { session: agent.session.id, failures: report.failures.length })
+          return report
+        }
+        try {
+          // Serialize against an in-flight session transition: the gate
+          // queue is FIFO, so this no-op task waits for a running
+          // transition to settle (the surface teardown above already
+          // aborted its create/resume via the lifecycle controller). The
+          // barrier freezes TUI writers for the retirement's write
+          // boundary. The gate/barrier are constructed BEFORE any owner can
+          // exist (see the hoisted declarations), so an owner always has a
+          // serialization path.
+          return await transitionGate.run(() => operationBarrier.runTransition(retire))
+        } catch (error) {
+          // Defensive: a reentrant gate/barrier means a transition is STILL
+          // active — retiring now would race it. Record the failure and SKIP
+          // the retirement (the process is exiting; the appExit watchdog
+          // bounds it). The normal teardown paths never reach here: they
+          // queue through the FIFO gate, and retireOwnedSession is never
+          // called from inside a transition context.
+          diag.error('retire barrier failed', { error: safeErrorMessage(error) })
+          return { failures: [{ phase: 'cancel', error: `retirement skipped: ${safeErrorMessage(error)}` }] }
+        } finally {
+          diag.dispose()
+        }
+      })()
+      return retirementPromise
+    }
+    retireOwnedSessionRef = retireOwnedSession
+    // Await an agent's quiescence, cancelling it if the runner lifecycle
+    // aborts first. A transition's pre-commit whenIdle and the pre-mount
+    // wait do NOT observe the lifecycle signal — without the cancel a busy
+    // agent would keep the await hanging past the appExit watchdog and the
+    // ordered retirement would never run.
+    const whenIdleOrAbort = async (agent: Agent, signal: AbortSignal): Promise<boolean> => {
+      if (signal.aborted) {
+        agent.cancel({ kind: 'user' })
+        await agent.whenIdle()
+        return true
+      }
+      let aborted = false
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = (): void => {
+          aborted = true
+          agent.cancel({ kind: 'user' })
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+        agent.whenIdle().then(
+          () => { signal.removeEventListener('abort', onAbort); resolve() },
+          (error) => { signal.removeEventListener('abort', onAbort); reject(error) },
+        )
+      })
+      return aborted
+    }
 
     // Persisted TUI preferences: register the namespace FIRST — before any
     // agent compose/resume — so the Focus runtime state is restored before
@@ -1743,7 +1901,6 @@ export function apply(ctx: Context, config: Config): void {
     // The live Agent is declared before the TUI-facing facade so every read
     // after a transition follows the current Session rather than a startup
     // snapshot. It remains undefined for deferred-start surfaces.
-    let liveAgent: Agent | undefined
     const modelSelections = new DirectModelSelectionOwner(
       defaultModel as unknown as DefaultModelServiceLike,
     )
@@ -1976,7 +2133,12 @@ export function apply(ctx: Context, config: Config): void {
         // installs an Agent-local selection and reconstructs the target
         // Session's durable model choice after resume.
         const fallback = defaultModel.currentSelection()
-        if (lifecycleController.signal.aborted) return
+        if (lifecycleController.signal.aborted) {
+          // No owner exists yet and the full fiber disposer is not
+          // registered: close the diagnostics handle (idempotent).
+          diag.dispose()
+          return
+        }
         handle = await backend.sessionLifecycle.resume({
           resumeSessionId: SessionId(sessionId),
           provider: fallback.provider,
@@ -2021,6 +2183,9 @@ export function apply(ctx: Context, config: Config): void {
         if (lifecycleController.signal.aborted && !resumeResolved) {
           startupStatus.clear()
           diag.debug('startup resume cancelled', { session: sessionId })
+          // No owner was published and the full fiber disposer is not
+          // registered: close the diagnostics handle (idempotent).
+          diag.dispose()
           return
         }
         // Suspend the pre-mount status BEFORE the failure logs: the
@@ -2046,7 +2211,7 @@ export function apply(ctx: Context, config: Config): void {
       // session at all — zero agent, zero log, zero persistence — and the
       // first user message creates it (see ensureSession below).
     }
-    let liveHandle = handle?.direct?.ownerHandle as AgentHandle | undefined
+    liveHandle = handle?.direct?.ownerHandle as AgentHandle | undefined
     liveAgent = handle?.direct?.agent as Agent | undefined
     // The completion-notification controller follows the live identity:
     // a resumed idle session must never notify (no observed running).
@@ -2058,7 +2223,15 @@ export function apply(ctx: Context, config: Config): void {
       // and STAYS until the barrier completes (the catalog prefetch can
       // take seconds; a cleared line would read as a hang again).
       startupStatus.show('Preparing conversation…')
-      await liveAgent.whenIdle()
+      // The pre-mount whenIdle does NOT observe the lifecycle signal, and
+      // the full surface disposer is not registered yet (the pre-mount
+      // abort path below has not been reached) — an early HMR/app disposal
+      // would otherwise leave this await hanging forever and the
+      // just-created owner would never be retired. Cancel the agent on
+      // abort so whenIdle settles, then the pre-mount abort path below
+      // retires the owner.
+      const resumedAgent = liveAgent
+      await whenIdleOrAbort(resumedAgent, lifecycleController.signal)
     }
     // Surface catalog resolution BEFORE the TUI mounts (the ready barrier):
     // a resumed agent prefetches its effective catalog (a live read emits no
@@ -2162,7 +2335,7 @@ export function apply(ctx: Context, config: Config): void {
     /** The ONE writer for the live session: every path that changes which
      * session owns the surface — /new, /fork, rewind, `/sessions` switch,
      * the first-session creation — runs its WHOLE workflow (prepare/create
-     * → flush → dispose old → assign new → generation bump) inside
+     * → flush → COMMIT (assign new + generation bump) → retire old) inside
      * {@link transitionGate}. Without the gate a transition can interleave
      * with another: a fork child could be created (and its seed published
      * to persistence) before a stale check sees the surface already moved —
@@ -2173,12 +2346,9 @@ export function apply(ctx: Context, config: Config): void {
      * `createForkedAgent` (the create itself is inside the exclusive
      * section), so a stale rewind never creates a child at all.
      * @see SessionTransitionGate */
-    const transitionGate = new SessionTransitionGate()
-    // The writer/transition barrier: transitions freeze TUI writers and
-    // wait for in-flight ones to drain; writers run inside runWriter so a
-    // transition started later can never interleave with a write already
-    // awaiting a provider/IO (convergence plan phase 3).
-    const operationBarrier = new SessionOperationBarrier()
+    // (The transition gate and operation barrier are constructed BEFORE the
+    // first Agent can exist — see the hoisted declarations above — so the
+    // retirement coordinator is fully wired before any owner is created.)
 
     /**
      * The ONE session-transition transaction, shared by /new, /fork,
@@ -2205,9 +2375,11 @@ export function apply(ctx: Context, config: Config): void {
      *      durable rollback);
      *   4. COMMIT — a synchronous critical section (generation bump, live
      *      handle/agent replacement) with no awaits between its steps;
-     *   5. RETIRE — old-handle dispose (now idle: no abort closures), child
-     *      whenIdle, surface rebuild, catalog refresh — failures WARN ONLY,
-     *      the committed child always stands.
+     *   5. RETIRE — retire the old Direct owner in the fixed order
+     *      (cancel → idle → drain continuable descendants → final flush →
+     *      dispose — see src/runtime/direct/owned-session-retirement.ts),
+     *      then child whenIdle, surface rebuild, catalog refresh —
+     *      failures WARN ONLY, the committed child always stands.
      *
      * Must be called inside {@link transitionGate} (via
      * `withSessionTransition` or the rewind commit's own gate wrapper).
@@ -2225,6 +2397,7 @@ export function apply(ctx: Context, config: Config): void {
         const opening = { id: steps.target.id, events: [] as SessionEvent[] }
         openingSession = opening
       const oldHandle = liveHandle
+      const oldAgent = liveAgent
       return runTransitionTo<T>({
         quiesceOld: async () => {
           if (liveAgent === undefined) return
@@ -2232,8 +2405,12 @@ export function apply(ctx: Context, config: Config): void {
           // produce turn events, so the final flush below is truly final.
           // (A /new or /fork while the agent is busy now WAITS for the
           // current activity instead of aborting it — the deliberate
-          // product semantics, see docs/concurrency.md.)
-          await liveAgent.whenIdle()
+          // product semantics, see docs/concurrency.md.) The wait is
+          // abort-aware: an exit during the quiesce cancels the CURRENT
+          // agent (which may be a NEW owner committed by an earlier queued
+          // transition), so the transition settles instead of hanging past
+          // the appExit watchdog.
+          await whenIdleOrAbort(liveAgent, lifecycleController.signal)
           // Final flush before the switch. The DSH SessionWriteLease
           // (kernel flock) is the only cross-process writer authority, so
           // no TUI-side lock bookkeeping is needed around the flush.
@@ -2288,23 +2465,50 @@ export function apply(ctx: Context, config: Config): void {
         },
         retireOld: async (next) => {
           const retired: string[] = []
-          // 1. Dispose the OLD handle FIRST: whenIdle only idles the agent
-          // machine — session-scoped async writers (e.g. the title
-          // generator awaiting a provider) are aborted only by
-          // session/disposed, which the dispose fires.
-          if (oldHandle !== undefined) {
-            try {
-              await oldHandle.dispose()
-            } catch (error) {
+          // 1. Retire the OLD Direct owner in the fixed order
+          //    cancel → idle → descendants → final flush → dispose (the
+          //    same order as the official DSH ACP session close). The
+          //    pre-commit quiesce already idled + flushed; this post-commit
+          //    pass covers the window where the old agent was re-woken by a
+          //    Host-side continuation, drains its continuable descendants
+          //    (the core of the exit-retirement fix), establishes the final
+          //    durability boundary, and releases the old handle. Every
+          //    phase failure is contained — the committed child always
+          //    stands.
+          if (oldHandle !== undefined && oldAgent !== undefined) {
+            const report = await retireDirectOwnedSession({
+              cancel: () => oldAgent.cancel({ kind: 'user' }),
+              whenIdle: () => oldAgent.whenIdle(),
+              drainDescendants: async () => {
+                const subagents = ctx.get('subagents') as {
+                  drainContinuableDescendants?(parents: readonly unknown[]): Promise<void>
+                } | undefined
+                await subagents?.drainContinuableDescendants?.([oldAgent])
+              },
+              flush: async () => { await sessions.flush(oldAgent.session) },
+              disposeOwner: () => oldHandle.dispose(),
+            })
+            for (const failure of report.failures) {
               // A failed dispose means the old session may still have
               // writers; the child stays current and the failure is
               // recorded (the DSH SessionWriteLease still guards the
               // session cross-process).
-              retired.push(`old handle dispose: ${safeErrorMessage(error)}`)
+              retired.push(`old ${failure.phase}: ${failure.error}`)
             }
           }
           try {
-            await (directAgentOf(next) as Agent).whenIdle()
+            // The child quiesce is abort-aware too: an exit during this
+            // post-commit phase (with further transitions queued) must
+            // cancel the NEW owner instead of hanging past the watchdog.
+            // When the lifecycle aborted, the surface is already disposed
+            // and the retirement takes over: skip the surface
+            // initialization below (it would repaint into the disposed
+            // app) and let the committed child stand.
+            const aborted = await whenIdleOrAbort(directAgentOf(next) as Agent, lifecycleController.signal)
+            if (aborted) {
+              retired.push('child quiesce aborted by lifecycle')
+              return
+            }
           } catch (error) {
             retired.push(`child whenIdle: ${safeErrorMessage(error)}`)
           }
@@ -2841,10 +3045,13 @@ export function apply(ctx: Context, config: Config): void {
     // command item). Hoisted with the whole-footer slots for the same TDZ
     // guards; cleanup disposes it so no child/timer survives a remount.
     let footerDynamicItemRuntime: FooterDynamicItemRuntime | undefined
-    // Idempotent teardown: abort lifecycle loads, stop the TUI, close diag.
-    // Shared by /exit, the effect cleanup, and the startup-failure path.
+    // Idempotent CLIENT-SURFACE teardown: abort lifecycle loads, stop the
+    // TUI. Shared by /exit, the effect cleanup, and the startup-failure
+    // path. The Direct owned-session retirement is a SEPARATE step
+    // (retireOwnedSession below) that runs after the surface stops — diag
+    // stays open until the retirement diagnostics are recorded.
     let cleanedUp = false
-    const cleanup = (): void => {
+    const disposeSurface = (): void => {
       if (cleanedUp) return
       cleanedUp = true
       // Fence the completion-notification controller: after teardown a
@@ -2918,20 +3125,21 @@ export function apply(ctx: Context, config: Config): void {
       // makes a stale detach a no-op (P1).
       extensionService?.detachSurface(extensionHost?.surfaceId)
       extensionHost = undefined
-      diag.dispose()
+      // NOTE: diag.dispose() is NOT here — the Direct owned-session
+      // retirement (retireOwnedSession) records its diagnostics first and
+      // closes diag last (see below).
     }
     // The ONE exit orchestration, shared by every exit entry (the exit keys,
-    // /exit, /quit): flush with a hard timeout → record → idempotent cleanup
-    // → warn on a failed/timed-out flush → resume hint → process exit. A
-    // later request while one is in flight is a no-op (createExitController
-    // latches), so a command plus a key can never double-flush or double-exit.
+    // /exit, /quit): latch once → dispose/restore the Client surface →
+    // resume-hint policy → request appExit. A later request while one is
+    // in flight is a no-op (createExitController latches), so a command
+    // plus a key can never double-cleanup or double-exit. The Direct
+    // owned-session retirement is NOT awaited here: it runs inside the
+    // application-tree disposal that appExit starts, under the DSH
+    // process-shutdown watchdog (see docs/concurrency.md).
     const { requestExit } = createExitController({
-      session: () => liveAgent?.session as ExitSessionLike | undefined,
-      flush: (session) => sessions.flush(session as Parameters<typeof sessions.flush>[0]),
-      timeoutMs: EXIT_FLUSH_TIMEOUT_MS,
       diag,
-      cleanup,
-      warn: (message) => process.stderr.write(`\n${color.textDim('Warning:')} ${message}\n`),
+      cleanup: disposeSurface,
       hint: (message) => process.stdout.write(`\n${message}\n`),
       resumeHint: () => {
         const resume = resumeCommand(runningProfile(), liveAgent?.session.id ?? '')
@@ -2944,13 +3152,40 @@ export function apply(ctx: Context, config: Config): void {
     // the fatal startup path.
     if (lifecycleController.signal.aborted) {
       startupStatus.clear()
+      // A pre-mount unload AFTER the resume succeeded: the fiber disposer
+      // below was never registered, so retire the Direct owner here before
+      // returning (the transition gate / barrier / retirement helper are
+      // all defined by this point — the resume that produced the live
+      // agent ran after them). Without a live owner there is nothing to
+      // retire; close the diagnostics handle either way (idempotent).
+      if (liveAgent !== undefined && liveHandle !== undefined) {
+        await retireOwnedSession()
+      } else {
+        diag.dispose()
+      }
       return
     }
     // Stop the TUI when this fiber is disposed (a loader hot-reload unloads
     // the row; the reloaded row starts its own instance in the same process).
+    // The disposer is ASYNC: the fiber unload awaits it (Cordis contract), so
+    // an HMR unload retires the Direct owned session exactly like an
+    // interactive exit — surface cleanup first, then the Host retirement.
+    // A throwing surface step must NEVER skip the retirement: the surface
+    // teardown is protected, the error is recorded (diag is still open —
+    // retireOwnedSession closes it last), and the retirement promise is
+    // always returned.
     ctx.effect(function* () {
       yield () => {
-        cleanup()
+        try {
+          disposeSurface()
+        } catch (error) {
+          try {
+            diag.error('surface dispose failed', { error: safeErrorMessage(error) })
+          } catch {
+            // No lower sink.
+          }
+        }
+        return retireOwnedSession()
       }
     })
 
@@ -4863,8 +5098,9 @@ export function apply(ctx: Context, config: Config): void {
       },
       onExit: () => {
         // Keyboard exit requests route through the SAME exit orchestration as
-        // /exit and /quit (createExitController above): flush with a hard
-        // timeout, idempotent cleanup, warning, resume hint, process exit.
+        // /exit and /quit (createExitController above): latch once, dispose
+        // the Client surface, resume hint, process exit — the Direct
+        // owned-session retirement runs inside the appExit disposal.
         requestExit()
       },
       onCancel: () => {
@@ -6745,7 +6981,13 @@ export function apply(ctx: Context, config: Config): void {
         // so failures are recorded, never a fallback (the same
         // retire-warn-only semantics as every other transition).
         try {
-          await liveAgent.whenIdle()
+          const aborted = await whenIdleOrAbort(liveAgent, lifecycleController.signal)
+          if (aborted) {
+            // The lifecycle aborted during the first-session quiesce: the
+            // surface is disposed and the retirement takes over — skip the
+            // surface initialization below.
+            return
+          }
         } catch (error) {
           diag.warn('first session whenIdle failed', { error: safeErrorMessage(error) })
         }
@@ -7586,7 +7828,7 @@ export function apply(ctx: Context, config: Config): void {
         })),
       }
     })
-  })().catch((error: unknown) => {
+  })().catch(async (error: unknown) => {
     // Terminal-total final catch of the startup lifecycle root: error
     // observation, logging, abort, dispose and exit are each individually
     // protected, so a hostile rejection or a throwing dependency can never
@@ -7621,10 +7863,50 @@ export function apply(ctx: Context, config: Config): void {
     } catch {
       // The abort must not block dispose/exit.
     }
+    // A startup failure AFTER the Direct owner was created (the resume
+    // succeeded, then a later initialization threw) must still retire the
+    // owned session — the SAME memoized teardown the fiber disposer uses.
+    // The wait is BOUNDED: a busy LLM could hang the retirement's whenIdle,
+    // and the fatal exit must never wait unboundedly in front of appExit
+    // (the same constraint as the interactive exit). When the fiber
+    // disposer is registered, the appExit disposal below joins the same
+    // memoized promise under the DSH process-shutdown watchdog; when it is
+    // NOT registered (a pre-mount failure), this bounded wait is the only
+    // window the retirement gets before the process exits — the bound is
+    // generous because the retirement is cancel-first and a healthy
+    // teardown settles in milliseconds. diag is closed by the
+    // retirement's own finalizer (or by the no-owner branch below).
     try {
-      diag.dispose()
+      if (liveAgent !== undefined && liveHandle !== undefined) {
+        const retirement = retireOwnedSessionRef?.()
+        if (retirement !== undefined) {
+          let timer: NodeJS.Timeout | undefined
+          try {
+            await Promise.race([
+              retirement,
+              new Promise<void>(resolve => { timer = setTimeout(resolve, 2000) }),
+            ])
+          } finally {
+            if (timer !== undefined) clearTimeout(timer)
+          }
+        } else {
+          // Defensive only: the coordinator is defined BEFORE any owner can
+          // exist (see the hoisted declaration), so an owner without a
+          // coordinator is unreachable. Close diag and exit.
+          diag.dispose()
+        }
+      } else {
+        diag.dispose()
+      }
     } catch {
-      // The dispose must not block the process exit.
+      // TDZ (startup failed before the live-owner declarations ran — no
+      // owner existed then either) or a synchronous retirement failure:
+      // never block the fatal exit.
+      try {
+        diag.dispose()
+      } catch {
+        // The dispose must not block the process exit.
+      }
     }
     try {
       exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1587,6 +1587,19 @@ export function apply(ctx: Context, config: Config): void {
   // into the shell. The guarded writer swallows broken-stream async
   // errors; every use is additionally wrapped for synchronous throws.
   const notificationWriter = guardedStreamWriter(process.stdout)
+  // A process-wide guarded stderr writer for user-visible warnings: the
+  // error listener swallows async stream errors (EPIPE when the terminal
+  // closed — a plain try/catch around write() cannot see those), and every
+  // use is additionally wrapped for synchronous throws. A warning must
+  // never crash the host, even during shutdown.
+  const stderrWarningWriter = guardedStreamWriter(process.stderr)
+  const safeTerminalWarning = (message: string): void => {
+    try {
+      stderrWarningWriter.write(message)
+    } catch {
+      // A throwing stderr write must not break the retirement.
+    }
+  }
 
   // The Direct owner slots are hoisted to the RUNNER scope (outside the
   // startup IIFE) so the terminal-total fatal catch can see whether a
@@ -1711,15 +1724,11 @@ export function apply(ctx: Context, config: Config): void {
           // bounded shutdown.
           if (report.failures.length > 0) {
             const flushFailure = report.failures.find(failure => failure.phase === 'flush')
-            try {
-              if (flushFailure !== undefined) {
-                process.stderr.write(`\n${color.textDim('Warning:')} session flush failed during retirement (${flushFailure.error}) — the latest events may not be persisted\n`)
-              } else {
-                const phases = report.failures.map(failure => failure.phase).join(', ')
-                process.stderr.write(`\n${color.textDim('Warning:')} session retirement failed during ${phases}\n`)
-              }
-            } catch {
-              // A throwing stderr write must not break the retirement.
+            if (flushFailure !== undefined) {
+              safeTerminalWarning(`\n${color.textDim('Warning:')} session flush failed during retirement (${flushFailure.error}) — the latest events may not be persisted\n`)
+            } else {
+              const phases = report.failures.map(failure => failure.phase).join(', ')
+              safeTerminalWarning(`\n${color.textDim('Warning:')} session retirement failed during ${phases}\n`)
             }
           }
           diag.info('retire complete', { session: agent.session.id, failures: report.failures.length })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1703,6 +1703,25 @@ export function apply(ctx: Context, config: Config): void {
               error: failure.error,
             })
           }
+          // A retirement failure is USER-VISIBLE, not just a diag line: the
+          // terminal is already restored (the surface teardown ran before
+          // the appExit disposal), so a failed final flush would otherwise
+          // look like a clean exit while the latest events may not be
+          // persisted. The warning is best-effort and never blocks the
+          // bounded shutdown.
+          if (report.failures.length > 0) {
+            const flushFailure = report.failures.find(failure => failure.phase === 'flush')
+            try {
+              if (flushFailure !== undefined) {
+                process.stderr.write(`\n${color.textDim('Warning:')} session flush failed during retirement (${flushFailure.error}) — the latest events may not be persisted\n`)
+              } else {
+                const phases = report.failures.map(failure => failure.phase).join(', ')
+                process.stderr.write(`\n${color.textDim('Warning:')} session retirement failed during ${phases}\n`)
+              }
+            } catch {
+              // A throwing stderr write must not break the retirement.
+            }
+          }
           diag.info('retire complete', { session: agent.session.id, failures: report.failures.length })
           return report
         }

--- a/src/runtime/direct/owned-session-retirement.ts
+++ b/src/runtime/direct/owned-session-retirement.ts
@@ -1,0 +1,98 @@
+/**
+ * Direct-only owned-session retirement — the fixed teardown order for a
+ * top-level Agent the Direct TUI owns in-process:
+ *
+ * ```text
+ * cancel → idle → descendants → flush → dispose
+ * ```
+ *
+ * This is NOT a semantic port, NOT a Remote API, and NOT a future
+ * `session.close` RPC. It exists only because the current Direct backend
+ * runs the TUI and the Host in one process and the TUI itself created the
+ * Agent: closing the TUI surface must also retire that Direct ownership
+ * (quiesce the main Agent, drain its continuable descendants, flush the
+ * final durability boundary, and release the AgentHandle). A future Remote
+ * client closes its client-side observation/connection state through
+ * official DSH client contracts — it does NOT destroy the Host Agent.
+ *
+ * The order mirrors the official DSH ACP session close (cancel admission →
+ * agent.cancel → whenIdle → drain continuable descendants → flush →
+ * AgentHandle.dispose). Every step is individually contained: a failure is
+ * recorded and the NEXT step still runs, so one failure can never re-create
+ * a handle leak (a skipped dispose would pin the old session lease).
+ *
+ * The helper is deliberately structural: it receives plain callbacks and
+ * never imports Host types or touches `ctx`, so it adds no Host coupling
+ * (see docs/client-server-coupling.md) and cannot be mistaken for a
+ * cross-backend capability.
+ * @module @xmoon76/dsh-pi-tui/runtime/direct/owned-session-retirement
+ */
+
+import { safeErrorMessage } from '../../error-boundary.ts'
+
+/** The Direct ownership surface the retirement drives (structural — the
+ * runner wires the live Agent / AgentHandle / sessions / subagents). */
+export interface DirectOwnedSessionRetirementDeps {
+  /** Cancel the main Agent's current work (`agent.cancel({ kind: 'user' })`). */
+  cancel(): void
+  /** Await the main Agent's quiescence (`agent.whenIdle()`). */
+  whenIdle(): Promise<void>
+  /** Drain the main Agent's continuable descendants
+   * (`subagents.drainContinuableDescendants([agent])`). */
+  drainDescendants(): Promise<void>
+  /** Final durable flush of the session (`sessions.flush(session)`). */
+  flush(): Promise<void>
+  /** Release the AgentHandle (`handle.dispose()` — also stops Agent-scoped
+   * background jobs; the TUI never enumerates/kills jobs itself). */
+  disposeOwner(): Promise<void>
+}
+
+/** One contained retirement-phase failure. */
+export interface RetirementFailure {
+  phase: 'cancel' | 'idle' | 'descendants' | 'flush' | 'dispose'
+  error: string
+}
+
+/** The retirement outcome: every phase failure, never a throw. */
+export interface RetirementReport {
+  failures: readonly RetirementFailure[]
+}
+
+/** Run one phase, recording (never throwing on) its failure. */
+async function runPhase(
+  phase: RetirementFailure['phase'],
+  step: () => Promise<void> | void,
+  failures: RetirementFailure[],
+): Promise<void> {
+  try {
+    await step()
+  } catch (error) {
+    failures.push({ phase, error: safeErrorMessage(error) })
+  }
+}
+
+/**
+ * Retire one Direct-owned session in the fixed order
+ * `cancel → idle → descendants → flush → dispose`. Never throws: every
+ * phase failure is recorded in the report and the remaining phases still
+ * run (a failed flush must not skip the handle dispose, and a failed drain
+ * must not skip the final flush).
+ * @param deps - the structural ownership surface.
+ * @returns the retirement report (empty `failures` = clean retirement).
+ */
+export async function retireDirectOwnedSession(
+  deps: DirectOwnedSessionRetirementDeps,
+): Promise<RetirementReport> {
+  const failures: RetirementFailure[] = []
+  // cancel is synchronous: a throwing cancel is still contained.
+  try {
+    deps.cancel()
+  } catch (error) {
+    failures.push({ phase: 'cancel', error: safeErrorMessage(error) })
+  }
+  await runPhase('idle', deps.whenIdle, failures)
+  await runPhase('descendants', deps.drainDescendants, failures)
+  await runPhase('flush', deps.flush, failures)
+  await runPhase('dispose', deps.disposeOwner, failures)
+  return { failures }
+}

--- a/src/transition-gate.ts
+++ b/src/transition-gate.ts
@@ -4,9 +4,9 @@
  *
  * Every path that changes which session owns the surface — /new, /fork,
  * conversation rewind, `/sessions` switch/resume, the first-session
- * creation — must run its whole workflow (prepare/create/resume → flush →
- * dispose old → assign new → generation bump) inside {@link
- * SessionTransitionGate.run}. Without it, two interleaved transitions can:
+ * creation — must run its whole workflow (quiesce old → preflight →
+ * create/resume → COMMIT (assign new + generation bump) → retire old)
+ * inside {@link SessionTransitionGate.run}. Without it, two interleaved transitions can:
  *
  * - create a child whose metadata mixes two surfaces (parent captured
  *   before an await, cwd read after a concurrent switch — the P2 "cwd
@@ -16,7 +16,7 @@
  *   durable ghost branch the user never entered — `handle.dispose()` stops
  *   the agent but does NOT delete the persisted session;
  * - pass a stale identity check and then yield inside the swap (flush /
- *   old-handle dispose), letting a second transition land in between and
+ *   old-owner retirement), letting a second transition land in between and
  *   later get overwritten by the first continuation.
  *
  * The gate is a promise chain (a single-writer queue): tasks run strictly
@@ -38,11 +38,21 @@ const transitionContext = new AsyncLocalStorage<boolean>()
 export class SessionTransitionGate {
   private tail: Promise<unknown> = Promise.resolve()
   private active = false
+  private queued = 0
 
   /** Whether a transition task is currently executing (visible to every
    * caller — the AsyncLocalStorage context is task-internal only). */
   get busy(): boolean {
     return this.active
+  }
+
+  /** Whether a transition task is QUEUED or executing. The exit retirement
+   * pre-cancel keys on this, not on `busy`: a queued-but-not-started
+   * transition is about to quiesce the old agent, whose `whenIdle()` does
+   * not observe the lifecycle signal — the pre-cancel must fire before the
+   * task starts, or the retirement queued behind it can never unblock it. */
+  get pending(): boolean {
+    return this.queued > 0
   }
 
   /**
@@ -59,6 +69,7 @@ export class SessionTransitionGate {
     if (transitionContext.getStore() === true) {
       throw new Error('session transition re-entered while one is in flight')
     }
+    this.queued += 1
     const start = this.tail.then(() => transitionContext.run(true, () => {
       this.active = true
       return task()
@@ -68,8 +79,8 @@ export class SessionTransitionGate {
     // task's continuation finishes — before the next queued task starts —
     // so `busy` is true for the whole exclusive section.
     this.tail = start.then(
-      () => { this.active = false },
-      () => { this.active = false },
+      () => { this.active = false; this.queued -= 1 },
+      () => { this.active = false; this.queued -= 1 },
     )
     return start
   }

--- a/src/transition.ts
+++ b/src/transition.ts
@@ -10,8 +10,9 @@
  *    the old session stays current and the user may retry
  * 4. COMMIT — a synchronous critical section (generation bump, live
  *    replacement)
- * 5. RETIRE — dispose the old handle; child surface/catalog work is
- *    best-effort and the committed child always stands
+ * 5. RETIRE — retire the old Direct owner (cancel → idle → drain
+ *    continuable descendants → final flush → dispose); child surface/catalog
+ *    work is best-effort and the committed child always stands
  * ```
  *
  * The DSH SessionWriteLease (kernel flock) is the ONLY cross-process writer
@@ -90,8 +91,9 @@ export async function runTransitionTo<T>(
   }
   // Phase 4 — COMMIT: a synchronous critical section, no awaits.
   host.commit(next)
-  // Phase 5 — RETIRE: dispose the old handle; the child surface/catalog
-  // work is best-effort.
+  // Phase 5 — RETIRE: retire the old Direct owner (the host adapter runs
+  // cancel → idle → drain descendants → final flush → dispose); the child
+  // surface/catalog work is best-effort.
   try {
     await host.retireOld(next)
   } catch (error) {

--- a/test/direct-owned-session-retirement.test.ts
+++ b/test/direct-owned-session-retirement.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Headless tests for the Direct owned-session retirement helper: the fixed
+ * order `cancel → idle → descendants → flush → dispose` and the failure
+ * containment contract (a failed phase is recorded and the NEXT phase still
+ * runs — a skipped dispose would re-create a handle leak).
+ * @module @xmoon76/dsh-pi-tui/direct-owned-session-retirement.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  retireDirectOwnedSession,
+  type DirectOwnedSessionRetirementDeps,
+} from '../src/runtime/direct/owned-session-retirement.ts'
+
+/** A recording retirement surface; every phase can be made to fail. */
+function retirementHarness(options: {
+  cancelError?: unknown
+  idleError?: unknown
+  drainError?: unknown
+  flushError?: unknown
+  disposeError?: unknown
+} = {}): {
+  deps: DirectOwnedSessionRetirementDeps
+  events: string[]
+} {
+  const events: string[] = []
+  const fail = (error: unknown): void => {
+    if (error !== undefined) throw error
+  }
+  return {
+    deps: {
+      cancel: () => {
+        events.push('cancel')
+        fail(options.cancelError)
+      },
+      whenIdle: async () => {
+        events.push('idle')
+        fail(options.idleError)
+      },
+      drainDescendants: async () => {
+        events.push('descendants')
+        fail(options.drainError)
+      },
+      flush: async () => {
+        events.push('flush')
+        fail(options.flushError)
+      },
+      disposeOwner: async () => {
+        events.push('dispose')
+        fail(options.disposeError)
+      },
+    },
+    events,
+  }
+}
+
+test('the fixed retirement order is cancel → idle → descendants → flush → dispose', async () => {
+  const { deps, events } = retirementHarness()
+  const report = await retireDirectOwnedSession(deps)
+  assert.deepEqual(events, ['cancel', 'idle', 'descendants', 'flush', 'dispose'])
+  assert.deepEqual(report.failures, [], 'a clean retirement reports no failures')
+})
+
+test('a throwing cancel is recorded and the remaining phases still run', async () => {
+  const { deps, events } = retirementHarness({ cancelError: new Error('cancel exploded') })
+  const report = await retireDirectOwnedSession(deps)
+  assert.deepEqual(events, ['cancel', 'idle', 'descendants', 'flush', 'dispose'])
+  assert.deepEqual(report.failures, [{ phase: 'cancel', error: 'cancel exploded' }])
+})
+
+test('a rejecting whenIdle is recorded and descendants/flush/dispose still run', async () => {
+  const { deps, events } = retirementHarness({ idleError: new Error('idle exploded') })
+  const report = await retireDirectOwnedSession(deps)
+  assert.deepEqual(events, ['cancel', 'idle', 'descendants', 'flush', 'dispose'])
+  assert.deepEqual(report.failures, [{ phase: 'idle', error: 'idle exploded' }])
+})
+
+test('a rejecting drain is recorded and flush/dispose still run', async () => {
+  const { deps, events } = retirementHarness({ drainError: new Error('drain exploded') })
+  const report = await retireDirectOwnedSession(deps)
+  assert.deepEqual(events, ['cancel', 'idle', 'descendants', 'flush', 'dispose'])
+  assert.deepEqual(report.failures, [{ phase: 'descendants', error: 'drain exploded' }])
+})
+
+test('a rejecting flush is recorded and dispose still runs (no handle leak)', async () => {
+  const { deps, events } = retirementHarness({ flushError: new Error('flush exploded') })
+  const report = await retireDirectOwnedSession(deps)
+  assert.deepEqual(events, ['cancel', 'idle', 'descendants', 'flush', 'dispose'])
+  assert.deepEqual(report.failures, [{ phase: 'flush', error: 'flush exploded' }])
+})
+
+test('a rejecting dispose is recorded and the report still settles', async () => {
+  const { deps, events } = retirementHarness({ disposeError: new Error('dispose exploded') })
+  const report = await retireDirectOwnedSession(deps)
+  assert.deepEqual(events, ['cancel', 'idle', 'descendants', 'flush', 'dispose'])
+  assert.deepEqual(report.failures, [{ phase: 'dispose', error: 'dispose exploded' }])
+})
+
+test('multiple phase failures are all recorded, never aggregated into a throw', async () => {
+  const { deps, events } = retirementHarness({
+    idleError: new Error('idle exploded'),
+    drainError: new Error('drain exploded'),
+    disposeError: new Error('dispose exploded'),
+  })
+  const report = await retireDirectOwnedSession(deps)
+  assert.deepEqual(events, ['cancel', 'idle', 'descendants', 'flush', 'dispose'])
+  assert.deepEqual(report.failures, [
+    { phase: 'idle', error: 'idle exploded' },
+    { phase: 'descendants', error: 'drain exploded' },
+    { phase: 'dispose', error: 'dispose exploded' },
+  ])
+})
+
+test('a hostile thrown value is contained by safeErrorMessage', async () => {
+  const hostile = {
+    toString() {
+      throw new Error('stringify exploded')
+    },
+  }
+  const { deps } = retirementHarness({ flushError: hostile })
+  const report = await retireDirectOwnedSession(deps)
+  assert.equal(report.failures.length, 1)
+  assert.equal(report.failures[0]?.phase, 'flush')
+  assert.equal(report.failures[0]?.error, '<unprintable error>')
+})

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,13 +1,17 @@
 /**
- * Headless tests for the lifecycle primitives: the exit flush contract
- * (resolve / reject / hang / late-settle) and the detached-task entry
- * (rejection capture, cancellation classification, recoverable notify).
+ * Headless tests for the lifecycle primitives: the exit orchestration
+ * (latch once → surface cleanup → hint → appExit; idempotent, total) and
+ * the detached-task entry (rejection capture, cancellation classification,
+ * recoverable notify). The Direct owned-session retirement is a SEPARATE
+ * step that runs inside the appExit disposal — see
+ * test/direct-owned-session-retirement.test.ts and the runner integration
+ * tests.
  * @module @xmoon76/dsh-pi-tui/lifecycle.test
  */
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { createExitController, flushWithTimeout, type ExitSessionLike } from '../src/exit.ts'
+import { createExitController } from '../src/exit.ts'
 import { cancellationError, isCancellation, runDetached, runOwned } from '../src/detached.ts'
 import { createDiag, type Diag } from '../src/diag.ts'
 
@@ -40,46 +44,6 @@ function abortError(): Error {
   error.name = 'AbortError'
   return error
 }
-
-test('flush resolving settles ok with the elapsed time', async () => {
-  let clock = 1000
-  const outcome = await flushWithTimeout(async () => {
-    clock += 25
-  }, 1000, () => clock)
-  assert.deepEqual(outcome, { kind: 'ok', tookMs: 25 })
-})
-
-test('flush rejecting settles failed with the error message', async () => {
-  const outcome = await flushWithTimeout(async () => {
-    throw new Error('disk full')
-  }, 1000)
-  assert.equal(outcome.kind, 'failed')
-  if (outcome.kind === 'failed') {
-    assert.equal(outcome.error, 'disk full')
-    assert.ok(outcome.tookMs >= 0)
-  }
-})
-
-test('a hung flush settles timed-out after the hard timeout, not forever', async () => {
-  const started = Date.now()
-  const outcome = await flushWithTimeout(() => new Promise<never>(() => {}), 40)
-  assert.equal(outcome.kind, 'timed-out')
-  assert.ok(Date.now() - started >= 35, 'should wait for the timeout')
-  if (outcome.kind === 'timed-out') assert.ok(outcome.tookMs >= 35)
-})
-
-test('a flush settling after the timeout cannot overwrite the timed-out outcome', async () => {
-  let release!: () => void
-  const gate = new Promise<void>(resolve => { release = resolve })
-  const pending = flushWithTimeout(() => gate, 30)
-  const outcome = await pending
-  assert.equal(outcome.kind, 'timed-out')
-  release() // the flush finishes late
-  await new Promise(resolve => setTimeout(resolve, 10))
-  // The outcome is settled once: still timed-out.
-  const outcome2 = await pending
-  assert.equal(outcome2.kind, 'timed-out')
-})
 
 test('runDetached captures a rejection into diag without rethrowing', async () => {
   const { diag, lines } = captureDiag()
@@ -802,116 +766,47 @@ test('isCancellation recognizes AbortError name and ABORT_ERR code', () => {
 
 // --- createExitController: the ONE exit orchestration (Ctrl+C/D, /exit, /quit) ---
 
-const SESSION: ExitSessionLike = { id: 'session-exit', seq: 7 }
-
 /** A controller harness recording every side effect; `exit` resolves the
  * returned promise so tests await the orchestration's completion. */
 function exitHarness(options: {
-  session?: () => ExitSessionLike | undefined
-  flush?: () => Promise<unknown>
-  timeoutMs?: number
   resumeHint?: () => string | undefined
 } = {}) {
   const { diag, lines } = captureDiag()
   const calls = {
-    flush: 0,
     cleanup: 0,
-    warns: [] as string[],
     hints: [] as string[],
     exits: [] as number[],
   }
   let resolveExit!: (code: number) => void
   const exitDone = new Promise<number>(resolve => { resolveExit = resolve })
-  const flushImpl = options.flush ?? (async () => {})
   const { requestExit } = createExitController({
-    session: options.session ?? (() => SESSION),
-    flush: async () => { calls.flush += 1; await flushImpl() },
-    timeoutMs: options.timeoutMs ?? 1000,
     diag,
     cleanup: () => { calls.cleanup += 1 },
-    warn: (message) => { calls.warns.push(message) },
     hint: (message) => { calls.hints.push(message) },
-    resumeHint: options.resumeHint ?? (() => `dsh --profile pi-tui --session ${SESSION.id}`),
+    resumeHint: options.resumeHint ?? (() => 'dsh --profile pi-tui --session session-exit'),
     exit: (code) => { calls.exits.push(code); resolveExit(code) },
   })
   return { requestExit, calls, exitDone, lines }
 }
 
-test('exit without a session flushes nothing and exits once', async () => {
-  const { requestExit, calls, exitDone } = exitHarness({ session: () => undefined })
-  requestExit()
-  assert.equal(await exitDone, 0)
-  assert.equal(calls.flush, 0, 'no session: nothing to flush')
-  assert.equal(calls.cleanup, 1)
-  assert.deepEqual(calls.warns, [], 'a clean no-session exit must not warn')
-})
-
-test('exit flushes, cleans up, hints, and exits once on a resolving flush', async () => {
+test('exit cleans up, hints, and exits once', async () => {
   const { requestExit, calls, exitDone, lines } = exitHarness()
   requestExit()
   assert.equal(await exitDone, 0)
-  assert.equal(calls.flush, 1)
   assert.equal(calls.cleanup, 1)
   assert.deepEqual(calls.exits, [0])
   assert.deepEqual(calls.hints, ['dsh --profile pi-tui --session session-exit'])
-  assert.match(lines.join('\n'), /outcome=ok/)
-})
-
-test('a rejecting flush still exits, warns, and never leaks an unhandled rejection', async () => {
-  const unhandled: unknown[] = []
-  const onUnhandled = (reason: unknown): void => { unhandled.push(reason) }
-  process.on('unhandledRejection', onUnhandled)
-  try {
-    const { requestExit, calls, exitDone } = exitHarness({
-      flush: async () => { throw new Error('disk full') },
-    })
-    requestExit()
-    assert.equal(await exitDone, 0)
-    assert.equal(calls.cleanup, 1)
-    assert.deepEqual(calls.warns, ['session flush failed (disk full) — the latest events may not be persisted'])
-    assert.deepEqual(unhandled, [], 'the exit path must capture the flush rejection')
-  } finally {
-    process.off('unhandledRejection', onUnhandled)
-  }
-})
-
-test('a hung flush exits after the hard timeout', async () => {
-  const started = Date.now()
-  const { requestExit, calls, exitDone } = exitHarness({
-    flush: () => new Promise<never>(() => {}),
-    timeoutMs: 40,
-  })
-  requestExit()
-  assert.equal(await exitDone, 0)
-  assert.ok(Date.now() - started >= 35, 'must wait for the hard timeout')
-  assert.equal(calls.cleanup, 1)
-  assert.match(calls.warns[0] ?? '', /timed out/)
+  assert.match(lines.join('\n'), /exit/)
 })
 
 test('exit is idempotent: later requests while in flight or after are no-ops', async () => {
-  let release!: () => void
-  const gate = new Promise<void>(resolve => { release = resolve })
-  const { requestExit, calls, exitDone } = exitHarness({ flush: () => gate })
+  const { requestExit, calls, exitDone } = exitHarness()
   requestExit()
   requestExit() // in-flight: must be a no-op
-  release()
   assert.equal(await exitDone, 0)
   requestExit() // after completion: must be a no-op
-  assert.equal(calls.flush, 1, 'a second request must not flush again')
   assert.equal(calls.cleanup, 1, 'a second request must not clean up again')
   assert.deepEqual(calls.exits, [0], 'a second request must not exit again')
-})
-
-test('a late flush resolving after the timeout cannot re-run cleanup or exit', async () => {
-  let release!: () => void
-  const gate = new Promise<void>(resolve => { release = resolve })
-  const { requestExit, calls, exitDone } = exitHarness({ flush: () => gate, timeoutMs: 30 })
-  requestExit()
-  assert.equal(await exitDone, 0)
-  release() // the flush settles late
-  await new Promise(resolve => setTimeout(resolve, 10))
-  assert.equal(calls.cleanup, 1)
-  assert.deepEqual(calls.exits, [0])
 })
 
 test('exit without a resume hint prints none', async () => {
@@ -921,65 +816,9 @@ test('exit without a resume hint prints none', async () => {
   assert.deepEqual(calls.hints, [])
 })
 
-// --- lifecycle-root hostile inputs: flush and exit must stay total ---
+// --- lifecycle-root hostile inputs: exit must stay total ---
 
-/** An object whose stringification throws (a legal thrown value). */
-function hostileFlushValue(): object {
-  return {
-    toString() {
-      throw new Error('flush stringify exploded')
-    },
-  }
-}
-
-test('flushWithTimeout: a hostile flush rejection settles `failed` immediately, never timed-out', async () => {
-  const unhandled = await unhandledOf(() => {
-    void flushWithTimeout(() => Promise.reject(hostileFlushValue()), 40)
-  })
-  assert.deepEqual(unhandled, [], 'a hostile flush rejection must never leak')
-  const outcome = await flushWithTimeout(() => Promise.reject(hostileFlushValue()), 40)
-  assert.equal(outcome.kind, 'failed', 'the failure must be reported as failed, not timed-out')
-  if (outcome.kind === 'failed') {
-    assert.equal(outcome.error, '<unprintable error>')
-  }
-})
-
-test('flushWithTimeout: with the timeout disabled a hostile rejection still settles', async () => {
-  const outcome = await flushWithTimeout(() => Promise.reject(hostileFlushValue()), 0)
-  assert.equal(outcome.kind, 'failed', 'the disabled-timeout path must still settle')
-})
-
-test('exit: a throwing session() still cleans up exactly once and exits 1, zero unhandled', async () => {
-  const unhandled: unknown[] = []
-  const listener = (reason: unknown): void => { unhandled.push(reason) }
-  process.on('unhandledRejection', listener)
-  try {
-    const { diag, lines } = captureDiag()
-    const calls = { cleanup: 0, exits: [] as number[] }
-    let resolveExit!: (code: number) => void
-    const exitDone = new Promise<number>(resolve => { resolveExit = resolve })
-    createExitController({
-      session: () => { throw hostileFlushValue() },
-      flush: async () => {},
-      timeoutMs: 1000,
-      diag,
-      cleanup: () => { calls.cleanup += 1 },
-      warn: () => {},
-      hint: () => {},
-      resumeHint: () => undefined,
-      exit: (code) => { calls.exits.push(code); resolveExit(code) },
-    }).requestExit()
-    assert.equal(await exitDone, 1, 'an orchestration failure must exit with code 1')
-    assert.equal(calls.cleanup, 1, 'cleanup runs exactly once')
-    assert.deepEqual(calls.exits, [1])
-    assert.deepEqual(unhandled, [], 'a throwing session() must never leak from the discarded IIFE')
-    assert.match(lines.join('\n'), /exit orchestration failed/)
-  } finally {
-    process.off('unhandledRejection', listener)
-  }
-})
-
-test('exit: throwing cleanup/warn/hint cannot skip the exit, zero unhandled', async () => {
+test('exit: throwing cleanup/hint cannot skip the exit, zero unhandled', async () => {
   const unhandled: unknown[] = []
   const listener = (reason: unknown): void => { unhandled.push(reason) }
   process.on('unhandledRejection', listener)
@@ -989,19 +828,15 @@ test('exit: throwing cleanup/warn/hint cannot skip the exit, zero unhandled', as
     let resolveExit!: (code: number) => void
     const exitDone = new Promise<number>(resolve => { resolveExit = resolve })
     createExitController({
-      session: () => SESSION,
-      flush: async () => { throw new Error('disk full') },
-      timeoutMs: 1000,
       diag,
       cleanup: () => { calls.cleanup += 1; throw new Error('cleanup exploded') },
-      warn: () => { throw new Error('warn exploded') },
       hint: () => { throw new Error('hint exploded') },
       resumeHint: () => 'resume',
       exit: (code) => { calls.exits.push(code); resolveExit(code) },
     }).requestExit()
-    assert.equal(await exitDone, 0, 'a flush failure is not an orchestration failure: exit 0')
+    assert.equal(await exitDone, 0, 'a throwing cleanup is not an orchestration failure: exit 0')
     assert.equal(calls.cleanup, 1, 'cleanup still runs (and its throw is consumed)')
-    assert.deepEqual(calls.exits, [0], 'a throwing warn/hint/cleanup must never skip the exit')
+    assert.deepEqual(calls.exits, [0], 'a throwing hint/cleanup must never skip the exit')
     assert.deepEqual(unhandled, [], 'no step may leak a rejection')
   } finally {
     process.off('unhandledRejection', listener)

--- a/test/notification-wiring.test.ts
+++ b/test/notification-wiring.test.ts
@@ -52,7 +52,7 @@ test('focus reporting is enabled at mount and disabled on EVERY exit path', () =
   assert.equal(disables, 2, 'disable exactly twice: the normal cleanup AND the startup-failure catch')
   // The normal cleanup disables BEFORE the app dies (first teardown
   // step, before any throwable operation).
-  const cleanupStart = indexSource.indexOf('const cleanup = (): void => {')
+  const cleanupStart = indexSource.indexOf('const disposeSurface = (): void => {')
   const cleanup = indexSource.slice(cleanupStart, indexSource.indexOf('diag.dispose()', cleanupStart) + 20)
   const disableIndex = cleanup.indexOf('notificationWriter.write(DISABLE_FOCUS_REPORTING)')
   const disposeIndex = cleanup.indexOf('app?.dispose()')

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -280,12 +280,12 @@ test('the runner cleanup closure never references a later-declared binding (TDZ 
     block.statements.some(statement =>
       ts.isVariableStatement(statement)
       && statement.declarationList.declarations.some(declaration =>
-        ts.isIdentifier(declaration.name) && declaration.name.text === 'cleanup'))
+        ts.isIdentifier(declaration.name) && declaration.name.text === 'disposeSurface'))
   const lifecycleRoot = candidates.find(statement => {
     const arrow = arrowOf(statement)
     return arrow !== undefined && ts.isBlock(arrow.body) && hasCleanup(arrow.body)
   })
-  assert.ok(lifecycleRoot !== undefined, 'the startup lifecycle root IIFE (the void expression whose arrow declares cleanup) must exist')
+  assert.ok(lifecycleRoot !== undefined, 'the startup lifecycle root IIFE (the void expression whose arrow declares disposeSurface) must exist')
   const arrow = arrowOf(lifecycleRoot)!
   const runnerBlock = arrow.body
   assert.ok(ts.isBlock(runnerBlock), 'the lifecycle root body must be a block')
@@ -320,17 +320,17 @@ test('the runner cleanup closure never references a later-declared binding (TDZ 
     }
   }
 
-  // The cleanup function declaration (runner-scope).
+  // The disposeSurface function declaration (runner-scope).
   const cleanupDecl = runnerBlock.statements.find(statement =>
     ts.isVariableStatement(statement)
     && ts.isIdentifier(statement.declarationList.declarations[0]!.name)
-    && statement.declarationList.declarations[0]!.name.text === 'cleanup'
+    && statement.declarationList.declarations[0]!.name.text === 'disposeSurface'
   ) as ts.VariableStatement | undefined
-  assert.ok(cleanupDecl !== undefined, 'cleanup must exist in the runner scope')
+  assert.ok(cleanupDecl !== undefined, 'disposeSurface must exist in the runner scope')
   const cleanupInitializer = cleanupDecl.declarationList.declarations[0]!.initializer
-  assert.ok(cleanupInitializer !== undefined && ts.isArrowFunction(cleanupInitializer), 'cleanup must be an arrow function')
+  assert.ok(cleanupInitializer !== undefined && ts.isArrowFunction(cleanupInitializer), 'disposeSurface must be an arrow function')
   const cleanupBody = cleanupInitializer.body
-  assert.ok(ts.isBlock(cleanupBody), 'cleanup body must be a block')
+  assert.ok(ts.isBlock(cleanupBody), 'disposeSurface body must be a block')
   const cleanupLine = sourceFile.getLineAndCharacterOfPosition(cleanupDecl.getStart()).line + 1
 
   // Collect the identifiers referenced in the cleanup body (excluding its
@@ -464,12 +464,12 @@ test('startup-eager callbacks of startProcessTui never reference a later-declare
     block.statements.some(statement =>
       ts.isVariableStatement(statement)
       && statement.declarationList.declarations.some(declaration =>
-        ts.isIdentifier(declaration.name) && declaration.name.text === 'cleanup'))
+        ts.isIdentifier(declaration.name) && declaration.name.text === 'disposeSurface'))
   const lifecycleRoot = candidates.find(statement => {
     const arrow = arrowOf(statement)
     return arrow !== undefined && ts.isBlock(arrow.body) && hasCleanup(arrow.body)
   })
-  assert.ok(lifecycleRoot !== undefined, 'the startup lifecycle root IIFE (the void expression whose arrow declares cleanup) must exist')
+  assert.ok(lifecycleRoot !== undefined, 'the startup lifecycle root IIFE (the void expression whose arrow declares disposeSurface) must exist')
   const runnerBlock = arrowOf(lifecycleRoot)!.body as ts.Block
 
   /** Collect every bound name of a binding pattern. */

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -3142,3 +3142,46 @@ test('exit during the post-commit child quiesce skips surface init and retires t
   assert.ok(events.filter(event => event === `cancel:${created.id}`).length >= 1,
     'the committed child must be cancelled by the abort-aware quiesce')
 })
+
+test('a retirement flush failure warns the user on stderr (durability is not silently lost)', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-warn-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-warn-session',
+    header: { id: 'retire-warn-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('resumed answer'),
+  })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, retirementSubagents)
+  // The final retirement flush fails (disk full): the user must see a
+  // warning, not a silent clean exit.
+  ;(harness.sessions as { flush: (session?: unknown) => Promise<unknown> }).flush = async () => {
+    throw new Error('disk full')
+  }
+  const stderrWrites: string[] = []
+  const originalWrite = process.stderr.write.bind(process.stderr)
+  process.stderr.write = ((chunk: unknown) => {
+    stderrWrites.push(String(chunk))
+    return true
+  }) as typeof process.stderr.write
+  life.defer(() => { process.stderr.write = originalWrite })
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  await fiber.dispose()
+  fiber = undefined
+  assert.ok(stderrWrites.some(write => write.includes('session flush failed during retirement') && write.includes('disk full')),
+    `the user must see the flush-failure warning on stderr: ${JSON.stringify(stderrWrites)}`)
+  assert.ok(stderrWrites.some(write => write.includes('the latest events may not be persisted')),
+    'the warning must state the durability consequence')
+})

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -223,9 +223,13 @@ interface RunnerHarness {
   readonly createdSessions: FakeSession[]
   readonly commands: unknown
   readonly subagents?: unknown
+  /** Retirement-phase records (`cancel:<id>` / `idle:<id>` / `drain:<id>` /
+   * `flush:<id>` / `dispose:<id>`) in call order — the Direct
+   * owned-session retirement assertions. */
+  readonly retirementEvents: string[]
 }
 
-function fakeAgent(session: FakeSession, whenIdleGate?: () => Promise<void>): Agent {
+function fakeAgent(session: FakeSession, whenIdleGate?: () => Promise<void>, retirementEvents?: string[]): Agent {
   // A small structural Agent context is sufficient for the Direct setup
   // callbacks and lets the harness expose the public `ctx.agent` setup seam.
   const agentContext = {
@@ -233,13 +237,33 @@ function fakeAgent(session: FakeSession, whenIdleGate?: () => Promise<void>): Ag
     on: () => () => {},
     agent: undefined as Agent | undefined,
   }
+  // cancel is idempotent and BREAKS a pending whenIdle (the real Agent
+  // contract): a cancelled agent's whenIdle settles immediately, which is
+  // exactly what the exit pre-cancel relies on to unblock a transition
+  // stuck in its pre-commit quiesce.
+  let cancelled = false
+  let releaseIdle: (() => void) | undefined
   const agent = {
     session,
     ctx: agentContext,
     options: { provider: 'p', model: 'm' },
     status: 'idle',
     inbox: { nextTurn: [], nextStep: [] },
-    whenIdle: async () => { await whenIdleGate?.() },
+    whenIdle: async () => {
+      retirementEvents?.push(`idle:${session.id}`)
+      if (cancelled) return
+      await new Promise<void>(resolve => {
+        releaseIdle = resolve
+        const gate = whenIdleGate?.()
+        if (gate !== undefined) void gate.then(resolve, resolve)
+        else resolve()
+      })
+    },
+    cancel: () => {
+      retirementEvents?.push(`cancel:${session.id}`)
+      cancelled = true
+      releaseIdle?.()
+    },
   } as unknown as Agent
   agentContext.agent = agent
   return agent
@@ -252,13 +276,16 @@ function makeHarness(
   initialDefault: { provider: string; model: string; reasoningEffort?: string } = { provider: 'p', model: 'm' },
   saveDefault?: (next: { provider: string; model: string; reasoningEffort?: string }) => Promise<unknown>,
   createGate?: () => Promise<unknown>,
-  subagents?: unknown,
+  /** A subagents service, or a factory receiving the harness retirement
+   * events array (so a drain fake records into the SAME assertion log). */
+  subagents?: unknown | ((events: string[]) => unknown),
   whenIdleGate?: (sessionId: string) => Promise<void>,
   resumeGate?: (sessionId: string) => Promise<void>,
   resumeError?: Error,
 ): RunnerHarness {
   const persisted = new Map<string, FakeSession>()
   const live = new Map<string, Agent>()
+  const retirementEvents: string[] = []
   const createOptions: { provider?: string; model?: string }[] = []
   const createInheritedEventCounts: (number | undefined)[] = []
   const createSignals: (AbortSignal | undefined)[] = []
@@ -269,11 +296,12 @@ function makeHarness(
   }
 
   const makeHandle = (session: FakeSession): { agent: Agent; dispose: () => Promise<void> } => {
-    const agent = fakeAgent(session, whenIdleGate === undefined ? undefined : () => whenIdleGate(session.id))
+    const agent = fakeAgent(session, whenIdleGate === undefined ? undefined : () => whenIdleGate(session.id), retirementEvents)
     live.set(session.id, agent)
     return {
       agent,
       dispose: async () => {
+        retirementEvents.push(`dispose:${session.id}`)
         live.delete(session.id)
       },
     }
@@ -339,7 +367,9 @@ function makeHarness(
     get: (id: string) => live.get(id),
   }
   const sessions = {
-    flush: async () => {},
+    flush: async (session?: unknown) => {
+      retirementEvents.push(`flush:${(session as { id?: string } | undefined)?.id ?? '?'}`)
+    },
     get: (id: string) => live.get(id)?.session,
   }
   let defaultSelection = { ...initialDefault }
@@ -368,7 +398,10 @@ function makeHarness(
     execute: async () => ({ result: { kind: 'success' } }),
     handler: (name: string) => definitions.get(name)?.handler,
   }
-  return { persistence, sessionQuery, agents, sessions, defaultModel, llm, createOptions, createInheritedEventCounts, createSignals, resumeSignals, createdSessions, commands, subagents }
+  const subagentsService = typeof subagents === 'function'
+    ? (subagents as (events: string[]) => unknown)(retirementEvents)
+    : subagents
+  return { persistence, sessionQuery, agents, sessions, defaultModel, llm, createOptions, createInheritedEventCounts, createSignals, resumeSignals, createdSessions, commands, subagents: subagentsService, retirementEvents }
 }
 
 async function settle(): Promise<void> {
@@ -2523,4 +2556,589 @@ test('a fresh start with a FAILING preset resolution stays silent (no Preparing 
   // The TUI still mounts (degraded — the failure is a one-shot warn).
   const app = probe.apps.at(-1)
   assert.ok(app, 'the production runner must still create a TuiApp')
+})
+
+// --- Direct owned-session retirement (exit / HMR / transition) ---
+
+/** A subagents fake recording drainContinuableDescendants calls. */
+function retirementSubagents(events: string[]): { drainContinuableDescendants: (parents: readonly unknown[]) => Promise<void> } {
+  return {
+    drainContinuableDescendants: async (parents: readonly unknown[]) => {
+      const parent = parents[0] as { session: { id: string } } | undefined
+      events.push(`drain:${parent?.session.id ?? '?'}`)
+    },
+  }
+}
+
+test('fiber unload retires the Direct owned session: cancel → idle → drain → flush → dispose (HMR path)', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-hmr-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-hmr-session',
+    header: { id: 'retire-hmr-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('resumed answer'),
+  })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, retirementSubagents)
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const app = probe.apps.at(-1)
+  assert.ok(app, 'the production runner must create a TuiApp')
+  // HMR unload: dispose the runner fiber directly (no interactive exit).
+  await fiber.dispose()
+  fiber = undefined
+  // The retirement order is the fixed Direct order; the drain of the
+  // continuable descendants happens BEFORE the parent handle dispose.
+  const events = harness.retirementEvents
+  const cancel = events.filter(event => event === 'cancel:retire-hmr-session')
+  const idle = events.filter(event => event === 'idle:retire-hmr-session')
+  const drain = events.filter(event => event === 'drain:retire-hmr-session')
+  const flush = events.filter(event => event === 'flush:retire-hmr-session')
+  const dispose = events.filter(event => event === 'dispose:retire-hmr-session')
+  assert.equal(cancel.length, 1, 'the owned agent must be cancelled exactly once')
+  assert.equal(drain.length, 1, 'drainContinuableDescendants must be called exactly once')
+  assert.equal(dispose.length, 1, 'the owned handle must be disposed exactly once')
+  assert.ok(events.indexOf('drain:retire-hmr-session') < events.indexOf('dispose:retire-hmr-session'),
+    'descendant drain must complete before the parent handle dispose')
+  assert.ok(events.indexOf('flush:retire-hmr-session') < events.indexOf('dispose:retire-hmr-session'),
+    'the final flush must complete before the parent handle dispose')
+  assert.ok(events.indexOf('cancel:retire-hmr-session') < events.indexOf('drain:retire-hmr-session'),
+    'cancel must precede the descendant drain')
+  assert.ok(idle.length >= 1, 'whenIdle must be awaited during retirement')
+  assert.ok(flush.length >= 1, 'the final flush must run during retirement')
+})
+
+test('deferred-start exit retires nothing and disposes the surface only', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-deferred-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  // Deferred start: no session, no agent, no handle.
+  const harness = makeHarness(home)
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, {}, {})
+  const app = probe.apps.at(-1)
+  assert.ok(app, 'the production runner must create a TuiApp')
+  await fiber.dispose()
+  fiber = undefined
+  assert.deepEqual(harness.retirementEvents, [],
+    'a sessionless exit must not cancel/drain/flush/dispose anything')
+})
+
+test('a successful /new retires the OLD owner post-commit (cancel → idle → drain → flush → dispose)', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-switch-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-switch-old',
+    header: { id: 'retire-switch-old', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('old answer'),
+  })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, retirementSubagents)
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const newHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+  assert.ok(newHandler, 'the real runner must register the /new transition command')
+  await newHandler()
+  await settle()
+  // The OLD owner was retired post-commit: cancel + drain + dispose exactly
+  // once each, and the drain happened before the old handle dispose.
+  const events = harness.retirementEvents
+  const oldCancel = events.filter(event => event === 'cancel:retire-switch-old')
+  const oldDrain = events.filter(event => event === 'drain:retire-switch-old')
+  const oldDispose = events.filter(event => event === 'dispose:retire-switch-old')
+  assert.equal(oldCancel.length, 1, 'the old agent must be cancelled exactly once post-commit')
+  assert.equal(oldDrain.length, 1, 'the old continuable descendants must be drained exactly once post-commit')
+  assert.equal(oldDispose.length, 1, 'the old handle must be disposed exactly once post-commit')
+  assert.ok(events.indexOf('drain:retire-switch-old') < events.indexOf('dispose:retire-switch-old'),
+    'the old descendant drain must precede the old handle dispose')
+  // The child stays current: the surface still owns the NEW session.
+  const created = harness.createdSessions.at(-1)
+  assert.ok(created, '/new must create a child session')
+  assert.notEqual(created.id, 'retire-switch-old')
+  // A later teardown retires the NEW owner exactly once (the old owner is
+  // not retired again — the memoized retirement is per-owner).
+  await fiber.dispose()
+  fiber = undefined
+  const newDispose = events.filter(event => event === `dispose:${created.id}`)
+  assert.equal(newDispose.length, 1, 'the new current owner must be retired on teardown')
+  assert.equal(oldDispose.length, 1, 'the old owner must never be retired twice')
+})
+
+test('a failed child create does NOT drain or dispose the current old owner', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-create-fail-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-create-fail-old',
+    header: { id: 'retire-create-fail-old', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('old answer'),
+  })
+  // The child create throws: the transition must abort with ZERO old-owner
+  // side effects (no drain, no dispose — the old session stays current).
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, async () => { throw new Error('create failed') }, retirementSubagents)
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const newHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+  assert.ok(newHandler, 'the real runner must register the /new transition command')
+  await newHandler()
+  await settle()
+  const events = harness.retirementEvents
+  assert.ok(!events.some(event => event === 'drain:retire-create-fail-old'),
+    'a failed child create must never drain the old owner descendants')
+  assert.ok(!events.some(event => event === 'dispose:retire-create-fail-old'),
+    'a failed child create must never dispose the old owner handle')
+  assert.equal(harness.createdSessions.length, 0, 'a failed create must not publish a child')
+  // The old session is still current: teardown retires it exactly once.
+  await fiber.dispose()
+  fiber = undefined
+  assert.equal(events.filter(event => event === 'dispose:retire-create-fail-old').length, 1,
+    'the still-current old owner must be retired on teardown')
+})
+
+test('exit during an in-flight transition does not deadlock and retires the current owner exactly once', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-during-switch-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-during-switch-old',
+    header: { id: 'retire-during-switch-old', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('old answer'),
+  })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, retirementSubagents)
+  // The child create awaits the lifecycle signal: an exit during the
+  // transition aborts it (the unsafe late commit is prevented).
+  let createStarted!: () => void
+  const createStartedPromise = new Promise<void>(resolve => { createStarted = resolve })
+  const agents = harness.agents as {
+    create: (options: { sessionId: unknown; signal?: AbortSignal }) => Promise<never>
+  }
+  agents.create = async ({ signal }) => {
+    createStarted()
+    if (signal === undefined) throw new Error('test create did not receive a lifecycle signal')
+    if (signal.aborted) throw new Error('create cancelled')
+    return await new Promise<never>((_, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('create cancelled')), { once: true })
+    })
+  }
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const newHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+  assert.ok(newHandler, 'the real runner must register the /new transition command')
+  const transition = newHandler()
+  await createStartedPromise
+  // Exit while the child create is still awaiting: the fiber disposer must
+  // not deadlock on the transition gate (the abort settles the create).
+  await fiber.dispose()
+  fiber = undefined
+  await transition
+  const events = harness.retirementEvents
+  const oldDispose = events.filter(event => event === 'dispose:retire-during-switch-old')
+  assert.equal(oldDispose.length, 1, 'the still-current old owner must be retired exactly once')
+  assert.equal(harness.createdSessions.length, 0, 'the aborted create must not publish a child')
+})
+
+test('an interactive exit retires the owned session through the appExit disposal', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-interactive-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-interactive-session',
+    header: { id: 'retire-interactive-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('resumed answer'),
+  })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, retirementSubagents)
+  let exitCalls = 0
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id }, () => {
+    exitCalls += 1
+    // The launcher's appExit disposes the application tree: the runner
+    // fiber disposer runs the Direct owned-session retirement.
+    void fiber?.dispose()
+  })
+  const app = probe.apps.at(-1)
+  assert.ok(app, 'the production runner must create a TuiApp')
+  // Interactive exit: submit the plain `exit` prompt (shell muscle memory).
+  app.setDraft('exit')
+  ;(app as unknown as { submitDraft(): void }).submitDraft()
+  await settle()
+  assert.equal(exitCalls, 1, 'the interactive exit must request appExit exactly once')
+  const events = harness.retirementEvents
+  assert.equal(events.filter(event => event === 'cancel:retire-interactive-session').length, 1,
+    'the interactive exit must cancel the owned agent')
+  assert.equal(events.filter(event => event === 'drain:retire-interactive-session').length, 1,
+    'the interactive exit must drain the continuable descendants')
+  assert.equal(events.filter(event => event === 'dispose:retire-interactive-session').length, 1,
+    'the interactive exit must dispose the owned handle')
+  assert.ok(events.indexOf('drain:retire-interactive-session') < events.indexOf('dispose:retire-interactive-session'),
+    'the descendant drain must precede the parent handle dispose on the interactive path too')
+})
+
+test('exit after a transition COMMITTED retires the NEW current owner, never the old twice', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-after-commit-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-after-commit-old',
+    header: { id: 'retire-after-commit-old', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('old answer'),
+  })
+  // The child create is gated: the transition commits only after the gate
+  // releases, so the test can exit in the post-commit window.
+  let releaseCreate!: () => void
+  const createGate = new Promise<void>(resolve => { releaseCreate = resolve })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, () => createGate, retirementSubagents)
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const newHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+  assert.ok(newHandler, 'the real runner must register the /new transition command')
+  const transition = newHandler()
+  await settle()
+  // The child create completes and the transition commits.
+  releaseCreate()
+  await settle()
+  // Exit in the post-commit window: the retirement must target the NEW
+  // current owner (the old owner was already retired post-commit).
+  await fiber.dispose()
+  fiber = undefined
+  await transition
+  const events = harness.retirementEvents
+  const created = harness.createdSessions.at(-1)
+  assert.ok(created, '/new must create a child session')
+  const oldDisposes = events.filter(event => event === 'dispose:retire-after-commit-old')
+  const newDisposes = events.filter(event => event === `dispose:${created.id}`)
+  assert.equal(oldDisposes.length, 1, 'the old owner must be retired exactly once (post-commit)')
+  assert.equal(newDisposes.length, 1, 'the NEW current owner must be the shutdown target')
+  assert.ok(events.indexOf(`dispose:${created.id}`) > events.indexOf('dispose:retire-after-commit-old'),
+    'the new owner retirement must follow the old owner retirement')
+})
+
+test('exit during a transition stuck in pre-commit whenIdle: the pre-cancel unblocks it and the old owner is retired', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-whenidle-stuck-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-whenidle-stuck-old',
+    header: { id: 'retire-whenidle-stuck-old', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('old answer'),
+  })
+  // The FIRST whenIdle (startup resume) settles; the SECOND (the /new
+  // pre-commit quiesce) hangs — the old agent is "busy" and its whenIdle
+  // does not observe the lifecycle signal, exactly like a real LLM turn.
+  let idleCalls = 0
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, retirementSubagents, async () => {
+    idleCalls += 1
+    if (idleCalls >= 2) {
+      await new Promise<void>(() => {})
+    }
+  })
+  // The child create observes the lifecycle signal: the exit aborts it.
+  const agents = harness.agents as {
+    create: (options: { sessionId: unknown; signal?: AbortSignal }) => Promise<never>
+  }
+  agents.create = async ({ signal }) => {
+    if (signal === undefined) throw new Error('test create did not receive a lifecycle signal')
+    if (signal.aborted) throw new Error('create cancelled')
+    return await new Promise<never>((_, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('create cancelled')), { once: true })
+    })
+  }
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const newHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+  assert.ok(newHandler, 'the real runner must register the /new transition command')
+  const transition = newHandler()
+  await settle()
+  assert.equal(idleCalls, 2, 'the /new pre-commit quiesce must be awaiting the stuck whenIdle')
+  // Exit while the transition is stuck in its pre-commit quiesce: the
+  // retirement pre-cancel must unblock the whenIdle (no deadlock), the
+  // aborted create must fail the transition, and the still-current old
+  // owner must be retired.
+  await fiber.dispose()
+  fiber = undefined
+  await transition
+  const events = harness.retirementEvents
+  assert.equal(events.filter(event => event === 'dispose:retire-whenidle-stuck-old').length, 1,
+    'the still-current old owner must be retired exactly once')
+  assert.ok(events.filter(event => event === 'cancel:retire-whenidle-stuck-old').length >= 1,
+    'the old owner must be cancelled (pre-cancel and/or the retirement cancel phase)')
+  assert.equal(harness.createdSessions.length, 0, 'the aborted create must not publish a child')
+})
+
+test('a pre-mount unload while the resume whenIdle is pending cancels the agent and retires the owner', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-premount-whenidle-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  const resumed: FakeSession = fakeSession({
+    id: 'premount-whenidle-session',
+    header: { id: 'premount-whenidle-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('resumed answer'),
+  })
+  // The resume whenIdle hangs (a busy agent): the pre-mount wait must be
+  // broken by the lifecycle abort, not left hanging forever.
+  let whenIdleStarted!: () => void
+  const whenIdleStartedPromise = new Promise<void>(resolve => { whenIdleStarted = resolve })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, retirementSubagents, async () => {
+    whenIdleStarted()
+    await new Promise<void>(() => {})
+  })
+  context = new Context()
+  // Provide the same host services as mountRunner, but do NOT await the
+  // startup settle: the IIFE is stuck in the pre-mount whenIdle. The early
+  // lifecycle-cancellation effect is registered before the resume, so
+  // disposing the context aborts the signal.
+  context.provide('appExit', () => {})
+  context.provide(TUI_STARTUP_SERVICE, { sessionId: resumed.id, shippedPresetRoot: home })
+  context.provide('sessionPersistence', harness.persistence as never)
+  context.provide('sessionQuery', harness.sessionQuery as never)
+  context.provide('agents', harness.agents as never)
+  context.provide('sessions', harness.sessions as never)
+  context.provide('agentDefaultModel', harness.defaultModel as never)
+  context.provide('llm', harness.llm as never)
+  context.provide('commands', harness.commands as never)
+  context.provide('subagents', harness.subagents as never)
+  context.provide('loader', { await: async () => {} } as never)
+  const fiber = context.plugin((pluginCtx) => applyRunner(pluginCtx, { sessionId: resumed.id }))
+  await fiber
+  await whenIdleStartedPromise
+  await disposeContext(context)
+  context = undefined
+  await settle()
+  const events = harness.retirementEvents
+  assert.ok(events.some(event => event === 'cancel:premount-whenidle-session'),
+    'the abort must cancel the agent so the pre-mount whenIdle settles')
+  assert.equal(events.filter(event => event === 'dispose:premount-whenidle-session').length, 1,
+    'the just-created owner must be retired exactly once')
+  assert.equal(probe.apps.length, 0, 'the cancelled startup must not mount a TUI')
+})
+
+test('exit with TWO queued transitions: the second quiesce is abort-aware and the current owner is retired', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-two-queued-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-two-queued-old',
+    header: { id: 'retire-two-queued-old', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('old answer'),
+  })
+  // The FIRST /new create is gated; the SECOND /new queues behind it. The
+  // second transition's quiesce targets the FIRST transition's committed
+  // child, whose whenIdle hangs (busy) — the exit must cancel it.
+  let releaseCreateA!: () => void
+  const createGateA = new Promise<void>(resolve => { releaseCreateA = resolve })
+  let createCalls = 0
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, async () => {
+    createCalls += 1
+    if (createCalls === 1) await createGateA
+  }, retirementSubagents, async (sessionId) => {
+    // The FIRST child (committed by the first /new) is busy: its whenIdle
+    // hangs in BOTH the first transition's post-commit child quiesce and
+    // the second transition's pre-commit quiesce.
+    if (sessionId !== 'retire-two-queued-old') {
+      await new Promise<void>(() => {})
+    }
+  })
+  // The SECOND create observes the lifecycle signal: the exit aborts it.
+  const agents = harness.agents as {
+    create: (options: { sessionId: unknown; signal?: AbortSignal }) => Promise<never>
+  }
+  const originalCreate = agents.create as (options: { sessionId: unknown; signal?: AbortSignal }) => Promise<never>
+  agents.create = async (options) => {
+    createCalls += 1
+    if (createCalls === 1) {
+      await createGateA
+      return originalCreate(options)
+    }
+    if (options.signal === undefined) throw new Error('test create did not receive a lifecycle signal')
+    if (options.signal.aborted) throw new Error('create cancelled')
+    return await new Promise<never>((_, reject) => {
+      options.signal!.addEventListener('abort', () => reject(new Error('create cancelled')), { once: true })
+    })
+  }
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const newHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+  assert.ok(newHandler, 'the real runner must register the /new transition command')
+  const first = newHandler()
+  const second = newHandler()
+  await settle()
+  releaseCreateA()
+  await settle()
+  // Exit: the pre-cancel (and the abort-aware quiesce) must unblock the
+  // first transition's post-commit child quiesce AND the second
+  // transition's pre-commit quiesce, the aborted create must fail the
+  // second transition, and the current owner must be retired.
+  await fiber.dispose()
+  fiber = undefined
+  await first
+  await second
+  const events = harness.retirementEvents
+  const created = harness.createdSessions.at(-1)
+  assert.ok(created, 'the first /new must create a child')
+  assert.equal(events.filter(event => event === 'dispose:retire-two-queued-old').length, 1,
+    'the original owner must be retired exactly once (first transition post-commit)')
+  assert.equal(events.filter(event => event === `dispose:${created.id}`).length, 1,
+    'the still-current first child must be retired exactly once (teardown)')
+  assert.ok(events.filter(event => event === `cancel:${created.id}`).length >= 1,
+    'the first child must be cancelled (pre-cancel and/or the abort-aware quiesce)')
+})
+
+test('exit during the post-commit child quiesce skips surface init and retires the committed child', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-child-idle-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'exit-after-commit-old',
+    header: { id: 'exit-after-commit-old', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('old answer'),
+  })
+  let releaseCreate!: () => void
+  const createGate = new Promise<void>(resolve => { releaseCreate = resolve })
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, () => createGate, retirementSubagents, async (sessionId) => {
+    // The committed child is busy: its post-commit quiesce hangs.
+    if (sessionId !== 'exit-after-commit-old') {
+      await new Promise<void>(() => {})
+    }
+  })
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  const newHandler = (harness.commands as { handler(name: string): ((...args: never[]) => unknown) | undefined }).handler('new')
+  assert.ok(newHandler, 'the real runner must register the /new transition command')
+  const transition = newHandler()
+  await settle()
+  releaseCreate()
+  await settle()
+  // The transition committed the child and is now stuck in the post-commit
+  // child quiesce. Exit: the abort-aware quiesce cancels the child, the
+  // surface init is skipped, and the committed child is retired.
+  await fiber.dispose()
+  fiber = undefined
+  await transition
+  const events = harness.retirementEvents
+  const created = harness.createdSessions.at(-1)
+  assert.ok(created, '/new must create a child session')
+  assert.equal(events.filter(event => event === 'dispose:exit-after-commit-old').length, 1,
+    'the old owner must be retired exactly once (post-commit)')
+  assert.equal(events.filter(event => event === `dispose:${created.id}`).length, 1,
+    'the committed child must be retired exactly once (teardown)')
+  assert.ok(events.filter(event => event === `cancel:${created.id}`).length >= 1,
+    'the committed child must be cancelled by the abort-aware quiesce')
 })

--- a/test/runner-session-bootstrap.test.ts
+++ b/test/runner-session-bootstrap.test.ts
@@ -3185,3 +3185,48 @@ test('a retirement flush failure warns the user on stderr (durability is not sil
   assert.ok(stderrWrites.some(write => write.includes('the latest events may not be persisted')),
     'the warning must state the durability consequence')
 })
+
+test('a retirement descendant-drain failure warns with the failing phases (not the flush wording)', async (t) => {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-retire-warn-drain-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const probe = installProbe()
+  life.defer(probe.restore)
+  let context: Context | undefined
+  let fiber: { dispose: () => Promise<unknown> } | undefined
+  life.defer(() => { if (context !== undefined) return disposeContext(context) })
+  life.defer(() => { if (fiber !== undefined) return fiber.dispose() })
+  const resumed: FakeSession = fakeSession({
+    id: 'retire-warn-drain-session',
+    header: { id: 'retire-warn-drain-session', cwd: home, createdAt: 1_700_000_000_000, version: SESSION_FORMAT_VERSION },
+    events: sessionEvents('resumed answer'),
+  })
+  // The descendant drain fails: the warning must name the failing phases,
+  // NOT use the flush-specific durability wording.
+  const harness = makeHarness(home, resumed, { provider: 'p', model: 'm' }, undefined, undefined, (events: string[]) => ({
+    drainContinuableDescendants: async () => {
+      events.push('drain:retire-warn-drain-session')
+      throw new Error('drain exploded')
+    },
+  }))
+  const stderrWrites: string[] = []
+  const originalWrite = process.stderr.write.bind(process.stderr)
+  process.stderr.write = ((chunk: unknown) => {
+    stderrWrites.push(String(chunk))
+    return true
+  }) as typeof process.stderr.write
+  life.defer(() => { process.stderr.write = originalWrite })
+  context = new Context()
+  fiber = await mountRunner(context, home, harness, { sessionId: resumed.id }, { sessionId: resumed.id })
+  await fiber.dispose()
+  fiber = undefined
+  assert.ok(stderrWrites.some(write => write.includes('session retirement failed during descendants')),
+    `the warning must name the failing phase: ${JSON.stringify(stderrWrites)}`)
+  assert.ok(!stderrWrites.some(write => write.includes('the latest events may not be persisted')),
+    'a non-flush failure must not claim a durability loss')
+})

--- a/test/transition-gate.test.ts
+++ b/test/transition-gate.test.ts
@@ -110,3 +110,31 @@ test('a transition in flight is visible to concurrent submissions (write fence)'
   await pending
   assert.equal(gate.busy, false, 'the fence lifts once the transition settles')
 })
+
+// ── exit retirement: pending covers the queued-but-not-started window ──────
+
+test('pending reports a QUEUED transition before it starts (the exit pre-cancel window)', async () => {
+  const gate = new SessionTransitionGate()
+  const block = deferred<void>()
+  // Immediately after run() returns, the task is QUEUED but not started:
+  // busy is false, pending is true — the exact window the exit pre-cancel
+  // must cover (a transition about to quiesce the old agent, whose
+  // whenIdle does not observe the lifecycle signal).
+  const first = gate.run(async () => { await block.promise })
+  assert.equal(gate.busy, false, 'the queued transition has not started yet')
+  assert.equal(gate.pending, true, 'the queued transition is pending before it starts')
+  await settle()
+  assert.equal(gate.busy, true, 'the running transition is busy')
+  assert.equal(gate.pending, true, 'the running transition is pending')
+  // A second transition queues behind the first: busy stays true (the
+  // first still runs) and pending stays true.
+  const second = gate.run(async () => {})
+  await settle()
+  assert.equal(gate.busy, true, 'the first transition still runs')
+  assert.equal(gate.pending, true, 'the queued transition keeps pending true')
+  block.resolve()
+  await first
+  await second
+  assert.equal(gate.busy, false, 'no transition runs after both settle')
+  assert.equal(gate.pending, false, 'no transition is queued after both settle')
+})


### PR DESCRIPTION
## Summary

Fixes the Direct-mode exit leak: after the TUI printed the exit hint, the
node process could linger for ~5 minutes because the Direct top-level
Agent, its continuable subagents and Agent-scoped jobs were never retired.

The fix adds a **Direct-only owned-session retirement** (fixed order
`cancel → idle → drainContinuableDescendants → final flush →
AgentHandle.dispose`, per-phase failure containment) and runs it inside the
`appExit` application-tree disposal under the DSH process-shutdown watchdog.
The exit controller is narrowed to `latch → surface cleanup → resume hint →
appExit`; a memoized coordinator is shared by every teardown path
(interactive exit, HMR/fiber unload, pre-mount abort, fatal startup catch)
and serializes through the transition gate + operation barrier. Successful
session transitions retire the old owner post-commit; a failed child create
never drains or disposes the old owner. A retirement failure (final flush,
descendant drain, handle dispose) now prints a user-visible warning on the
restored stderr (flush failures state "the latest events may not be
persisted"), guarded against both synchronous throws and async stream
errors.

## Server/client boundary

- Direct-only ownership code: `src/runtime/direct/owned-session-retirement.ts`
  (structural callbacks, zero Host coupling — client-boundary gate clean).
- No semantic-port changes (`SessionLifecycle` untouched), no Remote
  session-close RPC, no `drainContinuableDescendants` as a cross-backend
  capability. M2 stays NOT STARTED; Direct stays the only backend.
- `packages/pi-tui/**` untouched; `src/startup.ts` untouched.

## Tests

- Targeted: 113 pass / 0 fail (retirement helper 8, lifecycle 45, runner
  integration 37, transition-gate 7, rules 10, transition 5).
- Full product suite: 3666 pass / 0 fail (TAP).
- `pnpm build` / `pnpm typecheck` / `git diff --check` clean;
  client-boundary-gate ok (21 files, no new Host coupling).
- Real-process acceptance (dsh-next launcher, isolated DSH_HOME, real
  `ollama/deepseek-v4-flash:0731-cloud`): started a real continuable
  background subagent (task browser: `subagent · continuable · running`),
  exited the main TUI — the process terminated within 1 second (the field
  incident lingered ~300s) with the full ordered retirement
  (`cancel→idle→descendants→flush→dispose→complete failures=0`) and no
  remaining processes.

## Review

Reviewed through the review-fix loop (openai-codex/gpt-5.6-luna, xhigh):
all findings fixed (lifecycle races, static-rule allowlist, diag leaks,
stale docs/comments, user-visible retirement-failure warning); final
verdict **accepted, no open P0/P1/P2**.

## Commits

- `b73616a` fix: add direct owned-session retirement
- `ccd1fff` fix: retire direct sessions during tui shutdown
- `07defa2` docs: document direct shutdown ownership boundary
- `ae30c86` fix: warn the user when the exit retirement fails