### PR TITLE
feat: align workflow lifecycle model with dsh alpha.2

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Workflow lifecycle/model parity with DSH alpha.2.** Workflow runs now fold
+  into their own transcript semantic model instead of a generic tool card: run
+  and member statuses keep the full `running/completed/failed/cancelled/
+  interrupted` vocabulary (no longer collapsed to ok/error), members preserve
+  `seq`, `childId` and exact phase identity (a missing phase and an explicit
+  empty phase no longer merge); a run whose owning step/turn closed without
+  terminal events projects as `interrupted` (cold replay and live append
+  agree); search matches by run name/status, and `/export md` keeps workflow
+  records.
 - **Welcome card visual refresh.** The session-head card now shows an original round-backed whale ASCII mascot (five variants, one picked per process) with three responsive layouts: side-by-side (whale left, facts right) at 72+ columns, stacked (whale centered above the facts) at 24–71 columns, and a compact text layout (🐋 title) below 24 columns. The whale keeps a fixed cyan → blue brand gradient that does not follow theme switches; facts still render in full (long values wrap, never truncate); the idle invitation, the `setWelcomeCard()` contract, and fullscreen scroll/anchor/click mapping are unchanged.
 
 ## [0.4.3-alpha.2] - 2026-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ### 新增
 
+- **Workflow 生命周期/模型对齐 DSH alpha.2。** Workflow 从普通工具卡中拆出独立
+  semantic model：run/member 状态完整保留 `running/completed/failed/cancelled/
+  interrupted`（不再折叠成 ok/error），成员保留 `seq`/`childId` 与精确 phase
+  身份（缺失 phase 与显式空 phase 不再合并）；所属 step/turn 关闭而缺少终态
+  事件的 run 投影为 `interrupted`（冷回放与 live append 一致）；搜索按 run
+  名称/状态命中，`/export md` 保留 Workflow 记录。
 - **Welcome Card 视觉重构。** 首屏欢迎卡引入原创圆润鲸鱼 ASCII mascot(5 种变体,每次启动随机一个),按终端宽度使用三档响应式布局:72 列以上鲸鱼与 session facts 左右并排,24～71 列鲸鱼居中、facts 在下,24 列以下切换为紧凑文本布局(🐋 标题)。鲸鱼保留 cyan → blue 品牌渐变,不随主题切换改色;facts 继续完整显示(长值 wrap、不截断),idle 邀请、`setWelcomeCard()` 契约、fullscreen 滚动/锚点/点击映射均保持不变。
 
 ## [0.4.3-alpha.2] - 2026-09-08

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -40,8 +40,10 @@ import type {
 import type {} from '@deepseek-ai/dsh-commands'
 // Load the official subagent event declarations.
 import type {} from '@deepseek-ai/dsh-subagent'
-// Load the official workflow event declarations.
-import type {} from '@deepseek-ai/dsh-tool-workflow/types'
+// The official workflow durable event payloads. The branded run/session
+// identities are derived from them (indexed access on the direct dependency
+// — no new dependency surface, plan §4.1).
+import type { ToolWorkflowAgentStartData, ToolWorkflowRunStartData } from '@deepseek-ai/dsh-tool-workflow/types'
 // Load the official retry event declarations.
 import type {} from '@deepseek-ai/dsh-llm-retry'
 
@@ -96,6 +98,7 @@ export type TranscriptMessage =
    */
   | { kind: 'system'; turn: number; text: string; label?: string; summary?: string; icon?: IconSemantic }
   | TranscriptToolMessage
+  | TranscriptWorkflowMessage
   /** Older-than-window turns collapsed into one line (windowing). */
   | { kind: 'summary'; text: string }
   /**
@@ -147,14 +150,67 @@ function bumpAssistantPresentationRevision(message: Extract<TranscriptMessage, {
   assistantPresentationRevisions.set(message, assistantPresentationRevision(message) + 1)
 }
 
+/** The official branded workflow run identity (agent-start/run-end
+ * `runId`), derived from the direct dependency's event payload. */
+export type WorkflowRunId = ToolWorkflowRunStartData['runId']
+
+/** The official branded child-session identity (agent-start `childId`),
+ * derived from the direct dependency's event payload. */
+export type WorkflowChildSessionId = ToolWorkflowAgentStartData['childId']
+
+/** The run status vocabulary of one Workflow run or member (plan §2.2).
+ * `interrupted` is a presentation projection of a MISSING terminal fact plus
+ * a closed owner location — it is never a durable stop reason. */
+export type WorkflowRunStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'interrupted'
+
 /** One member row of a workflow run card. */
 export interface WorkflowMemberView {
+  /** The member's durable sequence within its run (agent-start `seq`). */
+  seq: number
   /** The member agent's label. */
   label: string
-  /** The run phase the member ran under, when the event carried one. */
-  phase?: string
+  /** The run phase the member ran under: `null` when the event carried no
+   * phase, `''` when it carried an explicit empty phase — the two stay
+   * distinct identities (plan §4.2). */
+  phase: string | null
+  /** The member's child session identity (agent-start `childId`), kept for
+   * PR2 child-session navigation. */
+  childId: WorkflowChildSessionId
   /** The member's settled state (running until agent-end). */
-  status: 'ok' | 'error' | 'running'
+  status: WorkflowRunStatus
+}
+
+/** The collision-free phase identity key: `null` (absent) and `''` (explicit
+ * empty) must never share a group (plan §4.2 — the renderer must stop using
+ * `member.phase ?? ''` as the grouping key). */
+export function workflowPhaseKey(phase: string | null): string {
+  return phase === null ? 'missing' : `value:${phase.length}:${phase}`
+}
+
+/** Strict member-outcome mapping (plan §6.3): exhaustive so a new official
+ * union variant fails typecheck instead of collapsing into a generic error. */
+function workflowMemberStatus(outcome: 'completed' | 'failed' | 'cancelled'): WorkflowRunStatus {
+  switch (outcome) {
+    case 'completed': return 'completed'
+    case 'failed': return 'failed'
+    case 'cancelled': return 'cancelled'
+  }
+}
+
+/** Strict run stop-reason mapping (plan §6.4): `error` becomes the
+ * Transcript `failed` vocabulary (Web alpha2 parity) — never stored as
+ * `error`. Exhaustive like the member mapping. */
+function workflowRunStatus(stopReason: 'completed' | 'cancelled' | 'error'): WorkflowRunStatus {
+  switch (stopReason) {
+    case 'completed': return 'completed'
+    case 'cancelled': return 'cancelled'
+    case 'error': return 'failed'
+  }
 }
 
 /**
@@ -195,11 +251,25 @@ export interface TranscriptToolMessage {
    * (in-place child mutations) invalidate the component even though the
    * `subCalls` array reference never changes. */
   subtreeRevision?: number
-  /**
-   * Workflow run cards only: the run's member rows, folded into the card
-   * (Web WorkflowRunPanel parity) instead of standalone member cards.
-   */
-  members?: WorkflowMemberView[]
+}
+
+/**
+ * One workflow run card — a durable lifecycle record, NOT a model
+ * tool/call (it never enters the Focus Tool slot or the tool count). The
+ * run and its members keep the full alpha.2 status vocabulary; `seq`,
+ * `childId` and the exact phase identity are preserved for PR2 navigation
+ * and disclosure (plan §4).
+ */
+export interface TranscriptWorkflowMessage {
+  kind: 'workflow'
+  turn: number
+  /** The durable run identity (the official branded WorkflowRunId). */
+  runId: WorkflowRunId
+  /** The run's display name (run-start `name`). */
+  name: string
+  status: WorkflowRunStatus
+  /** The run's member rows in durable `agent-start` arrival order. */
+  members: WorkflowMemberView[]
 }
 
 /** Stable identity of one raw transcript item within ONE TranscriptFolder
@@ -234,6 +304,13 @@ export function transcriptSearchText(message: TranscriptMessage, depth = 0): str
     const own = `${message.name} ${message.args} ${message.result}`
     if (message.subCalls === undefined || message.subCalls.length === 0 || depth >= PTC_MAX_DEPTH) return own
     return `${own} ${message.subCalls.map(child => transcriptSearchText(child, depth + 1)).join(' ')}`
+  }
+  if (message.kind === 'workflow') {
+    // The run's stable search identity: the kind, the run name, and the
+    // current status (the terminal reason's presentation equivalent — plan
+    // §7.3). Members are deliberately not indexed (PR1 keeps the legacy
+    // tool-card search surface; member/session search is PR2).
+    return `workflow ${message.name} ${message.status}`
   }
   return message.text ?? ''
 }
@@ -912,6 +989,29 @@ interface NextStepInboxIdentity {
   insertionTurn: number | undefined
 }
 
+/** The owner location captured at run-start: the authoritative open
+ * lifecycle state at fold time (plan §5.2) — never a look-back guess over
+ * nearby events. */
+type WorkflowOwner =
+  | { kind: 'step'; turn: number; step: number }
+  | { kind: 'turn'; turn: number }
+  | { kind: 'session' }
+
+/** Per-run fold bookkeeping for the ACTIVE Workflow lifecycle. The
+ * TranscriptWorkflowMessage itself is the durable model; this state only
+ * serves the fold (owner matching, interruption projection, search dirty
+ * marking). Deliberately Workflow-only — no generic lifecycle base class
+ * (plan §6). */
+interface WorkflowFoldState {
+  message: TranscriptWorkflowMessage
+  /** The raw item index (search dirty marking). */
+  index: number
+  /** The owner location captured at run-start. */
+  owner: WorkflowOwner
+  /** Whether the owner location has closed (step/end or turn/end). */
+  ownerClosed: boolean
+}
+
 export class TranscriptFolder {
   private readonly items: TranscriptMessage[] = []
   /** Durable next-step identities awaiting a claim or replacement. */
@@ -972,10 +1072,11 @@ export class TranscriptFolder {
   private readonly callNames = new Map<string, string>()
   /** Command names by commandId, from command/run events. */
   private readonly commandNames = new Map<string, string>()
-  /** Workflow run cards by runId, for member/run settlement. */
-  private readonly workflowRuns = new Map<string, Extract<TranscriptMessage, { kind: 'tool' }>>()
-  /** Workflow member rows by `${runId}/${seq}`, for agent-end settlement. */
-  private readonly workflowMembers = new Map<string, WorkflowMemberView>()
+  /** Active Workflow runs by runId, for member/run settlement and the
+   * owner-close interruption projection. */
+  private readonly workflowRuns = new Map<string, WorkflowFoldState>()
+  /** The currently open step (owner capture for run-start). */
+  private openStep: { turn: number; step: number } | undefined
   /** Compaction lifecycle: compactionId → items index (start/summary/end). */
   private readonly compacting = new Map<string, number>()
   /** The turn most recently opened by turn/start. */
@@ -1018,8 +1119,6 @@ export class TranscriptFolder {
    * stepKey(turn, step) — an un-namespaced map would let one kind's deltas
    * land on the other kind's searchable entry. */
   private readonly searchIndexByStepKey = new Map<string, number>()
-  /** Workflow run card indices by runId (run-end fills the result text). */
-  private readonly workflowRunIndex = new Map<string, number>()
   // Test-only counters exposed by searchDiagnosticsForTest().
   private searchRefreshCount = 0
   /** Test-only: the number of dirty entries scanned by lazy normalization
@@ -1497,6 +1596,36 @@ export class TranscriptFolder {
     if (entry === undefined) return
     this.dirtySearchEntries.add(index)
     this.searchRevisionCounter += 1
+  }
+
+  /** Project `interrupted` on every active Workflow run whose owner location
+   * just closed and which has no terminal fact yet (plan §5.3). A turn/end
+   * closes BOTH turn-owned and step-owned runs of that turn — upstream
+   * `locationClosed(step)` is `step closed OR owning turn closed`. */
+  private closeWorkflowOwner(closed: WorkflowOwner): void {
+    for (const state of this.workflowRuns.values()) {
+      if (state.ownerClosed) continue
+      const owner = state.owner
+      const matches = owner.kind === 'step'
+        ? (closed.kind === 'step' && closed.turn === owner.turn && closed.step === owner.step)
+          || (closed.kind === 'turn' && closed.turn === owner.turn)
+        : owner.kind === 'turn' && closed.kind === 'turn' && closed.turn === owner.turn
+      if (matches) this.projectWorkflowInterrupted(state)
+    }
+  }
+
+  /** The owner-close projection: `interrupted` is a presentation/model
+   * projection of a MISSING terminal fact plus a closed owner — never a
+   * durable stop reason (plan §6.4). Members without an agent-end follow the
+   * run; settled members keep their durable outcome. */
+  private projectWorkflowInterrupted(state: WorkflowFoldState): void {
+    state.ownerClosed = true
+    state.message.status = 'interrupted'
+    state.message.members = state.message.members.map(member =>
+      member.status === 'running' ? { ...member, status: 'interrupted' } : member,
+    )
+    // The run status became searchable: mark the entry dirty (lazy).
+    this.markSearchEntryDirty(state.index)
   }
 
   /** Mark a raw-item range dirty (the DEFENSIVE reflow path — O(run), rare;
@@ -3093,6 +3222,10 @@ export class TranscriptFolder {
         const activity = this.activityFor(event.data.turn)
         if (activity.completed) break
         this.usage.onStepStart(event.data.turn, event.data.step)
+        // Owner lifecycle: the step is now open (plan §5.1). Guarded by the
+        // same replay fence as the usage accounting — a late step/start
+        // after turn/end must not reopen the step for owner capture.
+        this.openStep = { turn: event.data.turn, step: event.data.step }
         const candidate = activity.messageCandidate
         if (candidate !== undefined && candidate.step < event.data.step) {
           this.confirmMessageCandidate(activity)
@@ -3116,6 +3249,13 @@ export class TranscriptFolder {
         this.markAttemptEvidenceInterrupted(event.data.turn, event.data.step)
         this.usage.onStepEnd(event.data.turn, event.data.step)
         this.syncUsage(activity)
+        // Owner lifecycle: the step closed — clear the matching open step
+        // and project interrupted for step-owned Workflow runs without a
+        // terminal fact (plan §5.1/§5.3).
+        if (this.openStep?.turn === event.data.turn && this.openStep.step === event.data.step) {
+          this.openStep = undefined
+        }
+        this.closeWorkflowOwner({ kind: 'step', turn: event.data.turn, step: event.data.step })
         break
       }
       case 'turn/start': {
@@ -3525,8 +3665,18 @@ export class TranscriptFolder {
         // synthetic cards or re-settle the activity (review finding).
         const endTurn = event.data.turn
         if (this.openTurn === endTurn) this.openTurn = undefined
+        // Owner lifecycle: the turn closed — a still-open step of this turn
+        // must not leak into the next turn-less/session-level segment (plan
+        // §5.1/§14.2). Cleared BEFORE the replay fence: a replayed turn/end
+        // must still not leave a stale openStep behind.
+        if (this.openStep?.turn === endTurn) this.openStep = undefined
         const endActivity = this.activityFor(endTurn)
         if (endActivity.completed) break
+        // Owner lifecycle: the turn closed — project interrupted on every
+        // turn-owned AND step-owned Workflow run of this turn without a
+        // terminal fact (plan §5.3 — upstream `locationClosed(step)` is
+        // `step closed OR owning turn closed`).
+        this.closeWorkflowOwner({ kind: 'turn', turn: endTurn })
         // Every still-open thinking entry of THIS turn stops streaming when
         // the turn closes (interrupted steps never see their
         // assistant/message). Settled entries were removed when their
@@ -3585,60 +3735,77 @@ export class TranscriptFolder {
         break
       }
       case 'tool-workflow/run-start': {
-        const card: Extract<TranscriptMessage, { kind: 'tool' }> = {
-          kind: 'tool',
+        // Owner capture: the authoritative open lifecycle state at fold
+        // time — the open step wins, then the open turn, else the session
+        // (plan §5.2). Never a look-back guess over nearby events.
+        const owner: WorkflowOwner = this.openStep !== undefined
+          ? { kind: 'step', turn: this.openStep.turn, step: this.openStep.step }
+          : this.openTurn !== undefined
+            ? { kind: 'turn', turn: this.openTurn }
+            : { kind: 'session' }
+        const message: TranscriptWorkflowMessage = {
+          kind: 'workflow',
           turn: this.currentTurn,
-          name: 'workflow',
-          args: event.data.name,
-          result: '',
+          runId: event.data.runId,
+          name: event.data.name,
           status: 'running',
           members: [],
         }
-        this.workflowRuns.set(event.data.runId, card)
-        this.workflowRunIndex.set(event.data.runId, this.appendItem(card))
+        const index = this.appendItem(message)
+        this.workflowRuns.set(event.data.runId, { message, index, owner, ownerClosed: false })
         // Focus aggregation: a workflow run is a durable lifecycle event,
         // NOT a model tool/call — it never touches the Tool slot or the
         // tool count (plan §17).
         break
       }
       case 'tool-workflow/agent-start': {
-        const { runId, seq, label, phase } = event.data
-        const run = this.workflowRuns.get(runId)
+        const { runId, seq, label, phase, childId } = event.data
+        const state = this.workflowRuns.get(runId)
+        if (state === undefined) break
         // The member folds INTO the run card (Web WorkflowRunPanel parity):
-        // phase grouping happens at render time over the arrival-ordered rows.
+        // phase grouping happens at render time over the arrival-ordered
+        // rows. A member starting after its owner closed is interrupted
+        // from birth (plan §6.2 — the projection comes from the current
+        // fold facts, no invented recovery flow).
         const member: WorkflowMemberView = {
+          seq,
           label,
-          ...phase === undefined ? {} : { phase },
-          status: 'running',
+          phase: phase === undefined ? null : phase,
+          childId,
+          status: state.ownerClosed ? 'interrupted' : 'running',
         }
-        this.workflowMembers.set(`${runId}/${seq}`, member)
-        run?.members?.push(member)
+        // Replace the members array reference so the render cache observes
+        // the live append (plan §6.2 — never rely on in-place push).
+        state.message.members = [...state.message.members, member]
         break
       }
       case 'tool-workflow/agent-end': {
-        const member = this.workflowMembers.get(`${event.data.runId}/${event.data.seq}`)
-        const outcome = event.data.outcome
-        if (member !== undefined) {
-          member.status = outcome === 'completed' ? 'ok' : 'error'
-        }
+        const { runId, seq, outcome } = event.data
+        const state = this.workflowRuns.get(runId)
+        if (state === undefined) break
+        // Only the started member with the matching runId + seq settles
+        // (plan §6.3 — never infer a member outcome from run-end).
+        const target = state.message.members.find(member => member.seq === seq)
+        if (target === undefined) break
+        const status = workflowMemberStatus(outcome)
+        // Replace the settled member AND the members array reference so the
+        // render cache observes the live update (plan §6.2).
+        state.message.members = state.message.members.map(member =>
+          member === target ? { ...member, status } : member,
+        )
         break
       }
       case 'tool-workflow/run-end': {
-        const card = this.workflowRuns.get(event.data.runId)
-        if (card !== undefined) {
-          card.status = event.data.stopReason === 'completed' ? 'ok' : 'error'
-          card.result = `stop: ${event.data.stopReason}`
-          // The run result became searchable: mark the entry dirty (lazy).
-          const index = this.workflowRunIndex.get(event.data.runId)
-          if (index !== undefined) this.markSearchEntryDirty(index)
+        const state = this.workflowRuns.get(event.data.runId)
+        if (state !== undefined) {
+          state.message.status = workflowRunStatus(event.data.stopReason)
+          // The run status became searchable: mark the entry dirty (lazy).
+          this.markSearchEntryDirty(state.index)
         }
-        // The run's bookkeeping is done: drop the run card and every member
-        // card keyed under it so long sessions do not accumulate stale maps.
+        // The run's bookkeeping is done: drop the fold state so long
+        // sessions do not accumulate stale maps. The
+        // TranscriptWorkflowMessage itself stays in the transcript items.
         this.workflowRuns.delete(event.data.runId)
-        this.workflowRunIndex.delete(event.data.runId)
-        for (const memberKey of this.workflowMembers.keys()) {
-          if (memberKey.startsWith(`${event.data.runId}/`)) this.workflowMembers.delete(memberKey)
-        }
         break
       }
       case 'llm/retry': {
@@ -3815,6 +3982,14 @@ export function renderTranscriptMarkdown(session: {
       : [`- agent preset: ${session.header.agentPreset}`],
     '',
   ]
+  // Workflow runs: the durable lifecycle events fold into one readable block
+  // per run, flushed at run-end (or at export end for a run without one —
+  // plan §7.4: no rich format, the new semantic kind must not regress the
+  // export).
+  const workflowRuns = new Map<string, {
+    name: string
+    members: Map<number, { label: string; phase?: string; outcome?: string }>
+  }>()
   // Alpha.4 Session shape: the event log arrives as a snapshot read, never a
   // live array — the markdown export is a full-log fold by definition.
   for (const event of session.snapshotEvents()) {
@@ -3868,9 +4043,61 @@ export function renderTranscriptMarkdown(session: {
         lines.push(`> /${event.data.name}${event.data.args === '' ? '' : ` ${event.data.args}`}\n`)
         break
       }
+      case 'tool-workflow/run-start': {
+        workflowRuns.set(event.data.runId, { name: event.data.name, members: new Map() })
+        break
+      }
+      case 'tool-workflow/agent-start': {
+        const run = workflowRuns.get(event.data.runId)
+        if (run !== undefined) {
+          run.members.set(event.data.seq, {
+            label: event.data.label,
+            ...(event.data.phase === undefined ? {} : { phase: event.data.phase }),
+          })
+        }
+        break
+      }
+      case 'tool-workflow/agent-end': {
+        const run = workflowRuns.get(event.data.runId)
+        const member = run?.members.get(event.data.seq)
+        if (member !== undefined) member.outcome = event.data.outcome
+        break
+      }
+      case 'tool-workflow/run-end': {
+        const run = workflowRuns.get(event.data.runId)
+        if (run !== undefined) {
+          lines.push(workflowMarkdownBlock(run.name, run.members, event.data.stopReason))
+          workflowRuns.delete(event.data.runId)
+        }
+        break
+      }
       default:
         break
     }
   }
+  // A run without a terminal event still exports its current state (the
+  // export is a full-log fold — never drop the record).
+  for (const run of workflowRuns.values()) {
+    lines.push(workflowMarkdownBlock(run.name, run.members, undefined))
+  }
   return lines.join('\n')
+}
+
+/** One readable Workflow export block (plan §7.4): the run line with its
+ * terminal status, then the member rows in arrival order. `error` renders as
+ * the Transcript `failed` vocabulary; a missing terminal fact renders
+ * `running`. */
+function workflowMarkdownBlock(
+  name: string,
+  members: Map<number, { label: string; phase?: string; outcome?: string }>,
+  stopReason: 'completed' | 'cancelled' | 'error' | undefined,
+): string {
+  const status = stopReason === undefined ? 'running' : stopReason === 'error' ? 'failed' : stopReason
+  const memberLines = [...members.values()].map(member => {
+    const identity = member.phase === undefined || member.phase === ''
+      ? member.label
+      : `${member.phase} / ${member.label}`
+    return `  ${identity} — ${member.outcome ?? 'running'}`
+  })
+  return [`Workflow: ${name} — ${status}`, ...memberLines].join('\n')
 }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -133,7 +133,7 @@ import { HistoryPanel, historyOverlayGeometry } from './history-panel.ts'
 import type { HistorySearchSource } from './history-search.ts'
 import { QuestionFlow } from './question.ts'
 import { MentionProvider } from './mentions.ts'
-import { assistantPresentationRevision, PTC_MAX_DEPTH, recentTurnThreshold, textWithAttachmentMarkers, type AssistantDisplayBlock, subCallDisplayStatus, type TranscriptMessage, type TurnActivity } from './transcript.ts'
+import { assistantPresentationRevision, PTC_MAX_DEPTH, recentTurnThreshold, textWithAttachmentMarkers, type AssistantDisplayBlock, subCallDisplayStatus, type TranscriptMessage, type TurnActivity, type WorkflowMemberView, type WorkflowRunStatus, workflowPhaseKey } from './transcript.ts'
 import { finalizedBlockFallbackText, fileAttachmentSummary, openOpaqueBlockFallbackText } from './content-block-presentation.ts'
 import type { TranscriptWindowState } from './transcript-window.ts'
 import { FocusActivityComponent, focusPreparingSummary, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
@@ -235,8 +235,36 @@ export interface TranscriptViewportAnchor {
 function isFocusSecondaryDisclosure(message: TranscriptMessage): boolean {
   return message.kind === 'thinking'
     || message.kind === 'tool'
+    || message.kind === 'workflow'
     || message.kind === 'system'
     || message.kind === 'compaction'
+}
+
+/** The Workflow run header pill: the REAL status (plan §7.1 — the run's
+ * state must be perceivable in the header). The old three-state
+ * ok/error/running chrome is a generic-tool presentation; the Workflow card
+ * is its own kind and never collapses cancelled/interrupted into error. */
+function workflowStatusPill(status: WorkflowRunStatus): string {
+  switch (status) {
+    case 'running': return color.textDim('[running]')
+    case 'completed': return color.success('[completed]')
+    case 'failed':
+    case 'cancelled':
+    case 'interrupted': return color.error(`[${status}]`)
+  }
+}
+
+/** The Workflow member row mark: completed → success, running → primary,
+ * failed/cancelled/interrupted → error (the old chrome mapping, kept only
+ * at this presentation boundary — never written back into the model). */
+function workflowMemberMark(status: WorkflowRunStatus): string {
+  switch (status) {
+    case 'completed': return color.success('•')
+    case 'running': return color.primary('●')
+    case 'failed':
+    case 'cancelled':
+    case 'interrupted': return color.error('✗')
+  }
 }
 
 /** The compaction lifecycle phase the working row advertises: idle (no
@@ -8581,6 +8609,10 @@ export class TuiApp {
       }
       case 'summary':
         return { kind: 'summary', turn: 0, text: message.text }
+      case 'workflow':
+        // Host-owned card: extension renderers never present workflow
+        // records (the host fallback below renders them).
+        return undefined
       case 'compaction':
         // Host-owned card: extension renderers never present compaction
         // records (the host fallback below renders them).
@@ -8669,7 +8701,7 @@ export class TuiApp {
       }
       return this.toolOutputExpanded || this.expandedOverride.get(message) === true
     }
-    return (message.kind === 'system' || message.kind === 'tool' || message.kind === 'compaction')
+    return (message.kind === 'system' || message.kind === 'tool' || message.kind === 'workflow' || message.kind === 'compaction')
       && (message.turn >= boundary || this.expandedOverride.get(message) === true)
   }
 
@@ -8807,7 +8839,7 @@ export class TuiApp {
       // on a resize.
       return message.kind === 'tool' && (message.name === 'edit' || (message.subCalls?.length ?? 0) > 0)
     }
-    return message.kind === 'system' || message.kind === 'compaction'
+    return message.kind === 'system' || message.kind === 'compaction' || message.kind === 'workflow'
       || (message.kind === 'tool' && !isCompactActionTool(message.name, message.args))
   }
 
@@ -8892,11 +8924,17 @@ export class TuiApp {
         entry.args = message.args
         entry.result = message.result
         entry.meta = message.meta
-        entry.members = message.members
         entry.subCalls = message.subCalls
         entry.subtreeRevision = message.subtreeRevision
         entry.error = message.error
         entry.resultBlocks = message.resultBlocks
+        break
+      case 'workflow':
+        // The run status and the members array reference (replaced on every
+        // visible member/status change — plan §6.2) drive the staleness
+        // check; the run name is durable and never changes.
+        entry.status = message.status
+        entry.members = message.members
         break
       case 'summary':
         break
@@ -8926,11 +8964,16 @@ export class TuiApp {
         return entry.text !== message.text || entry.label !== message.label || entry.summary !== message.summary
       case 'tool':
         return entry.status !== message.status || entry.args !== message.args
-          || entry.result !== message.result || entry.meta !== message.meta || entry.members !== message.members
+          || entry.result !== message.result || entry.meta !== message.meta
           || entry.subCalls !== message.subCalls
           || entry.subtreeRevision !== message.subtreeRevision
           || ((message.subCalls?.length ?? 0) > 0 && entry.subCallExpandedRev !== this.subCallExpandedRevision)
           || entry.error !== message.error || entry.resultBlocks !== message.resultBlocks
+      case 'workflow':
+        // The members array reference is replaced on every visible change
+        // (plan §6.2), so reference comparison is the reliable invalidation
+        // evidence — never an in-place-mutation coincidence.
+        return entry.status !== message.status || entry.members !== message.members
       case 'summary':
         return false
       case 'compaction':
@@ -9247,6 +9290,9 @@ export class TuiApp {
         ), 0, 0))
       }
       return card
+    }
+    if (message.kind === 'workflow') {
+      return this.renderWorkflowCard(message, expanded, width)
     }
     // Tool card: the Web row-model header (design title + relativized args
     // summary + status pill), with the result body when expanded. The whole
@@ -9711,6 +9757,53 @@ export class TuiApp {
   }
 
   /**
+   * Render one Workflow run card (plan §7.1): the run header with the REAL
+   * status pill (running/completed/failed/cancelled/interrupted), and the
+   * member tree grouped by phase identity — `null` (absent) and `''`
+   * (explicit empty) are distinct groups via {@link workflowPhaseKey}, never
+   * merged by `phase ?? ''`. PR1 keeps the single-card disclosure shape;
+   * nested Run/Phase disclosure and child navigation are PR2.
+   */
+  private renderWorkflowCard(
+    message: Extract<TranscriptMessage, { kind: 'workflow' }>,
+    expanded: boolean,
+    width: number,
+  ): Component {
+    const card = new Container()
+    const icon = iconPrefix('workflow', this.iconStyle)
+    const head = `${color.textDim(`${icon}Workflow ${message.name}`)} ${workflowStatusPill(message.status)}`
+    if (expanded) {
+      card.addChild(new Text(head, 0, 0))
+      // Phase grouping over the durable arrival-ordered rows (Web
+      // WorkflowRunPanel parity). The phase identity key keeps absent and
+      // explicit-empty phases in separate groups (plan §4.2).
+      const groups = new Map<string, WorkflowMemberView[]>()
+      for (const member of message.members) {
+        const key = workflowPhaseKey(member.phase)
+        const list = groups.get(key)
+        if (list === undefined) groups.set(key, [member])
+        else list.push(member)
+      }
+      for (const members of groups.values()) {
+        const phase = members[0]?.phase
+        if (phase !== null && phase !== '') card.addChild(new Text(color.textMuted(`  ${phase}`), 0, 0))
+        for (const member of members) {
+          card.addChild(new Text(
+            `  ${workflowMemberMark(member.status)} ${member.label} — ${color.textDim(member.status)}`,
+            0,
+            0,
+          ))
+        }
+      }
+    } else {
+      // The folded row truncates to the content width (same rule as the
+      // folded tool cards — the width-baking cache contract).
+      card.addChild(new Text(truncateToWidth(head, width, '…'), 0, 0))
+    }
+    return card
+  }
+
+  /**
    * Render one expanded tool card's body. When the runner wired a presenter,
    * the body follows the tool's own render intent (presentResult): a read
    * card shows numbered lines plus the relativized path and total line
@@ -9786,35 +9879,8 @@ export class TuiApp {
         return
       }
     }
-    // Workflow run cards: the body is the run's member tree, grouped by phase
-    // in arrival order (Web WorkflowRunPanel parity). Rows render even while
-    // the run is still streaming (members land incrementally).
-    if (message.name === 'workflow' && message.members !== undefined) {
-      const groups = new Map<string, NonNullable<Extract<TranscriptMessage, { kind: 'tool' }>['members']>>()
-      for (const member of message.members) {
-        const key = member.phase ?? ''
-        const list = groups.get(key)
-        if (list === undefined) groups.set(key, [member])
-        else list.push(member)
-      }
-      for (const [phase, members] of groups) {
-        if (phase !== '') card.addChild(new Text(color.textMuted(`  ${phase}`), 0, 0))
-        for (const member of members) {
-          const mark = member.status === 'ok'
-            ? color.success('•')
-            : member.status === 'error'
-              ? color.error('✗')
-              : color.primary('●')
-          const statusText = member.status === 'ok'
-            ? 'completed'
-            : member.status === 'error'
-              ? 'failed'
-              : 'running'
-          card.addChild(new Text(`  ${mark} ${member.label} — ${color.textDim(statusText)}`, 0, 0))
-        }
-      }
-      return
-    }
+    // Workflow run cards are their own semantic kind and render through
+    // renderWorkflowCard — they never reach the generic tool body.
     // Running: surface the pending call's salient raw input when the tool
     // offered one (e.g. a background job id); edit/write calls render their
     // call-time diff (old_string → new_string / the written content) right

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -1064,6 +1064,32 @@ test('workflow/subagent lifecycle events never touch the Tool slot or the count 
   assert.equal(activity.tool, undefined)
 })
 
+test('workflow rows stay out of the collapsed Focus and visible when expanded (plan §7.2)', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('user/message', {
+      id: MessageId('u0'), role: 'user',
+      content: [{ type: 'text', text: 'run the audit' }],
+      source: { kind: 'user' },
+    }, 1001, 1),
+    eventAt('tool-workflow/run-start', { runId: 'r1', name: 'audit' }, 1002, 2),
+    eventAt('tool-workflow/agent-start', { runId: 'r1', seq: 0, label: 'checker', childId: 'session-x' }, 1003, 3),
+  ])
+  const collapsed = projectFocus(folder.messages(), folder.turnActivities(), new Set(), true)
+  assert.equal(
+    collapsed.filter(block => block.kind === 'message' && block.message.kind === 'workflow').length,
+    0,
+    'a collapsed Focus must not show the workflow process row',
+  )
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  const workflowBlocks = expanded.filter(block => block.kind === 'message' && block.message.kind === 'workflow')
+  assert.equal(workflowBlocks.length, 1, 'an expanded Focus must keep the workflow row')
+  const block = workflowBlocks[0]
+  assert.ok(block !== undefined && block.kind === 'message' && block.message.kind === 'workflow')
+  assert.equal(block.message.name, 'audit')
+})
+
 // ── Per-turn token usage (plan §12/§13/§45) ────────────────────────────
 
 /** One step with a usage chunk + assistant/message + step/end. */

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -20,7 +20,7 @@ import { color, currentPalette, darkColors, lightColors, setTheme } from '../src
 import { iconFor } from '../src/icons.ts'
 import { TuiApp, BulletedComponent, TRANSCRIPT_RIGHT_GUTTER, transcriptContentWidth, TranscriptGutterComponent, type TranscriptViewportAnchor } from '../src/tui-app.ts'
 import { WorkingIndicator, workingFramesFor } from '../src/working.ts'
-import { TranscriptFolder, type TranscriptMessage, type TurnActivity } from '../src/transcript.ts'
+import { TranscriptFolder, type TranscriptMessage, type TurnActivity, type WorkflowRunId } from '../src/transcript.ts'
 import { TranscriptWindowController } from '../src/transcript-window.ts'
 import { Text, visibleWidth, wrapTextWithAnsi, stripTerminalSequences, type Terminal } from '@xmoon76/pi-tui'
 import { VirtualTerminal } from './virtual-terminal.ts'
@@ -2776,7 +2776,7 @@ test('tool and context cards render the symbols palette', async (t) => {
     { kind: 'tool', turn: 0, name: 'edit', args: '', result: '', status: 'ok' },
     { kind: 'tool', turn: 0, name: 'unknown-thing', args: '', result: '', status: 'ok' },
     { kind: 'tool', turn: 0, name: 'subagent', args: '', result: '', status: 'ok' },
-    { kind: 'tool', turn: 0, name: 'workflow', args: '', result: '', status: 'ok' },
+    { kind: 'workflow', turn: 0, runId: 'run-1' as WorkflowRunId, name: 'audit', status: 'completed', members: [] },
     // The ERROR semantic belongs to the synthetic error card (the
     // `error`-named tool); an ordinary tool that FAILED keeps its own
     // variant icon — the status pill carries the failure.
@@ -2810,7 +2810,7 @@ test('minimal hides decorative icons with no dangling whitespace', async (t) => 
   app.setTranscript([
     { kind: 'tool', turn: 0, name: 'read', args: JSON.stringify({ path: '/ws/src/foo.ts' }), result: '', status: 'ok' },
     { kind: 'tool', turn: 0, name: 'subagent', args: '', result: '', status: 'ok' },
-    { kind: 'tool', turn: 0, name: 'workflow', args: '', result: '', status: 'ok' },
+    { kind: 'workflow', turn: 0, runId: 'run-1' as WorkflowRunId, name: 'audit', status: 'completed', members: [] },
     { kind: 'tool', turn: 0, name: 'some-tool', args: '', result: 'boom', status: 'error' },
     { kind: 'tool', turn: 0, name: 'error', args: '', result: '', status: 'error' },
     { kind: 'tool', turn: 0, name: '/compact', args: '', result: 'executed', status: 'ok' },
@@ -3677,21 +3677,20 @@ test('workflow runs expand into a phase-grouped member tree', async () => {
   const { vt, app } = startApp()
   app.setToolOutputExpanded(true)
   app.setTranscript([{
-    kind: 'tool',
+    kind: 'workflow',
     turn: 0,
-    name: 'workflow',
-    args: 'audit',
-    result: 'stop: completed',
-    status: 'ok',
+    runId: 'run-1' as WorkflowRunId,
+    name: 'audit',
+    status: 'completed',
     members: [
-      { label: 'checker', phase: 'review', status: 'ok' },
-      { label: 'patcher', phase: 'review', status: 'error' },
-      { label: 'reporter', phase: 'report', status: 'ok' },
-      { label: 'live-agent', status: 'running' },
+      { seq: 0, label: 'checker', phase: 'review', childId: 'session-x' as never, status: 'completed' },
+      { seq: 1, label: 'patcher', phase: 'review', childId: 'session-y' as never, status: 'failed' },
+      { seq: 2, label: 'reporter', phase: 'report', childId: 'session-z' as never, status: 'completed' },
+      { seq: 3, label: 'live-agent', phase: null, childId: 'session-w' as never, status: 'running' },
     ],
   }])
   const view = await viewport(vt)
-  assert.ok(view.includes('Workflow audit [ok]'), `run header missing:\n${view}`)
+  assert.ok(view.includes('Workflow audit [completed]'), `run header missing:\n${view}`)
   assert.ok(view.includes('  review'), `phase header missing:\n${view}`)
   assert.ok(view.includes('checker — completed'), `completed member missing:\n${view}`)
   assert.ok(view.includes('patcher — failed'), `failed member missing:\n${view}`)
@@ -3703,17 +3702,55 @@ test('workflow runs expand into a phase-grouped member tree', async () => {
 test('workflow runs stay a single folded row until expanded', async () => {
   const { vt, app } = startApp()
   app.setTranscript([{
-    kind: 'tool',
+    kind: 'workflow',
     turn: 0,
-    name: 'workflow',
-    args: 'audit',
-    result: 'stop: completed',
-    status: 'ok',
-    members: [{ label: 'checker', phase: 'review', status: 'ok' }],
+    runId: 'run-1' as WorkflowRunId,
+    name: 'audit',
+    status: 'completed',
+    members: [{ seq: 0, label: 'checker', phase: 'review', childId: 'session-x' as never, status: 'completed' }],
   }])
   const view = await viewport(vt)
-  assert.ok(view.includes('Workflow audit [ok]'), `folded header missing:\n${view}`)
+  assert.ok(view.includes('Workflow audit [completed]'), `folded header missing:\n${view}`)
   assert.ok(!view.includes('checker — completed'), `members leaked while folded:\n${view}`)
+})
+
+test('workflow live member/status updates invalidate the cached card (plan §8.11)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setToolOutputExpanded(true)
+  app.setTranscript(folder.messages())
+  const cache = (app as unknown as { messageComponents: Map<object, { component: object }> }).messageComponents
+  const first = folder.messages()[0]
+  assert.ok(first !== undefined && first.kind === 'workflow')
+  const firstComponent = cache.get(first)?.component
+  assert.ok(firstComponent !== undefined)
+  let view = await viewport(vt)
+  assert.ok(!view.includes('checker'), `no member before agent-start:\n${view}`)
+  // agent-start: the members array reference changes → the card rebuilds.
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'checker', childId: 'session-x' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  const secondComponent = cache.get(first)?.component
+  assert.notStrictEqual(secondComponent, firstComponent, 'agent-start must invalidate the cached workflow card')
+  view = await viewport(vt)
+  assert.ok(view.includes('checker — running'), `live member row missing:\n${view}`)
+  // agent-end: the member status changes → rebuild.
+  folder.apply([
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  const thirdComponent = cache.get(first)?.component
+  assert.notStrictEqual(thirdComponent, secondComponent, 'agent-end must invalidate the cached workflow card')
+  view = await viewport(vt)
+  assert.ok(view.includes('checker — completed'), `live member status missing:\n${view}`)
+  // An unchanged re-render keeps the component.
+  app.setTranscript(folder.messages())
+  assert.strictEqual(cache.get(first)?.component, thirdComponent, 'an unchanged workflow card must not churn the component')
 })
 
 test('askQuestions marks recommended options and renders detail blocks', async () => {

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -141,6 +141,7 @@ function compactionEvent(type: 'compaction/start' | 'compaction/summary' | 'comp
 function cardText(message: TranscriptMessage | undefined): string {
   if (message === undefined) return ''
   if (message.kind === 'tool') return `${message.name} ${message.args} ${message.result}`
+  if (message.kind === 'workflow') return `workflow ${message.name} ${message.status}`
   return message.text ?? ''
 }
 
@@ -153,7 +154,9 @@ function legacySearchForTest(folder: TranscriptFolder, query: string): Transcrip
   const needle = query.trim().toLowerCase()
   if (needle === '') return []
   return folder.messages().filter(message => {
-    const text = message.kind === 'tool' ? `${message.name} ${message.args} ${message.result}` : message.text
+    const text = message.kind === 'tool' ? `${message.name} ${message.args} ${message.result}`
+      : message.kind === 'workflow' ? `workflow ${message.name} ${message.status}`
+        : message.text
     return text.toLowerCase().includes(needle)
   })
 }
@@ -611,10 +614,23 @@ test('command/done and workflow cards are searchable exactly like legacy', () =>
     rawEvent('tool-workflow/run-end', { runId: 'run1', stopReason: 'completed' }, 4),
     turnEnd(5, 0),
   ])
-  assertCorpusParity(folder, ['theme set to dark', '/theme', 'audit', 'stop: completed'])
-  const workflow = folder.search('stop: completed')
+  assertCorpusParity(folder, ['theme set to dark', '/theme', 'audit', 'completed'])
+  const workflow = folder.search('audit')
   assert.equal(workflow.length, 1)
-  assert.equal(folder.resolveSearchMatch(workflow[0]!)?.kind, 'tool')
+  assert.equal(folder.resolveSearchMatch(workflow[0]!)?.kind, 'workflow')
+})
+
+test('workflow search text follows the live run status (plan §8.12)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run1', name: 'audit' }, 1),
+  ])
+  assertCorpusParity(folder, ['workflow', 'audit', 'running'])
+  assert.equal(folder.search('completed').length, 0, 'a running run must not match the terminal status')
+  folder.apply([rawEvent('tool-workflow/run-end', { runId: 'run1', stopReason: 'completed' }, 2)])
+  assertCorpusParity(folder, ['workflow', 'audit', 'completed'])
+  assert.equal(folder.search('running').length, 0, 'the settled run must not keep the start-time status in the corpus')
 })
 
 test('a settled assistant message created WITHOUT chunks stays searchable after replacement', () => {

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -2289,6 +2289,41 @@ test('workflow: step/end without terminal facts projects interrupted (plan §8.6
   assert.equal(after.members[0]?.status, 'interrupted')
 })
 
+test('workflow: late durable terminal facts override the derived interrupted state', () => {
+  // `interrupted` is a projection of a MISSING terminal fact plus a closed
+  // owner — never a durable stop reason. The fold state stays alive after
+  // the projection, so a LATER agent-end / run-end must override it with
+  // the real terminal fact (plan §2.2/§6.4).
+  const cases = [
+    { runId: 'run-a', outcome: 'completed', stopReason: 'completed', member: 'completed', run: 'completed' },
+    { runId: 'run-b', outcome: 'failed', stopReason: 'error', member: 'failed', run: 'failed' },
+    { runId: 'run-c', outcome: 'cancelled', stopReason: 'cancelled', member: 'cancelled', run: 'cancelled' },
+  ] as const
+  for (const c of cases) {
+    const folder = new TranscriptFolder()
+    folder.apply([
+      event('turn/start', { turn: 0 }, 0),
+      event('step/start', { turn: 0, step: 0 }, 1),
+      rawEvent('tool-workflow/run-start', { runId: c.runId, name: 'audit' }, 2),
+      rawEvent('tool-workflow/agent-start', { runId: c.runId, seq: 0, label: 'checker', childId: 'session-x' }, 3),
+      event('step/end', { turn: 0, step: 0 }, 4),
+    ])
+    const interrupted = folder.messages()[0]
+    assert.ok(interrupted !== undefined && interrupted.kind === 'workflow')
+    assert.equal(interrupted.status, 'interrupted', `${c.runId} run must project interrupted`)
+    assert.equal(interrupted.members[0]?.status, 'interrupted', `${c.runId} member must project interrupted`)
+    // Late durable facts override the derived projection.
+    folder.apply([
+      rawEvent('tool-workflow/agent-end', { runId: c.runId, seq: 0, outcome: c.outcome }, 5),
+      rawEvent('tool-workflow/run-end', { runId: c.runId, stopReason: c.stopReason }, 6),
+    ])
+    const settled = folder.messages()[0]
+    assert.ok(settled !== undefined && settled.kind === 'workflow')
+    assert.equal(settled.members[0]?.status, c.member, `${c.runId} member must settle to the durable outcome`)
+    assert.equal(settled.status, c.run, `${c.runId} run must settle to the durable stop reason`)
+  }
+})
+
 test('workflow: turn/end without terminal facts projects interrupted (plan §8.7)', () => {
   const messages = foldTranscript([
     event('turn/start', { turn: 0 }, 0),

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -12,7 +12,7 @@ import { BlockAssembler, expandAssistantStream, ToolCallId, MessageId, type Assi
 import { CommandId } from '@deepseek-ai/dsh-commands'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { RetryId } from '@deepseek-ai/dsh-llm-retry'
-import { foldTranscript, groupConsecutiveReads, PTC_MAX_DEPTH, renderTranscriptMarkdown, subCallDisplayStatus, TranscriptFolder, windowMessages, type TranscriptMessage } from '../src/transcript.ts'
+import { foldTranscript, groupConsecutiveReads, PTC_MAX_DEPTH, renderTranscriptMarkdown, subCallDisplayStatus, TranscriptFolder, windowMessages, workflowPhaseKey, type TranscriptMessage } from '../src/transcript.ts'
 import { projectFocus } from '../src/focus-activity.ts'
 import { computeStats, StatsFolder } from '../src/stats.ts'
 import { TranscriptWindowController } from '../src/transcript-window.ts'
@@ -2149,7 +2149,7 @@ test('subagent/descriptor folds into a delegation card', () => {
   assert.ok(card.result.includes('model: deepseek-chat'))
 })
 
-test('workflow run events fold into one run card with member rows', () => {
+test('workflow run events fold into one workflow card with member rows', () => {
   const messages = foldTranscript([
     event('turn/start', { turn: 0 }, 0),
     rawEvent('tool-workflow/run-start', { runId: 'run-1', name: 'audit' }, 1),
@@ -2157,17 +2157,22 @@ test('workflow run events fold into one run card with member rows', () => {
     rawEvent('tool-workflow/agent-end', { runId: 'run-1', seq: 0, outcome: 'completed' }, 3),
     rawEvent('tool-workflow/run-end', { runId: 'run-1', stopReason: 'completed' }, 4),
   ])
-  assert.deepEqual(kinds(messages), ['tool'])
+  assert.deepEqual(kinds(messages), ['workflow'])
   const run = messages[0]
-  assert.ok(run !== undefined && run.kind === 'tool')
-  assert.equal(run.name, 'workflow')
-  assert.equal(run.args, 'audit')
-  assert.equal(run.status, 'ok')
-  assert.equal(run.result, 'stop: completed')
-  assert.deepEqual(run.members, [{ label: 'checker', phase: 'review', status: 'ok' }])
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.name, 'audit')
+  assert.equal(run.runId, 'run-1')
+  assert.equal(run.status, 'completed')
+  assert.deepEqual(run.members, [{
+    seq: 0,
+    label: 'checker',
+    phase: 'review',
+    childId: 'session-x',
+    status: 'completed',
+  }])
 })
 
-test('a failed workflow member settles its row as error', () => {
+test('a failed workflow member settles its row as failed', () => {
   const messages = foldTranscript([
     event('turn/start', { turn: 0 }, 0),
     rawEvent('tool-workflow/run-start', { runId: 'run-2', name: 'audit' }, 1),
@@ -2175,8 +2180,204 @@ test('a failed workflow member settles its row as error', () => {
     rawEvent('tool-workflow/agent-end', { runId: 'run-2', seq: 0, outcome: 'failed' }, 3),
   ])
   const run = messages[0]
-  assert.ok(run !== undefined && run.kind === 'tool')
-  assert.deepEqual(run.members, [{ label: 'checker', status: 'error' }])
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.members[0]?.status, 'failed')
+})
+
+// ── Workflow lifecycle/model parity (PR1 plan §8) ───────────────────────
+
+test('workflow: a complete run folds into one workflow card (plan §8.1)', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    rawEvent('tool-workflow/run-start', { runId: 'run-1', name: 'audit' }, 2),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-1', seq: 0, label: 'checker', phase: 'review', childId: 'session-x' }, 3),
+    rawEvent('tool-workflow/agent-end', { runId: 'run-1', seq: 0, outcome: 'completed' }, 4),
+    rawEvent('tool-workflow/run-end', { runId: 'run-1', stopReason: 'completed' }, 5),
+    event('step/end', { turn: 0, step: 0 }, 6),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 7),
+  ])
+  assert.deepEqual(kinds(messages), ['workflow'])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.name, 'audit')
+  assert.equal(run.runId, 'run-1')
+  assert.equal(run.status, 'completed')
+  assert.deepEqual(run.members, [{
+    seq: 0,
+    label: 'checker',
+    phase: 'review',
+    childId: 'session-x',
+    status: 'completed',
+  }])
+})
+
+test('workflow: run-end error maps to failed, never error (plan §8.2)', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run-2', name: 'audit' }, 1),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-2', seq: 0, label: 'checker', childId: 'session-x' }, 2),
+    rawEvent('tool-workflow/agent-end', { runId: 'run-2', seq: 0, outcome: 'failed' }, 3),
+    rawEvent('tool-workflow/run-end', { runId: 'run-2', stopReason: 'error' }, 4),
+  ])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.status, 'failed')
+  assert.equal(run.members[0]?.status, 'failed')
+})
+
+test('workflow: cancelled member and run stay cancelled (plan §8.3)', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run-3', name: 'audit' }, 1),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-3', seq: 0, label: 'checker', childId: 'session-x' }, 2),
+    rawEvent('tool-workflow/agent-end', { runId: 'run-3', seq: 0, outcome: 'cancelled' }, 3),
+    rawEvent('tool-workflow/run-end', { runId: 'run-3', stopReason: 'cancelled' }, 4),
+  ])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.status, 'cancelled')
+  assert.equal(run.members[0]?.status, 'cancelled')
+})
+
+test('workflow: absent phase stays null and empty phase stays distinct (plan §8.4)', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run-4', name: 'audit' }, 1),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-4', seq: 0, label: 'a', childId: 's-a' }, 2),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-4', seq: 1, label: 'b', phase: '', childId: 's-b' }, 3),
+  ])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.members[0]?.phase, null)
+  assert.equal(run.members[1]?.phase, '')
+  assert.notEqual(
+    workflowPhaseKey(run.members[0]!.phase),
+    workflowPhaseKey(run.members[1]!.phase),
+    'absent and explicit-empty phases must never share an identity key',
+  )
+})
+
+test('workflow: a zero-member run settles completed (plan §8.5)', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run-5', name: 'audit' }, 1),
+    rawEvent('tool-workflow/run-end', { runId: 'run-5', stopReason: 'completed' }, 2),
+  ])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.status, 'completed')
+  assert.deepEqual(run.members, [])
+})
+
+test('workflow: step/end without terminal facts projects interrupted (plan §8.6)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    rawEvent('tool-workflow/run-start', { runId: 'run-6', name: 'audit' }, 2),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-6', seq: 0, label: 'checker', childId: 'session-x' }, 3),
+  ])
+  const before = folder.messages()[0]
+  assert.ok(before !== undefined && before.kind === 'workflow')
+  assert.equal(before.status, 'running')
+  assert.equal(before.members[0]?.status, 'running')
+  folder.apply([event('step/end', { turn: 0, step: 0 }, 4)])
+  const after = folder.messages()[0]
+  assert.ok(after !== undefined && after.kind === 'workflow')
+  assert.equal(after.status, 'interrupted')
+  assert.equal(after.members[0]?.status, 'interrupted')
+})
+
+test('workflow: turn/end without terminal facts projects interrupted (plan §8.7)', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run-7', name: 'audit' }, 1),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-7', seq: 0, label: 'checker', childId: 'session-x' }, 2),
+    event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, 3),
+  ])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.status, 'interrupted')
+  assert.equal(run.members[0]?.status, 'interrupted')
+})
+
+test('workflow: turn/end closes a step-owned run without step/end (plan §8.8)', () => {
+  const messages = foldTranscript([
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    rawEvent('tool-workflow/run-start', { runId: 'run-8', name: 'audit' }, 2),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-8', seq: 0, label: 'checker', childId: 'session-x' }, 3),
+    event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, 4),
+  ])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.status, 'interrupted')
+  assert.equal(run.members[0]?.status, 'interrupted')
+})
+
+test('workflow: a session-level run without terminal facts stays running (plan §8.9)', () => {
+  const messages = foldTranscript([
+    rawEvent('tool-workflow/run-start', { runId: 'run-9', name: 'audit' }, 0),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-9', seq: 0, label: 'checker', childId: 'session-x' }, 1),
+  ])
+  const run = messages[0]
+  assert.ok(run !== undefined && run.kind === 'workflow')
+  assert.equal(run.status, 'running')
+  assert.equal(run.members[0]?.status, 'running')
+})
+
+test('workflow: live append and cold replay produce the same model (plan §8.10)', () => {
+  const events = [
+    event('turn/start', { turn: 0 }, 0),
+    event('step/start', { turn: 0, step: 0 }, 1),
+    rawEvent('tool-workflow/run-start', { runId: 'run-10', name: 'audit' }, 2),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-10', seq: 0, label: 'a', phase: '', childId: 's-a' }, 3),
+    rawEvent('tool-workflow/agent-start', { runId: 'run-10', seq: 1, label: 'b', childId: 's-b' }, 4),
+    rawEvent('tool-workflow/agent-end', { runId: 'run-10', seq: 0, outcome: 'completed' }, 5),
+    rawEvent('tool-workflow/agent-end', { runId: 'run-10', seq: 1, outcome: 'failed' }, 6),
+    rawEvent('tool-workflow/run-end', { runId: 'run-10', stopReason: 'error' }, 7),
+    event('step/end', { turn: 0, step: 0 }, 8),
+    event('turn/end', { turn: 0, reason: { kind: 'completed' } }, 9),
+  ]
+  const cold = foldTranscript(events)
+  const folder = new TranscriptFolder()
+  for (const single of events) folder.apply([single])
+  const live = folder.messages()
+  assert.deepEqual(live, cold)
+})
+
+test('workflow: live member mutations are visible through fresh references (plan §8.11)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([event('turn/start', { turn: 0 }, 0)])
+  folder.apply([rawEvent('tool-workflow/run-start', { runId: 'run-11', name: 'audit' }, 1)])
+  const first = folder.messages()[0]
+  assert.ok(first !== undefined && first.kind === 'workflow')
+  assert.deepEqual(first.members, [])
+  // The message object is mutated IN PLACE (the same item object is
+  // returned by every messages() read), so the render cache must observe
+  // the change through the members ARRAY reference — capture it before the
+  // mutation to prove the replacement.
+  const firstMembers = first.members
+  folder.apply([rawEvent('tool-workflow/agent-start', { runId: 'run-11', seq: 0, label: 'checker', childId: 'session-x' }, 2)])
+  const second = folder.messages()[0]
+  assert.ok(second !== undefined && second.kind === 'workflow')
+  assert.equal(second.members.length, 1)
+  assert.notEqual(second.members, firstMembers, 'agent-start must replace the members array reference')
+  const secondMembers = second.members
+  const secondMember = second.members[0]
+  folder.apply([rawEvent('tool-workflow/agent-end', { runId: 'run-11', seq: 0, outcome: 'completed' }, 3)])
+  const third = folder.messages()[0]
+  assert.ok(third !== undefined && third.kind === 'workflow')
+  assert.equal(third.members[0]?.status, 'completed')
+  assert.notEqual(third.members, secondMembers, 'agent-end must replace the members array reference')
+  assert.notEqual(third.members[0], secondMember, 'agent-end must replace the settled member object')
+  const thirdMembers = third.members
+  folder.apply([event('turn/end', { turn: 0, reason: { kind: 'aborted', reason: { kind: 'user' } } }, 4)])
+  const interrupted = folder.messages()[0]
+  assert.ok(interrupted !== undefined && interrupted.kind === 'workflow')
+  assert.equal(interrupted.status, 'interrupted')
+  assert.notEqual(interrupted.members, thirdMembers, 'interruption must replace the members array reference')
 })
 
 test('llm/retry folds into a system line with the delay', () => {
@@ -4734,6 +4935,32 @@ test('open opaque attempt state is excluded from markdown export', () => {
   } as never)
   assert.doesNotMatch(markdown, /future-open|Unknown block: future-open/)
   assert.match(markdown, /Unknown block: future-final/)
+})
+
+test('workflow lifecycle events survive the markdown export (plan §8.13)', () => {
+  const markdown = renderTranscriptMarkdown({
+    header: { id: 'session-export' as never, cwd: '/workspace' },
+    snapshotEvents: () => [
+      rawEvent('tool-workflow/run-start', { runId: 'run-1', name: 'audit' }, 1),
+      rawEvent('tool-workflow/agent-start', { runId: 'run-1', seq: 0, label: 'checker', phase: 'review', childId: 'session-x' }, 2),
+      rawEvent('tool-workflow/agent-end', { runId: 'run-1', seq: 0, outcome: 'completed' }, 3),
+      rawEvent('tool-workflow/run-end', { runId: 'run-1', stopReason: 'completed' }, 4),
+    ],
+  } as never)
+  assert.match(markdown, /Workflow: audit — completed/)
+  assert.match(markdown, /review \/ checker — completed/)
+})
+
+test('a workflow run without a terminal event still exports its current state', () => {
+  const markdown = renderTranscriptMarkdown({
+    header: { id: 'session-export' as never, cwd: '/workspace' },
+    snapshotEvents: () => [
+      rawEvent('tool-workflow/run-start', { runId: 'run-2', name: 'audit' }, 1),
+      rawEvent('tool-workflow/agent-start', { runId: 'run-2', seq: 0, label: 'checker', childId: 'session-x' }, 2),
+    ],
+  } as never)
+  assert.match(markdown, /Workflow: audit — running/)
+  assert.match(markdown, /checker — running/)
 })
 
 test('failed-attempt reasoning resets on retry and matches a cold replay', () => {


### PR DESCRIPTION
## Summary

- give Workflow its own transcript semantic model
- preserve member seq/childId and exact phase identity
- preserve completed/failed/cancelled states instead of collapsing to ok/error
- derive interrupted when the owning step/turn closes without terminal workflow events
- keep cold replay and live append projections aligned

## Scope

This PR intentionally does not add nested Run/Phase disclosures or child-session navigation; those remain presentation work for the next PR.

## Validation

- pnpm typecheck:bundle
- pnpm test:product
- pnpm gate:boundary
- pnpm build:bundle
