### PR TITLE
feat: complete inline /skill references in prompt drafts

### DIFF
--- a/docs/client-server-migration.md
+++ b/docs/client-server-migration.md
@@ -85,6 +85,16 @@ Connection transport, or Remote upload state is implemented here.
 Locality is explicit: `/attach` and `/image` use the Client-local cwd, while
 `@` mentions remain Host/session-scoped.
 
+### Inline skill references (pre-M2 locality note)
+
+Inline skill references are Client-local input presentation backed by the
+existing skill catalog semantic port: the editor completes plain-text
+`/name` tokens from the detached `HumanSkillSummary[]` and inserts literal
+text only. Invocation is an ordinary user prompt; the Host `dsh-tool-skill`
+pre-step owns gesture resolution and body injection. A future Remote
+adapter must map the existing catalog to the official `skills.list` and must
+not add a `skill.invoke`-style TUI RPC — the input layer needs no rewrite.
+
 ### Open/opaque Assistant block presentation timing (Stage C3 / pre-M2)
 
 Stage C3 aligns the TUI's transient and durable-attempt presentation with

--- a/docs/surface-catalog.md
+++ b/docs/surface-catalog.md
@@ -79,6 +79,43 @@ follow-up read always observes the current ownership.
 | `src/surface-catalog.ts` | Frozen snapshot types; `readSurfaceCatalog(agent, signal, ctx)` — the LIVE collector (prefetch, first session, switches); scoped-override derivation; `isUserInvocable` filter; detached issues |
 | `src/skill-catalog.ts` | The single narrow seam to dsh services (plan appendix B): structural `SkillRegistryLike`/`AgentPresetsLike`, `readHumanSkillCatalog()` (snapshot-first, `list()` fallback, policy filter, freeze), `resolveColdSkillTarget()` (standing → rosterless global → degraded global + notice), `resolveLiveSkillTarget()` |
 | `src/skill-catalog-refresh.ts` | `CatalogRefreshCoordinator` (epoch + abort + latest-only commit; target-change transitions; same-target retention; standing degradation notices; dispose cancellation) and `CoalescingRefreshGate` |
+| `src/skill-reference-completion.ts` | The pure Client-local inline skill reference grammar: `extractInlineSkillPrefix()` (whitespace-boundary `/name` token classification, first-line command seat excluded) and `applyInlineSkillReference()` (replace `/query` with `/name `, one separator, cursor on it). No Context/Agent/Session/registry/Remote access |
+| `src/mentions.ts` | `MentionProvider` inline skill source: prompt-mode routing, fuzzy candidates from the detached `HumanSkillSummary[]`, query-part prefix (never `/`-prefixed), strict snapshot fence, catalog-guarded apply |
+| `src/tui-editor.ts` | The consumer-side natural trigger: the vendored editor rejects `/` as a trigger character, so the host editor re-triggers the provider on the pure classifier (same pattern as the `@`-mention trigger) |
+
+## Skill catalog consumers
+
+The human skill catalog feeds TWO independent consumers with different
+ownership:
+
+1. **Existing per-skill command wrappers** (`replaceSkillCommands` in
+   `src/commands.ts`)
+   - Direct compatibility surface: each human-invocable skill is a leading
+     slash command (`/eli5`, `/find-skills`, …) with its own completion
+     rows, claims and transition behavior.
+   - This PR does NOT migrate or retire them; they keep their own
+     completion/claim path.
+
+2. **Inline skill reference lexicon** (`currentSkillReferences` in
+   `src/commands.ts`, fed into `MentionProvider`)
+   - Client-local completion/presentation for plain-text `/name` tokens at
+     whitespace boundaries in the draft body.
+   - Consumes the SAME detached `HumanSkillSummary[]`; never loads a skill
+     body, never authorizes an invocation, and is NOT part of the command
+     `claims` — a skill reference is not a command advertisement.
+   - Submission stays an ordinary user prompt; the Host `agent/pre-step`
+     gesture is the invocation authority.
+
+Transition semantics for the inline lexicon (mirrors the wrapper rules):
+
+```text
+target-changing transition:
+  inline skill lexicon clears (no old-owner suggestions for the new owner)
+
+same-target refresh:
+  last-good inline lexicon may be retained until a successful replacement
+  (a failed/incomplete skills observation never replaces it)
+```
 
 ## Invariants (never break)
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1205,6 +1205,16 @@ export function registerTuiCommands(
   // lacks must be consumed with an explicit error, never sent to the model.
   /** The advertised names of the currently installed completion list. */
   let claims = new Set<string>()
+  /**
+   * The detached human skill catalog for INLINE skill reference completion
+   * (the plain-text `/name` lexicon). A Client presentation cache: it owns
+   * no skill body, no registry, and is NOT an authorization — the Host
+   * pre-step decides invocation. Deliberately NOT part of the command
+   * `claims`: a skill reference is not a command advertisement (the
+   * per-skill command wrappers keep their own completion/claim path, so
+   * the command plane can retire them independently later).
+   */
+  let currentSkillReferences: readonly HumanSkillSummary[] = []
   /** Slash commands whose single argument is a path: the fork's
    * `getArgumentCompletions` extension point completes it against the
    * Client-local cwd (natural typing shows candidates, Tab accepts them).
@@ -1257,6 +1267,10 @@ export function registerTuiCommands(
       // `/attach` and `/image` are Client-local. Direct mode uses the process cwd; a remote
       // adapter can keep this independent from the Host session scope.
       () => runner.cwd,
+      // The inline skill reference lexicon rides the same install: the
+      // provider completes plain-text `/name` tokens from this detached
+      // list, never from the command registry.
+      currentSkillReferences,
     )
     claims = new Set(sorted.map(command => command.name))
   }
@@ -2753,6 +2767,12 @@ export function registerTuiCommands(
     const skillsFailed = snapshot.issues.some(issue => issue.provider === 'skills')
     withCommandCommit(() => {
       if (!skillsFailed) replaceSkillCommands(snapshot.skills, scopedNames)
+      // The inline skill lexicon follows the same success rule as the
+      // wrappers: a FAILED or incomplete skills observation never replaces
+      // the current lexicon (a target change already cleared it; a
+      // same-target refresh keeps the last-good list — the coordinator's
+      // mergePartial already retained it in `snapshot.skills`).
+      if (!skillsFailed) currentSkillReferences = snapshot.skills
       savedScopedCommands = snapshot.scopedCommands
       installCompletions(mergeGlobalAndSavedScoped())
     })
@@ -2771,6 +2791,9 @@ export function registerTuiCommands(
       for (const dispose of skillDisposers.values()) dispose()
       skillDisposers.clear()
       savedScopedCommands = []
+      // The inline skill lexicon clears with the target change: the new
+      // owner's suggestions must never come from the old owner's catalog.
+      currentSkillReferences = []
       for (const name of names) {
         try {
           const dispose = commands.register({
@@ -4071,6 +4094,7 @@ export function registerTuiCommands(
     // exist before a session, so the merge base is the current global view.
     withCommandCommit(() => {
       replaceSkillCommands(initial.skills!.skills, new Set())
+      currentSkillReferences = initial.skills!.skills
       savedScopedCommands = []
       installCompletions(mergeGlobalAndSavedScoped())
     })

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -25,6 +25,7 @@ import { homedir } from 'node:os'
 import { isAbsolute, join, win32 } from 'node:path'
 import {
   CombinedAutocompleteProvider,
+  fuzzyFilter,
   type AutocompleteItem,
   type AutocompleteProvider,
   type AutocompleteSuggestions,
@@ -32,6 +33,8 @@ import {
 } from '@xmoon76/pi-tui'
 import { shellCompletionContext, suggestShellCompletion } from './shell-completion.ts'
 import { shellPrefixForMode, type EditorInputMode } from './editor-input-mode.ts'
+import { applyInlineSkillReference, extractInlineSkillPrefix } from './skill-reference-completion.ts'
+import type { HumanSkillSummary } from './skill-catalog.ts'
 import {
   classifyFileCompletionContext,
   extractAtPrefix,
@@ -294,6 +297,13 @@ export class MentionProvider implements AutocompleteProvider {
    * session scope so a future remote attach cannot make image completion read
    * the Host workspace. */
   private readonly localCwdOf: () => string
+  /** The detached human skill catalog for INLINE skill reference completion
+   * (the plain-text `/name` lexicon). A read-only Client presentation cache:
+   * it never loads a skill body, never authorizes an invocation, and is
+   * deliberately NOT part of the command `claims` — a skill reference is not
+   * a command advertisement (the per-skill command wrappers keep their own
+   * completion/claim path). */
+  private readonly skillReferences: readonly HumanSkillSummary[]
   /** The REQUEST SNAPSHOT (plan §9.2): the exact document lines + cursor
    * + mode + SCOPE of the most recent getSuggestions call that produced a
    * suggestion list. Strict file/extension results may apply ONLY when the
@@ -331,12 +341,14 @@ export class MentionProvider implements AutocompleteProvider {
     scope: MentionScope | (() => MentionScope) = { kind: 'workspace', cwd: workDir },
     localFdPath: string | null | undefined = undefined,
     localCwd: string | (() => string) = workDir,
+    skillReferences: readonly HumanSkillSummary[] = [],
   ) {
     this.workDir = workDir
     this.fileReferences = fileReferences ?? NO_HOST_REFERENCES
     this.inputModeSource = inputModeSource
     this.scopeOf = typeof scope === 'function' ? scope : () => scope
     this.localCwdOf = typeof localCwd === 'function' ? localCwd : () => localCwd
+    this.skillReferences = skillReferences
     this.inner = new CombinedAutocompleteProvider([...slashCommands], workDir, null)
     this.pathArgumentCommands = FILE_ARGUMENT_COMMANDS
     // `/attach` and `/image` discovery source: the CLIENT's own filesystem.
@@ -488,11 +500,33 @@ export class MentionProvider implements AutocompleteProvider {
     // 5. PROMPT MODE, ordinary position (plan §2.1): file completion is
     // CLOSED — `foo`, `./foo`, `../foo`, `/tmp/foo`, `hello foo` never
     // produce a file dropdown, natural or forced (a forced request is
-    // refused by shouldTriggerFileCompletion before it gets here). The ONE
-    // keeper: slash command NAME completion — a separate mechanism (plan
-    // §27) that never touches file paths.
+    // refused by shouldTriggerFileCompletion before it gets here). The
+    // keepers: the INLINE SKILL REFERENCE lexicon (the plain-text `/name`
+    // completion at whitespace token boundaries — a separate mechanism
+    // from the command plane, plan §5 Cut B) and the slash command NAME
+    // completion (plan §27) that never touches file paths.
+    const inline = extractInlineSkillPrefix(lines, cursorLine, cursorCol)
+    if (inline !== undefined) {
+      const items = this.suggestInlineSkills(inline.query)
+      if (items.length > 0) {
+        // The inline prefix is the QUERY part only — never `/`-prefixed:
+        // the vendored editor's confirm treats a `/`-prefixed prefix as a
+        // leading command and falls through to submit, while an inline
+        // accept must only insert the reference. The result binds the
+        // FULL request snapshot (strict fence), so a stale dropdown can
+        // never apply into a changed draft or a switched scope.
+        return this.withRequestSnapshot(generation, requestScope, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, { prefix: inline.query, items })
+      }
+      // No candidates: clear the snapshot (nothing to accept) — the same
+      // null-clears contract as the file path, so a later direct apply
+      // can never reuse an older request's dropdown.
+      return this.withRequestSnapshot(generation, requestScope, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, null)
+    }
+    // 6. PROMPT MODE leading command name (the FIRST logical line's
+    // command seat only — a later line's leading `/name` is an inline
+    // skill seat, never a command).
     if (options.force === true) return null
-    if (textBeforeCursor.trimStart().startsWith('/') && !textBeforeCursor.trimStart().includes(' ')) {
+    if (cursorLine === 0 && textBeforeCursor.trimStart().startsWith('/') && !textBeforeCursor.trimStart().includes(' ')) {
       try {
         const result = await this.getSlashCommandSuggestions(lines, cursorLine, cursorCol, options)
         return this.withRequestSnapshot(generation, requestScope, requestMode, requestLocalCwd, lines, cursorLine, cursorCol, result, false)
@@ -501,6 +535,19 @@ export class MentionProvider implements AutocompleteProvider {
       }
     }
     return null
+  }
+
+  /** The inline skill candidates for one query: the detached human skill
+   * catalog filtered by the fork's fuzzy matcher (never a copied fuzzy
+   * algorithm), name/label/description presentation only. The command
+   * list is deliberately NOT mixed in — a skill reference is not a
+   * command advertisement. */
+  private suggestInlineSkills(query: string): AutocompleteItem[] {
+    return fuzzyFilter([...this.skillReferences], query, skill => skill.name).map(skill => ({
+      value: skill.name,
+      label: skill.name,
+      description: skill.description,
+    }))
   }
 
   /** The vendored slash-command provider currently expects `/name` at
@@ -760,6 +807,37 @@ export class MentionProvider implements AutocompleteProvider {
         lines: resultLines,
         cursorLine: applied.cursorLine,
         cursorCol: Math.max(0, applied.cursorCol - semantic.prefixLength),
+      }
+    }
+    // INLINE SKILL REFERENCE apply (the plain-text `/name` lexicon): the
+    // suggestion prefix is the QUERY part — never `/`-prefixed, so the
+    // vendored editor's confirm does NOT fall through to submit. This
+    // branch re-verifies the slash token position (the classifier), the
+    // catalog membership AND the request snapshot before replacing
+    // `/query` with `/name ` — only the current token is touched, the
+    // suffix survives, and the cursor lands on the separator position
+    // ready to keep typing. The snapshot must be the STRICT one this
+    // provider produced (inline or extension results): a null snapshot
+    // (cleared by a null result) or a non-strict legacy shell/command
+    // snapshot (a different document/mode) must never apply here — a
+    // catalog member at an inline seat without the strict snapshot is
+    // rejected outright (identity), never handed to the fork's
+    // argument-apply (which would mangle the reference).
+    const inline = extractInlineSkillPrefix(lines, cursorLine, cursorCol)
+    if (inline !== undefined && inline.query === prefix) {
+      const isSkill = this.skillReferences.some(skill => skill.name === item.value)
+      if (isSkill && this.requestSnapshot?.strict !== true) {
+        return { lines, cursorLine, cursorCol }
+      }
+      if (isSkill) {
+        const applied = applyInlineSkillReference(currentLine, inline.slashStart, cursorCol, item.value)
+        const newLines = [...lines]
+        newLines[cursorLine] = applied.line
+        return {
+          lines: newLines,
+          cursorLine,
+          cursorCol: applied.cursorCol,
+        }
       }
     }
     return this.inner.applyCompletion(lines, cursorLine, cursorCol, item, prefix)

--- a/src/skill-reference-completion.ts
+++ b/src/skill-reference-completion.ts
@@ -1,0 +1,147 @@
+/**
+ * Pure Client-local inline skill reference completion: the plain-text
+ * `/skill-name` token grammar behind the editor's inline skill
+ * autocomplete (the 2026-09-07 next inline multi-skill plan).
+ *
+ * This module is deliberately PURE: it never reads Context, Agent,
+ * Session, filesystem, registry or Remote. It only classifies a cursor
+ * position and computes the apply replacement for a literal `/name `
+ * reference. The candidate source is the detached `HumanSkillSummary[]`
+ * catalog (fed by the app), and invocation authority stays with the Host
+ * `agent/pre-step` gesture — this module never loads, authorizes or
+ * injects a skill body.
+ *
+ * Token grammar (compatible with the upstream Host gesture
+ * `(^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)(?=\s|$)`):
+ *
+ * ```text
+ * name := [a-z0-9]+(?:-[a-z0-9]+)*
+ * ```
+ *
+ * While typing, an empty or partial query is allowed (`/`, ` /e`,
+ * ` /eli`, ` /html-`), but the WHOLE current token must stay inside the
+ * grammar: a second `/` (`/usr/bin`), a non-name character (`/eli5。`)
+ * or a non-boundary `/` (`x/eli`, `foo 5/8`) is never an inline skill
+ * seat. The FIRST logical line's leading slash-command seat (line 0 with
+ * only whitespace before the `/`) is deliberately NOT claimed here — the
+ * existing command completion owns it.
+ * @module @xmoon76/dsh-pi-tui/skill-reference-completion
+ */
+
+/** One inline skill completion seat: the `/` position and the query text
+ * between the `/` and the cursor. */
+export interface InlineSkillPrefix {
+  /** The code-unit index of the `/` that starts the token. */
+  readonly slashStart: number
+  /** The text between the `/` and the cursor ('' right after the `/`). */
+  readonly query: string
+}
+
+/** The token-boundary whitespace set: the same `\s` semantics as the
+ * upstream Host gesture `(^|\s)\/...` and the vendored editor's
+ * `isWhitespaceChar` — space, tab, newline, CR, form feed, NBSP,
+ * ideographic space (`\u3000`, common in CJK text), etc. */
+function isWhitespaceChar(char: string): boolean {
+  return /\s/.test(char)
+}
+
+/** A valid COMPLETE skill name (the upstream Host gesture grammar
+ * `[a-z0-9]+(?:-[a-z0-9]+)*` — the registry rejects anything else at
+ * registration, so a catalog name is always Host-recognizable). */
+const SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+/** A valid IN-PROGRESS skill token: empty (just typed `/`), a complete
+ * name, or a name prefix with ONE trailing hyphen (`/html-`). Anything
+ * else (`/-`, `/a--`, `/--a`, a second `/`, a non-name char) can never
+ * become a Host-recognizable name and is not a skill seat. */
+const SKILL_TOKEN = /^(?:[a-z0-9]+(?:-[a-z0-9]+)*(?:-)?)?$/
+
+/**
+ * Classify the cursor position as an inline skill reference seat.
+ *
+ * Rules (plan §5 Cut A):
+ * - the current token (bounded by whitespace / line start) must START
+ *   with a `/` at a token boundary — line start or after whitespace;
+ * - the cursor must sit AT or AFTER the `/` (a cursor before the `/` is
+ *   navigation, never a completion seat);
+ * - the WHOLE token (before AND after the cursor) must be a valid
+ *   in-progress skill name (empty, a complete name, or a name prefix
+ *   with one trailing hyphen) — a second `/`, a non-name character or a
+ *   mid-word `/` is never a skill seat;
+ * - the first logical line's leading command seat (line 0, only
+ *   whitespace before the `/`) is NOT an inline seat — the existing
+ *   command completion owns it;
+ * - the query is the text between the `/` and the cursor (the apply
+ *   replaces exactly that span).
+ *
+ * @param lines - the editor document lines.
+ * @param cursorLine - the cursor's line index.
+ * @param cursorCol - the cursor's code-unit column.
+ * @returns the seat, or undefined when the position is not an inline
+ *   skill reference.
+ */
+export function extractInlineSkillPrefix(
+  lines: readonly string[],
+  cursorLine: number,
+  cursorCol: number,
+): InlineSkillPrefix | undefined {
+  const line = lines[cursorLine] ?? ''
+  // The current token start: scan back to the last whitespace (or line
+  // start). The token is the word the cursor is inside.
+  let tokenStart = cursorCol
+  while (tokenStart > 0 && !isWhitespaceChar(line[tokenStart - 1] ?? '')) tokenStart -= 1
+  // The token must START with `/` at a token boundary, and the cursor
+  // must sit at or after the `/` (a cursor before it is navigation).
+  if (line[tokenStart] !== '/' || cursorCol <= tokenStart) return undefined
+  // The WHOLE token (after the `/`) must be a valid in-progress skill
+  // name: scan forward to the token end and validate it as one unit.
+  let tokenEnd = tokenStart + 1
+  while (tokenEnd < line.length && !isWhitespaceChar(line[tokenEnd] ?? '')) tokenEnd += 1
+  if (!SKILL_TOKEN.test(line.slice(tokenStart + 1, tokenEnd))) return undefined
+  // The first logical line's leading command seat is not an inline seat
+  // (the existing command completion owns `/name` at line start).
+  if (cursorLine === 0 && line.slice(0, tokenStart).trim() === '') return undefined
+  return {
+    slashStart: tokenStart,
+    query: line.slice(tokenStart + 1, cursorCol),
+  }
+}
+
+/**
+ * The apply replacement for one accepted inline skill reference: replace
+ * the `/` + query span with `/name` and guarantee exactly one separator
+ * whitespace after it, with the cursor on the separator position.
+ *
+ * Rules (plan §5 Cut C):
+ * - the suffix already starts with whitespace: keep it (no double space);
+ * - the suffix is empty or does not start with whitespace: insert one
+ *   space;
+ * - the cursor lands right after the separator, ready to keep typing.
+ *
+ * @param line - the current editor line.
+ * @param slashStart - the `/` index of the token (from
+ *   {@link extractInlineSkillPrefix}).
+ * @param cursorCol - the cursor column (the end of the query span).
+ * @param name - the accepted skill name.
+ * @returns the new line and cursor column.
+ */
+export function applyInlineSkillReference(
+  line: string,
+  slashStart: number,
+  cursorCol: number,
+  name: string,
+): { line: string; cursorCol: number } {
+  const before = line.slice(0, slashStart)
+  const after = line.slice(cursorCol)
+  const firstAfter = after[0]
+  const hasSeparator = firstAfter !== undefined && isWhitespaceChar(firstAfter)
+  const newLine = hasSeparator
+    ? `${before}/${name}${after}`
+    : `${before}/${name} ${after}`
+  return {
+    line: newLine,
+    // The separator is exactly one char in both branches: the kept
+    // whitespace or the inserted space.
+    cursorCol: before.length + 1 + name.length + 1,
+  }
+}

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -11091,6 +11091,10 @@ export class TuiApp {
    * @param localCwd - the Client-local base for `/image` completion. Keep it
    *   separate from the Host session cwd; a remote attach may have different
    *   local and Host filesystems. A function keeps the client base live.
+   * @param skillReferences - the detached human skill catalog for INLINE
+   *   skill reference completion (the plain-text `/name` lexicon). A
+   *   read-only Client presentation cache — never a command claim, never
+   *   an authorization; the Host pre-step owns invocation.
    */
   setCommandCompletions(
     commands: readonly SlashCommand[],
@@ -11106,6 +11110,7 @@ export class TuiApp {
     scope: import('./runtime/host-file-port.ts').HostFileScope
       | (() => import('./runtime/host-file-port.ts').HostFileScope) = { kind: 'workspace', cwd },
      localCwd: string | (() => string) = cwd,
+    skillReferences: readonly import('./skill-catalog.ts').HumanSkillSummary[] = [],
   ): void {
     const base = new MentionProvider(
       [...commands],
@@ -11115,6 +11120,7 @@ export class TuiApp {
       scope,
       undefined,
       localCwd,
+      skillReferences,
     )
     if (extensionSuggest === undefined) {
       this.editor.setAutocompleteProvider(base)

--- a/src/tui-editor.ts
+++ b/src/tui-editor.ts
@@ -27,6 +27,7 @@ import { SelectedMarquee } from './marquee.ts'
 import { color } from './theme.ts'
 import { classifyFileCompletionContext, FILE_ARGUMENT_COMMANDS } from './file-completion/context.ts'
 import { editorModeFromHistoryEntry, type EditorInputMode } from './editor-input-mode.ts'
+import { extractInlineSkillPrefix } from './skill-reference-completion.ts'
 
 /** Host render-routing options for the host editor. */
 export interface TuiEditorOptions {
@@ -402,13 +403,17 @@ export class TuiEditor extends Editor {
       // complete paste segments — recursion per segment would overflow
       // the stack. The autocomplete reopen runs AFTER the normalized
       // pastes and the residual input landed, so a pasted `@dir/` reopens
-      // like ordinary input.
+      // like ordinary input. The inline skill check runs on the POST-PASTE
+      // document state (never the raw paste event, which carries ESC and
+      // would trip the per-keystroke gate below).
       this.processPasteChunks(data)
+      this.requestInlineSkillCompletionIfSeated()
       this.reopenAutocompleteAfterInput()
       return
     }
     if (data !== '') super.handleInput(data)
     this.triggerNonstandardMentionCompletion(data)
+    this.triggerInlineSkillCompletion(data)
     this.reopenAutocompleteAfterInput()
   }
 
@@ -438,6 +443,37 @@ export class TuiEditor extends Editor {
     const quotedMention = context.query.startsWith('@"')
     const nonstandardBoundary = beforeAt !== undefined && beforeAt !== ' ' && beforeAt !== '\t'
     if (!quotedMention && !nonstandardBoundary) return
+    this.requestAutocomplete({ force: false, explicitTab: false })
+  }
+
+  /** Trigger the provider for an INLINE SKILL REFERENCE position (a
+   * `/name` token at a whitespace boundary in prompt mode). The vendored
+   * editor's generic symbol gate REJECTS `/` as a trigger character
+   * (slash commands own the line-start seat —
+   * `setAutocompleteTriggerCharacters` filters it), so the host editor
+   * re-triggers on the pure classifier — the same consumer-side pattern
+   * as {@link triggerNonstandardMentionCompletion}. The provider itself
+   * decides the candidates; this seam only opens the dropdown. */
+  private triggerInlineSkillCompletion(data: string): void {
+    const printable = decodePrintableKey(data) ?? (data.length === 1 && data.charCodeAt(0) >= 32 ? data : undefined)
+    // Escape sequences are navigation/control keys, not text, even though
+    // their bytes include printable characters (same rule as the mention
+    // trigger).
+    if (printable === undefined && data.includes('\x1b')) return
+    if (printable === undefined && ![...data].some(character => character.charCodeAt(0) >= 32)) return
+    this.requestInlineSkillCompletionIfSeated()
+  }
+
+  /** The shared post-input check: when the cursor now sits in an inline
+   * skill seat (and the dropdown is closed), open the provider. Used by
+   * the per-keystroke trigger AND the bracketed-paste path — the paste
+   * path must judge the POST-PASTE document state, never the raw paste
+   * event (which carries ESC and would trip the per-keystroke gate). */
+  private requestInlineSkillCompletionIfSeated(): void {
+    if (this.isShowingAutocomplete()) return
+    if (this.inputMode !== 'prompt') return
+    const { line, col } = this.getCursor()
+    if (extractInlineSkillPrefix(this.getLines(), line, col) === undefined) return
     this.requestAutocomplete({ force: false, explicitTab: false })
   }
 

--- a/test/input-experience.test.ts
+++ b/test/input-experience.test.ts
@@ -639,3 +639,117 @@ test('slash-command autocomplete paints the fresh list on the keystroke frame', 
   assert.ok(!view.includes('reload'), `stale list still painted after /res:\n${view}`)
   app.stop()
 })
+
+// ── inline skill reference completion (the 2026-09-07 next plan §8.3) ─────
+
+/** The detached human skill catalog for the inline integration tests. */
+const INLINE_SKILLS = [
+  { name: 'eli5', description: 'Explain like I am five' },
+  { name: 'html-maker', description: 'Make HTML' },
+  { name: 'diagnosing-skills', description: 'Diagnose skills' },
+]
+
+/** Start an app with the inline skill catalog installed. */
+function startInlineApp(): { vt: VirtualTerminal; app: TuiApp; submitted: string[] } {
+  const started = startApp()
+  started.app.setCommandCompletions(
+    [{ name: 'help', description: 'Help' }, { name: 'settings', description: 'Panel' }],
+    '/ws',
+    null,
+    undefined,
+    undefined,
+    undefined,
+    INLINE_SKILLS,
+  )
+  return started
+}
+
+test('Case A: accepting an inline skill inserts the reference and does NOT submit', async () => {
+  const { vt, app, submitted } = startInlineApp()
+  vt.sendInput('请用 /el')
+  await vt.waitForRender()
+  vt.sendInput('\r') // accept the highlighted eli5
+  await vt.waitForRender()
+  assert.equal(app.getDraft(), '请用 /eli5 ', 'the accept must insert the reference with a separator')
+  assert.deepEqual(submitted, [], 'an inline accept must never submit the draft')
+  app.stop()
+})
+
+test('Case B: one draft accepts THREE inline skills and submits the full original line once', async () => {
+  const { vt, app, submitted } = startInlineApp()
+  // 1. 你知道 /el → eli5
+  vt.sendInput('你知道 /el')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.equal(app.getDraft(), '你知道 /eli5 ', 'first reference must insert')
+  assert.deepEqual(submitted, [], 'no submit after the first accept')
+  // 2. 可以利用 /ht → html-maker
+  vt.sendInput('可以利用 /ht')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.equal(app.getDraft(), '你知道 /eli5 可以利用 /html-maker ', 'second reference must insert')
+  assert.deepEqual(submitted, [], 'no submit after the second accept')
+  // 3. 进行 /diag → diagnosing-skills
+  vt.sendInput('进行 /diag')
+  await vt.waitForRender()
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.equal(app.getDraft(), '你知道 /eli5 可以利用 /html-maker 进行 /diagnosing-skills ', 'third reference must insert')
+  assert.deepEqual(submitted, [], 'no submit after the third accept')
+  // The final real submit carries the complete original line ONCE.
+  vt.sendInput('吗!!')
+  vt.sendInput('\r')
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['你知道 /eli5 可以利用 /html-maker 进行 /diagnosing-skills 吗!!'],
+    'the final submit must be one ordinary prompt with every literal /name token')
+  app.stop()
+})
+
+test('Case C: leading slash-command Enter still submits (inline prefix workaround untouched)', async () => {
+  const { vt, app, submitted } = startInlineApp()
+  vt.sendInput('/he')
+  await vt.waitForRender()
+  vt.sendInput('\r') // accept the highlighted help command
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['/help'], 'a leading command accept must still submit')
+  app.stop()
+})
+
+test('Case D: the inline dropdown never leaks ordinary commands', async () => {
+  const { vt, app } = startInlineApp()
+  vt.sendInput('请执行 /set')
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(!view.includes('settings'), `the inline dropdown must not list commands:\n${view}`)
+  assert.ok(view.includes('请执行 /set'), `the draft must stay intact:\n${view}`)
+  app.stop()
+})
+
+test('reinstalling the completion provider cancels the open inline dropdown', async () => {
+  const { vt, app, submitted } = startInlineApp()
+  vt.sendInput('请用 /el')
+  await vt.waitForRender()
+  // The catalog owner changed: the provider is reinstalled (the editor
+  // cancels the open dropdown — setAutocompleteProvider → cancelAutocomplete).
+  app.setCommandCompletions([{ name: 'help', description: 'Help' }], '/ws', null, undefined, undefined, undefined, [])
+  await vt.waitForRender()
+  vt.sendInput('\r') // the cancelled dropdown must not accept: Enter submits the draft
+  await vt.waitForRender()
+  assert.deepEqual(submitted, ['请用 /el'], 'a reinstalled provider must cancel the old dropdown')
+  app.stop()
+})
+
+test('a bracketed paste ending in an inline skill token opens the dropdown (review finding)', async () => {
+  const { vt, app } = startInlineApp()
+  // The paste lands the draft; the post-paste state must trigger the
+  // provider like ordinary typing (the raw paste event carries ESC, which
+  // the per-keystroke trigger gate must not swallow).
+  vt.sendInput('\x1b[200~请用 /el\x1b[201~')
+  await vt.waitForRender()
+  const view = vt.getViewport().join('\n')
+  assert.ok(view.includes('eli5'), `the pasted inline token must open the dropdown:\n${view}`)
+  assert.ok(view.includes('请用 /el'), `the pasted draft must be intact:\n${view}`)
+  app.stop()
+})

--- a/test/mentions.test.ts
+++ b/test/mentions.test.ts
@@ -657,3 +657,179 @@ test('a scope switch MID-FLIGHT drops the in-flight candidate list (no cross-ses
   release!()
   assert.equal(await pending, null, 'a result resolved for the OLD session must never commit')
 })
+
+// ── inline skill reference completion (the 2026-09-07 next plan) ──────────
+
+/** The detached human skill catalog used by the inline tests. */
+const SKILLS = [
+  { name: 'eli5', description: 'Explain like I am five' },
+  { name: 'html-maker', description: 'Make HTML' },
+  { name: 'diagnosing-skills', description: 'Diagnose skills' },
+]
+
+test('inline skill completion returns ONLY skill candidates at ordinary positions', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  const provider = new MentionProvider(
+    [{ name: 'exit', description: 'Quit' }, { name: 'settings', description: 'Panel' }],
+    root,
+    fallbackSeam(),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    SKILLS,
+  )
+  const result = await provider.getSuggestions(['请用 /el'], 0, 6, { signal: abort })
+  assert.ok(result !== null, `请用 /el must suggest:\n${JSON.stringify(result)}`)
+  assert.equal(result.prefix, 'el', 'the inline prefix is the QUERY part, never /-prefixed')
+  assert.deepEqual(result.items.map(item => item.value), ['eli5'], 'only skill names, never commands')
+  assert.equal(result.items[0]!.description, 'Explain like I am five', 'the skill description rides along')
+  // A later line's leading `/` is an inline seat too.
+  const second = await provider.getSuggestions(['foo', '/ht'], 1, 3, { signal: abort })
+  assert.ok(second !== null, `line-2 /ht must suggest:\n${JSON.stringify(second)}`)
+  assert.deepEqual(second.items.map(item => item.value), ['html-maker'])
+  // An empty query lists the whole catalog (typing a bare `/`).
+  const all = await provider.getSuggestions(['请用 /'], 0, 4, { signal: abort })
+  assert.ok(all !== null, `请用 / must suggest:\n${JSON.stringify(all)}`)
+  assert.equal(all.prefix, '')
+  assert.deepEqual(all.items.map(item => item.value), ['eli5', 'html-maker', 'diagnosing-skills'])
+})
+
+test('inline skill completion never leaks commands and never claims the command seat', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  const provider = new MentionProvider(
+    [{ name: 'exit', description: 'Quit' }, { name: 'settings', description: 'Panel' }],
+    root,
+    fallbackSeam(),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    SKILLS,
+  )
+  // The inline namespace is the skill catalog ONLY: `/set` in prose must
+  // not surface the `/settings` command — with no matching skill the
+  // dropdown stays closed (a command-leaking implementation would list
+  // `settings` here).
+  const inline = await provider.getSuggestions(['请执行 /set'], 0, 8, { signal: abort })
+  assert.equal(inline, null, `请执行 /set must not leak commands:\n${JSON.stringify(inline)}`)
+  // The FIRST logical line's leading command seat stays command completion.
+  const leading = await provider.getSuggestions(['/se'], 0, 3, { signal: abort })
+  assert.ok(leading !== null, `/se must suggest:\n${JSON.stringify(leading)}`)
+  assert.ok(leading.items.some(item => item.value === 'settings'), `the command must answer the command seat:\n${JSON.stringify(leading.items)}`)
+  assert.ok(leading.items.every(item => item.value !== 'eli5'), `skills must not claim the command seat:\n${JSON.stringify(leading.items)}`)
+  // A path-like token is never a skill seat.
+  assert.equal(await provider.getSuggestions(['foo /usr/lo'], 0, 10, { signal: abort }), null)
+  assert.equal(await provider.getSuggestions(['foo 5/8'], 0, 7, { signal: abort }), null)
+})
+
+test('inline skill completion stays closed in shell mode (shell/path logic unchanged)', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  const provider = new MentionProvider(
+    [],
+    root,
+    fallbackSeam(),
+    () => 'shell-context',
+    undefined,
+    undefined,
+    undefined,
+    SKILLS,
+  )
+  const result = await provider.getSuggestions(['请用 /el'], 0, 6, { signal: abort })
+  assert.ok(result === null || result.items.every(item => item.value !== 'eli5'),
+    `shell mode must never answer inline skills:\n${JSON.stringify(result)}`)
+})
+
+test('inline skill accept applies the reference and never submits', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  const provider = new MentionProvider([], root, fallbackSeam(), undefined, undefined, undefined, undefined, SKILLS)
+  const result = await provider.getSuggestions(['请用 /el'], 0, 6, { signal: abort })
+  assert.ok(result !== null)
+  const applied = provider.applyCompletion(['请用 /el'], 0, 6, result.items[0]!, result.prefix)
+  assert.deepEqual(applied, { lines: ['请用 /eli5 '], cursorLine: 0, cursorCol: 9 },
+    'the accept must insert the reference with a separator and keep the draft')
+  // A non-skill item value is never applied as an inline reference: the
+  // inline branch requires catalog membership, so a foreign value falls
+  // through to the fork's argument-apply (the pre-existing fallback).
+  const foreign = provider.applyCompletion(['请用 /el'], 0, 6, { value: 'not-a-skill', label: 'not-a-skill' }, 'el')
+  assert.deepEqual(foreign, { lines: ['请用 /not-a-skill'], cursorLine: 0, cursorCol: 15 },
+    'a value outside the skill catalog must not take the inline path')
+  // A suffix already separated by whitespace keeps exactly one space.
+  const spaced = await provider.getSuggestions(['请用 /el 看看'], 0, 6, { signal: abort })
+  assert.ok(spaced !== null)
+  const appliedSpaced = provider.applyCompletion(['请用 /el 看看'], 0, 6, spaced.items[0]!, spaced.prefix)
+  assert.deepEqual(appliedSpaced, { lines: ['请用 /eli5 看看'], cursorLine: 0, cursorCol: 9 })
+})
+
+test('a scope switch fences the open inline dropdown (no stale accept)', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  let scope: import('../src/mentions.ts').MentionScope = { kind: 'workspace', cwd: root }
+  const provider = new MentionProvider([], root, fallbackSeam(), undefined, () => scope, undefined, undefined, SKILLS)
+  const result = await provider.getSuggestions(['请用 /el'], 0, 6, { signal: abort })
+  assert.ok(result !== null)
+  // The session/workspace generation changes while the dropdown is open.
+  scope = { kind: 'workspace', cwd: '/other-workspace' }
+  const applied = provider.applyCompletion(['请用 /el'], 0, 6, result.items[0]!, result.prefix)
+  assert.deepEqual(applied, { lines: ['请用 /el'], cursorLine: 0, cursorCol: 6 },
+    'a switched scope must fence the old dropdown')
+})
+
+test('a changed draft fences the open inline dropdown (no stale accept)', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  const provider = new MentionProvider([], root, fallbackSeam(), undefined, undefined, undefined, undefined, SKILLS)
+  const result = await provider.getSuggestions(['请用 /el'], 0, 6, { signal: abort })
+  assert.ok(result !== null)
+  // The user typed more after the dropdown opened: the strict snapshot
+  // fence must reject the accept.
+  const applied = provider.applyCompletion(['请用 /eli'], 0, 7, result.items[0]!, result.prefix)
+  assert.deepEqual(applied, { lines: ['请用 /eli'], cursorLine: 0, cursorCol: 7 },
+    'a changed draft must fence the old dropdown')
+})
+
+test('an inline no-match clears the previous snapshot (no stale accept after null)', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  const provider = new MentionProvider([], root, fallbackSeam(), undefined, undefined, undefined, undefined, SKILLS)
+  const result = await provider.getSuggestions(['请用 /el'], 0, 6, { signal: abort })
+  assert.ok(result !== null, `请用 /el must suggest:\n${JSON.stringify(result)}`)
+  // A later request at an inline seat with NO matching candidates returns
+  // null and must clear the snapshot (the null-clears contract).
+  assert.equal(await provider.getSuggestions(['请用 /zz'], 0, 6, { signal: abort }), null)
+  // The old dropdown must no longer apply — even to the exact document
+  // state that produced it.
+  const applied = provider.applyCompletion(['请用 /el'], 0, 6, result.items[0]!, result.prefix)
+  assert.deepEqual(applied, { lines: ['请用 /el'], cursorLine: 0, cursorCol: 6 },
+    'a null result must clear the previous inline snapshot')
+})
+
+test('a NON-STRICT legacy snapshot never feeds the inline apply (shell/command leak)', async (t) => {
+  const life = testLifecycle(t)
+  const root = fixtureWorkspace(life)
+  // The command `git` and the skill `git` share a name: a stale non-strict
+  // command snapshot must not be consumable at an inline seat.
+  const provider = new MentionProvider(
+    [{ name: 'git', description: 'VCS' }],
+    root,
+    fallbackSeam(),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    [{ name: 'git', description: 'Git skill' }],
+  )
+  // The command seat produces a NON-STRICT snapshot (strict=false).
+  const command = await provider.getSuggestions(['/gi'], 0, 3, { signal: abort })
+  assert.ok(command !== null, `/gi must suggest:\n${JSON.stringify(command)}`)
+  assert.ok(command.items.some(item => item.value === 'git'))
+  // A later inline accept at a DIFFERENT document position must be
+  // rejected: the snapshot is not the strict inline one.
+  const applied = provider.applyCompletion(['foo /g'], 0, 6, { value: 'git', label: 'git' }, 'g')
+  assert.deepEqual(applied, { lines: ['foo /g'], cursorLine: 0, cursorCol: 6 },
+    'a non-strict legacy snapshot must never feed the inline apply')
+})

--- a/test/skill-reference-completion.test.ts
+++ b/test/skill-reference-completion.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the pure inline skill reference completion grammar:
+ * token classification and the apply replacement (the 2026-09-07 next
+ * inline multi-skill plan §8.1).
+ * @module @xmoon76/dsh-pi-tui/skill-reference-completion.test
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { applyInlineSkillReference, extractInlineSkillPrefix } from '../src/skill-reference-completion.ts'
+
+test('extractInlineSkillPrefix finds inline skill tokens at whitespace boundaries', () => {
+  // `请用 /` — the `/` after a space is an inline seat with an empty query.
+  assert.deepEqual(extractInlineSkillPrefix(['请用 /'], 0, 4), { slashStart: 3, query: '' })
+  assert.deepEqual(extractInlineSkillPrefix(['请用 /e'], 0, 5), { slashStart: 3, query: 'e' })
+  assert.deepEqual(extractInlineSkillPrefix(['foo /eli'], 0, 8), { slashStart: 4, query: 'eli' })
+  // A later line's leading `/` is an inline seat (only the FIRST logical
+  // line's leading command seat belongs to command completion).
+  assert.deepEqual(extractInlineSkillPrefix(['foo', '/eli'], 1, 4), { slashStart: 0, query: 'eli' })
+  // Hyphenated names complete like the Host gesture grammar.
+  assert.deepEqual(extractInlineSkillPrefix(['foo /html-maker'], 0, 15), { slashStart: 4, query: 'html-maker' })
+  // A trailing hyphen is a legal in-progress query.
+  assert.deepEqual(extractInlineSkillPrefix(['foo /html-'], 0, 10), { slashStart: 4, query: 'html-' })
+  // The cursor may sit MID-token: the query is the text before the cursor,
+  // the rest of the token stays untouched by the apply.
+  assert.deepEqual(extractInlineSkillPrefix(['请用 /eli5'], 0, 7), { slashStart: 3, query: 'eli' })
+})
+
+test('extractInlineSkillPrefix never claims the first-line leading command seat', () => {
+  assert.equal(extractInlineSkillPrefix(['/eli'], 0, 4), undefined, 'a line-start command seat is not inline')
+  assert.equal(extractInlineSkillPrefix(['/'], 0, 1), undefined, 'a bare line-start slash is not inline')
+  assert.equal(extractInlineSkillPrefix(['   /eli'], 0, 7), undefined, 'an indented command seat is not inline')
+  assert.equal(extractInlineSkillPrefix(['   /'], 0, 4), undefined, 'an indented bare slash is not inline')
+})
+
+test('extractInlineSkillPrefix rejects non-skill tokens', () => {
+  // A `/` glued to a word is not a token boundary.
+  assert.equal(extractInlineSkillPrefix(['x/eli'], 0, 5), undefined)
+  assert.equal(extractInlineSkillPrefix(['foo 5/8'], 0, 7), undefined)
+  // A second `/` inside the token is a path, never a skill.
+  assert.equal(extractInlineSkillPrefix(['/usr/bin'], 1, 8), undefined, 'a path token on a later line is not a skill')
+  assert.equal(extractInlineSkillPrefix(['foo /usr/bin'], 0, 11), undefined)
+  // A non-name character ends the grammar: `/eli5。` has no legal
+  // whitespace/end boundary yet, so it is not a completion seat.
+  assert.equal(extractInlineSkillPrefix(['请用 /eli5。'], 0, 8), undefined)
+  assert.equal(extractInlineSkillPrefix(['foo /eli5.'], 0, 10), undefined)
+  // Uppercase is outside the Host gesture grammar.
+  assert.equal(extractInlineSkillPrefix(['foo /ELI'], 0, 8), undefined)
+  // Tokens that can never become a Host-recognizable name are not seats:
+  // a bare hyphen, a double hyphen, or a leading hyphen.
+  assert.equal(extractInlineSkillPrefix(['foo /-'], 0, 5), undefined)
+  assert.equal(extractInlineSkillPrefix(['foo /a--'], 0, 7), undefined)
+  assert.equal(extractInlineSkillPrefix(['foo /--a'], 0, 7), undefined)
+  // No `/` at all: ordinary prose.
+  assert.equal(extractInlineSkillPrefix(['请用 eli'], 0, 6), undefined)
+  assert.equal(extractInlineSkillPrefix([''], 0, 0), undefined)
+})
+
+test('extractInlineSkillPrefix never claims a seat when the cursor is BEFORE the slash', () => {
+  // `foo |/el` — the cursor sits on the `/` (navigation, not completion).
+  assert.equal(extractInlineSkillPrefix(['foo /el'], 0, 4), undefined)
+  // A later line with the cursor at column 0 (before the `/`) is not a
+  // seat either.
+  assert.equal(extractInlineSkillPrefix(['foo', '/el'], 1, 0), undefined)
+  // The cursor AT or AFTER the `/` still completes.
+  assert.deepEqual(extractInlineSkillPrefix(['foo /el'], 0, 5), { slashStart: 4, query: '' })
+  assert.deepEqual(extractInlineSkillPrefix(['foo /el'], 0, 7), { slashStart: 4, query: 'el' })
+})
+
+test('extractInlineSkillPrefix uses the Host \\s whitespace semantics (ideographic space)', () => {
+  // A full-width ideographic space (`\u3000`, common in CJK text) is a
+  // token boundary for the Host gesture `(^|\s)\/` — the classifier must
+  // agree.
+  assert.deepEqual(extractInlineSkillPrefix(['请用\u3000/el'], 0, 6), { slashStart: 3, query: 'el' })
+  assert.deepEqual(extractInlineSkillPrefix(['请用\u3000/'], 0, 4), { slashStart: 3, query: '' })
+  // NBSP is a boundary too.
+  assert.deepEqual(extractInlineSkillPrefix(['foo\u00a0/el'], 0, 7), { slashStart: 4, query: 'el' })
+})
+
+test('applyInlineSkillReference keeps a \\s separator without adding an ASCII space', () => {
+  // A suffix starting with an ideographic space keeps it (no double
+  // separator), the cursor lands on the separator position.
+  assert.deepEqual(applyInlineSkillReference('请用 /el\u3000看看', 3, 6, 'eli5'), { line: '请用 /eli5\u3000看看', cursorCol: 9 })
+  // An NBSP suffix behaves the same.
+  assert.deepEqual(applyInlineSkillReference('请用 /el\u00a0看看', 3, 6, 'eli5'), { line: '请用 /eli5\u00a0看看', cursorCol: 9 })
+})
+
+test('extractInlineSkillPrefix ignores tokens before the cursor', () => {
+  // The cursor is past the token: the current token is `看看` — no seat.
+  assert.equal(extractInlineSkillPrefix(['请用 /eli5 看看'], 0, 11), undefined)
+  // The cursor sits on the whitespace AFTER a completed reference: the
+  // current token is empty — no seat (the reference is already complete).
+  assert.equal(extractInlineSkillPrefix(['请用 /eli5 '], 0, 9), undefined)
+})
+
+test('applyInlineSkillReference replaces only the current token and keeps the suffix', () => {
+  // No suffix: insert the separator space, cursor after it.
+  assert.deepEqual(applyInlineSkillReference('请用 /el', 3, 6, 'eli5'), { line: '请用 /eli5 ', cursorCol: 9 })
+  // Suffix already starts with whitespace: keep it (no double space), the
+  // cursor lands on the separator position.
+  assert.deepEqual(applyInlineSkillReference('请用 /el 看看', 3, 6, 'eli5'), { line: '请用 /eli5 看看', cursorCol: 9 })
+  // Suffix without whitespace: insert one space, the suffix survives.
+  assert.deepEqual(applyInlineSkillReference('请用 /el看看', 3, 6, 'eli5'), { line: '请用 /eli5 看看', cursorCol: 9 })
+  // Multi-byte (CJK) text before the token: code-unit cursor math stays
+  // correct (each BMP char is one code unit).
+  assert.deepEqual(applyInlineSkillReference('看看 /el', 3, 6, 'eli5'), { line: '看看 /eli5 ', cursorCol: 9 })
+  // A later-line token: the line is replaced in isolation.
+  assert.deepEqual(applyInlineSkillReference('/el', 0, 3, 'eli5'), { line: '/eli5 ', cursorCol: 6 })
+  // A tab separator is kept like any whitespace.
+  assert.deepEqual(applyInlineSkillReference('foo /el\tbar', 4, 7, 'eli5'), { line: 'foo /eli5\tbar', cursorCol: 10 })
+})


### PR DESCRIPTION
## What

Implements **inline skill reference completion** on `next` (the 2026-09-07 inline multi-skill plan): in a prompt-mode draft, a plain-text `/name` token at a whitespace boundary completes against the detached human skill catalog. Accepting inserts the literal `/name ` reference **without submitting**; the final ordinary submit lets the Host `dsh-tool-skill` pre-step inject every recognized skill — the TUI never loads, authorizes or injects a skill body.

```text
你知道 /eli5 可以利用 /html-maker 进行 /diagnosing-skills 吗!!
```

- `src/skill-reference-completion.ts` (new, pure): token grammar (`[a-z0-9]+(?:-[a-z0-9]+)*`, in-progress prefixes incl. one trailing hyphen), whitespace-boundary classification (`\s` semantics, first-line command seat excluded, cursor at/after the `/`), apply math (replace only the current token, one separator, cursor on it).
- `src/mentions.ts`: `MentionProvider` inline source — prompt-mode routing before the leading-command branch (now first-line only), candidates via the fork's `fuzzyFilter`, **query-part prefix (never `/`-prefixed)** so the vendored editor's Enter-confirm never falls through to submit, strict request-snapshot fence, catalog-guarded apply (strict snapshot required; non-skill items keep the pre-existing fallback).
- `src/tui-editor.ts`: consumer-side natural trigger (the vendored editor filters `/` as a trigger character, so the host editor re-triggers on the pure classifier — same pattern as the `@`-mention trigger; paste path checks the post-paste document state).
- `src/tui-app.ts` / `src/commands.ts`: optional `skillReferences` seam; detached lexicon kept alongside the catalog commit (initial snapshot / cold standing / live commit with the `!skillsFailed` guard), cleared on target-changing transitions, **never part of command claims**.
- Docs: `docs/surface-catalog.md` (two-consumer split + transition semantics), `docs/client-server-migration.md` (locality note; M2 stays NOT STARTED).

## Why

The TUI modeled skills mainly as leading slash commands; a draft-body `/skill` reference had no completion, and repeated references in one prompt were awkward. The Host already owns multi-skill gesture resolution (`agent/pre-step`), so this PR only produces correct plain-text prompts — no new RPC, no Host coupling, no vendor changes.

## Verification

- Tests: pure grammar 8, mentions 44, input-experience 33 (Case A accept-not-submit, Case B three accepts → one submit, Case C leading command unchanged, Case D no command leak, reinstall cancels dropdown, paste trigger, fence/grammar regressions).
- Gates: `pnpm build`, `pnpm typecheck:bundle`, `node scripts/client-boundary-gate.mjs` (PASS, no baseline change), `pnpm test:product` (3684 pass / 0 fail), `git diff --check`.
- Real Direct smoke (tmux, isolated DSH_HOME, 3 local skills): three inline accepts without premature submit → one ordinary prompt → Host injected 3 `skill-invocation` events; repeated same-name gesture deduped by Host; unknown `/not-a-real-skill` stayed plain text; leading `/he` command unchanged.
- Review loop: 4 rounds, all P2 findings fixed with pre-fix-failing regression tests, final verdict **accepted**.
