### PR TITLE
chore: retire redundant pi-tui divergences (X012, X019)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,9 +147,19 @@ When entering a development worktree:
 pnpm dev:doctor
 ```
 
-Use `pnpm dev:bootstrap` only when the environment is not ready. Keep each
-worktree's `node_modules` and `dist` independent; never symlink them, and build
-in that worktree before using a profile.
+Use `pnpm dev:bootstrap` only when the environment is not ready. On a
+source-mode worktree (a worktree whose tracked `test/compat/dsh-mode.json`
+selects `source` — `next` is not always source-mode), a plain `pnpm install`
+before bootstrap leaves the DSH workspace state incorrect (`workspace DSH
+incorrect` / `local state missing`); run `pnpm dev:doctor` first and let
+`pnpm dev:bootstrap` perform the dependency install itself, then re-run
+`pnpm dev:doctor` until it reports `READY`. A plain `pnpm install` after
+bootstrap re-resolves `@deepseek-ai/*` to registry versions and breaks the
+source-mode workspace again; use `pnpm dev:shell` (or
+`source ./.dsh-dev-env`) for commands that need the source environment, and
+re-run `pnpm dev:bootstrap` after any real install. Keep each worktree's
+`node_modules` and `dist` independent; never symlink them, and build in that
+worktree before using a profile.
 
 * `main` is the released npm-backed compatibility line; `next` is the
   forward-integration line and may use its tracked Source Mode.

--- a/packages/pi-tui/DIVERGENCES.md
+++ b/packages/pi-tui/DIVERGENCES.md
@@ -13,8 +13,8 @@
 
 ## Audit snapshot
 
-- Audited local source commit: `5709dfc1a1f7b36abc314d8cfb87e68fd3226557`
-- Branch audited: `feat/searchable-picker-host-migration-next`
+- Audited local source commit: `6a5857dd5c0b8ab1242a32fbcc428196eecf3e5e`
+- Branch audited: `chore/retire-pi-divergences-x012-x019`
 - Audit date: `2026-09-07`
 - Upstream reference snapshot: `earendil-works/pi@b8b873b9872db04a938fb4357b5e8e824ddc051c`
 - Kimi reference snapshot: `MoonshotAI/kimi-code@9e881528a89945a373002b0b229f91735e8f2c4f`
@@ -26,6 +26,7 @@
 - Ran focused deletion experiments for X019, X030, X037, X038, X043, and X044; existing checks caught the first five, while X044 required a compile-only subclass fixture.
 - Historical removed and absorbed records were retained as explicit records instead of disappearing from the manifest.
 - PR1 relocation audit: X001/X002/X041 moved to the Host SearchablePicker (src/searchable-picker.ts) with the vendored SelectList restored to the pinned baseline; X042 narrowed to the SettingsList seam. The audit was performed against the immutable local source snapshot recorded in verification.auditedSourceCommit.
+- PR2 retirement audit: X012's explicit fuzzy tie-break was removed in favor of the supported stable-sort runtime contract; X019's Text no-op dispose shim was removed while Loader-owned X007 timer cleanup remained direct and guarded.
 
 ## Audit rules
 
@@ -62,8 +63,9 @@
 - `DELIBERATELY_KEPT`: `X030` — A host copy of decodePrintableKey would duplicate the implementation; the package exports map exposes only the root entry.
 - `MOVED_TO_HOST`: `X001`, `X002`, `X041` — The DSH searchable picker behavior moved to the Host-owned src/searchable-picker.ts SearchablePicker (guarded by test/searchable-picker.test.ts); the vendored SelectList is restored to the pinned upstream baseline.
 - `NOT_MOVABLE`: `X042` — The remaining X042 seam is SettingsList focus/row-budget propagation inside the vendored fork; the SelectList-side Input focus ownership moved to the Host SearchablePicker.
-- `NOT_MOVABLE`: `X004A`, `X004B`, `X005`, `X006`, `X007`, `X008`, `X009`, `X010`, `X011`, `X012`, `X014`, `X016`, `X018`, `X019`, `X020`, `X021`, `X022`, `X023`, `X024`, `X025`, `X027`, `X028`, `X029`, `X031`, `X032`, `X033`, `X034`, `X035`, `X036`, `X037`, `X038`, `X039`, `X040`, `X043`, `X044`, `X045`, `X046`, `X047` — The behavior is vendor-internal, terminal-owned, protocol-owned, performance-owned, or requires metadata unavailable at a host wrapper boundary.
-- `UPSTREAM_LEVER`: `X005`, `X006`, `X007`, `X008`, `X012`, `X014`, `X016`, `X021`, `X033`, `X035` — Generic improvements may be proposed upstream; an upstream issue or similar implementation is not absorption evidence.
+- `NOT_MOVABLE`: `X004A`, `X004B`, `X005`, `X006`, `X007`, `X008`, `X009`, `X010`, `X011`, `X014`, `X016`, `X018`, `X020`, `X021`, `X022`, `X023`, `X024`, `X025`, `X027`, `X028`, `X029`, `X031`, `X032`, `X033`, `X034`, `X035`, `X036`, `X037`, `X038`, `X039`, `X040`, `X043`, `X044`, `X045`, `X046`, `X047` — The behavior is vendor-internal, terminal-owned, protocol-owned, performance-owned, or requires metadata unavailable at a host wrapper boundary.
+- `UPSTREAM_LEVER`: `X005`, `X006`, `X007`, `X008`, `X014`, `X016`, `X021`, `X033`, `X035` — Generic improvements may be proposed upstream; an upstream issue or similar implementation is not absorption evidence.
+- `SUPERSEDED`: `X012`, `X019` — X012's explicit fuzzy tie-break is redundant under the supported stable-sort runtime contract; X019's Text no-op dispose shim is replaced by Loader-owned X007 cleanup without a base super call.
 
 ## Removed or superseded legacy surfaces
 
@@ -78,7 +80,7 @@
 ## Summary
 
 - Records: 48
-- Statuses: `ABSORBED_UPSTREAM`: 3, `ACTIVE`: 38, `MOVED_TO_HOST`: 3, `REDUNDANT_SHIM`: 1, `REMOVED_UNUSED`: 2, `RETIREMENT_CANDIDATE`: 1
+- Statuses: `ABSORBED_UPSTREAM`: 3, `ACTIVE`: 38, `MOVED_TO_HOST`: 3, `REMOVED_UNUSED`: 2, `SUPERSEDED`: 2
 
 | ID | Status | Risk | Categories | Upstream equivalence |
 | --- | --- | --- | --- | --- |
@@ -94,14 +96,14 @@
 | X009 | ACTIVE | MEDIUM | BUGFIX_MISSING_UPSTREAM | NO |
 | X010 | ACTIVE | MEDIUM | BUGFIX_MISSING_UPSTREAM | NO |
 | X011 | ACTIVE | MEDIUM | BUGFIX_MISSING_UPSTREAM | NO |
-| X012 | RETIREMENT_CANDIDATE | LOW | BUGFIX_MISSING_UPSTREAM | YES |
+| X012 | SUPERSEDED | LOW | BUGFIX_MISSING_UPSTREAM | YES |
 | X013 | REMOVED_UNUSED | MEDIUM | BUGFIX_MISSING_UPSTREAM | YES |
 | X014 | ACTIVE | MEDIUM | PERF_HOST_DEPENDENT | NO |
 | X015 | ABSORBED_UPSTREAM | LOW | BUGFIX_MISSING_UPSTREAM | YES |
 | X016 | ACTIVE | CRITICAL | BUGFIX_MISSING_UPSTREAM | NO |
 | X017 | ABSORBED_UPSTREAM | LOW | LOCAL_UX | YES |
 | X018 | ACTIVE | HIGH | HARD_HOST_API | NO |
-| X019 | REDUNDANT_SHIM | HIGH | HARD_HOST_API, PUBLIC_COMPONENT_CONTRACT | NO |
+| X019 | SUPERSEDED | HIGH | HARD_HOST_API, PUBLIC_COMPONENT_CONTRACT | PARTIAL |
 | X020 | ACTIVE | HIGH | HARD_HOST_API | NO |
 | X021 | ACTIVE | HIGH | BUGFIX_MISSING_UPSTREAM | PARTIAL |
 | X022 | ACTIVE | HIGH | HARD_HOST_API | NO |
@@ -682,7 +684,7 @@ Forward word navigation should cross leading punctuation at the next word-like s
 - Status: `ACTIVE`
 - Category: `HARD_HOST_API`, `PUBLIC_COMPONENT_CONTRACT`
 - Risk: `CRITICAL`
-- Files: `src/tui.ts`, `src/components/scroll-view.ts`, `src/components/text.ts`, `src/components/loader.ts`, `src/components/box.ts`, `src/components/settings-list.ts`, `src/components/stack.ts`
+- Files: `src/tui.ts`, `src/components/scroll-view.ts`, `src/components/loader.ts`, `src/components/box.ts`, `src/components/settings-list.ts`, `src/components/stack.ts`
 - Last audited: `2026-09-03`
 - Baseline compared: `earendil-works/pi@b79e4cc834970cca69daebffab7df1da7d1e52c4`
 
@@ -704,7 +706,7 @@ The host owns timers, callbacks, child components, submenu slots, and overlay le
 - Audit note: The patch is an ownership graph, not one helper.
 
 **Inheritance / structural**
-- Loader extends Text and historically used Text.dispose as an inheritance shim (X019).
+- Loader extends Text; the X019 Text.dispose shim was retired (PR2) and Loader.dispose owns the timer cleanup directly.
 - ScrollView and Stack override container lifecycle methods.
 - Audit note: Override and super edges were checked before any retirement classification.
 
@@ -1066,16 +1068,16 @@ Input must render a clipped prompt at tiny widths instead of emitting an overwid
 
 ### X012 — Deterministic fuzzy tie sort
 
-- Status: `RETIREMENT_CANDIDATE`
+- Status: `SUPERSEDED`
 - Category: `BUGFIX_MISSING_UPSTREAM`
 - Risk: `LOW`
 - Files: `src/fuzzy.ts`
-- Last audited: `2026-09-03`
+- Last audited: `2026-09-07`
 - Baseline compared: `earendil-works/pi@b79e4cc834970cca69daebffab7df1da7d1e52c4`
 
 #### Why it exists
 
-The local comparator explicitly preserves input order for equal fuzzy scores. Supported Node engines guarantee stable Array.prototype.sort, so the explicit tie term may be redundant but must be checked as a semantic runtime assumption.
+The local comparator explicitly preserved input order for equal fuzzy scores. Supported Node engines guarantee stable Array.prototype.sort, so the explicit tie term was redundant and has been removed (PR2).
 
 #### Changed surface
 
@@ -1118,7 +1120,7 @@ The local comparator explicitly preserves input order for equal fuzzy scores. Su
 - packages/tui/package.json
 - Relevant issues/PRs:
 - None recorded; issue/PR state was not used as semantic proof.
-- Remaining semantic delta: With the package's supported Node engine, upstream score-only sort is stable and preserves the same input-order ties. The explicit index comparator is therefore runtime-equivalent, subject to the engine and input-order assumptions recorded here.
+- Remaining semantic delta: With the package's supported Node engine, upstream score-only sort is stable and preserves the same input-order ties. The explicit index comparator was therefore runtime-equivalent and has been removed. Semantic equivalence relies on the supported runtime stable-sort guarantee; this is not evidence of a new upstream implementation.
 
 #### Retirement conditions
 
@@ -1127,16 +1129,19 @@ The local comparator explicitly preserves input order for equal fuzzy scores. Su
 
 #### Replacement mapping
 
-- None recorded.
+- fuzzyFilter explicit index tie-break -> supported Node/ECMAScript stable-sort state -> packages/pi-tui/test/fuzzy.test.ts equal-score ordering test
 
 #### Retirement evidence
 
-- None recorded.
+- supported engine range is Node >=22.19 / >=24 (root and pi-tui package engines)
+- fuzzy.ts restored byte-identical to pinned upstream b79e4cc (blob 73c10dcf4b134bfefba2978281b2a6f94352c5b8)
+- existing equal-score regression remains green after deletion (packages/pi-tui/test/fuzzy.test.ts)
+- fork typecheck/test/build, surface compat, divergence ledger, strict vendor diff, root build/typecheck/test:bundle green
 
 #### Audit record
 
 - Scope: `vendor-internal`, `inheritance-structural`, `host`, `public-extension`, `behavioral`, `tests`
-- Notes: Candidate only. Current package.json declares the stable-sort-capable Node floor; source comparison confirmed upstream still uses score-only sort. The equal-score fixture now guards input-order preservation; behavior was not changed in this ledger task.
+- Notes: Retired in PR2: the explicit index tie-break was removed and fuzzy.ts restored byte-identical to the pinned upstream. Equal-score input order is preserved by the supported ECMAScript stable-sort guarantee and remains guarded by the equal-score regression; this is not evidence of a new upstream implementation.
 
 ### X013 — setIndicator never revives a stopped loader
 
@@ -1593,16 +1598,16 @@ The host needs single-cell fullscreen clicks for click-to-expand. Double-click s
 
 ### X019 — Text no-op dispose inheritance shim
 
-- Status: `REDUNDANT_SHIM`
+- Status: `SUPERSEDED`
 - Category: `HARD_HOST_API`, `PUBLIC_COMPONENT_CONTRACT`
 - Risk: `HIGH`
 - Files: `src/components/text.ts`
-- Last audited: `2026-09-03`
+- Last audited: `2026-09-07`
 - Baseline compared: `earendil-works/pi@b79e4cc834970cca69daebffab7df1da7d1e52c4`
 
 #### Why it exists
 
-Text.dispose is currently a no-op solely so Loader's dispose override and super.dispose call typecheck. The inheritance edge is real, but the base no-op can be removed by an atomic Loader cleanup.
+Text.dispose was a no-op solely so Loader's dispose override and super.dispose call typechecked. The inheritance edge was real, but the base no-op has been removed by an atomic Loader cleanup (PR2).
 
 #### Changed surface
 
@@ -1640,14 +1645,14 @@ Text.dispose is currently a no-op solely so Loader's dispose override and super.
 #### Upstream comparison
 
 - Baseline: `earendil-works/pi@b79e4cc834970cca69daebffab7df1da7d1e52c4`
-- Semantic equivalence: `NO`
+- Semantic equivalence: `PARTIAL`
 - Reference snapshot: `earendil-works/pi@b8b873b9872db04a938fb4357b5e8e824ddc051c`
 - Relevant upstream files:
 - packages/tui/src/components/text.ts
 - packages/tui/src/components/loader.ts
 - Relevant issues/PRs:
 - None recorded; issue/PR state was not used as semantic proof.
-- Remaining semantic delta: Upstream has neither the local Component disposal contract nor the current Text/Loader shim. Restoring upstream wholesale would remove the broader X007 lifecycle behavior.
+- Remaining semantic delta: Upstream Text has no dispose member, and the local Text now matches upstream byte-identically. Loader disposal remains intentionally local under X007: Loader.dispose owns the timer cleanup directly without a base super call.
 
 #### Retirement conditions
 
@@ -1656,17 +1661,20 @@ Text.dispose is currently a no-op solely so Loader's dispose override and super.
 
 #### Replacement mapping
 
-- Atomic replacement: Text.dispose no-op -> no base method; Loader.dispose remains the owning cleanup and calls stop directly without super.dispose.
+- Text.dispose no-op + Loader super.dispose chain -> X007 Loader.dispose owner keeps timer-cleanup state directly -> packages/pi-tui/test/dispose-lifecycle.test.ts
 
 #### Retirement evidence
 
-- Current source proves a live Loader -> Text.dispose -> super.dispose inheritance edge.
-- Deletion experiment: temporarily removing Text.dispose made the package typecheck fail in loader.ts with TS4113/TS2339 because Loader's override and super.dispose call lost their base member; the existing lifecycle tests remained green.
+- text.ts restored byte-identical to pinned upstream b79e4cc (blob 7a50e2721028d544f641ab5f66ef1b752ff6d1f7)
+- Loader.dispose remains and calls stop() directly; no override keyword and no super.dispose() remain
+- package typecheck green (no inheritance type errors after removing the base member)
+- dispose-lifecycle tests green (Loader cleanup and idempotency)
+- surface compatibility + divergence ledger + strict vendor diff + root build/typecheck/test:bundle green
 
 #### Audit record
 
 - Scope: `vendor-internal`, `inheritance-structural`, `host`, `public-extension`, `behavioral`, `tests`
-- Notes: Classified as REDUNDANT_SHIM rather than unused. It remains active until the dedicated atomic cleanup is implemented and verified.
+- Notes: Retired in PR2: Text.dispose was removed and text.ts restored byte-identical to the pinned upstream. Loader keeps the real X007 timer cleanup directly (dispose -> stop -> clearInterval) without override/super.dispose; the X019 base-class shim is gone while Loader disposal remains intentionally local under X007.
 
 ### X020 — Editor clearHistory
 

--- a/packages/pi-tui/DIVERGENCES.md
+++ b/packages/pi-tui/DIVERGENCES.md
@@ -1611,30 +1611,30 @@ Text.dispose was a no-op solely so Loader's dispose override and super.dispose c
 
 #### Changed surface
 
-- Text.dispose(): void no-op
-- Loader.dispose override calls stop and super.dispose
+- Text.dispose(): void no-op (pre-retirement, removed in PR2)
+- Loader.dispose override called stop and super.dispose (pre-retirement, removed in PR2)
 
 #### Dependency map
 
 **Vendor internal**
-- Loader extends Text and calls super.dispose in its current local implementation.
-- Audit note: This is an existing inheritance consumer, not unused code.
+- Loader extended Text and called super.dispose in the pre-retirement local implementation.
+- Audit note: This was an existing inheritance consumer, not unused code.
 
 **Inheritance / structural**
-- Loader -> Text.dispose -> super.dispose
+- Loader -> Text.dispose -> super.dispose (pre-retirement edge, removed in PR2)
 - Audit note: The required structural audit sample is present.
 
 **Host**
 - X007 lifecycle consumers can dispose Loader through the Component contract.
-- Audit note: No direct host call to Text.dispose exists, but X007 owns the lifecycle edge.
+- Audit note: No direct host call to Text.dispose exists; X007 owns the Loader disposal edge.
 
 **Public / extension**
 - Component.dispose is optional and public component consumers may dispose a Loader instance.
-- Audit note: Removing the shim must not remove Loader timer cleanup.
+- Audit note: Removing the shim did not remove Loader timer cleanup.
 
 **Behavioral coupling**
 - Loader.stop timer cleanup must remain exactly once
-- Text remains disposable only if a distinct owner requires it
+- Text no longer carries a dispose member (X019 retired in PR2)
 - Audit note: The safe change is an atomic inheritance cleanup, not a REMOVED_UNUSED classification.
 
 #### Guarding tests

--- a/packages/pi-tui/src/components/loader.ts
+++ b/packages/pi-tui/src/components/loader.ts
@@ -62,9 +62,8 @@ export class Loader extends Text {
 	}
 
 	/** Release the animation timer; containers call this on removal. (dsh-pi-tui divergence X007.) */
-	override dispose(): void {
+	dispose(): void {
 		this.stop();
-		super.dispose();
 	}
 
 	setIndicator(indicator?: LoaderIndicatorOptions): void {

--- a/packages/pi-tui/src/components/text.ts
+++ b/packages/pi-tui/src/components/text.ts
@@ -42,9 +42,6 @@ export class Text implements Component {
 		this.cachedLines = undefined;
 	}
 
-	/** No-op lifecycle hook; subclasses (e.g. Loader) may override it. (dsh-pi-tui divergence X019.) */
-	dispose(): void {}
-
 	render(width: number): string[] {
 		// Check cache
 		if (this.cachedLines && this.cachedText === this.text && this.cachedWidth === width) {

--- a/packages/pi-tui/src/fuzzy.ts
+++ b/packages/pi-tui/src/fuzzy.ts
@@ -110,7 +110,7 @@ export function fuzzyFilter<T>(items: T[], query: string, getText: (item: T) => 
 		return items;
 	}
 
-	const results: { item: T; totalScore: number; index: number }[] = [];
+	const results: { item: T; totalScore: number }[] = [];
 
 	for (const item of items) {
 		const text = getText(item);
@@ -128,14 +128,10 @@ export function fuzzyFilter<T>(items: T[], query: string, getText: (item: T) => 
 		}
 
 		if (allMatch) {
-			results.push({ item, totalScore, index: results.length });
+			results.push({ item, totalScore });
 		}
 	}
 
-	// Scores accumulate fractional parts (i * 0.1), so ties can occur even
-	// between genuinely different matches; the original index tie-break makes
-	// the order deterministic instead of depending on sort engine internals.
-	// (dsh-pi-tui divergence X012.)
-	results.sort((a, b) => a.totalScore - b.totalScore || a.index - b.index);
+	results.sort((a, b) => a.totalScore - b.totalScore);
 	return results.map((r) => r.item);
 }

--- a/packages/pi-tui/test/dispose-lifecycle.test.ts
+++ b/packages/pi-tui/test/dispose-lifecycle.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import { Box } from "../src/components/box.ts";
 import { ScrollView } from "../src/components/scroll-view.ts";
-import { Container } from "../src/tui.ts";
+import { Container, type TUI } from "../src/tui.ts";
 import { SettingsList } from "../src/components/settings-list.ts";
 import { Text } from "../src/components/text.ts";
+import { Loader } from "../src/components/loader.ts";
 import { TuiMainScreen } from "../src/tui-main-screen.ts";
 import { VirtualTerminal } from "./virtual-terminal.ts";
 
@@ -335,10 +336,32 @@ describe("Component dispose lifecycle completeness (X007)", () => {
 		assert.equal(followUp.disposeCount, 0, "the follow-up submenu stays mounted");
 	});
 
-	it("Text.dispose() stays a harmless no-op inside disposed containers", () => {
+	it("a Text child inside a container is cleared without throwing", () => {
 		const box = new Box(1, 1);
 		box.addChild(new Text("hello", 1, 0));
 		box.clear(); // must not throw
 		assert.ok(true);
+	});
+
+	it("Loader.dispose clears the animation timer and repeated dispose stays safe", () => {
+		mock.timers.enable({ apis: ["setInterval"] });
+		try {
+			let renders = 0;
+			const ui = { requestRender: () => { renders += 1; } } as unknown as TUI;
+			const loader = new Loader(ui, (s) => s, (s) => s, "Loading...", { frames: ["⠋", "⠙"], intervalMs: 10 });
+
+			const rendersAfterStart = renders;
+			mock.timers.tick(100);
+			assert.ok(renders > rendersAfterStart, "the animation timer drives renders while alive");
+
+			loader.dispose();
+			const rendersAfterDispose = renders;
+			mock.timers.tick(1000);
+			assert.equal(renders, rendersAfterDispose, "dispose must clear the animation timer");
+
+			loader.dispose(); // repeated dispose stays safe
+		} finally {
+			mock.timers.reset();
+		}
 	});
 });

--- a/packages/pi-tui/vendor-divergences.json
+++ b/packages/pi-tui/vendor-divergences.json
@@ -8,8 +8,8 @@
   },
   "verification": {
     "auditedAt": "2026-09-07",
-    "branch": "feat/searchable-picker-host-migration-next",
-    "auditedSourceCommit": "5709dfc1a1f7b36abc314d8cfb87e68fd3226557",
+    "branch": "chore/retire-pi-divergences-x012-x019",
+    "auditedSourceCommit": "6a5857dd5c0b8ab1242a32fbcc428196eecf3e5e",
     "referenceSnapshots": {
       "upstream": {
         "repository": "earendil-works/pi",
@@ -26,7 +26,8 @@
       "Compared recorded Pi and Kimi reference snapshots for semantic comparison; issue and PR references are background only.",
       "Ran focused deletion experiments for X019, X030, X037, X038, X043, and X044; existing checks caught the first five, while X044 required a compile-only subclass fixture.",
       "Historical removed and absorbed records were retained as explicit records instead of disappearing from the manifest.",
-      "PR1 relocation audit: X001/X002/X041 moved to the Host SearchablePicker (src/searchable-picker.ts) with the vendored SelectList restored to the pinned baseline; X042 narrowed to the SettingsList seam. The audit was performed against the immutable local source snapshot recorded in verification.auditedSourceCommit."
+      "PR1 relocation audit: X001/X002/X041 moved to the Host SearchablePicker (src/searchable-picker.ts) with the vendored SelectList restored to the pinned baseline; X042 narrowed to the SettingsList seam. The audit was performed against the immutable local source snapshot recorded in verification.auditedSourceCommit.",
+      "PR2 retirement audit: X012's explicit fuzzy tie-break was removed in favor of the supported stable-sort runtime contract; X019's Text no-op dispose shim was removed while Loader-owned X007 timer cleanup remained direct and guarded."
     ]
   },
   "categoryDefinitions": {
@@ -50,8 +51,9 @@
     {"decision": "DELIBERATELY_KEPT", "records": ["X030"], "reason": "A host copy of decodePrintableKey would duplicate the implementation; the package exports map exposes only the root entry."},
     {"decision": "MOVED_TO_HOST", "records": ["X001", "X002", "X041"], "reason": "The DSH searchable picker behavior moved to the Host-owned src/searchable-picker.ts SearchablePicker (guarded by test/searchable-picker.test.ts); the vendored SelectList is restored to the pinned upstream baseline."},
     {"decision": "NOT_MOVABLE", "records": ["X042"], "reason": "The remaining X042 seam is SettingsList focus/row-budget propagation inside the vendored fork; the SelectList-side Input focus ownership moved to the Host SearchablePicker."},
-    {"decision": "NOT_MOVABLE", "records": ["X004A", "X004B", "X005", "X006", "X007", "X008", "X009", "X010", "X011", "X012", "X014", "X016", "X018", "X019", "X020", "X021", "X022", "X023", "X024", "X025", "X027", "X028", "X029", "X031", "X032", "X033", "X034", "X035", "X036", "X037", "X038", "X039", "X040", "X043", "X044", "X045", "X046", "X047"], "reason": "The behavior is vendor-internal, terminal-owned, protocol-owned, performance-owned, or requires metadata unavailable at a host wrapper boundary."},
-    {"decision": "UPSTREAM_LEVER", "records": ["X005", "X006", "X007", "X008", "X012", "X014", "X016", "X021", "X033", "X035"], "reason": "Generic improvements may be proposed upstream; an upstream issue or similar implementation is not absorption evidence."}
+    {"decision": "NOT_MOVABLE", "records": ["X004A", "X004B", "X005", "X006", "X007", "X008", "X009", "X010", "X011", "X014", "X016", "X018", "X020", "X021", "X022", "X023", "X024", "X025", "X027", "X028", "X029", "X031", "X032", "X033", "X034", "X035", "X036", "X037", "X038", "X039", "X040", "X043", "X044", "X045", "X046", "X047"], "reason": "The behavior is vendor-internal, terminal-owned, protocol-owned, performance-owned, or requires metadata unavailable at a host wrapper boundary."},
+    {"decision": "UPSTREAM_LEVER", "records": ["X005", "X006", "X007", "X008", "X014", "X016", "X021", "X033", "X035"], "reason": "Generic improvements may be proposed upstream; an upstream issue or similar implementation is not absorption evidence."},
+    {"decision": "SUPERSEDED", "records": ["X012", "X019"], "reason": "X012's explicit fuzzy tie-break is redundant under the supported stable-sort runtime contract; X019's Text no-op dispose shim is replaced by Loader-owned X007 cleanup without a base super call."}
   ],
   "removedLegacy": [
     {"surface": "inlineSlashTrigger and inline-slash helpers", "decision": "PRODUCT_DECISION", "reason": "The host uses explicit, context-gated Tab completion; the old opt-in inline dropdown is not part of DSH UX."},
@@ -306,12 +308,12 @@
       "status": "ACTIVE",
       "category": ["HARD_HOST_API", "PUBLIC_COMPONENT_CONTRACT"],
       "risk": "CRITICAL",
-      "files": ["src/tui.ts", "src/components/scroll-view.ts", "src/components/text.ts", "src/components/loader.ts", "src/components/box.ts", "src/components/settings-list.ts", "src/components/stack.ts"],
+      "files": ["src/tui.ts", "src/components/scroll-view.ts", "src/components/loader.ts", "src/components/box.ts", "src/components/settings-list.ts", "src/components/stack.ts"],
       "why": "The host owns timers, callbacks, child components, submenu slots, and overlay leases. A single optional Component.dispose contract releases each resource exactly once across removal, hide, replacement, and final surface teardown.",
       "changedSurface": ["optional Component.dispose and idempotent Container disposal", "Container/Box/Stack child ownership and removal", "ScrollView timer/callback cleanup", "Loader, SettingsList submenu, and opt-in overlay disposal"],
       "dependencies": {
         "vendorInternal": {"audited": true, "items": ["Container, Box, Stack, ScrollView, SettingsList, Text, and Loader each participate in the release graph."], "notes": "The patch is an ownership graph, not one helper."},
-        "inheritanceStructural": {"audited": true, "items": ["Loader extends Text and historically used Text.dispose as an inheritance shim (X019).", "ScrollView and Stack override container lifecycle methods."], "notes": "Override and super edges were checked before any retirement classification."},
+        "inheritanceStructural": {"audited": true, "items": ["Loader extends Text; the X019 Text.dispose shim was retired (PR2) and Loader.dispose owns the timer cleanup directly.", "ScrollView and Stack override container lifecycle methods."], "notes": "Override and super edges were checked before any retirement classification."},
         "host": {"audited": true, "items": ["src/tui-app.ts OverlayBroker.disposeAll and overlay leases", "editor seat, panels, timers, and fullscreen surface teardown", "test/pi-component-compat.test.ts public component compatibility"], "notes": "Host final teardown relies on exactly-once release."},
         "publicExtension": {"audited": true, "items": ["Stable/Advanced/Unstable extension mounts and public component leases", "component compatibility surface accepts optional dispose"], "notes": "Extension-owned remountable leases intentionally opt out of overlay disposeOnHide."},
         "behavioral": {"audited": true, "items": ["removed children are detached before disposal", "repeated dispose is a no-op", "disposeOnHide is opt-in so remountable overlays survive hide", "Stack clears its second layout representation"], "notes": "Type-compatible removal can leak timers or resurrect disposed children."}
@@ -473,11 +475,11 @@
     },
     "X012": {
       "title": "Deterministic fuzzy tie sort",
-      "status": "RETIREMENT_CANDIDATE",
+      "status": "SUPERSEDED",
       "category": ["BUGFIX_MISSING_UPSTREAM"],
       "risk": "LOW",
       "files": ["src/fuzzy.ts"],
-      "why": "The local comparator explicitly preserves input order for equal fuzzy scores. Supported Node engines guarantee stable Array.prototype.sort, so the explicit tie term may be redundant but must be checked as a semantic runtime assumption.",
+      "why": "The local comparator explicitly preserved input order for equal fuzzy scores. Supported Node engines guarantee stable Array.prototype.sort, so the explicit tie term was redundant and has been removed (PR2).",
       "changedSurface": ["fuzzyFilter result index tie-breaker"],
       "dependencies": {
         "vendorInternal": {"audited": true, "items": ["fuzzyFilter constructs result order and passes it directly to sort."], "notes": "No secondary randomization or map is involved."},
@@ -492,17 +494,17 @@
         "checkedAgainst": {"repo": "earendil-works/pi", "baselineRef": "b79e4cc834970cca69daebffab7df1da7d1e52c4", "referenceRef": "b8b873b9872db04a938fb4357b5e8e824ddc051c"},
         "relevantFiles": ["packages/tui/src/fuzzy.ts", "packages/tui/package.json"],
         "relevantIssues": [],
-        "semanticDelta": "With the package's supported Node engine, upstream score-only sort is stable and preserves the same input-order ties. The explicit index comparator is therefore runtime-equivalent, subject to the engine and input-order assumptions recorded here."
+        "semanticDelta": "With the package's supported Node engine, upstream score-only sort is stable and preserves the same input-order ties. The explicit index comparator was therefore runtime-equivalent and has been removed. Semantic equivalence relies on the supported runtime stable-sort guarantee; this is not evidence of a new upstream implementation."
       },
       "retirement": {
         "conditions": ["Confirm the project engine floor, comparator input order, and equal-score regression on every supported Node boundary.", "Run the deletion experiment: restore upstream fuzzy.ts, run vendor fuzzy tests, bundle tests, typecheck, and both vendor gates; keep the explicit comparator if any result changes."],
-        "replacementMapping": [],
-        "evidence": []
+        "replacementMapping": ["fuzzyFilter explicit index tie-break -> supported Node/ECMAScript stable-sort state -> packages/pi-tui/test/fuzzy.test.ts equal-score ordering test"],
+        "evidence": ["supported engine range is Node >=22.19 / >=24 (root and pi-tui package engines)", "fuzzy.ts restored byte-identical to pinned upstream b79e4cc (blob 73c10dcf4b134bfefba2978281b2a6f94352c5b8)", "existing equal-score regression remains green after deletion (packages/pi-tui/test/fuzzy.test.ts)", "fork typecheck/test/build, surface compat, divergence ledger, strict vendor diff, root build/typecheck/test:bundle green"]
       },
       "audit": {
-        "lastAuditedAt": "2026-09-03",
+        "lastAuditedAt": "2026-09-07",
         "scope": ["vendor-internal", "inheritance-structural", "host", "public-extension", "behavioral", "tests"],
-        "notes": "Candidate only. Current package.json declares the stable-sort-capable Node floor; source comparison confirmed upstream still uses score-only sort. The equal-score fixture now guards input-order preservation; behavior was not changed in this ledger task."
+        "notes": "Retired in PR2: the explicit index tie-break was removed and fuzzy.ts restored byte-identical to the pinned upstream. Equal-score input order is preserved by the supported ECMAScript stable-sort guarantee and remains guarded by the equal-score regression; this is not evidence of a new upstream implementation."
       }
     },
     "X013": {
@@ -711,11 +713,11 @@
     },
     "X019": {
       "title": "Text no-op dispose inheritance shim",
-      "status": "REDUNDANT_SHIM",
+      "status": "SUPERSEDED",
       "category": ["HARD_HOST_API", "PUBLIC_COMPONENT_CONTRACT"],
       "risk": "HIGH",
       "files": ["src/components/text.ts"],
-      "why": "Text.dispose is currently a no-op solely so Loader's dispose override and super.dispose call typecheck. The inheritance edge is real, but the base no-op can be removed by an atomic Loader cleanup.",
+      "why": "Text.dispose was a no-op solely so Loader's dispose override and super.dispose call typechecked. The inheritance edge was real, but the base no-op has been removed by an atomic Loader cleanup (PR2).",
       "changedSurface": ["Text.dispose(): void no-op", "Loader.dispose override calls stop and super.dispose"],
       "dependencies": {
         "vendorInternal": {"audited": true, "items": ["Loader extends Text and calls super.dispose in its current local implementation."], "notes": "This is an existing inheritance consumer, not unused code."},
@@ -726,21 +728,21 @@
       },
       "tests": ["packages/pi-tui/test/dispose-lifecycle.test.ts: Loader cleanup and idempotency", "packages/pi-tui/test/layout.test.ts and test/pi-component-compat.test.ts: component lifecycle contract"],
       "upstream": {
-        "equivalence": "NO",
+        "equivalence": "PARTIAL",
         "checkedAgainst": {"repo": "earendil-works/pi", "baselineRef": "b79e4cc834970cca69daebffab7df1da7d1e52c4", "referenceRef": "b8b873b9872db04a938fb4357b5e8e824ddc051c"},
         "relevantFiles": ["packages/tui/src/components/text.ts", "packages/tui/src/components/loader.ts"],
         "relevantIssues": [],
-        "semanticDelta": "Upstream has neither the local Component disposal contract nor the current Text/Loader shim. Restoring upstream wholesale would remove the broader X007 lifecycle behavior."
+        "semanticDelta": "Upstream Text has no dispose member, and the local Text now matches upstream byte-identically. Loader disposal remains intentionally local under X007: Loader.dispose owns the timer cleanup directly without a base super call."
       },
       "retirement": {
         "conditions": ["Apply one atomic change: remove Text.dispose and remove Loader's super.dispose call while retaining Loader.dispose and timer cleanup.", "Run lifecycle, Loader timer, layout, surface compatibility, and typecheck gates before changing status."],
-        "replacementMapping": ["Atomic replacement: Text.dispose no-op -> no base method; Loader.dispose remains the owning cleanup and calls stop directly without super.dispose."],
-        "evidence": ["Current source proves a live Loader -> Text.dispose -> super.dispose inheritance edge.", "Deletion experiment: temporarily removing Text.dispose made the package typecheck fail in loader.ts with TS4113/TS2339 because Loader's override and super.dispose call lost their base member; the existing lifecycle tests remained green."]
+        "replacementMapping": ["Text.dispose no-op + Loader super.dispose chain -> X007 Loader.dispose owner keeps timer-cleanup state directly -> packages/pi-tui/test/dispose-lifecycle.test.ts"],
+        "evidence": ["text.ts restored byte-identical to pinned upstream b79e4cc (blob 7a50e2721028d544f641ab5f66ef1b752ff6d1f7)", "Loader.dispose remains and calls stop() directly; no override keyword and no super.dispose() remain", "package typecheck green (no inheritance type errors after removing the base member)", "dispose-lifecycle tests green (Loader cleanup and idempotency)", "surface compatibility + divergence ledger + strict vendor diff + root build/typecheck/test:bundle green"]
       },
       "audit": {
-        "lastAuditedAt": "2026-09-03",
+        "lastAuditedAt": "2026-09-07",
         "scope": ["vendor-internal", "inheritance-structural", "host", "public-extension", "behavioral", "tests"],
-        "notes": "Classified as REDUNDANT_SHIM rather than unused. It remains active until the dedicated atomic cleanup is implemented and verified."
+        "notes": "Retired in PR2: Text.dispose was removed and text.ts restored byte-identical to the pinned upstream. Loader keeps the real X007 timer cleanup directly (dispose -> stop -> clearInterval) without override/super.dispose; the X019 base-class shim is gone while Loader disposal remains intentionally local under X007."
       }
     },
     "X020": {

--- a/packages/pi-tui/vendor-divergences.json
+++ b/packages/pi-tui/vendor-divergences.json
@@ -718,13 +718,13 @@
       "risk": "HIGH",
       "files": ["src/components/text.ts"],
       "why": "Text.dispose was a no-op solely so Loader's dispose override and super.dispose call typechecked. The inheritance edge was real, but the base no-op has been removed by an atomic Loader cleanup (PR2).",
-      "changedSurface": ["Text.dispose(): void no-op", "Loader.dispose override calls stop and super.dispose"],
+      "changedSurface": ["Text.dispose(): void no-op (pre-retirement, removed in PR2)", "Loader.dispose override called stop and super.dispose (pre-retirement, removed in PR2)"],
       "dependencies": {
-        "vendorInternal": {"audited": true, "items": ["Loader extends Text and calls super.dispose in its current local implementation."], "notes": "This is an existing inheritance consumer, not unused code."},
-        "inheritanceStructural": {"audited": true, "items": ["Loader -> Text.dispose -> super.dispose"], "notes": "The required structural audit sample is present."},
-        "host": {"audited": true, "items": ["X007 lifecycle consumers can dispose Loader through the Component contract."], "notes": "No direct host call to Text.dispose exists, but X007 owns the lifecycle edge."},
-        "publicExtension": {"audited": true, "items": ["Component.dispose is optional and public component consumers may dispose a Loader instance."], "notes": "Removing the shim must not remove Loader timer cleanup."},
-        "behavioral": {"audited": true, "items": ["Loader.stop timer cleanup must remain exactly once", "Text remains disposable only if a distinct owner requires it"], "notes": "The safe change is an atomic inheritance cleanup, not a REMOVED_UNUSED classification."}
+        "vendorInternal": {"audited": true, "items": ["Loader extended Text and called super.dispose in the pre-retirement local implementation."], "notes": "This was an existing inheritance consumer, not unused code."},
+        "inheritanceStructural": {"audited": true, "items": ["Loader -> Text.dispose -> super.dispose (pre-retirement edge, removed in PR2)"], "notes": "The required structural audit sample is present."},
+        "host": {"audited": true, "items": ["X007 lifecycle consumers can dispose Loader through the Component contract."], "notes": "No direct host call to Text.dispose exists; X007 owns the Loader disposal edge."},
+        "publicExtension": {"audited": true, "items": ["Component.dispose is optional and public component consumers may dispose a Loader instance."], "notes": "Removing the shim did not remove Loader timer cleanup."},
+        "behavioral": {"audited": true, "items": ["Loader.stop timer cleanup must remain exactly once", "Text no longer carries a dispose member (X019 retired in PR2)"], "notes": "The safe change is an atomic inheritance cleanup, not a REMOVED_UNUSED classification."}
       },
       "tests": ["packages/pi-tui/test/dispose-lifecycle.test.ts: Loader cleanup and idempotency", "packages/pi-tui/test/layout.test.ts and test/pi-component-compat.test.ts: component lifecycle contract"],
       "upstream": {

--- a/test/pi-divergence-ledger-gate.test.mjs
+++ b/test/pi-divergence-ledger-gate.test.mjs
@@ -137,6 +137,9 @@ test('REDUNDANT_SHIM requires the atomic replacement and its evidence', () => {
   const good = errorsFor(manifest)
   assert.deepEqual(good, [], 'the real X019 inheritance edge has a complete atomic retirement record')
 
+  // X019 is SUPERSEDED in the checked-in ledger; re-classify it as the
+  // REDUNDANT_SHIM fixture so the gate rule stays covered.
+  manifest.divergences.X019.status = 'REDUNDANT_SHIM'
   manifest.divergences.X019.retirement.replacementMapping = ['remove the base method']
   const missingAtomic = errorsFor(manifest)
   assertHasError(missingAtomic, 'REDUNDANT_SHIM mapping must state the atomic replacement')

--- a/test/pi-divergence-ledger-gate.test.mjs
+++ b/test/pi-divergence-ledger-gate.test.mjs
@@ -135,7 +135,7 @@ test('MOVED_TO_HOST requires a capability replacement mapping', () => {
 test('REDUNDANT_SHIM requires the atomic replacement and its evidence', () => {
   const manifest = fixture()
   const good = errorsFor(manifest)
-  assert.deepEqual(good, [], 'the real X019 inheritance edge has a complete atomic retirement record')
+  assert.deepEqual(good, [], 'the checked-in ledger (X019 SUPERSEDED) has a complete retirement record')
 
   // X019 is SUPERSEDED in the checked-in ledger; re-classify it as the
   // REDUNDANT_SHIM fixture so the gate rule stays covered.


### PR DESCRIPTION
## Summary

Retire two redundant pi-tui fork divergences before the v0.85.1 re-vendor:

- X012: remove the explicit fuzzy-score index tie-break; supported Node runtimes already provide stable Array.prototype.sort, and the existing equal-score regression remains green.
- X019: remove Text's no-op dispose shim; Loader keeps the real X007 timer cleanup directly without override/super.dispose.

No product behavior, package version, upstream pin, or picker behavior changes.

## Source result

- `packages/pi-tui/src/fuzzy.ts` restored byte-identical to pinned v0.84.4.
- `packages/pi-tui/src/components/text.ts` restored byte-identical to pinned v0.84.4.
- `Loader.dispose()` remains local under X007 and calls `stop()` directly.

## Divergence ledger

- X012 -> SUPERSEDED
- X019 -> SUPERSEDED
- X007 remains ACTIVE and is narrowed away from the removed Text shim
- auditedSourceCommit points to the immutable source commit before the audit metadata commit

## Verification

- fuzzy equal-score regression ✓
- dispose lifecycle regression ✓ (incl. new animated-Loader timer/idempotency test)
- fork typecheck / test (1029) / build ✓
- pi surface compat ✓
- divergence ledger ✓
- generated DIVERGENCES in sync ✓
- strict vendor diff ✓
- root build / typecheck / test:bundle (251) ✓
