### PR TITLE
feat: responsive welcome card with whale mascot variants

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Welcome card visual refresh.** The session-head card now shows an original round-backed whale ASCII mascot with three responsive layouts: side-by-side (whale left, facts right) at 72+ columns, stacked (whale centered above the facts) at 40–71 columns, and a compact text layout (🐋 title) below 40 columns. The whale keeps a fixed cyan → blue → indigo brand gradient that does not follow theme switches; facts still render in full (long values wrap, never truncate); the idle invitation, the `setWelcomeCard()` contract, and fullscreen scroll/anchor/click mapping are unchanged.
+
 ## [0.4.3-alpha.2] - 2026-09-08
 
 ### Installation and version pairing

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Welcome card visual refresh.** The session-head card now shows an original round-backed whale ASCII mascot with three responsive layouts: side-by-side (whale left, facts right) at 72+ columns, stacked (whale centered above the facts) at 40–71 columns, and a compact text layout (🐋 title) below 40 columns. The whale keeps a fixed cyan → blue → indigo brand gradient that does not follow theme switches; facts still render in full (long values wrap, never truncate); the idle invitation, the `setWelcomeCard()` contract, and fullscreen scroll/anchor/click mapping are unchanged.
+- **Welcome card visual refresh.** The session-head card now shows an original round-backed whale ASCII mascot (five variants, one picked per process) with three responsive layouts: side-by-side (whale left, facts right) at 72+ columns, stacked (whale centered above the facts) at 24–71 columns, and a compact text layout (🐋 title) below 24 columns. The whale keeps a fixed cyan → blue brand gradient that does not follow theme switches; facts still render in full (long values wrap, never truncate); the idle invitation, the `setWelcomeCard()` contract, and fullscreen scroll/anchor/click mapping are unchanged.
 
 ## [0.4.3-alpha.2] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### 新增
 
-- **Welcome Card 视觉重构。** 首屏欢迎卡引入原创圆润鲸鱼 ASCII mascot,按终端宽度使用三档响应式布局:72 列以上鲸鱼与 session facts 左右并排,40～71 列鲸鱼居中、facts 在下,40 列以下切换为紧凑文本布局(🐋 标题)。鲸鱼 6 行保留 cyan → blue → indigo 品牌渐变,不随主题切换改色;facts 继续完整显示(长值 wrap、不截断),idle 邀请、`setWelcomeCard()` 契约、fullscreen 滚动/锚点/点击映射均保持不变。
+- **Welcome Card 视觉重构。** 首屏欢迎卡引入原创圆润鲸鱼 ASCII mascot(5 种变体,每次启动随机一个),按终端宽度使用三档响应式布局:72 列以上鲸鱼与 session facts 左右并排,24～71 列鲸鱼居中、facts 在下,24 列以下切换为紧凑文本布局(🐋 标题)。鲸鱼保留 cyan → blue 品牌渐变,不随主题切换改色;facts 继续完整显示(长值 wrap、不截断),idle 邀请、`setWelcomeCard()` 契约、fullscreen 滚动/锚点/点击映射均保持不变。
 
 ## [0.4.3-alpha.2] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### 新增
+
+- **Welcome Card 视觉重构。** 首屏欢迎卡引入原创圆润鲸鱼 ASCII mascot,按终端宽度使用三档响应式布局:72 列以上鲸鱼与 session facts 左右并排,40～71 列鲸鱼居中、facts 在下,40 列以下切换为紧凑文本布局(🐋 标题)。鲸鱼 6 行保留 cyan → blue → indigo 品牌渐变,不随主题切换改色;facts 继续完整显示(长值 wrap、不截断),idle 邀请、`setWelcomeCard()` 契约、fullscreen 滚动/锚点/点击映射均保持不变。
+
 ## [0.4.3-alpha.2] - 2026-09-08
 
 ### 安装与版本对应

--- a/src/index.ts
+++ b/src/index.ts
@@ -901,6 +901,18 @@ function packageVersion(): string {
 }
 
 /**
+ * The welcome card's version line: the installed dsh version plus the
+ * bundle's own version (header-badge parity — `dsh-0.1.3-alpha.2 ·
+ * tui-v0.4.3-alpha.2`). Without a resolvable dsh launcher it degrades to
+ * the bundle version alone.
+ * @returns the combined version string.
+ */
+function versionDisplay(): string {
+  const dsh = dshVersion()
+  return dsh === undefined ? `tui-v${bundleVersion()}` : `dsh-${dsh} · tui-v${bundleVersion()}`
+}
+
+/**
  * The BUNDLE's OWN version (`@xmoon76/dsh-pi-tui`'s package.json),
  * INDEPENDENT of the installed dsh version. The status snapshot's
  * host.tuiVersion and the footer's `version(format=tui)` item must report
@@ -2355,7 +2367,7 @@ export function apply(ctx: Context, config: Config): void {
         cwd: sessionCwd(),
         sessionId: liveAgent.session.id,
         model: `${provider}/${model}`,
-        version: packageVersion(),
+        version: versionDisplay(),
         ...currentPreset() === undefined ? {} : { preset: currentPreset() },
       })
     }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -291,6 +291,11 @@ export function themeOptOut(): boolean {
 const chalk = new Chalk({ level: 3 })
 const hex = (token: string): InstanceType<typeof Chalk> => chalk.hex(currentPalette[token as keyof ColorPalette] ?? currentPalette.text)
 
+/** Paint text with an explicit hex colour. Brand assets (the welcome whale
+ * gradient) use a fixed ramp that is NOT a semantic token: it must not
+ * follow the active palette, and custom themes do not override it. */
+export const hexPaint = (hexValue: string, text: string): string => chalk.hex(hexValue)(text)
+
 /** Style helpers by token name. The strong/dim/italic helpers accept an
  * optional TONE OVERRIDE (the footer layout's semantic tone override):
  * the override replaces the token, the style stays. */

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -61,6 +61,7 @@ import {
   detectThemeFromBackground,
   detectThemeFromColorFgBg,
   editorTheme,
+  hexPaint,
   HOST_MARKDOWN_OPTIONS,
   markdownTheme,
   selectListTheme,
@@ -524,9 +525,49 @@ class ResponsiveOverlayFrame extends FocusForwardingFrame {
   }
 }
 
+/** The final whale mascot: 6 rows, round back, big head, thin tail stalk,
+ * small tail fin. The belly stays open — the waterline carries the lower
+ * outline. Pure ASCII; colour is applied at render time. */
+const WELCOME_WHALE = [
+  '        .  .',
+  '         :',
+  "      _.-' `-._             \\/",
+  "    .'         `-.         /",
+  '   |   O          `------._/',
+  ' ~^~^~^~^~^~^~^~^~^~^~^~^~',
+] as const
+
+/** Brand ramp for the whale rows: cyan → blue → indigo. Fixed (not a
+ * semantic token): custom themes do not override the logo gradient. */
+const WELCOME_WHALE_COLORS = [
+  '#56D4DD',
+  '#50BCD4',
+  '#49A3CB',
+  '#438BC2',
+  '#3D73BA',
+  '#3042A8',
+] as const
+
+/** Cells between the whale block and the facts column in side-by-side. */
+const WELCOME_WHALE_GAP = 4
+
+/** Layout breakpoints: >= 72 side-by-side, 40..71 stacked, < 40 compact. */
+const WELCOME_SIDE_BY_SIDE_MIN_WIDTH = 72
+const WELCOME_STACKED_MIN_WIDTH = 40
+
+/** The widest whale row (visible width, ANSI-free). */
+const WELCOME_WHALE_WIDTH = Math.max(...WELCOME_WHALE.map(line => visibleWidth(line)))
+
+/** Facts column alignment: every label padded to this column. */
+const WELCOME_FACT_LABEL_WIDTH = 9
+
 /** The session head card: identity facts, wrapped to the available width so
- * nothing is truncated, framed with a box whose width matches the editor's
- * border below it (a fixed-width rule looked misaligned next to the frame). */
+ * nothing is truncated. Three responsive layouts keep the whale mascot
+ * readable without ever truncating facts:
+ * - width >= 72: whale left, facts right (side-by-side)
+ * - 40 <= width < 72: whale centered above the facts (stacked)
+ * - width < 40: compact text rows, no full whale
+ */
 class WelcomeCard implements Component {
   private facts: { cwd: string; sessionId: string; model: string; version: string; preset?: string } | undefined
   private idle = false
@@ -555,48 +596,95 @@ class WelcomeCard implements Component {
   }
 
   render(width: number): string[] {
-    const facts = this.facts
-    const b = color.border
-    const inner = Math.max(1, width - 4)
-    const renderRow = (line: string): string[] => wrapTextWithAnsi(line, inner).map(wrapped => {
-      const vis = visibleWidth(wrapped)
-      return `${b('│')} ${wrapped}${' '.repeat(Math.max(0, inner - vis))} ${b('│')}`
-    })
-    if (this.idle) {
-      if (this.lastWidth === width && this.cached.length > 0) return this.cached
-      this.lastWidth = width
-      this.cached = [
-        b(`╭${'─'.repeat(Math.max(0, width - 2))}╮`),
-        ...renderRow(color.textMuted('🐋  dsh-pi-tui — type a message to start a session')),
-        b(`╰${'─'.repeat(Math.max(0, width - 2))}╯`),
-      ]
-      return this.cached
-    }
-    if (facts === undefined) return []
     if (this.lastWidth === width && this.cached.length > 0) return this.cached
     this.lastWidth = width
-    // Three columns: the session identity (full id — never truncated), the
-    // model/preset, and the workspace. Each row wraps instead of ellipsizing,
-    // so the box keeps the important facts readable. The card is session
-    // chrome, so it reads muted — never as bright as user/assistant content.
-    const line1 = `🐋  session ${color.textMuted(facts.sessionId)}`
-    const line2 = [
-      color.textMuted(facts.model),
-      facts.preset === undefined ? '' : `preset ${color.textMuted(facts.preset)}`,
-    ].filter(part => part !== '').join(' · ')
-    const line3 = [
-      color.textMuted(facts.cwd),
-      color.textMuted(`v${facts.version}`),
-    ].filter(part => part !== '').join(' · ')
-    // Wrap each line to the box's inner width so long identities read in
-    // full instead of ending in an ellipsis; the box spans the same width
-    // as the editor border below it.
-    this.cached = [
-      b(`╭${'─'.repeat(Math.max(0, width - 2))}╮`),
-      ...[line1, line2, line3].flatMap(renderRow),
-      b(`╰${'─'.repeat(Math.max(0, width - 2))}╯`),
-    ]
+    this.cached = this.buildRows(width)
     return this.cached
+  }
+
+  private buildRows(width: number): string[] {
+    if (this.idle) {
+      const lines = width < WELCOME_STACKED_MIN_WIDTH
+        ? [color.textMuted('🐋 dsh-pi-tui'), color.textMuted('type a message to start a session')]
+        : [color.textMuted('dsh-pi-tui'), color.textMuted('type a message to start a session')]
+      return this.layout(width, lines)
+    }
+    if (this.facts === undefined) return []
+    const lines = width < WELCOME_STACKED_MIN_WIDTH ? this.compactFactLines() : this.factLines()
+    return this.layout(width, lines)
+  }
+
+  /** The three responsive layouts; the whale is never wrapped or cropped. */
+  private layout(width: number, lines: string[]): string[] {
+    if (width >= WELCOME_SIDE_BY_SIDE_MIN_WIDTH) return this.renderSideBySide(width, lines)
+    if (width >= WELCOME_STACKED_MIN_WIDTH) return this.renderStacked(width, lines)
+    return this.renderCompact(width, lines)
+  }
+
+  /** Whale left, facts right; extra wrapped fact rows continue below the
+   * 6 whale rows. */
+  private renderSideBySide(width: number, lines: string[]): string[] {
+    const whale = this.renderWhaleLines()
+    const factsStart = WELCOME_WHALE_WIDTH + WELCOME_WHALE_GAP
+    const factsWidth = Math.max(1, width - factsStart)
+    const facts = lines.flatMap(line => wrapTextWithAnsi(line, factsWidth))
+    const rows: string[] = []
+    const total = Math.max(whale.length, facts.length)
+    for (let index = 0; index < total; index += 1) {
+      const left = index < whale.length ? whale[index]! : ''
+      const right = index < facts.length ? facts[index]! : ''
+      rows.push(`${left}${' '.repeat(Math.max(0, factsStart - visibleWidth(left)))}${right}`)
+    }
+    return rows
+  }
+
+  /** Whale centered above the facts, one blank row between. */
+  private renderStacked(width: number, lines: string[]): string[] {
+    const whale = this.renderWhaleLines()
+    const left = Math.max(0, Math.floor((width - WELCOME_WHALE_WIDTH) / 2))
+    const rows = whale.map(line => `${' '.repeat(left)}${line}`)
+    rows.push('')
+    for (const line of lines) {
+      rows.push(...wrapTextWithAnsi(line, width))
+    }
+    return rows
+  }
+
+  /** Compact text rows; the full whale is not shown. */
+  private renderCompact(width: number, lines: string[]): string[] {
+    return lines.flatMap(line => wrapTextWithAnsi(line, width))
+  }
+
+  /** The whale rows painted with the fixed brand gradient. */
+  private renderWhaleLines(): string[] {
+    return WELCOME_WHALE.map((line, index) => hexPaint(WELCOME_WHALE_COLORS[index]!, line))
+  }
+
+  /** Session facts in the wide/stacked column layout. */
+  private factLines(): string[] {
+    const facts = this.facts!
+    const label = (text: string): string => `${text}${' '.repeat(Math.max(0, WELCOME_FACT_LABEL_WIDTH - text.length))}`
+    return [
+      color.textMuted(`dsh-pi-tui  v${facts.version}`),
+      `${label('model')}${color.textMuted(facts.model)}`,
+      ...(facts.preset === undefined ? [] : [`${label('preset')}${color.textMuted(facts.preset)}`]),
+      `${label('cwd')}${color.textMuted(facts.cwd)}`,
+      `${label('session')}${color.textMuted(facts.sessionId)}`,
+    ]
+  }
+
+  /** Session facts in the compact layout (whale emoji replaces the ASCII). */
+  private compactFactLines(): string[] {
+    const facts = this.facts!
+    return [
+      color.textMuted(`🐋 dsh-pi-tui v${facts.version}`),
+      [
+        color.textMuted(facts.model),
+        facts.preset === undefined ? '' : `preset ${color.textMuted(facts.preset)}`,
+      ].filter(part => part !== '').join(' · '),
+      color.textMuted(facts.cwd),
+      `session ${color.textMuted(facts.sessionId)}`,
+    ]
   }
 }
 
@@ -7259,8 +7347,9 @@ export class TuiApp {
 
   /**
    * Set the session head rendered above the transcript: the session identity,
-   * model, version, preset, and cwd, wrapped to the terminal width with a
-   * full-width rule beneath. Replaces any previous head.
+   * model, version, preset, and cwd, wrapped to the terminal width in the
+   * responsive whale layout (side-by-side / stacked / compact). Replaces any
+   * previous head.
    * @param facts - directory, session id, model, version, and the optional agent preset to display.
    */
   setWelcomeCard(facts: { cwd: string; sessionId: string; model: string; version: string; preset?: string }): void {
@@ -12354,8 +12443,8 @@ export class TuiApp {
   private repaintAllSurfaces(): void {
     // The welcome card keeps its OWN render cache (keyed on width): unlike
     // the Text-based surfaces, clearing the messages view never invalidates
-    // it, so a theme switch would leave its ANSI-baked borders/text in the
-    // OLD palette. Drop the cache here.
+    // it, so a theme switch would leave its ANSI-baked text in the OLD
+    // palette. Drop the cache here.
     this.welcomeCard.invalidate()
     this.rebuildMessages()
     // Extension outlets re-render with the live palette (theme revision).

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -665,8 +665,8 @@ class WelcomeCard implements Component {
   private buildRows(layoutWidth: number, width: number): string[] {
     if (this.idle) {
       const lines = width < WELCOME_STACKED_MIN_WIDTH
-        ? [color.textMuted('🐋 dsh-pi-tui'), color.textMuted('type a message to start a session')]
-        : [color.textMuted('dsh-pi-tui'), color.textMuted('type a message to start a session')]
+        ? [color.textStrong('🐋 dsh-pi-tui'), color.textDim('type a message to start a session')]
+        : [color.textStrong('dsh-pi-tui'), color.textDim('type a message to start a session')]
       return this.layout(layoutWidth, width, lines)
     }
     if (this.facts === undefined) return []
@@ -729,16 +729,18 @@ class WelcomeCard implements Component {
     ))
   }
 
-  /** Session facts in the wide/stacked column layout. */
+  /** Session facts in the wide/stacked column layout. The title reads
+   * strong, the version muted, labels dim, and values in the body text —
+   * the whale's saturated gradient is balanced by readable facts. */
   private factLines(): string[] {
     const facts = this.facts!
     const label = (text: string): string => `${text}${' '.repeat(Math.max(0, WELCOME_FACT_LABEL_WIDTH - text.length))}`
     return [
-      color.textMuted(`dsh-pi-tui  v${facts.version}`),
-      `${label('model')}${color.textMuted(facts.model)}`,
-      ...(facts.preset === undefined ? [] : [`${label('preset')}${color.textMuted(facts.preset)}`]),
-      `${label('cwd')}${color.textMuted(facts.cwd)}`,
-      `${label('session')}${color.textMuted(facts.sessionId)}`,
+      `${color.textStrong('dsh-pi-tui')}  ${color.textMuted(facts.version)}`,
+      `${color.textDim(label('model'))}${color.text(facts.model)}`,
+      ...(facts.preset === undefined ? [] : [`${color.textDim(label('preset'))}${color.text(facts.preset)}`]),
+      `${color.textDim(label('cwd'))}${color.text(facts.cwd)}`,
+      `${color.textDim(label('session'))}${color.text(facts.sessionId)}`,
     ]
   }
 
@@ -746,13 +748,13 @@ class WelcomeCard implements Component {
   private compactFactLines(): string[] {
     const facts = this.facts!
     return [
-      color.textMuted(`🐋 dsh-pi-tui v${facts.version}`),
+      `${color.textStrong('🐋 dsh-pi-tui')} ${color.textMuted(facts.version)}`,
       [
-        color.textMuted(facts.model),
-        facts.preset === undefined ? '' : `preset ${color.textMuted(facts.preset)}`,
+        color.text(facts.model),
+        facts.preset === undefined ? '' : `preset ${color.text(facts.preset)}`,
       ].filter(part => part !== '').join(' · '),
-      color.textMuted(facts.cwd),
-      `session ${color.textMuted(facts.sessionId)}`,
+      color.text(facts.cwd),
+      `${color.textDim('session')} ${color.text(facts.sessionId)}`,
     ]
   }
 }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -525,38 +525,71 @@ class ResponsiveOverlayFrame extends FocusForwardingFrame {
   }
 }
 
-/** The final whale mascot: 6 rows, round back, big head, thin tail stalk,
- * small tail fin. The belly stays open — the waterline carries the lower
- * outline. Pure ASCII; colour is applied at render time. */
-const WELCOME_WHALE = [
-  '        .  .',
-  '         :',
-  "      _.-' `-._             \\/",
-  "    .'         `-.         /",
-  '   |   O          `------._/',
-  ' ~^~^~^~^~^~^~^~^~^~^~^~^~',
+/** The whale mascot variants: five original designs; one is picked once
+ * per process (see WelcomeCard.whaleVariant). */
+const WELCOME_WHALES = [
+  [
+    '        o',
+    '      O',
+    '     :',
+    "  .--'---._      \\_/",
+    " (  o      `-----//",
+    ' ~~~\\_)~~~~~~~~~~~~',
+  ],
+  [
+    '       z Z',
+    "   .------._     \\_/",
+    "  (  -      `----//",
+    " ~~`~~\\_)~~~~~~~~~~",
+  ],
+  [
+    '                   *',
+    " \\_/      .-------.",
+    "  \\\\____.'     o  _>",
+    "   `-----------\\_)",
+  ],
+  [
+    '       <3',
+    '       :',
+    "   .---'--.",
+    " ( o      `.__  \\_/",
+    "   `---\\_)-----`-//",
+  ],
+  [
+    '          \\   /',
+    '           \\_/',
+    '           | |',
+    ' ~~~~~~~~~/ /~~~~~~',
+    "         '       o",
+    '               o',
+  ],
 ] as const
 
-/** Brand ramp for the whale rows: cyan → blue → indigo. Fixed (not a
- * semantic token): custom themes do not override the logo gradient. */
+/** Brand ramp for the whale rows: cyan → blue. Fixed (not a semantic
+ * token): custom themes do not override the logo gradient. */
 const WELCOME_WHALE_COLORS = [
-  '#56D4DD',
-  '#50BCD4',
-  '#49A3CB',
-  '#438BC2',
-  '#3D73BA',
-  '#3042A8',
+  '#63C7D1',
+  '#5DBBD4',
+  '#56AFD7',
+  '#50A3D9',
+  '#4996DA',
+  '#4389D8',
 ] as const
 
 /** Cells between the whale block and the facts column in side-by-side. */
 const WELCOME_WHALE_GAP = 4
 
-/** Layout breakpoints: >= 72 side-by-side, 40..71 stacked, < 40 compact. */
+/** Layout breakpoints: >= 72 side-by-side, 24..71 stacked, < 24 compact. */
 const WELCOME_SIDE_BY_SIDE_MIN_WIDTH = 72
-const WELCOME_STACKED_MIN_WIDTH = 40
 
-/** The widest whale row (visible width, ANSI-free). */
-const WELCOME_WHALE_WIDTH = Math.max(...WELCOME_WHALE.map(line => visibleWidth(line)))
+/** The widest whale row across all variants (visible width, ANSI-free).
+ * All variants share this layout width so the position stays consistent
+ * across picks. */
+const WELCOME_WHALE_WIDTH = Math.max(...WELCOME_WHALES.flat().map(line => visibleWidth(line)))
+
+/** Stacked minimum: the whale fills the inner width (widest variant + the
+ * 4 box cells). Below this the compact text layout takes over. */
+const WELCOME_STACKED_MIN_WIDTH = WELCOME_WHALE_WIDTH + 4
 
 /** Facts column alignment: every label padded to this column. */
 const WELCOME_FACT_LABEL_WIDTH = 9
@@ -565,14 +598,18 @@ const WELCOME_FACT_LABEL_WIDTH = 9
  * nothing is truncated. Three responsive layouts keep the whale mascot
  * readable without ever truncating facts:
  * - width >= 72: whale left, facts right (side-by-side)
- * - 40 <= width < 72: whale centered above the facts (stacked)
- * - width < 40: compact text rows, no full whale
+ * - 24 <= width < 72: whale centered above the facts (stacked)
+ * - width < 24: compact text rows, no full whale
  */
 class WelcomeCard implements Component {
   private facts: { cwd: string; sessionId: string; model: string; version: string; preset?: string } | undefined
   private idle = false
   private lastWidth = -1
   private cached: string[] = []
+  /** The picked whale variant index; -1 until the first render. Picked
+   * once per process — resize and facts changes keep it, only a restart
+   * re-picks. */
+  private whaleVariant = -1
 
   /** Replace the facts; the next render rebuilds the card. */
   setFacts(facts: { cwd: string; sessionId: string; model: string; version: string; preset?: string }): void {
@@ -597,32 +634,57 @@ class WelcomeCard implements Component {
 
   render(width: number): string[] {
     if (this.lastWidth === width && this.cached.length > 0) return this.cached
+    if (this.whaleVariant < 0) {
+      // First render of this process: pick the variant for the whole
+      // session. Resize and facts changes keep it; only a restart re-picks.
+      this.whaleVariant = Math.floor(Math.random() * WELCOME_WHALES.length)
+    }
     this.lastWidth = width
-    this.cached = this.buildRows(width)
+    const inner = Math.max(1, width - 4)
+    const rows = this.buildRows(inner, width)
+    // No facts and not idle: nothing to frame (an empty box would shift
+    // fullscreen row mapping by two rows).
+    this.cached = rows.length === 0 ? [] : this.frame(rows, width)
     return this.cached
   }
 
-  private buildRows(width: number): string[] {
+  /** Wrap the layout rows in the original full-width box. */
+  private frame(rows: string[], width: number): string[] {
+    const b = color.border
+    const inner = Math.max(1, width - 4)
+    return [
+      b(`╭${'─'.repeat(Math.max(0, width - 2))}╮`),
+      ...rows.map(row => {
+        const vis = visibleWidth(row)
+        return `${b('│')} ${row}${' '.repeat(Math.max(0, inner - vis))} ${b('│')}`
+      }),
+      b(`╰${'─'.repeat(Math.max(0, width - 2))}╯`),
+    ]
+  }
+
+  private buildRows(layoutWidth: number, width: number): string[] {
     if (this.idle) {
       const lines = width < WELCOME_STACKED_MIN_WIDTH
         ? [color.textMuted('🐋 dsh-pi-tui'), color.textMuted('type a message to start a session')]
         : [color.textMuted('dsh-pi-tui'), color.textMuted('type a message to start a session')]
-      return this.layout(width, lines)
+      return this.layout(layoutWidth, width, lines)
     }
     if (this.facts === undefined) return []
     const lines = width < WELCOME_STACKED_MIN_WIDTH ? this.compactFactLines() : this.factLines()
-    return this.layout(width, lines)
+    return this.layout(layoutWidth, width, lines)
   }
 
-  /** The three responsive layouts; the whale is never wrapped or cropped. */
-  private layout(width: number, lines: string[]): string[] {
-    if (width >= WELCOME_SIDE_BY_SIDE_MIN_WIDTH) return this.renderSideBySide(width, lines)
-    if (width >= WELCOME_STACKED_MIN_WIDTH) return this.renderStacked(width, lines)
-    return this.renderCompact(width, lines)
+  /** The three responsive layouts; the whale is never wrapped or cropped.
+   * Breakpoints key on the TERMINAL width; layout math uses the inner
+   * (boxed) width. */
+  private layout(layoutWidth: number, width: number, lines: string[]): string[] {
+    if (width >= WELCOME_SIDE_BY_SIDE_MIN_WIDTH) return this.renderSideBySide(layoutWidth, lines)
+    if (width >= WELCOME_STACKED_MIN_WIDTH) return this.renderStacked(layoutWidth, lines)
+    return this.renderCompact(layoutWidth, lines)
   }
 
   /** Whale left, facts right; extra wrapped fact rows continue below the
-   * 6 whale rows. */
+   * whale rows. */
   private renderSideBySide(width: number, lines: string[]): string[] {
     const whale = this.renderWhaleLines()
     const factsStart = WELCOME_WHALE_WIDTH + WELCOME_WHALE_GAP
@@ -638,7 +700,9 @@ class WelcomeCard implements Component {
     return rows
   }
 
-  /** Whale centered above the facts, one blank row between. */
+  /** Whale centered above the facts, one blank row between. The centering
+   * offset follows the widest variant, so it shrinks naturally as the
+   * width narrows (down to zero when the whale fills the inner width). */
   private renderStacked(width: number, lines: string[]): string[] {
     const whale = this.renderWhaleLines()
     const left = Math.max(0, Math.floor((width - WELCOME_WHALE_WIDTH) / 2))
@@ -655,9 +719,14 @@ class WelcomeCard implements Component {
     return lines.flatMap(line => wrapTextWithAnsi(line, width))
   }
 
-  /** The whale rows painted with the fixed brand gradient. */
+  /** The picked whale variant, painted with the fixed brand gradient (rows
+   * beyond the 6-color ramp reuse the last ramp color). */
   private renderWhaleLines(): string[] {
-    return WELCOME_WHALE.map((line, index) => hexPaint(WELCOME_WHALE_COLORS[index]!, line))
+    const whale = WELCOME_WHALES[this.whaleVariant]!
+    return whale.map((line, index) => hexPaint(
+      WELCOME_WHALE_COLORS[Math.min(index, WELCOME_WHALE_COLORS.length - 1)]!,
+      line,
+    ))
   }
 
   /** Session facts in the wide/stacked column layout. */

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -1981,30 +1981,44 @@ test('viewport anchors distinguish duplicate messages and cloned Focus activitie
   app.stop()
 })
 
-test('welcome card wraps long facts inside a full-width box', async () => {
+test('welcome card shows the whale and full facts in the wide layout', async () => {
   const { vt, app } = startApp()
+  // Values long enough to wrap inside the ~65-col side-by-side facts column.
+  const longCwd = `/very/long/working/directory/that/keeps/going/${'segment/'.repeat(12)}end`
+  const longSession = `session-${'x'.repeat(100)}`
   app.setWelcomeCard({
-    cwd: '/very/long/working/directory/that/keeps/going',
-    sessionId: `session-${'x'.repeat(40)}`,
+    cwd: longCwd,
+    sessionId: longSession,
     model: 'opencode-go/deepseek-v4-flash',
     version: '0.1.0-rc.6',
     preset: 'standard',
   })
   const view = await viewport(vt)
   // Facts render in full: the session id is never truncated, and long lines
-  // wrap instead of ending in an ellipsis.
-  assert.ok(view.includes(`session-${'x'.repeat(40)}`), `session id truncated:\n${view}`)
+  // wrap instead of ending in an ellipsis. The side-by-side facts column is
+  // 66 cells at width 100 (whale 30 + gap 4); the fixture values have no
+  // spaces, so each wrap segment is a hard cut that must survive in full.
+  const factsColumn = 100 - 34
+  for (const segment of longSession.match(new RegExp(`.{1,${factsColumn}}`, 'g'))!) {
+    assert.ok(view.includes(segment), `session id segment truncated:\n${view}`)
+  }
+  for (const segment of longCwd.match(new RegExp(`.{1,${factsColumn}}`, 'g'))!) {
+    assert.ok(view.includes(segment), `cwd segment truncated:\n${view}`)
+  }
   assert.ok(view.includes('deepseek-v4-flash'), `model missing:\n${view}`)
   assert.ok(view.includes('standard'), `preset missing:\n${view}`)
   assert.ok(view.includes('0.1.0-rc.6'), `version missing:\n${view}`)
-  assert.ok(view.includes('/very/long/working/directory/that/keeps/going'), `cwd truncated:\n${view}`)
-  // The box spans the full terminal width, matching the editor border below.
-  const lines = view.split('\n')
-  const top = lines.find(line => line.includes('╭') && line.includes('╮'))
-  assert.ok(top !== undefined, `box top missing:\n${view}`)
-  assert.equal(top.length, 100, `box top must be full width, got ${top.length}`)
-  assert.ok(lines.some(line => line.includes('╰') && line.includes('╯')), `box bottom missing:\n${view}`)
-  assert.ok(lines.some(line => line.includes('│')), `box sides missing:\n${view}`)
+  assert.ok(!view.includes('…'), `facts ellipsized:\n${view}`)
+  // 100 >= 72: the whale mascot renders side-by-side with the facts.
+  assert.ok(view.includes("_.-' `-._"), `whale missing:\n${view}`)
+  // No physical row overflows the terminal width (ANSI-aware).
+  for (const line of view.split('\n')) {
+    assert.ok(visibleWidth(line) <= 100, `row overflows terminal width:\n${view}`)
+  }
+  // The old full-width box presentation is no longer a contract.
+  assert.ok(!view.includes('╭'), `old box top survived:\n${view}`)
+  assert.ok(!view.includes('╰'), `old box bottom survived:\n${view}`)
+  assert.ok(!view.includes('│'), `old box sides survived:\n${view}`)
 })
 test('working indicator shows on the row directly above the editor while active', async () => {
   const { vt, app } = startApp()
@@ -2132,7 +2146,7 @@ test('live theme switch recolors every surface while the content stays identical
   app.stop()
 })
 
-test('theme switch recolors the welcome card (its width cache must not freeze ANSI)', async () => {
+test('theme switch repaints the welcome card: whale gradient stays, facts follow the palette', async () => {
   const vt = new VirtualTerminal(100, 24)
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
   app.start()
@@ -2140,13 +2154,130 @@ test('theme switch recolors the welcome card (its width cache must not freeze AN
   startedApps.add(app)
   app.setWelcomeCard({ cwd: '/ws', sessionId: 'session-x', model: 'p/m', version: '0.0.0' })
   await vt.waitForRender()
-  const row = vt.getViewport().findIndex(line => line.includes('╭'))
-  assert.ok(row >= 0, `welcome card missing:\n${vt.getViewport().join('\n')}`)
-  // Dark border #5A5A5A → light border #737373 after the switch.
-  assert.equal(vt.getCellFgRgb(row, 0), 0x5a5a5a, 'dark welcome border must be #5A5A5A')
+  const lines = vt.getViewport()
+  const whaleRow = lines.findIndex(line => line.includes("_.-' `-._"))
+  assert.ok(whaleRow >= 0, `welcome card missing:\n${lines.join('\n')}`)
+  // The whale gradient is a fixed brand ramp: line 3 paints #49A3CB.
+  assert.equal(vt.getCellFgRgb(whaleRow, 6), 0x49a3cb, 'whale line 3 must be #49A3CB')
+  // The facts title is the welcome card's own row (the header also reads
+  // "dsh-pi-tui", so match the versioned title).
+  const titleRow = lines.findIndex(line => line.includes('dsh-pi-tui  v'))
+  assert.ok(titleRow >= 0, `facts title missing:\n${lines.join('\n')}`)
+  const titleCol = lines[titleRow]!.indexOf('dsh-pi-tui')
+  assert.equal(vt.getCellFgRgb(titleRow, titleCol), 0x6b6b6b, 'dark facts must be #6B6B6B')
   app.applyTheme('light')
   await vt.waitForRender()
-  assert.equal(vt.getCellFgRgb(row, 0), 0x737373, 'welcome border must follow the live theme')
+  // Facts follow the live palette; the whale gradient stays fixed (the
+  // width cache must not freeze the old ANSI).
+  assert.equal(vt.getCellFgRgb(titleRow, titleCol), 0x5f5f5f, 'light facts must be #5F5F5F')
+  assert.equal(vt.getCellFgRgb(whaleRow, 6), 0x49a3cb, 'whale gradient must survive the theme switch')
+  app.stop()
+})
+
+test('welcome card stacks the whale above the facts at medium width', async () => {
+  const { vt, app } = startApp(60, 24)
+  app.setWelcomeCard({
+    cwd: '/ws',
+    sessionId: 'session-1',
+    model: 'p/m',
+    version: '0.1.0',
+    preset: 'code',
+  })
+  const view = await viewport(vt)
+  const lines = view.split('\n')
+  // 40 <= 60 < 72: the full whale renders, centered, above the facts.
+  const whaleRow = lines.findIndex(line => line.includes("_.-' `-._"))
+  assert.ok(whaleRow >= 0, `whale missing:\n${view}`)
+  // The whale rows are never wrapped: the widest row fits the terminal.
+  for (const line of lines.filter(candidate => candidate.includes('~^~^~^~^~^~^~^~^~^~^~^~^~') || candidate.includes('`------._/'))) {
+    assert.ok(visibleWidth(line) <= 60, `whale row wrapped:\n${view}`)
+  }
+  // Facts come after the whale block (one blank row between). The header
+  // also reads "dsh-pi-tui", so match the versioned welcome title.
+  const factsRow = lines.findIndex(line => line.includes('dsh-pi-tui  v'))
+  assert.ok(factsRow > whaleRow, `facts must follow the whale:\n${view}`)
+  assert.ok(view.includes('session-1'), `session id missing:\n${view}`)
+  assert.ok(view.includes('code'), `preset missing:\n${view}`)
+  // No full-width box.
+  assert.ok(!view.includes('╭'), `old box top survived:\n${view}`)
+})
+
+test('welcome card compacts to text rows at narrow width', async () => {
+  const { vt, app } = startApp(32, 24)
+  app.setWelcomeCard({
+    cwd: '/ws',
+    sessionId: 'session-1',
+    model: 'p/m',
+    version: '0.1.0',
+    preset: 'code',
+  })
+  const view = await viewport(vt)
+  // Below 40 columns the full whale is not shown.
+  assert.ok(!view.includes("_.-' `-._"), `whale leaked into compact:\n${view}`)
+  assert.ok(view.includes('🐋 dsh-pi-tui'), `compact title missing:\n${view}`)
+  assert.ok(view.includes('session-1'), `session id missing:\n${view}`)
+  assert.ok(view.includes('p/m'), `model missing:\n${view}`)
+  assert.ok(view.includes('code'), `preset missing:\n${view}`)
+  assert.ok(view.includes('/ws'), `cwd missing:\n${view}`)
+  assert.ok(view.includes('0.1.0'), `version missing:\n${view}`)
+  // No ellipsis truncation in compact mode.
+  assert.ok(!view.includes('…'), `compact truncated:\n${view}`)
+})
+
+test('welcome card switches layouts across resize breakpoints and back', async () => {
+  const { vt, app } = startApp(100, 24)
+  app.setWelcomeCard({ cwd: '/ws', sessionId: 'session-1', model: 'p/m', version: '0.1.0' })
+  await viewport(vt)
+  const viewText = (): string => vt.getViewport().join('\n')
+  assert.ok(viewText().includes("_.-' `-._"), 'wide layout must show the whale')
+  vt.resize(60, 24)
+  await viewport(vt)
+  assert.ok(viewText().includes("_.-' `-._"), 'stacked layout must show the whale')
+  vt.resize(32, 24)
+  await viewport(vt)
+  assert.ok(!viewText().includes("_.-' `-._"), 'compact layout must hide the whale')
+  assert.ok(viewText().includes('🐋 dsh-pi-tui'), 'compact layout must show the emoji title')
+  vt.resize(100, 24)
+  await viewport(vt)
+  assert.ok(viewText().includes("_.-' `-._"), 'wide layout must restore the whale')
+  assert.ok(!viewText().includes('🐋 dsh-pi-tui'), 'compact emoji must not survive the resize back')
+})
+
+test('fullscreen anchor offsets follow the welcome card height across layout breakpoints', async () => {
+  const { vt, app } = startApp(100, 30)
+  const messages = [
+    { kind: 'user' as const, turn: 1, text: 'first user' },
+    { kind: 'assistant' as const, turn: 1, text: 'first answer' },
+    ...Array.from({ length: 20 }, (_, index) => ({ kind: 'assistant' as const, turn: index + 2, text: `tail ${index}` })),
+  ]
+  app.setWelcomeCard({ cwd: '/ws', sessionId: 'session-1', model: 'p/m', version: '0.1.0' })
+  app.setTranscript(messages)
+  app.setFullscreen(true)
+  await viewport(vt)
+  const anchor: TranscriptViewportAnchor = {
+    scrollTop: 0,
+    top: {
+      turn: 5,
+      rowKind: 'message',
+      occurrence: 0,
+      message: { kind: 'assistant', turn: 5, text: 'tail 3' },
+      rowOffset: 0,
+      viewportOffset: 0,
+    },
+  }
+  // The anchored message must sit at the viewport top in EVERY layout: a
+  // stale welcome height would shift the row mapping.
+  const assertAnchored = async (label: string): Promise<void> => {
+    assert.equal(app.restoreTranscriptViewportAnchor(anchor, 'top'), true)
+    const view = await viewport(vt)
+    assert.ok(view.includes('tail 3'), `${label} anchor message missing:\n${view}`)
+    assert.ok(!view.includes('tail 2'), `${label} anchor must not leave the previous message at the top:\n${view}`)
+  }
+  await assertAnchored('wide')
+  vt.resize(60, 30)
+  await assertAnchored('stacked')
+  vt.resize(32, 30)
+  await assertAnchored('compact')
   app.stop()
 })
 

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -2172,16 +2172,16 @@ test('theme switch repaints the welcome card: whale gradient stays, facts follow
   const darkWhale = vt.getCellFgRgb(whaleRow, whaleCol)
   assert.ok(darkWhale !== undefined && ramp.includes(darkWhale), `whale must paint a brand ramp color, got ${darkWhale}:\n${lines.join('\n')}`)
   // The facts title is the welcome card's own row (the header also reads
-  // "dsh-pi-tui", so match the versioned title).
-  const titleRow = lines.findIndex(line => line.includes('dsh-pi-tui  v'))
+  // "dsh-pi-tui", so exclude the 🐋 header row).
+  const titleRow = lines.findIndex(line => line.includes('dsh-pi-tui') && !line.includes('🐋'))
   assert.ok(titleRow >= 0, `facts title missing:\n${lines.join('\n')}`)
   const titleCol = lines[titleRow]!.indexOf('dsh-pi-tui')
-  assert.equal(vt.getCellFgRgb(titleRow, titleCol), 0x6b6b6b, 'dark facts must be #6B6B6B')
+  assert.equal(vt.getCellFgRgb(titleRow, titleCol), 0xf5f5f5, 'dark title must be #F5F5F5 (textStrong)')
   app.applyTheme('light')
   await vt.waitForRender()
   // Facts follow the live palette; the whale gradient stays fixed (the
   // width cache must not freeze the old ANSI).
-  assert.equal(vt.getCellFgRgb(titleRow, titleCol), 0x5f5f5f, 'light facts must be #5F5F5F')
+  assert.equal(vt.getCellFgRgb(titleRow, titleCol), 0x1a1a1a, 'light title must be #1A1A1A (textStrong)')
   assert.equal(vt.getCellFgRgb(whaleRow, whaleCol), darkWhale, 'whale gradient must survive the theme switch')
   app.stop()
 })
@@ -2205,8 +2205,8 @@ test('welcome card stacks the whale above the facts at medium width', async () =
     assert.ok(visibleWidth(line) <= 60, `whale row wrapped:\n${view}`)
   }
   // Facts come after the whale block (one blank row between). The header
-  // also reads "dsh-pi-tui", so match the versioned welcome title.
-  const factsRow = lines.findIndex(line => line.includes('dsh-pi-tui  v'))
+  // also reads "dsh-pi-tui", so exclude the 🐋 header row.
+  const factsRow = lines.findIndex(line => line.includes('dsh-pi-tui') && !line.includes('🐋'))
   assert.ok(factsRow > whaleRow, `facts must follow the whale:\n${view}`)
   assert.ok(view.includes('session-1'), `session id missing:\n${view}`)
   assert.ok(view.includes('code'), `preset missing:\n${view}`)

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -22,7 +22,7 @@ import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWi
 import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
 import { TranscriptFolder, type TranscriptMessage, type TurnActivity } from '../src/transcript.ts'
 import { TranscriptWindowController } from '../src/transcript-window.ts'
-import { Text, visibleWidth, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
+import { Text, visibleWidth, wrapTextWithAnsi, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
 import { VirtualTerminal } from './virtual-terminal.ts'
 
 /** Re-vendor lifecycle follow-up P3: every TuiApp started in this file is
@@ -1981,9 +1981,14 @@ test('viewport anchors distinguish duplicate messages and cloned Focus activitie
   app.stop()
 })
 
+/** One unique marker per whale variant; any of them proves the whale is
+ * rendered (the variant is picked randomly once per process). */
+const WHALE_MARKERS = [".--'---._", '.------._', '.-------.', ".---'--.", '/ /~~~~~~']
+const hasWhale = (view: string): boolean => WHALE_MARKERS.some(marker => view.includes(marker))
+
 test('welcome card shows the whale and full facts in the wide layout', async () => {
   const { vt, app } = startApp()
-  // Values long enough to wrap inside the ~65-col side-by-side facts column.
+  // Values long enough to wrap inside the ~76-col side-by-side facts column.
   const longCwd = `/very/long/working/directory/that/keeps/going/${'segment/'.repeat(12)}end`
   const longSession = `session-${'x'.repeat(100)}`
   app.setWelcomeCard({
@@ -1996,29 +2001,31 @@ test('welcome card shows the whale and full facts in the wide layout', async () 
   const view = await viewport(vt)
   // Facts render in full: the session id is never truncated, and long lines
   // wrap instead of ending in an ellipsis. The side-by-side facts column is
-  // 66 cells at width 100 (whale 30 + gap 4); the fixture values have no
-  // spaces, so each wrap segment is a hard cut that must survive in full.
-  const factsColumn = 100 - 34
-  for (const segment of longSession.match(new RegExp(`.{1,${factsColumn}}`, 'g'))!) {
-    assert.ok(view.includes(segment), `session id segment truncated:\n${view}`)
+  // 72 cells at width 100 (inner 96 − widest whale 20 − gap 4); recompute
+  // the actual wrap segments (label + value) and check each survives in the
+  // stripped viewport.
+  const factsColumn = 100 - 4 - 24
+  const plain = view.split('\n').map(line => line.replace(/\x1b\[[0-9;]*m/g, '')).join('\n')
+  for (const segment of wrapTextWithAnsi(`session  ${longSession}`, factsColumn)) {
+    assert.ok(plain.includes(segment), `session id segment truncated:\n${view}`)
   }
-  for (const segment of longCwd.match(new RegExp(`.{1,${factsColumn}}`, 'g'))!) {
-    assert.ok(view.includes(segment), `cwd segment truncated:\n${view}`)
+  for (const segment of wrapTextWithAnsi(`cwd      ${longCwd}`, factsColumn)) {
+    assert.ok(plain.includes(segment), `cwd segment truncated:\n${view}`)
   }
   assert.ok(view.includes('deepseek-v4-flash'), `model missing:\n${view}`)
   assert.ok(view.includes('standard'), `preset missing:\n${view}`)
   assert.ok(view.includes('0.1.0-rc.6'), `version missing:\n${view}`)
   assert.ok(!view.includes('…'), `facts ellipsized:\n${view}`)
   // 100 >= 72: the whale mascot renders side-by-side with the facts.
-  assert.ok(view.includes("_.-' `-._"), `whale missing:\n${view}`)
+  assert.ok(hasWhale(view), `whale missing:\n${view}`)
   // No physical row overflows the terminal width (ANSI-aware).
   for (const line of view.split('\n')) {
     assert.ok(visibleWidth(line) <= 100, `row overflows terminal width:\n${view}`)
   }
-  // The old full-width box presentation is no longer a contract.
-  assert.ok(!view.includes('╭'), `old box top survived:\n${view}`)
-  assert.ok(!view.includes('╰'), `old box bottom survived:\n${view}`)
-  assert.ok(!view.includes('│'), `old box sides survived:\n${view}`)
+  // The full-width box frames the card.
+  assert.ok(view.includes('╭'), `box top missing:\n${view}`)
+  assert.ok(view.includes('╰'), `box bottom missing:\n${view}`)
+  assert.ok(view.includes('│'), `box sides missing:\n${view}`)
 })
 test('working indicator shows on the row directly above the editor while active', async () => {
   const { vt, app } = startApp()
@@ -2155,10 +2162,15 @@ test('theme switch repaints the welcome card: whale gradient stays, facts follow
   app.setWelcomeCard({ cwd: '/ws', sessionId: 'session-x', model: 'p/m', version: '0.0.0' })
   await vt.waitForRender()
   const lines = vt.getViewport()
-  const whaleRow = lines.findIndex(line => line.includes("_.-' `-._"))
+  const whaleRow = lines.findIndex(line => WHALE_MARKERS.some(marker => line.includes(marker)))
   assert.ok(whaleRow >= 0, `welcome card missing:\n${lines.join('\n')}`)
-  // The whale gradient is a fixed brand ramp: line 3 paints #49A3CB.
-  assert.equal(vt.getCellFgRgb(whaleRow, 6), 0x49a3cb, 'whale line 3 must be #49A3CB')
+  // The whale gradient is a fixed brand ramp: the first glyph of the
+  // marker row (skipping the box's `│ ` prefix) paints one of the six
+  // ramp colors (the variant is random).
+  const whaleCol = lines[whaleRow]!.slice(2).search(/\S/) + 2
+  const ramp = [0x63c7d1, 0x5dbbd4, 0x56afd7, 0x50a3d9, 0x4996da, 0x4389d8]
+  const darkWhale = vt.getCellFgRgb(whaleRow, whaleCol)
+  assert.ok(darkWhale !== undefined && ramp.includes(darkWhale), `whale must paint a brand ramp color, got ${darkWhale}:\n${lines.join('\n')}`)
   // The facts title is the welcome card's own row (the header also reads
   // "dsh-pi-tui", so match the versioned title).
   const titleRow = lines.findIndex(line => line.includes('dsh-pi-tui  v'))
@@ -2170,7 +2182,7 @@ test('theme switch repaints the welcome card: whale gradient stays, facts follow
   // Facts follow the live palette; the whale gradient stays fixed (the
   // width cache must not freeze the old ANSI).
   assert.equal(vt.getCellFgRgb(titleRow, titleCol), 0x5f5f5f, 'light facts must be #5F5F5F')
-  assert.equal(vt.getCellFgRgb(whaleRow, 6), 0x49a3cb, 'whale gradient must survive the theme switch')
+  assert.equal(vt.getCellFgRgb(whaleRow, whaleCol), darkWhale, 'whale gradient must survive the theme switch')
   app.stop()
 })
 
@@ -2185,11 +2197,11 @@ test('welcome card stacks the whale above the facts at medium width', async () =
   })
   const view = await viewport(vt)
   const lines = view.split('\n')
-  // 40 <= 60 < 72: the full whale renders, centered, above the facts.
-  const whaleRow = lines.findIndex(line => line.includes("_.-' `-._"))
+  // 24 <= 60 < 72: the full whale renders, centered, above the facts.
+  const whaleRow = lines.findIndex(line => WHALE_MARKERS.some(marker => line.includes(marker)))
   assert.ok(whaleRow >= 0, `whale missing:\n${view}`)
   // The whale rows are never wrapped: the widest row fits the terminal.
-  for (const line of lines.filter(candidate => candidate.includes('~^~^~^~^~^~^~^~^~^~^~^~^~') || candidate.includes('`------._/'))) {
+  for (const line of lines.filter(candidate => WHALE_MARKERS.some(marker => candidate.includes(marker)))) {
     assert.ok(visibleWidth(line) <= 60, `whale row wrapped:\n${view}`)
   }
   // Facts come after the whale block (one blank row between). The header
@@ -2198,12 +2210,12 @@ test('welcome card stacks the whale above the facts at medium width', async () =
   assert.ok(factsRow > whaleRow, `facts must follow the whale:\n${view}`)
   assert.ok(view.includes('session-1'), `session id missing:\n${view}`)
   assert.ok(view.includes('code'), `preset missing:\n${view}`)
-  // No full-width box.
-  assert.ok(!view.includes('╭'), `old box top survived:\n${view}`)
+  // The full-width box frames the card.
+  assert.ok(view.includes('╭'), `box top missing:\n${view}`)
 })
 
 test('welcome card compacts to text rows at narrow width', async () => {
-  const { vt, app } = startApp(32, 24)
+  const { vt, app } = startApp(23, 24)
   app.setWelcomeCard({
     cwd: '/ws',
     sessionId: 'session-1',
@@ -2212,8 +2224,8 @@ test('welcome card compacts to text rows at narrow width', async () => {
     preset: 'code',
   })
   const view = await viewport(vt)
-  // Below 40 columns the full whale is not shown.
-  assert.ok(!view.includes("_.-' `-._"), `whale leaked into compact:\n${view}`)
+  // Below 24 columns the full whale is not shown.
+  assert.ok(!hasWhale(view), `whale leaked into compact:\n${view}`)
   assert.ok(view.includes('🐋 dsh-pi-tui'), `compact title missing:\n${view}`)
   assert.ok(view.includes('session-1'), `session id missing:\n${view}`)
   assert.ok(view.includes('p/m'), `model missing:\n${view}`)
@@ -2229,17 +2241,17 @@ test('welcome card switches layouts across resize breakpoints and back', async (
   app.setWelcomeCard({ cwd: '/ws', sessionId: 'session-1', model: 'p/m', version: '0.1.0' })
   await viewport(vt)
   const viewText = (): string => vt.getViewport().join('\n')
-  assert.ok(viewText().includes("_.-' `-._"), 'wide layout must show the whale')
+  assert.ok(hasWhale(viewText()), 'wide layout must show the whale')
   vt.resize(60, 24)
   await viewport(vt)
-  assert.ok(viewText().includes("_.-' `-._"), 'stacked layout must show the whale')
-  vt.resize(32, 24)
+  assert.ok(hasWhale(viewText()), 'stacked layout must show the whale')
+  vt.resize(23, 24)
   await viewport(vt)
-  assert.ok(!viewText().includes("_.-' `-._"), 'compact layout must hide the whale')
+  assert.ok(!hasWhale(viewText()), 'compact layout must hide the whale')
   assert.ok(viewText().includes('🐋 dsh-pi-tui'), 'compact layout must show the emoji title')
   vt.resize(100, 24)
   await viewport(vt)
-  assert.ok(viewText().includes("_.-' `-._"), 'wide layout must restore the whale')
+  assert.ok(hasWhale(viewText()), 'wide layout must restore the whale')
   assert.ok(!viewText().includes('🐋 dsh-pi-tui'), 'compact emoji must not survive the resize back')
 })
 
@@ -2276,7 +2288,7 @@ test('fullscreen anchor offsets follow the welcome card height across layout bre
   await assertAnchored('wide')
   vt.resize(60, 30)
   await assertAnchored('stacked')
-  vt.resize(32, 30)
+  vt.resize(23, 30)
   await assertAnchored('compact')
   app.stop()
 })

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -1375,6 +1375,10 @@ test('the pre-session welcome invites the first message and clears on facts', as
 })
 
 test('the idle welcome adapts to stacked and compact widths', async () => {
+  // One unique marker per whale variant; any of them proves the whale is
+  // rendered (the variant is picked randomly once per process).
+  const whaleMarkers = [".--'---._", '.------._', '.-------.', ".---'--.", '/ /~~~~~~']
+  const hasWhale = (text: string): boolean => whaleMarkers.some(marker => text.includes(marker))
   // Stacked (60): the whale stays, the invitation reads without the emoji.
   const stackedVt = new VirtualTerminal(60, 24)
   const stackedApp = new TuiApp(stackedVt, { onSubmit: () => {}, onExit: () => {} })
@@ -1384,14 +1388,14 @@ test('the idle welcome adapts to stacked and compact widths', async () => {
   await stackedVt.waitForRender()
   let view = stackedVt.getViewport().join('\n')
   assert.ok(view.includes('type a message to start a session'), `stacked idle invitation missing:\n${view}`)
-  assert.ok(view.includes("_.-' `-._"), `stacked idle whale missing:\n${view}`)
+  assert.ok(hasWhale(view), `stacked idle whale missing:\n${view}`)
   assert.ok(!view.includes('🐋 dsh-pi-tui'), `stacked idle must not use the compact emoji title:\n${view}`)
   // Dispose releases the process-global TuiApp slot before the next app.
   stackedApp.dispose()
-  // Compact (32): the whale is replaced by the emoji title; the invitation
+  // Compact (23): the whale is replaced by the emoji title; the invitation
   // wraps, so join the stripped rows with a space (the wrap boundary is a
   // word boundary) before matching.
-  const compactVt = new VirtualTerminal(32, 24)
+  const compactVt = new VirtualTerminal(23, 24)
   const compactApp = new TuiApp(compactVt, { onSubmit: () => {}, onExit: () => {} })
   compactApp.start()
   startedApps.add(compactApp)
@@ -1399,12 +1403,12 @@ test('the idle welcome adapts to stacked and compact widths', async () => {
   await compactVt.waitForRender()
   view = compactVt.getViewport().join('\n')
   const joined = view.split('\n')
-    .map(line => line.replace(/\x1b\[[0-9;]*m/g, '').trimEnd())
+    .map(line => line.replace(/\x1b\[[0-9;]*m/g, '').replace(/[│╭╮╰╯]/g, '').trimEnd())
     .join(' ')
     .replace(/\s+/g, ' ')
   assert.ok(joined.includes('🐋 dsh-pi-tui'), `compact idle emoji title missing:\n${view}`)
   assert.ok(joined.includes('type a message to start a session'), `compact idle invitation missing:\n${view}`)
-  assert.ok(!view.includes("_.-' `-._"), `compact idle must not show the full whale:\n${view}`)
+  assert.ok(!hasWhale(joined), `compact idle must not show the full whale:\n${view}`)
   compactApp.dispose()
 })
 

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -1368,8 +1368,44 @@ test('the pre-session welcome invites the first message and clears on facts', as
   app.setWelcomeCard({ cwd: '/ws', sessionId: 'session-1', model: 'p/m', version: '0.1.0' })
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
-  assert.ok(view.includes('session session-1'), `welcome card missing:\n${view}`)
+  assert.ok(view.includes('session-1'), `welcome card missing:\n${view}`)
   assert.ok(!view.includes('type a message to start'), `invitation survived:\n${view}`)
+  // No preset was provided: the preset row is omitted entirely.
+  assert.ok(!view.includes('preset'), `preset row must be omitted when undefined:\n${view}`)
+})
+
+test('the idle welcome adapts to stacked and compact widths', async () => {
+  // Stacked (60): the whale stays, the invitation reads without the emoji.
+  const stackedVt = new VirtualTerminal(60, 24)
+  const stackedApp = new TuiApp(stackedVt, { onSubmit: () => {}, onExit: () => {} })
+  stackedApp.start()
+  startedApps.add(stackedApp)
+  stackedApp.setWelcomeIdle(true)
+  await stackedVt.waitForRender()
+  let view = stackedVt.getViewport().join('\n')
+  assert.ok(view.includes('type a message to start a session'), `stacked idle invitation missing:\n${view}`)
+  assert.ok(view.includes("_.-' `-._"), `stacked idle whale missing:\n${view}`)
+  assert.ok(!view.includes('🐋 dsh-pi-tui'), `stacked idle must not use the compact emoji title:\n${view}`)
+  // Dispose releases the process-global TuiApp slot before the next app.
+  stackedApp.dispose()
+  // Compact (32): the whale is replaced by the emoji title; the invitation
+  // wraps, so join the stripped rows with a space (the wrap boundary is a
+  // word boundary) before matching.
+  const compactVt = new VirtualTerminal(32, 24)
+  const compactApp = new TuiApp(compactVt, { onSubmit: () => {}, onExit: () => {} })
+  compactApp.start()
+  startedApps.add(compactApp)
+  compactApp.setWelcomeIdle(true)
+  await compactVt.waitForRender()
+  view = compactVt.getViewport().join('\n')
+  const joined = view.split('\n')
+    .map(line => line.replace(/\x1b\[[0-9;]*m/g, '').trimEnd())
+    .join(' ')
+    .replace(/\s+/g, ' ')
+  assert.ok(joined.includes('🐋 dsh-pi-tui'), `compact idle emoji title missing:\n${view}`)
+  assert.ok(joined.includes('type a message to start a session'), `compact idle invitation missing:\n${view}`)
+  assert.ok(!view.includes("_.-' `-._"), `compact idle must not show the full whale:\n${view}`)
+  compactApp.dispose()
 })
 
 test('overlay frame borders stay aligned when content is narrower than the panel', async () => {
@@ -1385,7 +1421,7 @@ test('overlay frame borders stay aligned when content is narrower than the panel
   await vt.waitForRender()
   const strip = (line: string): string => line.replace(/\x1b\[[0-9;]*m/g, '').replace(/\s+$/, '')
   const lines = vt.getViewport().map(strip)
-  // Locate the picker box around its first row, not the welcome card's frame.
+  // Locate the picker box around its first row, not the welcome card above it.
   const pickerRow = lines.findIndex(line => line.includes('short label one'))
   assert.ok(pickerRow >= 0, `picker row missing:\n${lines.join('\n')}`)
   let top = pickerRow


### PR DESCRIPTION
## Summary

Welcome card visual refresh with unchanged semantics (`setWelcomeCard()` contract, idle lifecycle, fullscreen scroll/anchor/click mapping all preserved).

### What changed

- **Whale mascot**: five original ASCII variants (spout/heart/star/zzz designs, each with a little hand `\_)` in the waterline), one picked randomly **per process** — resize and facts changes keep it, only a restart re-picks.
- **Responsive layouts**:
  - ≥72 cols: whale left, facts right (side-by-side)
  - 24–71 cols: whale centered above the facts (stacked); the centering offset shrinks naturally as the width narrows, down to zero when the whale fills the inner width
  - <24 cols: compact text layout (`🐋` title, no full whale)
- **Original full-width box** restored around the card.
- **Brand gradient**: fixed cyan → blue ramp (`#63C7D1 → #4389D8`) applied per row at render time; not a semantic token, does not follow theme switches; facts keep following the live palette.
- Facts still render in full: long values wrap, never ellipsized; preset row omitted when undefined; idle invitation unchanged.

### Tests

- Wide/stacked/compact layouts, long-facts wrap segments, theme repaint (gradient fixed + facts recolor), resize round-trip (100→60→23→100), fullscreen anchor across breakpoints, idle stacked/compact, preset omission.
- Whale assertions use per-variant markers so the random pick is stable.
- Full suite: 4889 tests, 0 fail; typecheck, client-boundary gate, `git diff --check` green.

### Out of scope (unchanged)

runner, session bootstrap/resume, commands, extension API, theme schema, footer, pi-tui fork.

Co-authored-by: Jecvay <ljwjiewei@gmail.com>