### PR TITLE
fix: text-input keyboard ownership and mode-accurate hints

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -16,6 +16,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Text-input keyboard ownership is corrected.** Free-text editing no
+  longer loses its line-editing keys to the parent: in Question's “Type
+  something.” edit, `←/→` are the text cursor (previously they could
+  commit and move on, or page back), and `Home/End/Ctrl+A/E/B/F/Delete`
+  etc. all reach the shared Input. Optionless questions now use an
+  explicit two-layer state: in the EDIT layer `←/→` move the text
+  cursor, `↵` commits, and `Esc/Ctrl+C` only leave the edit for the
+  NAVIGATION layer, where `↵` re-enters the edit, `←/→` page between
+  questions (or skip), and `Esc/Ctrl+C` cancel the whole flow (previously
+  Esc either stranded such a question in a half-dead, uneditable state
+  or cancelled the whole flow outright). The Question edit-mode and Task
+  Center search-mode footers only advertise what the current mode
+  actually does (no more `↑↓ select` / `A active/all` list actions while
+  typing). Transcript search now closes on Esc or Ctrl+C (the
+  `app.transcript.search.close` defaults were extended — previously the
+  overlay's Input swallowed Ctrl+C), and shows a
+  `↵ next · ⇧↵ prev · esc/ctrl+c close` hint under the input. The
+  `/keybindings` search box is rendered by the shared Input: full
+  cursor/Home/End/Delete/word-move editing works, and the hint flips
+  between `Esc: clear` (non-empty query) and `Esc: close`.
 - **Direct sessions are now fully retired on exit.** Exiting the TUI now
   retires the main Agent, its continuable subagents and Agent-scoped
   background jobs in a fixed order: cancel the main Agent and await

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@
 
 ### 修复
 
+- **文本输入态的键盘所有权修正。** 自由输入编辑不再被父层抢走行编辑键:
+  Question 的“Type something.”自由输入里 `←/→` 现在是文本光标(此前会误
+  提交或翻页),`Home/End/Ctrl+A/E/B/F/Delete` 等编辑键统一进入共享输入;
+  无选项的纯文本问题改为明确的两层状态:编辑层里 `←/→` 编辑文本、`↵` 提交、
+  `Esc/Ctrl+C` 只退出编辑回到导航层,导航层里 `↵` 重新进入编辑、`←/→` 翻题
+  (或跳过)、`Esc/Ctrl+C` 才取消整个流程(此前按 Esc 会把这类问题困在无法
+  重新编辑的半死状态,或直接取消整个提问);Question 编辑态与 Task Center
+  搜索态的底部提示改为只描述当前模式真实行为(不再宣传 `↑↓ select` /
+  `A active/all` 等列表动作)。Transcript 搜索现在可用 Esc 或 Ctrl+C 关闭
+  (`app.transcript.search.close` 默认键扩充,Ctrl+C 此前被搜索输入框吞掉),
+  并在输入框下显示 `↵ next · ⇧↵ prev · esc/ctrl+c close` 指引。
+  `/keybindings` 的搜索框改为共享 Input 渲染:支持光标移动/Home/End/删除/
+  词移动等完整行编辑,提示随查询是否为空在 `Esc: clear` 与 `Esc: close` 间
+  切换。
 - **退出时完整回收 Direct 会话。** 退出 TUI 时,主 Agent、continuable
   subagent 与 Agent 作用域后台任务现在按固定顺序回收:取消主 Agent 并等待
   静默 → 排空 continuable 后代 → 最终持久化 flush → 释放 AgentHandle。

--- a/src/input-router.ts
+++ b/src/input-router.ts
@@ -204,9 +204,12 @@ export class InputRouter {
     // The transcript-search overlay owns its keys. The toggle follows the
     // EFFECTIVE key (a remap of the configurable app.transcript.search
     // still closes/owns the overlay); the fixed close/next/previous stay
-    // physical (non-configurable overlay contracts).
+    // physical (non-configurable overlay contracts — close is Esc AND
+    // Ctrl+C, since the overlay's own shared Input would otherwise
+    // swallow Ctrl+C as its generic cancel and keep search open).
     if (ctx.searchActive) {
-      if (matchesKey(data, 'escape') || matchesKey(data, 'enter')
+      if (matchesKey(data, 'escape') || matchesKey(data, 'ctrl+c')
+        || matchesKey(data, 'enter')
         || matchesKey(data, 'shift+enter')
         || (ctx.matchesEffective?.(TUI_ACTION_SEARCH, data) ?? matchesKey(data, 'ctrl+f'))) {
         return { kind: 'consumed' }

--- a/src/keybinding-ui/list.ts
+++ b/src/keybinding-ui/list.ts
@@ -3,7 +3,8 @@
  * the shared detail/editor child view.
  */
 
-import { decodePrintableKey, matchesKey, truncateToWidth, visibleWidth, type Component } from '@xmoon76/pi-tui'
+import { matchesKey, truncateToWidth, visibleWidth, type Component } from '@xmoon76/pi-tui'
+import { Input } from '@xmoon76/pi-tui'
 import { color } from '../theme.ts'
 import { formatKeyId } from '../keybindings/hints.ts'
 import type { KeyId } from '@xmoon76/pi-tui'
@@ -35,16 +36,6 @@ type ListEntry =
 
 function commandKey(data: string, key: string): boolean {
   return matchesKey(data, key as KeyId) || (data.length === 1 && data.toLowerCase() === key.toLowerCase())
-}
-
-function printableChunk(data: string): string | undefined {
-  const decoded = decodePrintableKey(data)
-  if (decoded !== undefined) return decoded
-  if (data === '' || data.includes('\x1b')) return undefined
-  for (const character of data) {
-    if (character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127) return undefined
-  }
-  return data
 }
 
 function statusMarkers(row: KeybindingEditorRow): string {
@@ -106,7 +97,15 @@ export class KeybindingEditorPanel implements Component {
   private readonly onDispose: () => void
   private readonly requestRender: () => void
   private readonly maxRows: () => number
-  private query = ''
+  /** The shared Input is the ONLY query source of truth (left/right/Home/
+   * End/Ctrl+A/E/B/F/delete/kill/undo all work here — the old hand-rolled
+   * `query += chunk` string editing could only append and Backspace). */
+  private readonly searchInput = new Input()
+  /** Read-only query view (the render + filtering read this; the Input
+   * alone mutates it). */
+  private get query(): string {
+    return this.searchInput.getValue()
+  }
   private selectedId = 'leader'
   private selectedIndex = 0
   private actionEditor: ActionEditorPanel | undefined
@@ -141,7 +140,7 @@ export class KeybindingEditorPanel implements Component {
         ]
         : []),
       color.textDim(`Search actions, descriptions, IDs, categories, or keys · ${this.model.summary}`),
-      `${color.text('Search: ')}${this.query === '' ? color.textDim('type to filter') : color.text(this.query)}`,
+      this.searchRow(safeWidth),
       '',
     ]
     const entries = this.displayEntries()
@@ -169,8 +168,29 @@ export class KeybindingEditorPanel implements Component {
     if (start > 0) lines.push(color.textDim(`↑ ${start} more`))
     if (end < entries.length) lines.push(color.textDim(`↓ ${entries.length - end} more`))
     if (this.message !== undefined) lines.push(color.error(truncateToWidth(this.message, safeWidth)))
-    lines.push('', color.textDim('Enter: details · type: search · ↑↓: move · Esc: close'))
+    // The Esc verb follows the two-stage lifecycle: a non-empty query
+    // clears first, an empty query closes the panel.
+    const escVerb = this.query === '' ? 'close' : 'clear'
+    lines.push('', color.textDim(`Enter: details · type: search · ←→: edit · ↑↓: move · Esc: ${escVerb}`))
     return lines.slice(0, Math.max(1, this.maxRows()))
+  }
+
+  /** The search row: the `Search: ` label combined with the shared
+   * Input's real render (the user sees the actual cursor position while
+   * editing the query). An empty query keeps the dim placeholder. The
+   * combined row is truncated to the panel width (ANSI-safe — the Input's
+   * fake cursor rides inside, and truncateToWidth preserves escape
+   * sequences), so a very narrow terminal can never overflow. */
+  private searchRow(width: number): string {
+    const label = 'Search: '
+    const labelWidth = visibleWidth(label)
+    const inputLines = this.searchInput.render(Math.max(1, width - labelWidth))
+    const inputLine = inputLines[0] ?? ''
+    const stripped = inputLine.startsWith('> ') ? inputLine.slice(2) : inputLine
+    const content = this.query === ''
+      ? `${color.text(label)}${color.textDim('type to filter')}`
+      : `${color.text(label)}${color.text(stripped)}`
+    return truncateToWidth(content, Math.max(1, width), '…')
   }
 
   handleInput(data: string): void {
@@ -185,7 +205,7 @@ export class KeybindingEditorPanel implements Component {
     }
     if (matchesKey(data, 'escape')) {
       if (this.query !== '') {
-        this.query = ''
+        this.searchInput.setValue('')
         this.selectedId = 'leader'
         this.selectedIndex = 0
         this.message = undefined
@@ -198,6 +218,10 @@ export class KeybindingEditorPanel implements Component {
     }
     const selectable = this.selectableEntries(this.displayEntries())
     this.ensureSelection(selectable)
+    // The parent owns ONLY the list/control keys; EVERY other key —
+    // printable text, ←→/Home/End cursor movement, Ctrl+A/E/B/F/W/U/K/Y,
+    // Backspace/Delete, word moves, undo, paste — goes to the shared
+    // Input, the single query source of truth.
     if (matchesKey(data, 'up')) {
       this.moveSelection(-1, selectable)
       return
@@ -214,22 +238,14 @@ export class KeybindingEditorPanel implements Component {
       this.moveSelection(Math.max(1, this.maxRows() - 6), selectable)
       return
     }
-    if (matchesKey(data, 'backspace')) {
-      if (this.query !== '') {
-        this.query = this.query.slice(0, -1)
-        this.selectedId = 'leader'
-        this.selectedIndex = 0
-        this.requestRender()
-      }
-      return
-    }
     if (matchesKey(data, 'enter') || data === '\n' || data === '\r') {
       this.openSelected(selectable)
       return
     }
-    const chunk = printableChunk(data)
-    if (chunk !== undefined) {
-      this.query += chunk
+    const before = this.searchInput.getValue()
+    this.searchInput.handleInput(data)
+    if (this.searchInput.getValue() !== before) {
+      // The query changed: filter again and reset the selection to the top.
       this.selectedId = 'leader'
       this.selectedIndex = 0
       this.message = undefined
@@ -239,6 +255,7 @@ export class KeybindingEditorPanel implements Component {
 
   invalidate(): void {
     this.actionEditor?.invalidate?.()
+    this.searchInput.invalidate()
   }
 
   dispose(): void {

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -123,7 +123,10 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
   },
   'app.transcript.search.close': {
     id: 'app.transcript.search.close',
-    defaultKeys: ['escape'],
+    // Ctrl+C is the Input's generic cancel (tui.select.cancel) — without
+    // this key the overlay's own shared Input swallows it and search stays
+    // open. The semantic close keeps ownership: Esc AND Ctrl+C both close.
+    defaultKeys: ['escape', 'ctrl+c'],
     description: 'Close transcript search',
     category: 'Transcript',
     scope: 'search',

--- a/src/question.ts
+++ b/src/question.ts
@@ -11,7 +11,7 @@
  * @module @xmoon76/dsh-pi-tui/question
  */
 
-import { Input, type KeyId } from '@xmoon76/pi-tui'
+import { Input, matchesKey, type KeyId } from '@xmoon76/pi-tui'
 import type { Component, Focusable } from '@xmoon76/pi-tui'
 import { visibleWidth, wrapTextWithAnsi } from '@xmoon76/pi-tui'
 import { componentKeymap } from './keybindings/component-keymap.ts'
@@ -219,7 +219,23 @@ export class QuestionFlow implements Component, Focusable {
   private cursor = 0
   /** Free-text editing mode (the "Type something." row or an optionless question). */
   private editingOther = false
-  private readonly otherInput = new Input()
+  /**
+   * The free-text edit Input. REPLACED by a fresh instance whenever the
+   * edit moves to a different question (see {@link otherInputTab}): the
+   * Input's undo stack and kill ring are per-instance state, so reusing
+   * one instance across questions would let the previous question's
+   * editing history leak into the next row (round-3 finding — Ctrl+-
+   * undo / Ctrl+Y yank resurrected the previous question's text).
+   */
+  private otherInput = new Input()
+  /**
+   * The tab whose draft/in-progress text the {@link otherInput} currently
+   * holds. Entering a DIFFERENT question's edit replaces the Input and
+   * re-seeds from that question's draft; an Esc → navigation → ↵ round
+   * trip on the SAME question keeps the live Input and its in-progress
+   * text.
+   */
+  private otherInputTab = -1
   /**
    * Current content-row budget (8..38). The editor-seat QuestionFrame in
    * tui-app.ts re-derives it from the terminal height on every render and
@@ -273,7 +289,12 @@ export class QuestionFlow implements Component, Focusable {
     this.drafts = questions.map(() => ({ selected: new Set<string>(), custom: '', skipped: false }))
     // The free-text input keeps the last answer for re-entry.
     this.otherInput.onSubmit = (value) => this.commitOther(value)
-    this.otherInput.onEscape = () => this.exitOther()
+    // The Input's generic cancel (Esc/Ctrl+C) ALWAYS leaves the text
+    // edit back to the outer layer (option list for choices, navigation
+    // state for optionless) — the flow itself cancels only from that
+    // outer state (handleOtherEscape → exitOther; question.cancel /
+    // navigation-state Ctrl+C → onCancel).
+    this.otherInput.onEscape = () => this.handleOtherEscape()
     // An optionless first question edits text from the start.
     this.syncEditMode()
   }
@@ -505,6 +526,19 @@ export class QuestionFlow implements Component, Focusable {
     return rows
   }
 
+  /** Whether the current question has NO selectable choices — pure free
+   * text (an optionless question or a questions page whose only row is the
+   * free-text row). Such a question has no list mode to fall back to: the
+   * EDIT layer's Esc leaves for its NAVIGATION state (↵ re-enters the
+   * edit, ←/→ page, Esc cancels the flow) instead of an option list. The
+   * REVIEW page (tab past the last question) has no rows at all and must
+   * never read as an edit page — syncEditMode runs on every advance,
+   * review page included. */
+  private isOptionless(rows: Row[] = this.rows()): boolean {
+    if (this.tab >= this.questions.length) return false
+    return rows.length === 0 || (rows.length === 1 && rows[0]?.key === OTHER_ROW)
+  }
+
   /** The current question's draft. */
   private draft(): Draft | undefined {
     return this.drafts[this.tab]
@@ -527,6 +561,15 @@ export class QuestionFlow implements Component, Focusable {
   private confirm(): void {
     const draft = this.draft()
     if (draft === undefined) return
+    // An OPTIONLESS question in the NAVIGATION state (Esc left the edit):
+    // there are no rows to confirm — Enter re-enters the free-text edit
+    // (this is the re-entry path that keeps pure-text questions
+    // editable; without it a navigation-state optionless question would
+    // be a dead end).
+    if (this.isOptionless()) {
+      this.enterOther()
+      return
+    }
     const rows = this.rows()
     const row = rows[this.cursor]
     if (row !== undefined && row.key !== OTHER_ROW) {
@@ -561,12 +604,27 @@ export class QuestionFlow implements Component, Focusable {
   /** Optionless questions edit text directly; options start in list mode. */
   private syncEditMode(): void {
     this.resetBodyView()
-    const question = this.questions[this.tab]
-    const optionless = question !== undefined && (question.options?.length ?? 0) === 0
+    // Tab-change contract: in-progress free-text survives ONLY an Esc →
+    // navigation → ↵ round trip on the SAME question. The moment the
+    // user actually moves to ANOTHER question (←/→/skip/commit advance),
+    // the uncommitted edit is DROPPED — invalidate the Input's owner so
+    // the re-entry reseeds from the committed draft. This must happen on
+    // EVERY tab change regardless of the NEXT question's type (a choices
+    // stopover used to leave the old owner alive, so whether the text
+    // survived depended on the intermediate question's kind — round
+    // finding).
+    if (this.otherInputTab !== -1 && this.otherInputTab !== this.tab) {
+      this.otherInputTab = -1
+    }
+    const optionless = this.isOptionless()
     this.editingOther = optionless
     if (optionless) {
+      // A DIFFERENT question's edit gets a FRESH Input seeded from that
+      // question's committed draft (the Input's undo/kill history is
+      // per-instance, so reuse would leak the previous question's
+      // editing state — see resetOtherInput).
       const draft = this.draft()
-      this.otherInput.setValue(draft?.custom ?? '')
+      this.resetOtherInput(draft?.custom ?? '')
     } else {
       // The recommended row (intent.approve or a label suffix) is the default
       // highlight, so Enter adopts it directly (pi/questionnaire parity).
@@ -576,6 +634,18 @@ export class QuestionFlow implements Component, Focusable {
     this.otherInput.focused = this.focused && this.editingOther
   }
 
+  /** Esc inside the free-text edit ALWAYS leaves the text edit back to the
+   * outer layer — for a choices question back to its option list, for an
+   * OPTIONLESS question back to the question's navigation state (where
+   * Enter re-enters the edit, ←/→ page between questions, and Esc cancels
+   * the flow). The flow's cancel only ever fires from that outer state, so
+   * a pure-text question can never be stranded uneditable again. Shared by
+   * the flow's question.cancel match and the Input's generic cancel
+   * (tui.select.cancel: Esc/Ctrl+C). */
+  private handleOtherEscape(): void {
+    this.exitOther()
+  }
+
   /** Skip the current question (empty answer) and move on. */
   private skip(): void {
     const draft = this.draft()
@@ -583,15 +653,41 @@ export class QuestionFlow implements Component, Focusable {
     draft.selected.clear()
     draft.custom = ''
     draft.skipped = true
+    // The skip's advance() runs syncEditMode, which invalidates the
+    // free-text Input's owner on the tab change — a later re-entry
+    // reseeds from the EMPTY draft, so the (skipped) row never shows
+    // stale in-progress text beside it.
     this.advance()
   }
 
-  /** Enter the free-text editing mode for the current question. */
+  /** Enter the free-text editing mode for the current question. The shared
+   * Input keeps in-progress text across an Esc → navigation → ↵ round
+   * trip on the SAME question; entering a DIFFERENT question's edit (or a
+   * fresh entry) seeds from that question's committed draft — the
+   * previous question's text must never leak into the new row. */
   private enterOther(): void {
     this.editingOther = true
-    const draft = this.draft()
-    this.otherInput.setValue(draft?.custom ?? '')
+    if (this.otherInputTab !== this.tab) {
+      const draft = this.draft()
+      this.resetOtherInput(draft?.custom ?? '')
+    }
     this.otherInput.focused = this.focused
+  }
+
+  /** (Re)create the free-text Input for a NEW question owner and seed it
+   * with `value`. The Input's undo stack / kill ring / paste buffer are
+   * PER-INSTANCE state, so a cross-question ownership change must start
+   * from a fresh instance — reusing one Input across questions let
+   * Ctrl+- (undo) / Ctrl+Y (yank) resurrect the previous question's text
+   * in the new row (round-3 finding). */
+  private resetOtherInput(value: string): void {
+    const input = new Input()
+    input.onSubmit = (next) => this.commitOther(next)
+    input.onEscape = () => this.handleOtherEscape()
+    input.setValue(value)
+    input.focused = this.focused && this.editingOther
+    this.otherInput = input
+    this.otherInputTab = this.tab
   }
 
   /** Leave text mode back to the option list. */
@@ -654,25 +750,23 @@ export class QuestionFlow implements Component, Focusable {
     // silently dropped every key on terminals that report CSI-u (the
     // zellij + Kitty-protocol case).
     if (this.editingOther) {
+      // Text mode: EVERY editing key — Left/Right cursor movement,
+      // Home/End, Ctrl+A/E/B/F, Backspace/Delete, word moves, kill/undo —
+      // belongs to the shared Input (the flow previously intercepted
+      // question.previous/next, so → committed+advanced and ← could page
+      // back, stealing the text cursor). The flow keeps only its own
+      // mode verbs: Enter commits, Esc leaves the edit (back to the
+      // option list for choices, to the NAVIGATION state for optionless
+      // — the second Esc there cancels the flow), PageUp/PageDown scroll
+      // the body ('e' stays a letter here — expand is a list-mode verb).
       if (componentKeymap.matches(data, 'question.confirm')) {
         this.commitOther(this.otherInput.getValue())
       } else if (componentKeymap.matches(data, 'question.cancel')) {
-        this.exitOther()
+        this.handleOtherEscape()
       } else if (componentKeymap.matches(data, 'question.pageUp')) {
         this.scrollBody(-1)
       } else if (componentKeymap.matches(data, 'question.pageDown')) {
         this.scrollBody(1)
-      } else if (componentKeymap.matches(data, 'question.previous')) {
-        if (this.tab > 0) {
-          this.tab -= 1
-          this.cursor = 0
-          this.syncEditMode()
-        }
-      } else if (componentKeymap.matches(data, 'question.next')) {
-        // → in text mode: same "move on" verb as in list mode — commit the
-        // typed answer (an empty one counts as skipped) and advance. Enter
-        // stays the primary save key; → never discards in-progress text.
-        this.commitOther(this.otherInput.getValue())
       } else {
         this.otherInput.handleInput(data)
       }
@@ -685,7 +779,7 @@ export class QuestionFlow implements Component, Focusable {
       // the whole batch, Esc cancels the flow, ← returns to the last
       // question (drafts survive). The keys match user intuition and the
       // page carries one less state machine. `h` stays the vim alias for
-      // ← (as in list mode).
+      // ← (the review page has no text input to steal from).
       if (componentKeymap.matches(data, 'question.confirm')) {
         this.submit()
       } else if (componentKeymap.matches(data, 'question.cancel')) {
@@ -699,7 +793,10 @@ export class QuestionFlow implements Component, Focusable {
       return
     }
     const digit = /^[1-9]$/.exec(data)
-    if (digit !== null) {
+    if (digit !== null && !this.isOptionless()) {
+      // A digit in an OPTIONLESS question's navigation state is text —
+      // the option-choice shortcut does not exist without options (the
+      // fall-through re-enters the edit below).
       const row = rows[Number(digit[0]) - 1]
       if (row !== undefined) {
         this.cursor = rows.indexOf(row)
@@ -709,40 +806,50 @@ export class QuestionFlow implements Component, Focusable {
       return
     }
     if (componentKeymap.matches(data, 'question.cursorUp') || data === 'k') {
-      if (rows.length === 0) return
-      if (this.cursor === 0 && this.bodyScroll > 0) {
+      if (rows.length === 0) {
+        // An OPTIONLESS navigation state has no list: the PHYSICAL ↑ is a
+        // no-op here (no selection to move, and it must not bounce the
+        // user into the edit for nothing); the vim 'k' alias is plain
+        // text and falls through to the auto re-enter below.
+        if (componentKeymap.matches(data, 'question.cursorUp')) return
+      } else if (this.cursor === 0 && this.bodyScroll > 0) {
         // ↑ at the FIRST row with the page scrolled: scroll the body UP so
         // the question overview comes back into view (the pointer stays on
         // the first row — it is already visible, so no cursor follow).
         this.scrollBody(-1)
         return
+      } else {
+        this.cursor = (this.cursor - 1 + rows.length) % rows.length
+        this.pendingCursorScroll = true
+        return
       }
-      this.cursor = (this.cursor - 1 + rows.length) % rows.length
-      this.pendingCursorScroll = true
-      return
     }
     if (componentKeymap.matches(data, 'question.cursorDown') || data === 'j') {
-      if (rows.length === 0) return
-      const atLastRow = this.cursor === rows.length - 1
-      const scrolled = this.lastExpandable && this.lastContentRows > this.bodyScroll + this.lastVisibleRows
-      if (atLastRow && scrolled) {
+      if (rows.length === 0) {
+        // Same optionless rule: physical ↓ no-ops, 'j' is text.
+        if (componentKeymap.matches(data, 'question.cursorDown')) return
+      } else if (this.cursor === rows.length - 1
+        && this.lastExpandable && this.lastContentRows > this.bodyScroll + this.lastVisibleRows) {
         // ↓ at the LAST row with more page content below: scroll the body
         // DOWN (the pointer stays on the last row). Only when the page
         // actually overflows — otherwise ↓ keeps the wrap-around.
         this.scrollBody(1)
         return
+      } else {
+        this.cursor = (this.cursor + 1) % rows.length
+        this.pendingCursorScroll = true
+        return
       }
-      this.cursor = (this.cursor + 1) % rows.length
-      this.pendingCursorScroll = true
-      return
     }
     if (componentKeymap.matches(data, 'question.pageUp') || componentKeymap.matches(data, 'question.pageDown')) {
       // PageUp/PageDown: scroll the body scrollport (no-op when it fits).
       this.scrollBody(componentKeymap.matches(data, 'question.pageUp') ? -1 : 1)
       return
     }
-    if (componentKeymap.matches(data, 'question.toggleExpand')) {
+    if (componentKeymap.matches(data, 'question.toggleExpand') && !this.isOptionless()) {
       // Expand/collapse the body region (the scroll marker's keyboard twin).
+      // In an OPTIONLESS navigation state 'e' is plain text (no list to
+      // expand) — it falls through and re-enters the edit below.
       this.toggleExpanded()
       return
     }
@@ -750,7 +857,13 @@ export class QuestionFlow implements Component, Focusable {
       this.confirm()
       return
     }
-    if (componentKeymap.matches(data, 'question.previous') || data === 'h') {
+    // ←/→ back/next (the physical arrows own these verbs). The vim h/l
+    // aliases are LIST-mode conveniences only: they must NOT eat 'h'/'l'
+    // inside an OPTIONLESS question's NAVIGATION state, where every
+    // printable (h/l included) is text that auto-re-enters the edit
+    // below (round finding — typing 'hello'/'linux' was hijacked).
+    if (componentKeymap.matches(data, 'question.previous')
+      || (!this.isOptionless() && data === 'h')) {
       // ← back: previous question (keeps the draft).
       if (this.tab > 0) {
         this.tab -= 1
@@ -759,7 +872,8 @@ export class QuestionFlow implements Component, Focusable {
       }
       return
     }
-    if (componentKeymap.matches(data, 'question.next') || data === 'l') {
+    if (componentKeymap.matches(data, 'question.next')
+      || (!this.isOptionless() && data === 'l')) {
       // → move on (the arrows own back/skip now, replacing the old 's'
       // skip key): an UNANSWERED question is marked skipped and advances
       // (web QuestionComposer skip parity); an ANSWERED one keeps its draft
@@ -783,6 +897,24 @@ export class QuestionFlow implements Component, Focusable {
     }
     if (componentKeymap.matches(data, 'question.cancel')) {
       this.onCancel()
+      return
+    }
+    // An OPTIONLESS question in its NAVIGATION state (Esc left the edit):
+    // every key that is not one of the flow's navigation verbs (← back,
+    // → skip/next, ↵ re-edit, esc cancel, PgUp/PgDn scroll) is the user
+    // typing again — re-enter the text edit and hand the key to the
+    // shared Input (search-box semantics: no Enter prefix needed, and
+    // digits/'e' are text here, not list-mode verbs).
+    if (this.isOptionless()) {
+      // Ctrl+C mirrors Esc's two-stage lifecycle: the FIRST press exits
+      // the edit (the Input's tui.select.cancel → handleOtherEscape),
+      // the SECOND press here cancels the flow.
+      if (matchesKey(data, 'ctrl+c')) {
+        this.onCancel()
+        return
+      }
+      this.enterOther()
+      this.otherInput.handleInput(data)
     }
   }
 
@@ -882,7 +1014,7 @@ export class QuestionFlow implements Component, Focusable {
     const rows = this.rows()
     const multi = question.multiSelect === true
     const skippedRow = draft.skipped ? 1 : 0
-    const optionless = rows.length === 0 || (rows.length === 1 && rows[0]?.key === OTHER_ROW)
+    const optionless = this.isOptionless(rows)
     // Required tail — the rows that must render below the scrollport:
     //   choice page: (skipped) note + trailing blank + hint = 2 + skippedRow
     //   optionless:  input row + (skipped) note + trailing blank + hint =
@@ -967,26 +1099,64 @@ export class QuestionFlow implements Component, Focusable {
       lines.push(color.textDim('(skipped)'))
     }
     lines.push('')
-    // The hint composes from the parts that FIT: low-priority verbs drop out
-    // instead of the whole line being ellipsized by the frame. 'esc cancel'
-    // is the escape hatch and ALWAYS survives (it is reserved first — the
-    // verbs drop from the end, so e.g. '→ skip' goes before 'esc cancel').
-    // Scroll and expand are advertised only when the page overflows the
-    // scrollport; once expanded, 'e' always collapses (frame 80% -> 60%).
-    const optionCount = Math.min(rows.length, 9)
+    // The hint describes the CURRENT mode, never a generic list-mode verb
+    // set:
+    // - text EDIT (choices or optionless): ←→ are the TEXT cursor, Enter
+    //   confirms, Esc LEAVES the edit back to the navigation layer
+    //   (esc back — for choices its option list, for optionless its
+    //   navigation state);
+    // - optionless NAVIGATION state (after Esc): ↵ re-enters the edit,
+    //   ← back / → skip page between questions, esc cancels the flow;
+    // - choices list mode: ↑↓/digits/Enter select, ← back → skip, e
+    //   expand, esc cancel.
+    // List-only verbs (↑↓ select, 1-N choose, ↵ toggle, → next, e expand)
+    // are never advertised while editing.
+    // The hint composes from the parts that FIT: low-priority verbs drop
+    // out instead of the whole line being ellipsized by the frame. The
+    // escape verb ALWAYS survives (it is reserved first — the verbs drop
+    // from the end, so e.g. '→ skip' goes before 'esc cancel').
     const scrollable = this.lastExpandable
-    // Text mode commits on → (empty = skipped), list mode skips/moves on —
-    // the verb is advertised per mode ('→ next' vs '→ skip').
-    const arrowVerb = this.editingOther ? '→ next' : '→ skip'
+    if (this.editingOther) {
+      const editParts = [
+        '←→ edit',
+        '↵ confirm',
+        scrollable ? 'pgup/pgdn scroll' : '',
+      ].filter(part => part !== '')
+      const cancel = 'esc back'
+      let hint = ''
+      for (const part of editParts) {
+        const next = hint === '' ? part : `${hint} · ${part}`
+        if (visibleWidth(`${next} · ${cancel}`) > safeWidth) break
+        hint = next
+      }
+      lines.push(color.textDim(hint === '' ? cancel : `${hint} · ${cancel}`))
+      return lines
+    }
+    if (optionless) {
+      // Navigation state of an OPTIONLESS question: no list, no choice
+      // verbs — ↵ re-enters the text edit, arrows page, Esc cancels.
+      const navParts = [
+        '↵ edit',
+        this.questions.length > 1 || this.tab > 0 ? '← back · → skip' : '→ skip',
+      ].filter(part => part !== '')
+      const cancel = 'esc cancel'
+      let hint = ''
+      for (const part of navParts) {
+        const next = hint === '' ? part : `${hint} · ${part}`
+        if (visibleWidth(`${next} · ${cancel}`) > safeWidth) break
+        hint = next
+      }
+      lines.push(color.textDim(hint === '' ? cancel : `${hint} · ${cancel}`))
+      return lines
+    }
+    const optionCount = Math.min(rows.length, 9)
     const hintParts = [
       '↑↓ select',
       optionCount > 0 ? `1-${optionCount} choose` : '',
       multi ? '↵ toggle' : '↵ confirm',
       scrollable ? 'pgup/pgdn scroll' : '',
-      !this.editingOther
-        ? (this.bodyExpanded ? 'e collapse' : scrollable ? 'e expand' : '')
-        : '',
-      this.questions.length > 1 ? `← back · ${arrowVerb}` : arrowVerb,
+      this.bodyExpanded ? 'e collapse' : scrollable ? 'e expand' : '',
+      this.questions.length > 1 ? '← back · → skip' : '→ skip',
       'esc cancel',
     ].filter(part => part !== '')
     const cancel = 'esc cancel'

--- a/src/search.ts
+++ b/src/search.ts
@@ -7,9 +7,17 @@
  * @module @xmoon76/dsh-pi-tui/search
  */
 
-import { Input } from '@xmoon76/pi-tui'
+import { Input, truncateToWidth } from '@xmoon76/pi-tui'
 import type { Component, Focusable } from '@xmoon76/pi-tui'
 import { visibleWidth } from '@xmoon76/pi-tui'
+import { color } from './theme.ts'
+
+/** The one-line navigation hint under the search input: Enter/S⇧Enter step
+ * through matches, Esc/Ctrl+C close. Fixed text — the close/next/previous
+ * keys are NON-configurable overlay contracts (scope 'search'), so there is
+ * no effective binding to render (a remap of the configurable search TOGGLE
+ * is deliberately not shown here). */
+const SEARCH_HINT = '↵ next · ⇧↵ prev · esc/ctrl+c close'
 
 /** One-line search input with a "Find transcript" title and N/M counter. */
 export class TranscriptSearchComponent implements Component, Focusable {
@@ -63,6 +71,7 @@ export class TranscriptSearchComponent implements Component, Focusable {
     const gap = ' '.repeat(Math.max(1, safeWidth - labelWidth - statusWidth))
     const title = `${label}${gap}${status}`.slice(0, Math.max(1, safeWidth))
     const padding = ' '.repeat(Math.max(0, safeWidth - visibleWidth(title)))
-    return [`\x1b[7m${title}${padding}\x1b[27m`, ...this.input.render(safeWidth)]
+    const hint = color.textDim(truncateToWidth(SEARCH_HINT, safeWidth, '…'))
+    return [`\x1b[7m${title}${padding}\x1b[27m`, ...this.input.render(safeWidth), hint]
   }
 }

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -1088,9 +1088,17 @@ export class TaskBrowserPanel implements Component, Focusable {
       const interrupt = this.filtered.some(item => item.interruptible === true) ? 'i interrupt · ' : ''
       return `${search}${type}${interrupt}↑↓ navigate · enter open · esc close`
     }
+    if (this.searchMode) {
+      // Search mode owns every printable key as query text — A/S/N/R and
+      // the tree arrows are QUERY characters now, never the ordinary task
+      // actions. Advertise only what search mode actually does, with the
+      // ESCAPE verb FIRST: the hint is one line and a default 80-column
+      // terminal truncates the tail — esc back is the most important
+      // verb, so it must never be the piece that gets cut off.
+      return 'type filter · esc back · ←→ edit · ↑↓ navigate · pgup/pgdn page · tab type · enter open'
+    }
     const parts: string[] = []
-    if (this.searchMode) parts.push('search mode')
-    else if (this.searchEnabled) parts.push('/ search')
+    if (this.searchEnabled) parts.push('/ search')
     parts.push('A active/all', 'Tab type', '←→ tree', 'N next running', 'S stop', 'Enter open', 'R refresh')
     if (this.mode === 'quick') parts.push('T Task Center')
     parts.push('Esc back')

--- a/test/input-router.test.ts
+++ b/test/input-router.test.ts
@@ -235,6 +235,7 @@ test('InputRouter: search overlay owns its keys', () => {
   const r = router()
   const search = context({ searchActive: true })
   assert.equal(r.route('\x1b', search, noBindings()).kind, 'consumed', 'Esc closes search')
+  assert.equal(r.route('\x03', search, noBindings()).kind, 'consumed', 'Ctrl+C closes search (the overlay Input would swallow it otherwise)')
   assert.equal(r.route('\r', search, noBindings()).kind, 'consumed', 'Enter jumps next')
 })
 

--- a/test/keybinding-editor.test.ts
+++ b/test/keybinding-editor.test.ts
@@ -8,6 +8,7 @@ import { ActionEditorPanel } from '../src/keybinding-ui/action-editor.ts'
 import { KeybindingEditorPanel, KeybindingEditorUnavailablePanel } from '../src/keybinding-ui/list.ts'
 import type { KeybindingMutationResult } from '../src/keybinding-ui/controller.ts'
 import { buildKeybindingEditorModel } from '../src/keybinding-ui/model.ts'
+import { visibleWidth } from '@xmoon76/pi-tui'
 
 
 /** Re-vendor lifecycle follow-up P3: every TuiApp constructed in this file
@@ -511,5 +512,140 @@ test('Enter opens the selected action detail without making category headers sel
     assert.match(view, /Default: Enter/)
   } finally {
     manager.dispose()
+  }
+})
+
+// ── WP4: /keybindings search uses the shared Input (plan §5) ────────────
+
+test('editor search query edits mid-text with Left/Home/End/Delete', () => {
+  const { manager, panel } = makePanel(() => {})
+  try {
+    panel.handleInput('abc')
+    panel.handleInput('\x1b[D') // Left
+    panel.handleInput('X')
+    assert.match(plain(panel.render(88).join('\n')), /Search: abXc/, 'Left + X must insert mid-query')
+    // Home / End.
+    panel.handleInput('\x1bOH') // Home
+    panel.handleInput('Z')
+    assert.match(plain(panel.render(88).join('\n')), /Search: ZabXc/, 'Home + Z must prefix')
+    panel.handleInput('\x1bOF') // End
+    panel.handleInput('Y')
+    assert.match(plain(panel.render(88).join('\n')), /Search: ZabXcY/, 'End + Y must append')
+    // Delete removes forward; Backspace backward.
+    panel.handleInput('\x1bOH') // Home
+    panel.handleInput('\x1b[3~') // Delete removes Z
+    assert.match(plain(panel.render(88).join('\n')), /Search: abXcY/, 'Delete must remove forward')
+    panel.handleInput('\x7f') // Backspace — cursor is at index 0, no-op
+    assert.match(plain(panel.render(88).join('\n')), /Search: abXcY/, 'Backspace at the start is a no-op')
+    panel.handleInput('\x1bOF') // End
+    panel.handleInput('\x7f') // Backspace removes Y
+    assert.match(plain(panel.render(88).join('\n')), /Search: abXc/, 'Backspace must remove backward')
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('editor search query responds to Ctrl+A/E/B/F and word movement', () => {
+  const { manager, panel } = makePanel(() => {})
+  try {
+    panel.handleInput('hello world')
+    // Ctrl+A / Ctrl+E (Emacs line home/end).
+    panel.handleInput('\x01') // Ctrl+A
+    panel.handleInput('Z')
+    assert.match(plain(panel.render(88).join('\n')), /Search: Zhello world/, 'Ctrl+A + Z must prefix')
+    panel.handleInput('\x05') // Ctrl+E
+    panel.handleInput('Y')
+    assert.match(plain(panel.render(88).join('\n')), /Search: Zhello worldY/, 'Ctrl+E + Y must append')
+    // Ctrl+B / Ctrl+F (Emacs char movement).
+    panel.handleInput('\x02') // Ctrl+B — one left from the end
+    panel.handleInput('X')
+    assert.match(plain(panel.render(88).join('\n')), /Search: Zhello worldXY/, 'Ctrl+B + X must insert before Y')
+    panel.handleInput('\x06') // Ctrl+F — back to the end
+    panel.handleInput('W')
+    assert.match(plain(panel.render(88).join('\n')), /Search: Zhello worldXYW/, 'Ctrl+F + W must append')
+    // Word move: Alt+Left lands at the previous word start.
+    panel.handleInput('\x1bB') // Alt+Left
+    panel.handleInput('V')
+    // Zhello worldXYW → Alt+Left from the end lands before 'world', so V
+    // inserts there: Zhello VworldXYW.
+    assert.match(plain(panel.render(88).join('\n')), /Search: Zhello VworldXYW/, 'Alt+Left + V must insert at the word boundary')
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('editor search hint switches between Esc clear and Esc close', () => {
+  const { manager, panel } = makePanel(() => {})
+  try {
+    let view = plain(panel.render(88).join('\n'))
+    assert.match(view, /Esc: close/, 'empty query advertises Esc: close')
+    panel.handleInput('todo')
+    view = plain(panel.render(88).join('\n'))
+    assert.match(view, /Esc: clear/, 'non-empty query advertises Esc: clear')
+    assert.doesNotMatch(view, /Esc: close/, 'non-empty query must not advertise Esc: close')
+    // First Esc clears (not closes); the hint flips back to close.
+    panel.handleInput('\x1b')
+    view = plain(panel.render(88).join('\n'))
+    assert.match(view, /Esc: close/, 'after clear the hint returns to Esc: close')
+    // Second Esc closes.
+    let closed = 0
+    const { manager: m2, panel: p2 } = makePanel(() => { closed += 1 })
+    try {
+      p2.handleInput('todo')
+      p2.handleInput('\x1b') // clear
+      p2.handleInput('\x1b') // close
+      assert.equal(closed, 1, 'second Esc must close the panel (query was cleared first)')
+    } finally {
+      p2.dispose()
+      m2.dispose()
+    }
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('editor search: list navigation keys stay parent-owned while editing', () => {
+  const { manager, panel } = makePanel(() => {})
+  try {
+    panel.handleInput('submit')
+    // A filtered list: the matching action row is present.
+    assert.match(plain(panel.render(88).join('\n')), /Submit draft/, 'search must filter to submit')
+    // Up/Down move the selection through the filtered list (not query text).
+    panel.handleInput('\x1b[B')
+    panel.handleInput('\r') // Enter opens the selected action (not a newline)
+    const detail = plain(panel.render(88).join('\n'))
+    assert.match(detail, /shortcut/i, 'Enter must open the selected action details')
+    assert.doesNotMatch(detail, /Search:/, 'the detail view replaces the list (search row gone)')
+    // Esc back: the list returns with the query preserved.
+    panel.handleInput('\x1b')
+    assert.match(plain(panel.render(88).join('\n')), /Search: submit/, 'query must survive the detail round trip')
+  } finally {
+    panel.dispose()
+    manager.dispose()
+  }
+})
+
+test('editor search row never overflows the panel width (narrow terminals)', () => {
+  // The search row combines the 'Search: ' label with the shared Input's
+  // render; at narrow widths the joined row must still fit the panel
+  // (the Input's own render pads to its granted width, and the stripped
+  // prompt re-added to the label used to exceed the request).
+  for (const width of [4, 8, 10, 12, 20, 40]) {
+    const { manager, panel } = makePanel(() => {})
+    try {
+      panel.handleInput('abc')
+      panel.handleInput('\x1b[D') // a cursor position inside the text
+      for (const line of panel.render(width)) {
+        if (!line.includes('Search:')) continue
+        assert.ok(visibleWidth(line) <= width,
+          `search row overflows width ${width} (visible ${visibleWidth(line)}): ${JSON.stringify(line)}`)
+      }
+    } finally {
+      panel.dispose()
+      manager.dispose()
+    }
   }
 })

--- a/test/keybinding-manager.test.ts
+++ b/test/keybinding-manager.test.ts
@@ -141,7 +141,8 @@ test('keysLabelFor falls back to an overlay action default (the /help source)', 
   // '—' for Enter submission and the fixed overlay controls.
   const manager = managerWith({})
   assert.equal(manager.keysLabelFor('app.input.submit'), 'Enter', 'submit keeps its default label')
-  assert.equal(manager.keysLabelFor('app.transcript.search.close'), 'Esc')
+  assert.equal(manager.keysLabelFor('app.transcript.search.close'), 'Esc / Ctrl+C',
+    'search close advertises its full default set (the overlay Input swallows Ctrl+C otherwise)')
   assert.equal(manager.keysLabelFor('app.transcript.search.next'), 'Enter')
   assert.equal(manager.keysLabelFor('app.transcript.search.previous'), 'Shift+Enter')
   // Disabled actions still advertise nothing.

--- a/test/question-flow.test.ts
+++ b/test/question-flow.test.ts
@@ -140,7 +140,9 @@ test('budget matrix: optionless free-text question keeps the question and hint',
   for (const budget of BUDGETS) {
     for (const width of WIDTHS) {
       const f = makeFlow([{ id: 'q1', question: 'Type your answer to this long free-text question that wraps across rows. '.repeat(2).trim() }], budget)
-      assertPage(render(f, width), budget, width, 'Type your answer', { hint: 'esc cancel' })
+      // An optionless question OPENS in the text edit (esc back = leave
+      // the edit for the navigation layer).
+      assertPage(render(f, width), budget, width, 'Type your answer', { hint: 'esc back' })
     }
   }
 })
@@ -210,11 +212,12 @@ test('→ skips only unanswered questions; answered drafts advance untouched', (
   ])
 })
 
-test('text-mode → with an empty input never wipes an existing selection', () => {
-  // Regression for the arrow-key move-on invariant: entering the "Type
-  // something." row and pressing → with EMPTY text used to set skipped=true,
+test('Enter on empty custom text never wipes an existing selection', () => {
+  // Regression: committing EMPTY custom text used to set skipped=true,
   // and the skipped mark wins at submit (returns selected: []) — the
   // selection was silently destroyed. An answered draft must survive.
+  // (The old text-mode → move-on verb is gone — → is the text cursor now —
+  // so Enter is the commit key this invariant rides on.)
   // Single-select case.
   let done: unknown
   const f = new QuestionFlow([
@@ -232,9 +235,9 @@ test('text-mode → with an empty input never wipes an existing selection', () =
   render(f, 100)
   f.handleInput('\r') // enter the free-text row
   render(f, 100)
-  f.handleInput('\x1b[C') // → with EMPTY text: must NOT wipe the selection
+  f.handleInput('\r') // Enter with EMPTY text: must NOT wipe the selection
   const review = render(f, 100).join('\n')
-  assert.ok(review.includes('Submit'), `→ must reach the review page:\n${review}`)
+  assert.ok(review.includes('Submit'), `Enter must reach the review page:\n${review}`)
   assert.ok(!review.includes('(skipped)'), `the answered question must not become (skipped):\n${review}`)
   f.handleInput('\r') // submit
   assert.deepEqual(done, [{ id: 'q1', selected: ['A'] }])
@@ -247,16 +250,16 @@ test('text-mode → with an empty input never wipes an existing selection', () =
   render(g, 100)
   g.handleInput('\r') // toggle X (multi-select stays on the question)
   render(g, 100)
-  // Cursor onto "Type something." (last row), enter text mode, → empty.
+  // Cursor onto "Type something." (last row), enter text mode, Enter empty.
   g.handleInput('\x1b[B')
   g.handleInput('\x1b[B')
   render(g, 100)
   g.handleInput('\r')
   render(g, 100)
-  g.handleInput('\x1b[C') // → with EMPTY text on the answered multi-select
+  g.handleInput('\r') // Enter with EMPTY text on the answered multi-select
   // Single-question flow: commitOther advances straight to the review page.
   const review2 = render(g, 100).join('\n')
-  assert.ok(review2.includes('Submit'), `→ must reach the review page:\n${review2}`)
+  assert.ok(review2.includes('Submit'), `Enter must reach the review page:\n${review2}`)
   assert.ok(!review2.includes('(skipped)'), `the multi-select answer must not become (skipped):\n${review2}`)
   g.handleInput('\r') // submit
   assert.deepEqual(done2, [{ id: 'q1', selected: ['X'] }])
@@ -305,9 +308,10 @@ test('review page: Enter submits, ↓ never cancels, ← goes back to the last q
   assert.ok(render(g, 100).join('\n').includes('Two?'), `← must return to the last question:\n${render(g, 100).join('\n')}`)
 })
 
-test('→ in text mode commits the typed answer (empty counts as skipped)', () => {
-  // Text mode (optionless): → is the same "move on" verb — it commits the
-  // typed text and advances; an empty input counts as skipped (Enter parity).
+test('Enter in text mode commits the typed answer (empty counts as skipped)', () => {
+  // Text mode (optionless): Enter commits the typed text and advances; an
+  // empty input counts as skipped (the old → move-on verb is now the text
+  // cursor's key in edit mode — Enter is the commit path).
   let done: unknown
   const f = new QuestionFlow([
     { id: 'q1', question: 'Name?' },
@@ -316,8 +320,8 @@ test('→ in text mode commits the typed answer (empty counts as skipped)', () =
   f.setMaxRows(24)
   render(f, 100)
   f.handleInput('alice')
-  f.handleInput('\x1b[C') // → commits the typed answer
-  assert.ok(render(f, 100).join('\n').includes('Second?'), `→ must advance from text mode:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\r') // Enter commits the typed answer
+  assert.ok(render(f, 100).join('\n').includes('Second?'), `Enter must advance from text mode:\n${render(f, 100).join('\n')}`)
   f.handleInput('\x1b[C') // → on unanswered q2 → review (skipped)
   render(f, 100)
   f.handleInput('\r') // submit
@@ -335,11 +339,31 @@ test('the hint advertises ← back · → skip instead of the old letters', () =
   const questionPage = render(f, 100).join('\n')
   assert.ok(questionPage.includes('← back · → skip'), `hint must advertise the arrow verbs:\n${questionPage}`)
   assert.ok(!questionPage.includes('s skip'), `the old 's skip' verb must be gone:\n${questionPage}`)
-  // Text mode commits on → (empty = skipped), so the verb is '→ next' there.
+  // Text mode edits text: ←→ belong to the text cursor (edit hint), and
+  // the edit hint always says esc back (leave the edit).
   const g = makeFlow([{ id: 'q1', question: 'Your name?' }], 24)
   const textMode = render(g, 100).join('\n')
-  assert.ok(textMode.includes('→ next'), `text-mode hint must advertise → next:\n${textMode}`)
+  assert.ok(textMode.includes('←→ edit'), `text-mode hint must advertise ←→ edit:\n${textMode}`)
+  assert.ok(textMode.includes('esc back'), `edit hint must advertise esc back:\n${textMode}`)
+  assert.ok(!textMode.includes('esc cancel'), `edit hint must not advertise esc cancel:\n${textMode}`)
+  assert.ok(!textMode.includes('→ next'), `text-mode hint must not advertise → next:\n${textMode}`)
   assert.ok(!textMode.includes('→ skip'), `text-mode hint must not say → skip:\n${textMode}`)
+  assert.ok(!textMode.includes('↑↓ select'), `text-mode hint must not advertise ↑↓ select:\n${textMode}`)
+  assert.ok(!textMode.includes('1-1 choose'), `text-mode hint must not advertise digit choose:\n${textMode}`)
+  // The NAVIGATION state after Esc advertises the optionless verbs:
+  // ↵ re-enters the edit, ← back / → skip page (a multi-question flow),
+  // esc cancels the flow.
+  const g2 = makeFlow([
+    { id: 'q1', question: 'First?', options: [{ label: 'A' }] },
+    { id: 'q2', question: 'Your name?' },
+  ], 24)
+  g2.handleInput('1') // answer Q1 → Q2 (optionless, edit layer)
+  g2.handleInput('\x1b') // Esc → navigation state
+  const navMode = render(g2, 100).join('\n')
+  assert.ok(navMode.includes('↵ edit'), `navigation hint must advertise ↵ edit:\n${navMode}`)
+  assert.ok(navMode.includes('← back · → skip'), `navigation hint must advertise the arrow verbs:\n${navMode}`)
+  assert.ok(navMode.includes('esc cancel'), `navigation hint must advertise esc cancel:\n${navMode}`)
+  assert.ok(!navMode.includes('←→ edit'), `navigation hint must not advertise ←→ edit:\n${navMode}`)
   f.handleInput('1')
   render(f, 100)
   f.handleInput('1') // → review
@@ -794,4 +818,484 @@ test('Kitty CSI-u Esc cancels and CSI-u Tab/Enter work', () => {
   render(legacy, 100)
   legacy.handleInput('\x1b')
   assert.equal(cancelled, 3, `legacy Esc must still cancel: got ${cancelled}`)
+})
+
+// ── WP1: free-text edit keyboard ownership (plan §2) ─────────────────────
+
+/** Enter the free-text edit of a question WITH options: walk the cursor to
+ *  the "Type something." row (the last row) and confirm it. */
+function enterOtherEdit(f: QuestionFlow, optionCount: number): void {
+  render(f, 100)
+  for (let i = 0; i < optionCount; i++) f.handleInput('\x1b[B')
+  render(f, 100)
+  f.handleInput('\r') // confirm the OTHER row
+  render(f, 100)
+}
+
+test('edit mode: Left + X inserts mid-text and never commits/advances', () => {
+  // The headline regressions: → used to commit+advance and ← used to page
+  // back — the parent stole the text cursor. Now BOTH arrows go to the
+  // shared Input, so abc + Left + X must yield abXc and stay put.
+  let done: unknown
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'Name?', options: [{ label: 'A' }, { label: 'B' }] },
+  ], (answers) => { done = answers }, () => {})
+  f.setMaxRows(24)
+  enterOtherEdit(f, 2)
+  f.handleInput('abc')
+  f.handleInput('\x1b[D') // Left
+  f.handleInput('X')
+  let view = render(f, 100).join('\n')
+  assert.ok(view.includes('abXc'), `Left+X must insert mid-text:\n${view}`)
+  assert.ok(!view.includes('Review your answer'), `Left must not commit/advance:\n${view}`)
+  assert.ok(done === undefined, `Left must not submit the draft`)
+  // Right moves the cursor only (never commit/next).
+  f.handleInput('\x1b[C') // Right — back to the end
+  f.handleInput('Y')
+  view = render(f, 100).join('\n')
+  assert.ok(view.includes('abXcY'), `Right must move the cursor only:\n${view}`)
+  assert.ok(!view.includes('Review your answer'), `Right must not commit/advance:\n${view}`)
+  assert.ok(done === undefined, `Right must not submit the draft`)
+  // The double-left-right variant from the plan.
+  const g = new QuestionFlow([
+    { id: 'q1', question: 'Name?', options: [{ label: 'A' }] },
+  ], () => {}, () => {})
+  g.setMaxRows(24)
+  enterOtherEdit(g, 1)
+  g.handleInput('abc')
+  g.handleInput('\x1b[D')
+  g.handleInput('\x1b[D')
+  g.handleInput('\x1b[C')
+  g.handleInput('X')
+  view = render(g, 100).join('\n')
+  assert.ok(view.includes('abXc'), `Left Left Right + X must land between b and c:\n${view}`)
+  assert.ok(!view.includes('Review your answer'), `no advance in the double-arrow variant:\n${view}`)
+})
+
+test('edit mode: Home/End and Ctrl+A/E/B/F reach the shared Input', () => {
+  const f = makeFlow([{ id: 'q1', question: 'Name?' }], 24) // optionless → already editing
+  render(f, 100)
+  f.handleInput('abc')
+  f.handleInput('\x1bOH') // Home
+  f.handleInput('X')
+  assert.ok(render(f, 100).join('\n').includes('Xabc'), `Home + X must prepend:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x1bOF') // End
+  f.handleInput('Y')
+  assert.ok(render(f, 100).join('\n').includes('XabcY'), `End + Y must append:\n${render(f, 100).join('\n')}`)
+  // Ctrl+A / Ctrl+E (Emacs line home/end).
+  f.handleInput('\x01') // Ctrl+A
+  f.handleInput('Z')
+  assert.ok(render(f, 100).join('\n').includes('ZXabcY'), `Ctrl+A + Z must prepend:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x05') // Ctrl+E
+  f.handleInput('W')
+  assert.ok(render(f, 100).join('\n').includes('ZXabcYW'), `Ctrl+E + W must append:\n${render(f, 100).join('\n')}`)
+  // Ctrl+B / Ctrl+F (Emacs char movement).
+  f.handleInput('\x02') // Ctrl+B — one left from the end
+  f.handleInput('V')
+  assert.ok(render(f, 100).join('\n').includes('ZXabcYVW'), `Ctrl+B + V must insert before W:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x06') // Ctrl+F — back to the end
+  f.handleInput('U')
+  assert.ok(render(f, 100).join('\n').includes('ZXabcYVWU'), `Ctrl+F + U must append:\n${render(f, 100).join('\n')}`)
+})
+
+test('edit mode: Backspace/Delete, word movement and kill/undo reach the Input', () => {
+  const f = makeFlow([{ id: 'q1', question: 'Name?' }], 24)
+  render(f, 100)
+  f.handleInput('abc')
+  f.handleInput('\x7f') // Backspace
+  assert.ok(render(f, 100).join('\n').includes('ab'), `Backspace must delete backward:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x1bOH') // Home
+  f.handleInput('\x1b[3~') // Delete
+  assert.ok(render(f, 100).join('\n').includes('b'), `Delete must delete forward:\n${render(f, 100).join('\n')}`)
+  // Word movement: Alt+Left from the end lands at the previous word start.
+  const g = makeFlow([{ id: 'q1', question: 'Words?' }], 24)
+  render(g, 100)
+  g.handleInput('hello world')
+  g.handleInput('\x1bB') // Alt+Left
+  g.handleInput('X')
+  assert.ok(render(g, 100).join('\n').includes('hello Xworld'), `Alt+Left + X must insert at the word boundary:\n${render(g, 100).join('\n')}`)
+  // Kill/undo: Ctrl+U kills to line start, undo restores it.
+  const h = makeFlow([{ id: 'q1', question: 'Kill?' }], 24)
+  render(h, 100)
+  h.handleInput('abc')
+  h.handleInput('\x15') // Ctrl+U
+  assert.ok(!render(h, 100).join('\n').includes('abc'), `Ctrl+U must kill to line start:\n${render(h, 100).join('\n')}`)
+  h.handleInput('\x1f') // Ctrl+- undo
+  assert.ok(render(h, 100).join('\n').includes('abc'), `undo must restore the killed text:\n${render(h, 100).join('\n')}`)
+})
+
+test('edit mode: Enter confirms, Esc backs to choices (draft kept), PgUp/PgDn scroll the body', () => {
+  // Enter confirms the custom answer (parent-owned).
+  let done: unknown
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'Name?', options: [{ label: 'A' }] },
+    { id: 'q2', question: 'Second?', options: [{ label: 'B' }] },
+  ], (answers) => { done = answers }, () => {})
+  f.setMaxRows(24)
+  enterOtherEdit(f, 1)
+  f.handleInput('alice')
+  f.handleInput('\r') // Enter commits
+  assert.ok(render(f, 100).join('\n').includes('Second?'), `Enter must commit and advance:\n${render(f, 100).join('\n')}`)
+  // Esc with choices: back to the option list, the COMMITTED draft survives.
+  const g = new QuestionFlow([
+    { id: 'q1', question: 'Name?', options: [{ label: 'A' }] },
+    { id: 'q2', question: 'Second?', options: [{ label: 'B' }] },
+  ], () => {}, () => {})
+  g.setMaxRows(24)
+  enterOtherEdit(g, 1)
+  g.handleInput('alice')
+  g.handleInput('\r') // Enter commits → advances to q2
+  assert.ok(render(g, 100).join('\n').includes('Second?'), `precondition — committed custom advances:\n${render(g, 100).join('\n')}`)
+  g.handleInput('\x1b[D') // ← back to q1 (answered, custom 'alice')
+  enterOtherEdit(g, 1) // walk to the OTHER row and enter edit mode
+  const beforeEsc = render(g, 100).join('\n')
+  assert.ok(beforeEsc.includes('alice'), `precondition — draft text visible in the edit row:\n${beforeEsc}`)
+  g.handleInput('\x1b') // Esc → option mode
+  const backToChoices = render(g, 100).join('\n')
+  assert.ok(backToChoices.includes('↑↓ select'), `Esc must return to the option list:\n${backToChoices}`)
+  // Re-enter the edit: Esc leaves the cursor on the OTHER row, so Enter
+  // goes straight back in — the COMMITTED draft text must still be there.
+  render(g, 100)
+  g.handleInput('\r')
+  const reentered = render(g, 100).join('\n')
+  assert.ok(reentered.includes('alice'), `the committed draft must survive Esc and re-entry:\n${reentered}`)
+  // PgUp/PgDn still scroll the body while editing (a long detail).
+  const h = makeFlow([{ id: 'q1', question: 'Pick a side', detail: longDetail(60) }], 12)
+  const top = render(h, 100).join('\n')
+  assert.ok(top.includes('detail-00'), `precondition — body top visible:\n${top}`)
+  h.handleInput('\x1b[6~') // PageDown while editing
+  const scrolled = render(h, 100).join('\n')
+  assert.ok(!scrolled.includes('detail-00') || scrolled.includes('↑ '),
+    `PageDown must scroll the body while editing:\n${scrolled}`)
+  h.handleInput('\x1b[5~') // PageUp
+  const back = render(h, 100).join('\n')
+  assert.ok(back.includes('detail-00'), `PageUp must scroll the body back:\n${back}`)
+})
+
+test('optionless question: Esc enters the navigation state, Esc again cancels the flow', () => {
+  // Two-layer state machine: the EDIT layer owns the text; Esc leaves it
+  // for the navigation layer (← back / → skip / ↵ re-edit); ONLY the
+  // navigation layer's Esc cancels the whole flow. A single Esc must
+  // never cancel and must never strand the question uneditable.
+  let cancelled = 0
+  const f = new QuestionFlow([{ id: 'q1', question: 'Name?' }], () => {}, () => { cancelled += 1 })
+  f.setMaxRows(24)
+  render(f, 100)
+  f.handleInput('alice')
+  f.handleInput('\x1b') // Esc: leave the edit — NOT a cancel
+  assert.equal(cancelled, 0, `first Esc must not cancel: got ${cancelled}`)
+  const nav = render(f, 100).join('\n')
+  assert.ok(nav.includes('↵ edit'), `after Esc the navigation hint must advertise ↵ edit:\n${nav}`)
+  assert.ok(nav.includes('esc cancel'), `navigation hint must advertise esc cancel:\n${nav}`)
+  f.handleInput('\x1b') // navigation-state Esc cancels the flow
+  assert.equal(cancelled, 1, `navigation Esc must cancel the flow once: got ${cancelled}`)
+  // The Input's generic cancel (Ctrl+C) mirrors the same two-stage
+  // lifecycle: first press leaves the edit, second press cancels.
+  const g = new QuestionFlow([{ id: 'q1', question: 'Name?' }], () => {}, () => { cancelled += 1 })
+  g.setMaxRows(24)
+  render(g, 100)
+  g.handleInput('\x03') // Ctrl+C → navigation state (like Esc)
+  assert.equal(cancelled, 1, `first Ctrl+C must leave the edit, not cancel: got ${cancelled}`)
+  g.handleInput('\x03') // navigation-state Ctrl+C cancels
+  assert.equal(cancelled, 2, `navigation Ctrl+C must cancel the flow: got ${cancelled}`)
+})
+
+test('optionless navigation state: Enter and printable keys re-enter the edit', () => {
+  // After Esc leaves the edit, the question is NOT editable in place —
+  // the edit layer must be re-entered explicitly (Enter) or implicitly
+  // (any typing key drops straight back into the Input).
+  let cancelled = 0
+  const f = new QuestionFlow([{ id: 'q1', question: 'Name?' }], () => {}, () => { cancelled += 1 })
+  f.setMaxRows(24)
+  render(f, 100)
+  f.handleInput('ali')
+  f.handleInput('\x1b') // navigation state
+  const before = render(f, 100).join('\n')
+  assert.ok(!before.includes('←→ edit'), `navigation state must not advertise the edit hint:\n${before}`)
+  f.handleInput('\r') // ↵ re-enters the edit
+  const editing1 = render(f, 100).join('\n')
+  assert.ok(editing1.includes('←→ edit'), `↵ must re-enter the edit:\n${editing1}`)
+  f.handleInput('x') // typing inside the edit appends
+  assert.ok(render(f, 100).join('\n').includes('alix'), `edit must accept text after ↵:\n${render(f, 100).join('\n')}`)
+  // A printable key from the NAVIGATION state re-enters immediately with
+  // the key delivered to the Input (search-box semantics).
+  const g = new QuestionFlow([{ id: 'q1', question: 'Name?' }], () => {}, () => {})
+  g.setMaxRows(24)
+  render(g, 100)
+  g.handleInput('abc')
+  g.handleInput('\x1b') // navigation state
+  g.handleInput('Z') // typing while navigating → straight into the edit
+  const view = render(g, 100).join('\n')
+  assert.ok(view.includes('abcZ'), `a typed key from navigation must re-enter the edit with the key:\n${view}`)
+  assert.ok(view.includes('←→ edit'), `the hint must flip back to the edit after typing:\n${view}`)
+  assert.equal(cancelled, 0, `typing must never cancel the flow`)
+})
+
+test('optionless question: Esc-back navigation reaches the previous question (P1 regression)', () => {
+  // Q1 (choices) → Q2 (optionless) → review → ← back to Q2 → Esc leaves
+  // the edit → ← pages back to Q1. Previously Esc on optionless Q2
+  // cancelled the WHOLE flow, so the user could never keyboard back to
+  // Q1 to fix an answer.
+  let cancelled = 0
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'First?', options: [{ label: 'A' }] },
+    { id: 'q2', question: 'Second?' },
+  ], () => {}, () => { cancelled += 1 })
+  f.setMaxRows(24)
+  render(f, 100)
+  f.handleInput('1') // answer Q1 → Q2 (optionless, opens in edit mode)
+  render(f, 100)
+  f.handleInput('hello')
+  f.handleInput('\r') // Enter commits Q2 → review page
+  assert.ok(render(f, 100).join('\n').includes('Review your answer'), `precondition — review page:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x1b[D') // ← back to Q2 (drafts survive)
+  let view = render(f, 100).join('\n')
+  assert.ok(view.includes('Second?'), `← must return to Q2:\n${view}`)
+  assert.ok(view.includes('←→ edit'), `Q2 must be in the edit layer after ← from review:\n${view}`)
+  f.handleInput('\x1b') // Esc: leave Q2's edit (navigation layer)
+  assert.equal(cancelled, 0, `Esc on Q2 edit must NOT cancel the flow: got ${cancelled}`)
+  f.handleInput('\x1b[D') // ← pages back to Q1 (navigation layer)
+  view = render(f, 100).join('\n')
+  assert.ok(view.includes('First?'), `← from Q2 navigation must reach Q1:\n${view}`)
+  assert.equal(cancelled, 0, `navigation must never cancel the flow: got ${cancelled}`)
+})
+
+test('edit mode hint is mode-specific: esc back everywhere in the edit, esc cancel in navigation', () => {
+  // Choices + Other editing: esc BACK (leave the edit for the option list).
+  const f = makeFlow([{ id: 'q1', question: 'Pick', options: [{ label: 'A' }, { label: 'B' }] }], 24)
+  enterOtherEdit(f, 2)
+  const choicesEdit = render(f, 100).join('\n')
+  assert.ok(choicesEdit.includes('←→ edit'), `edit hint must advertise ←→ edit:\n${choicesEdit}`)
+  assert.ok(choicesEdit.includes('↵ confirm'), `edit hint must advertise ↵ confirm:\n${choicesEdit}`)
+  assert.ok(choicesEdit.includes('esc back'), `choices edit hint must say esc back:\n${choicesEdit}`)
+  assert.ok(!choicesEdit.includes('esc cancel'), `choices edit hint must not say esc cancel:\n${choicesEdit}`)
+  assert.ok(!choicesEdit.includes('↑↓ select'), `edit hint must not advertise ↑↓ select:\n${choicesEdit}`)
+  assert.ok(!choicesEdit.includes('1-2 choose'), `edit hint must not advertise digit choose:\n${choicesEdit}`)
+  assert.ok(!choicesEdit.includes('↵ toggle'), `edit hint must not advertise ↵ toggle (Enter confirms custom text):\n${choicesEdit}`)
+  assert.ok(!choicesEdit.includes('→ next'), `edit hint must not advertise → next:\n${choicesEdit}`)
+  // Optionless EDIT layer: same esc back (leave the edit for the
+  // navigation layer) — NOT esc cancel (that lives in navigation).
+  const g = makeFlow([{ id: 'q1', question: 'Name?', options: [] }, { id: 'q2', question: 'Second?' }], 24)
+  const optionless = render(g, 100).join('\n')
+  assert.ok(optionless.includes('←→ edit'), `optionless edit hint must advertise ←→ edit:\n${optionless}`)
+  assert.ok(optionless.includes('esc back'), `optionless edit hint must say esc back:\n${optionless}`)
+  assert.ok(!optionless.includes('esc cancel'), `optionless edit hint must not say esc cancel:\n${optionless}`)
+  // The optionless NAVIGATION layer (after Esc): ↵ re-enters the edit,
+  // arrows page, esc cancels.
+  g.handleInput('\x1b')
+  const nav = render(g, 100).join('\n')
+  assert.ok(nav.includes('↵ edit'), `navigation hint must advertise ↵ edit:\n${nav}`)
+  assert.ok(nav.includes('← back · → skip'), `navigation hint must advertise the arrow verbs:\n${nav}`)
+  assert.ok(nav.includes('esc cancel'), `navigation hint must advertise esc cancel:\n${nav}`)
+  assert.ok(!nav.includes('←→ edit'), `navigation hint must not advertise ←→ edit:\n${nav}`)
+  // List mode keeps its own hint (regression guard).
+  const list = render(makeFlow([{ id: 'q1', question: 'Pick', options: [{ label: 'A' }] }], 24), 100).join('\n')
+  assert.ok(list.includes('↑↓ select'), `list mode must keep ↑↓ select:\n${list}`)
+  assert.ok(list.includes('↵ confirm'), `list mode must keep ↵ confirm:\n${list}`)
+  assert.ok(list.includes('esc cancel'), `list mode must keep esc cancel:\n${list}`)
+})
+
+test('free-text input never leaks across questions (round-3 P1)', () => {
+  // Q1 choices → Other edit commits 'abc' → advance to Q2 (choices) →
+  // entering Q2's OTHER edit must start EMPTY, not show Q1's text.
+  let done: unknown
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'One?', options: [{ label: 'A' }, { label: 'B' }] },
+    { id: 'q2', question: 'Two?', options: [{ label: 'A' }, { label: 'B' }] },
+  ], (answers) => { done = answers }, () => {})
+  f.setMaxRows(24)
+  render(f, 100)
+  f.handleInput('\x1b[B'); f.handleInput('\x1b[B') // to Q1 OTHER row
+  render(f, 100)
+  f.handleInput('\r') // enter Q1 edit
+  f.handleInput('abc')
+  f.handleInput('\r') // commit → advance to Q2 (list)
+  assert.ok(render(f, 100).join('\n').includes('Two?'), `precondition — Q2 shown:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x1b[B'); f.handleInput('\x1b[B') // to Q2 OTHER row
+  render(f, 100)
+  f.handleInput('\r') // enter Q2 edit
+  const q2Edit = render(f, 100).join('\n')
+  assert.ok(!q2Edit.includes('abc'), `Q2 edit must not show Q1's committed text:\n${q2Edit}`)
+})
+
+test('clearing a committed free-text answer is not resurrected by Esc→navigation→re-edit', () => {
+  // An optionless question with a COMMITTED 'abc': revisit the edit,
+  // clear it (Ctrl+A + Delete), Esc to navigation, re-enter with ↵ —
+  // the deleted text must stay deleted (the shared Input's ownership is
+  // tracked per question, not by value emptiness).
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'One?', options: [{ label: 'A' }] },
+    { id: 'q2', question: 'Two?' },
+  ], () => {}, () => {})
+  f.setMaxRows(24)
+  render(f, 100)
+  f.handleInput('1') // answer Q1 → Q2 (optionless, edit layer)
+  f.handleInput('abc')
+  f.handleInput('\r') // commit Q2 → review
+  render(f, 100)
+  f.handleInput('\x1b[D') // ← back to Q2
+  assert.ok(render(f, 100).join('\n').includes('abc'), `precondition — committed text visible:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x01') // Ctrl+A (line start)
+  f.handleInput('\x1b[3~') // Delete clears 'abc'
+  assert.ok(!render(f, 100).join('\n').includes('abc'), `precondition — text cleared:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x1b') // Esc → navigation
+  f.handleInput('\r') // ↵ re-enters the edit
+  const reentered = render(f, 100).join('\n')
+  assert.ok(!reentered.includes('abc'), `cleared text must not be resurrected:\n${reentered}`)
+  // The SAME round trip still keeps genuine in-progress text.
+  f.handleInput('xyz')
+  f.handleInput('\x1b') // Esc → navigation
+  f.handleInput('\r') // ↵ re-enter
+  assert.ok(render(f, 100).join('\n').includes('xyz'), `in-progress text must survive the round trip:\n${render(f, 100).join('\n')}`)
+})
+
+test('free-text undo/yank history never leaks across questions', () => {
+  // The free-text Input's undo stack and kill ring are PER-INSTANCE: a
+  // cross-question ownership change must rebuild the Input (resetOtherInput),
+  // so Ctrl+- (undo) / Ctrl+Y (yank) in a later question cannot resurrect
+  // the previous question's editing history.
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'One?', options: [{ label: 'A' }, { label: 'B' }] },
+    { id: 'q2', question: 'Two?', options: [{ label: 'A' }, { label: 'B' }] },
+  ], () => {}, () => {})
+  f.setMaxRows(24)
+  render(f, 100)
+  // Q1 OTHER: type abc, Backspace → 'ab', commit → advance to Q2.
+  f.handleInput('\x1b[B'); f.handleInput('\x1b[B')
+  render(f, 100)
+  f.handleInput('\r') // enter Q1 edit
+  f.handleInput('abc')
+  f.handleInput('\x7f') // backspace → 'ab'
+  f.handleInput('\r') // commit → Q2 (list)
+  render(f, 100)
+  f.handleInput('\x1b[B'); f.handleInput('\x1b[B')
+  render(f, 100)
+  f.handleInput('\r') // enter Q2 edit (seeded empty)
+  assert.ok(!render(f, 100).join('\n').includes('ab'), `precondition — Q2 edit blank:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x1f') // Ctrl+- undo
+  assert.ok(!render(f, 100).join('\n').includes('ab'), `undo must not resurrect Q1's text:\n${render(f, 100).join('\n')}`)
+  f.handleInput('\x19') // Ctrl+Y yank
+  assert.ok(!render(f, 100).join('\n').includes('ab'), `yank must not paste Q1's killed history:\n${render(f, 100).join('\n')}`)
+})
+
+test('optionless navigation: h and l are TEXT, not vim page aliases', () => {
+  // Typing 'h'/'l' from the navigation state must re-enter the edit with
+  // the letter — never page back (h) or skip-and-advance (l). The vim
+  // aliases stay LIST-mode conveniences only (the review page has no
+  // input to steal from and keeps h).
+  let done: unknown
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'First?', options: [{ label: 'A' }] },
+    { id: 'q2', question: 'Second?' },
+  ], (answers) => { done = answers }, () => {})
+  f.setMaxRows(24)
+  render(f, 100)
+  f.handleInput('1') // answer Q1 → Q2 (optionless, edit layer)
+  render(f, 100)
+  f.handleInput('abc')
+  f.handleInput('\x1b') // → navigation state
+  f.handleInput('h') // 'h' must be text, NOT ← back
+  let view = render(f, 100).join('\n')
+  assert.ok(view.includes('abch'), `h must append to the edit:\n${view}`)
+  assert.ok(view.includes('←→ edit'), `h must re-enter the edit layer:\n${view}`)
+  assert.ok(!view.includes('First?'), `h must not page back to Q1:\n${view}`)
+  f.handleInput('\x1b') // → navigation again
+  f.handleInput('l') // 'l' must be text, NOT → skip
+  view = render(f, 100).join('\n')
+  assert.ok(view.includes('abchl'), `l must append to the edit:\n${view}`)
+  assert.ok(view.includes('←→ edit'), `l must re-enter the edit layer:\n${view}`)
+  assert.ok(!view.includes('Review your answer'), `l must not skip-and-advance:\n${view}`)
+  assert.ok(done === undefined, `l must not submit anything`)
+  // The physical arrows still page from the navigation layer.
+  f.handleInput('\x1b')
+  f.handleInput('\x1b[D') // ← pages back to Q1
+  assert.ok(render(f, 100).join('\n').includes('First?'), `← must still page back:\n${render(f, 100).join('\n')}`)
+})
+
+test('optionless navigation: physical ↑/↓ stay no-ops, j/k are text', () => {
+  const f = makeFlow([{ id: 'q1', question: 'Name?' }], 24)
+  render(f, 100)
+  f.handleInput('abc')
+  f.handleInput('\x1b') // navigation state
+  f.handleInput('\x1b[A') // physical ↑ — no-op, stays in navigation
+  let view = render(f, 100).join('\n')
+  assert.ok(view.includes('↵ edit'), `↑ must stay in the navigation layer:\n${view}`)
+  assert.ok(!view.includes('←→ edit'), `↑ must not bounce into the edit:\n${view}`)
+  f.handleInput('\x1b[B') // physical ↓ — no-op
+  view = render(f, 100).join('\n')
+  assert.ok(view.includes('↵ edit'), `↓ must stay in the navigation layer:\n${view}`)
+  f.handleInput('j') // 'j' IS text
+  view = render(f, 100).join('\n')
+  assert.ok(view.includes('abcj'), `j must append to the edit:\n${view}`)
+  assert.ok(view.includes('←→ edit'), `j must re-enter the edit layer:\n${view}`)
+})
+
+test('skip invalidates the free-text Input owner (no stale text beside (skipped))', () => {
+  // Q1 (optionless) has uncommitted 'abc' in the Input; → skip advances.
+  // Returning to Q1 must re-seed from the CLEARED draft — the (skipped)
+  // row must never show stale 'abc' next to it (the Input instance and
+  // ownership survive the skip otherwise, because Q2 never touches it).
+  const f = new QuestionFlow([
+    { id: 'q1', question: 'First?' },
+    { id: 'q2', question: 'Second?', options: [{ label: 'A' }] },
+  ], () => {}, () => {})
+  f.setMaxRows(24)
+  render(f, 100)
+  f.handleInput('abc') // Q1 edit (uncommitted)
+  f.handleInput('\x1b') // navigation state
+  f.handleInput('\x1b[C') // → skip Q1 → Q2 (choices list)
+  let view = render(f, 100).join('\n')
+  assert.ok(view.includes('Second?'), `precondition — Q2 shown:\n${view}`)
+  f.handleInput('\x1b[D') // ← back to Q1
+  view = render(f, 100).join('\n')
+  assert.ok(view.includes('First?'), `← must return to Q1:\n${view}`)
+  assert.ok(view.includes('(skipped)'), `Q1 must stay skipped:\n${view}`)
+  assert.ok(!view.includes('abc'), `the stale Input text must not show beside (skipped):\n${view}`)
+  // The skip ALSO cleared the draft: committing empty then re-entering
+  // still shows nothing stale.
+  f.handleInput('\x1b') // Q1 navigation (re-entered from Q2)
+  f.handleInput('\r') // ↵ re-enter the edit
+  view = render(f, 100).join('\n')
+  assert.ok(!view.includes('abc'), `re-entering the edit must not resurrect the skipped text:\n${view}`)
+})
+
+test('uncommitted edit is dropped on a real tab change regardless of the next question type', () => {
+  // Contract: in-progress free-text survives ONLY an Esc → navigation →
+  // ↵ round trip on the SAME question. Once the user actually pages to
+  // another question (←/→/skip/commit-advance), the uncommitted edit is
+  // dropped and re-entry reseeds from the committed draft — the outcome
+  // must NOT depend on whether the intermediate question itself uses the
+  // free-text Input (round finding: a choices stopover used to leave the
+  // old owner alive, so the text survived only for that path).
+  const scenarios: Array<{ label: string; second: QuestionFlowQuestion }> = [
+    { label: 'choices stopover', second: { id: 'q2', question: 'Second?', options: [{ label: 'B' }] } },
+    { label: 'optionless stopover', second: { id: 'q2', question: 'Second?' } },
+  ]
+  for (const scenario of scenarios) {
+    const f = new QuestionFlow([
+      { id: 'q1', question: 'First?' },
+      scenario.second,
+    ], () => {}, () => {})
+    f.setMaxRows(24)
+    render(f, 100)
+    f.handleInput('abc') // Q1 uncommitted
+    f.handleInput('\r') // commit → advance to Q2
+    assert.ok(render(f, 100).join('\n').includes('Second?'), `${scenario.label} — precondition Q2 shown`)
+    // ← back to Q1 (an optionless Q2 sits in its EDIT layer, where ← is
+    // the text cursor — leave it for the navigation layer first).
+    if (scenario.second.options === undefined) f.handleInput('\x1b')
+    f.handleInput('\x1b[D')
+    render(f, 100)
+    f.handleInput('X') // edit the committed draft: abcX (uncommitted)
+    assert.ok(render(f, 100).join('\n').includes('abcX'), `${scenario.label} — precondition abcX typed:\n${render(f, 100).join('\n')}`)
+    f.handleInput('\x1b') // Esc → navigation (Q1)
+    f.handleInput('\x1b[C') // → moves to Q2 (REAL tab change)
+    render(f, 100)
+    // ← back to Q1 (leave Q2's layer accordingly).
+    if (scenario.second.options === undefined) f.handleInput('\x1b')
+    f.handleInput('\x1b[D')
+    const back = render(f, 100).join('\n')
+    assert.ok(back.includes('abc'), `${scenario.label} — the committed draft survives the trip:\n${back}`)
+    assert.ok(!back.includes('abcX'), `${scenario.label} — the uncommitted X must be dropped on a REAL tab change:\n${back}`)
+  }
 })

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -1703,6 +1703,75 @@ test('ctrl+f opens and closes the transcript search (no fullscreen toggle)', asy
   assert.ok(!view.includes('Find transcript'), `search bar still open:\n${view}`)
 })
 
+test('transcript search: Ctrl+C closes the overlay and the hint advertises next/prev/close', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([{ kind: 'user', turn: 0, text: 'needle' }])
+  await viewport(vt)
+  vt.sendInput('\x06') // ctrl+f opens search
+  let view = await viewport(vt)
+  assert.ok(view.includes('Find transcript'), `search bar missing:\n${view}`)
+  // The next/prev/close hint rides under the input (fixed non-configurable
+  // overlay keys — no effective binding to render).
+  assert.ok(view.includes('↵ next'), `search hint must advertise next:\n${view}`)
+  assert.ok(view.includes('prev'), `search hint must advertise previous:\n${view}`)
+  assert.ok(view.includes('esc/ctrl+c close'), `search hint must advertise esc/ctrl+c close:\n${view}`)
+  // Ctrl+C closes search (the old behavior: the overlay's shared Input
+  // swallowed Ctrl+C as its generic cancel and search stayed open).
+  vt.sendInput('\x03') // ctrl+c
+  view = await viewport(vt)
+  assert.ok(!view.includes('Find transcript'), `Ctrl+C must close search:\n${view}`)
+  // Esc still closes, Enter/Shift+Enter still navigate (semantic close
+  // keeps both routes — no regression).
+  vt.sendInput('\x06')
+  await viewport(vt)
+  vt.sendInput('\x1b')
+  view = await viewport(vt)
+  assert.ok(!view.includes('Find transcript'), `Esc must still close search:\n${view}`)
+})
+
+test('transcript search hint stays on one line at min-width (no layout break)', async () => {
+  const { vt, app } = startApp(24, 24) // the overlay minWidth
+  app.setTranscript([{ kind: 'user', turn: 0, text: 'needle' }])
+  await viewport(vt)
+  vt.sendInput('\x06')
+  const view = await viewport(vt)
+  assert.ok(view.includes('Find transcript'), `search bar missing at min width:\n${view}`)
+  const hintRow = view.split('\n').find(line => line.includes('next'))
+  assert.ok(hintRow !== undefined, `hint must render at min width:\n${view}`)
+  assert.ok((hintRow ?? '').length <= 24, `hint must not overflow the overlay width:\n${view}`)
+})
+
+test('transcript search: Left/Right/Home/End edit the query inside the overlay', async () => {
+  const { TuiApp } = await import('../src/tui-app.ts')
+  const { VirtualTerminal } = await import('./virtual-terminal.ts')
+  const vt = new VirtualTerminal(100, 24)
+  const queries: string[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: () => {},
+    onExit: () => {},
+    onSearchQuery: (query) => queries.push(query),
+  })
+  app.start()
+  startedApps.add(app)
+  app.startTranscriptSearch()
+  await viewport(vt)
+  vt.sendInput('abc')
+  await viewport(vt)
+  vt.sendInput('\x1b[D') // Left
+  vt.sendInput('X')
+  await viewport(vt)
+  assert.ok(queries.includes('abXc'), `Left+X must insert mid-query: ${JSON.stringify(queries)}`)
+  vt.sendInput('\x1bOH') // Home
+  vt.sendInput('Z')
+  await viewport(vt)
+  assert.ok(queries.includes('ZabXc'), `Home+Z must prefix: ${JSON.stringify(queries)}`)
+  vt.sendInput('\x1bOF') // End
+  vt.sendInput('Y')
+  await viewport(vt)
+  assert.ok(queries.includes('ZabXcY'), `End+Y must append: ${JSON.stringify(queries)}`)
+  app.closeTranscriptSearch()
+})
+
 test('fullscreen Ctrl+F and Ctrl+Shift+F search the full folder and re-window to an old match', async () => {
   const folder = new TranscriptFolder()
   folder.apply(Array.from({ length: 100 }, (_, turn) => ({
@@ -3544,13 +3613,20 @@ test('askQuestions skip pages through and preserves drafts', async () => {
   await viewport(vt)
   view = await viewport(vt)
   assert.ok(view.includes('Second?'), `back to the second question:\n${view}`)
-  vt.sendInput('\x1b[D') // Q2 text mode: ← pages back to Q1
+  assert.ok(view.includes('hello'), `the committed draft survives the review round trip:\n${view}`)
+  // Q2 is an OPTIONLESS question: ←/→ are TEXT cursor keys in edit mode —
+  // they never page back to Q1, commit or advance (the WP1 ownership fix).
+  vt.sendInput('\x1b[D') // ← moves the text cursor (no page-back)
   await viewport(vt)
   view = await viewport(vt)
-  assert.ok(view.includes('First?'), `back to the first question:\n${view}`)
-  vt.sendInput('\x1b[C') // back to Q2
+  assert.ok(view.includes('Second?'), `← must stay on the optionless question:\n${view}`)
+  assert.ok(!view.includes('First?'), `← must not page back to Q1 in text mode:\n${view}`)
+  vt.sendInput('\x1b[C') // → moves the text cursor (no commit/advance)
   await viewport(vt)
-  vt.sendInput('\x1b[C') // Q2 → review
+  view = await viewport(vt)
+  assert.ok(view.includes('Second?'), `→ must stay on the optionless question:\n${view}`)
+  assert.ok(!view.includes('Review your answer'), `→ must not advance in text mode:\n${view}`)
+  vt.sendInput('\r') // Enter commits → review
   await viewport(vt)
   vt.sendInput('\r') // submit
   assert.deepEqual(await promise, [

--- a/test/task-center-refactor.test.ts
+++ b/test/task-center-refactor.test.ts
@@ -219,3 +219,63 @@ test('a STABLE id re-entering failure is exposed again (P2 edge: id reuse)', () 
     'the second failure of the same id must be exposed again (the runtime treats it as new)')
   panel.dispose()
 })
+
+test('search mode renders its own hint — query actions, never the task actions', () => {
+  const panel = new TaskBrowserPanel([
+    { ...job('stop-me'), label: 'build' },
+    { ...job('job:2'), status: 'completed' },
+  ], 10, {
+    mode: 'full', enableSearch: true, header: 'Tasks',
+  }, () => {}, () => {}, () => {})
+  panel.handleInput('/')
+  const view = panel.render(100).join('\n')
+  // esc back leads the verb list: a 1-line hint on an 80-column terminal
+  // truncates its tail, so the escape verb must never be the clipped part.
+  const searchHint = 'type filter · esc back · ←→ edit · ↑↓ navigate · pgup/pgdn page · tab type · enter open'
+  assert.ok(view.includes(searchHint), `search-mode hint must advertise the query actions:\n${view}`)
+  for (const stale of ['A active/all', 'N next running', 'S stop', 'R refresh', '←→ tree']) {
+    assert.ok(!view.includes(stale), `search-mode hint must not advertise '${stale}':\n${view}`)
+  }
+  panel.dispose()
+})
+
+test('search-mode hint keeps esc back visible at 80 columns', () => {
+  const panel = new TaskBrowserPanel([job('build')], 10, {
+    mode: 'full', enableSearch: true, header: 'Tasks',
+  }, () => {}, () => {}, () => {})
+  panel.handleInput('/')
+  const view = panel.render(80).join('\n')
+  const hintRow = view.split('\n').find(line => line.includes('type filter'))
+  assert.ok(hintRow !== undefined, `search hint missing at 80 cols:\n${view}`)
+  assert.ok(hintRow.includes('esc back'), `esc back must survive the 80-column hint:\n${view}`)
+  // The ordinary task actions stay out of search mode here too.
+  assert.ok(!view.includes('A active/all') && !view.includes('S stop'), `no task actions in search mode:\n${view}`)
+  panel.dispose()
+})
+
+test('search mode: A/S/R/N are query text, ←→ edit the query (never tree actions)', () => {
+  const panel = new TaskBrowserPanel([job('stop-me')], 10, {
+    mode: 'full', enableSearch: true, header: 'Tasks',
+  }, () => {}, () => {}, () => {})
+  panel.handleInput('/')
+  // Every ordinary task action letter is a query character in search mode.
+  for (const key of ['A', 'S', 'R', 'N', 's', 'a', 'n', 'r']) panel.handleInput(key)
+  assert.equal(panel.getFilter(), 'ASRNsanr')
+  assert.deepEqual(panel.visibleItems(), [],
+    'a non-matching query filters the list (no task action side effects)')
+  // ←→ edit the query text (cursor movement), never tree expand/collapse.
+  panel.handleInput('\x1b[D') // Left
+  panel.handleInput('X')
+  assert.equal(panel.getFilter(), 'ASRNsanXr', 'Left + X must insert before the last character')
+  const expandedBefore = [...panel.visibleItems()]
+  panel.handleInput('\x1b[C') // Right — moves the cursor, no tree action
+  assert.equal(panel.getFilter(), 'ASRNsanXr', 'Right must not alter the query')
+  assert.deepEqual(panel.visibleItems(), expandedBefore, 'Right must not expand/collapse rows')
+  // Esc still exits search mode (query kept) and the normal task hint
+  // returns (the search-mode hint is gone).
+  panel.handleInput('\x1b')
+  const afterEsc = panel.render(100).join('\n')
+  assert.ok(!afterEsc.includes('type filter · ←→ edit'), `first Esc must leave search mode:\n${afterEsc}`)
+  assert.ok(afterEsc.includes('A active/all'), `normal task actions return after Esc:\n${afterEsc}`)
+  panel.dispose()
+})


### PR DESCRIPTION
## 概要

修复几类「文本输入态键盘所有权不清 / UI 指引与实际行为不一致」的问题（计划 `temp/1.3/next-input-editing-fix-plan.md`，基于 `next@96dd4101`，当前 HEAD 为 `96dd410125a1`）。

### Question 自由输入（两层状态机，显式键盘所有权）

- **编辑层**：`←/→`、Home/End、Ctrl+A/E/B/F、Delete、词移动、kill/undo 全部进入共享 `Input`（此前被父层 `question.previous/next` 抢走）；`↵` 提交并前进；`Esc/Ctrl+C` **只退出编辑态**回到导航层。
- **导航层**（退出编辑后）：`←/→` 翻题（或跳过）、`↵` 重新进入编辑、`Esc/Ctrl+C` 才取消整个流程——无选项纯文本问题不再有"按 Esc 直接取消 / 或陷入无法重新编辑半死状态"的问题。
- 导航层内任意可打印键（h/l/j/k/数字/e 等）自动重进编辑并交给 Input（搜索框语义，无需先按 Enter；无选项时 h/l 等是文本，不是列表 vim alias）；物理 `↑/↓` 在导航层为 no-op。
- 共享 Input 在每次真实归属变化时重建（per-instance undo/kill 历史，杜绝跨题文本/历史泄漏）；未提交编辑只在**同一题内**的 Esc→导航→重进往返中保留，真正翻题即丢弃（以最后 committed draft 为准）；skip 会使 owner 失效，`(skipped)` 行不显示残留文本。
- 编辑态/导航态 hint 分模式（编辑 `←→ edit · ↵ confirm · esc back`；导航 `↵ edit · ← back · → skip · esc cancel`），不再宣传列表动作。

### Task Center 搜索态

- hint 改为纯搜索模式动作（`type filter · esc back · ←→ edit · ↑↓ navigate · pgup/pgdn page · tab type · enter open`），`esc back` 前置保证 80 列终端可见；不再混入 A/N/S/R/tree 普通任务动作。

### Transcript Search

- `app.transcript.search.close` 默认键扩为 `['escape', 'ctrl+c']`（此前 Ctrl+C 被 overlay 内共享 Input 吞掉，搜索不关闭）；输入框下新增 `↵ next · ⇧↵ prev · esc/ctrl+c close` 指引；窄宽度不破坏布局。

### /keybindings 搜索

- 改用共享 `Input` 作为 query 唯一数据源，支持中间插入/Home/End/Delete/Ctrl 编辑键；hint 随查询空/非空在 `Esc: close` / `Esc: clear` 间切换；搜索行窄宽度截断安全。

## Scope

- 未改 `packages/pi-tui/**`、`tui-alt-screen.ts`、Footer Configurator
- 未新增 keybinding action / abstraction

## 验证

- `pnpm build` / `pnpm typecheck`（fork + bundle）通过
- `pnpm test` 全量：fork 1029 / product 3855 / tooling 252 / docs 11 全绿
- `client-boundary-gate` 通过，`git diff --check` 通过
- review-fix-loop 5 轮：P1/P2 全部修复后 accepted（无 findings）
