### PR TITLE
feat: add scalable workflow run UI

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scalable Workflow UI.** Workflow cards now own a two-level Run/Phase
+  disclosure: small phases (≤5 agents) list every member inline in the
+  transcript, large phases show aggregate counts + a capped abnormal preview
+  (max 3) + a `View N agents` entry, so a 100+ agent run never grows the
+  transcript linearly; a completed run collapses by default but keeps its
+  aggregate summary (e.g. `126 agents · completed`). `cancelled`/`interrupted`
+  use the warning visual category (no longer fused into `failed` error), and
+  a missing / explicit-empty phase reads as `Unassigned` / `Empty`. A running
+  direct child opens the existing read-only Subagent Viewer from the card;
+  `View N agents` opens the Task Viewer filtered to the exact Workflow
+  dataset (the global task list is restored on close). Search now covers
+  phase/member labels and statuses — a member hidden inside a large phase
+  still hits its card.
 - **Workflow lifecycle/model parity with DSH alpha.2.** Workflow runs now fold
   into their own transcript semantic model instead of a generic tool card: run
   and member statuses keep the full `running/completed/failed/cancelled/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 
 ### 新增
 
+- **Workflow 可扩展 UI。** Workflow 卡片自带 Run/Phase 两层展开：小 phase
+  （≤5 个 agent）在 transcript 内完整列出成员，大 phase 只显示聚合计数 +
+  最多 3 个异常预览 + `View N agents` 入口，100+ agent 的 run 不再线性撑大
+  transcript；completed run 默认收起但仍显示聚合摘要（如 `126 agents ·
+  completed`）。`cancelled`/`interrupted` 改用 warning 视觉（不再与 `failed`
+  混为 error），缺失/显式空 phase 显示为 `Unassigned`/`Empty`。运行中的直接
+  child 可从卡片进入现有只读 Subagent Viewer；`View N agents` 打开按
+  Workflow 数据集过滤的 Task Viewer（关闭后恢复全局任务列表）。搜索扩展到
+  phase/member 标签与状态，隐藏在大 phase 里的 member 仍可命中所属卡片。
 - **Workflow 生命周期/模型对齐 DSH alpha.2。** Workflow 从普通工具卡中拆出独立
   semantic model：run/member 状态完整保留 `running/completed/failed/cancelled/
   interrupted`（不再折叠成 ok/error），成员保留 `seq`/`childId` 与精确 phase

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,12 +138,12 @@ import { Text } from '@xmoon76/pi-tui'
 import { SurfaceHost } from './extension/internal/surface-host.ts'
 import { PI_TUI_EXTENSIONS_SERVICE, type PiTuiExtensionService } from './extensions.ts'
 import {
-  buildTaskRows, isActiveJobStatus, isSubagentRowInterruptible, rowGroup, subagentInterruptParent, taskRowLabel, taskTreePrefix, viewerAccessHint, viewerAccessOf, isViewerAccessInteractive,
+  buildTaskRows, isActiveJobStatus, isSubagentRowInterruptible, rowGroup, subagentInterruptParent, taskRowLabel, taskTreePrefix, viewerAccessHint, viewerAccessOf, isViewerAccessInteractive, workflowMemberViewerTarget,
   type TaskBrowserRow, type ViewerAccess,
 } from './tasks-browser.ts'
 import type { TaskBrowserViewState, TaskPanelItem } from './task-panel.ts'
-import { TaskBrowserRuntime } from './task-browser-runtime.ts'
-import type { TaskBrowserHandle } from './tui-app.ts'
+import { TaskBrowserRuntime, type TaskBrowserDatasetScope } from './task-browser-runtime.ts'
+import type { TaskBrowserHandle, WorkflowAction } from './tui-app.ts'
 import { registerTuiCommands, type DefaultIntentRecord, type InitialCommandCatalog, type TuiCommandRunner } from './commands.ts'
 import { normalizePersistedTheme, resolveThemeSelection } from './theme-source.ts'
 import { diagFromEnv, dshHome, type Diag } from './diag.ts'
@@ -3732,6 +3732,9 @@ export function apply(ctx: Context, config: Config): void {
       activeTaskBrowser?.close()
       activeTaskBrowser = undefined
       taskRuntime?.reset()
+      // The dataset scope is session-scoped too: a switched-in session
+      // must never inherit a Workflow-scoped browser (PR2 plan §10.8).
+      taskBrowserScope = { kind: 'all' }
       app.setTaskSummary({ runningAgents: 0, totalAgents: 0, runningJobs: 0, totalJobs: 0, failedAttention: 0, failedTotal: 0 })
       app.setTasks([])
       app.setAgents([])
@@ -5862,6 +5865,10 @@ export function apply(ctx: Context, config: Config): void {
       unstableInputsLive: () => extensionService?._unstableInputsLive() ?? false,
       unstableInputsRevision: () => extensionService?._unstableInputsRevision() ?? 0,
       unstableFailSafeRelease: () => extensionService?._unstableEmergencyRelease(),
+      // PR2: the semantic Workflow card actions (member open / scoped
+      // agent browse). The handler is declared below (it needs the task
+      // browser + viewer openers); the closure only runs on a user click.
+      onWorkflowAction: (action) => handleWorkflowAction(action),
     })
     // M3: the user-orchestrable keybinding manager (the app built it with
     // the builtin defaults). Apply safe mode, the persisted user
@@ -6016,8 +6023,20 @@ export function apply(ctx: Context, config: Config): void {
     // the merged list + search is the single command-side entry, with
     // row-level `S` = confirmed Stop on capable rows (the old /subagents
     // SettingsList submenu is gone).
-    const openTasksBrowser = (viewMode: 'quick' | 'full' = 'full', restoreState?: TaskBrowserViewState): void => {
+    const openTasksBrowser = (
+      viewMode: 'quick' | 'full' = 'full',
+      restoreState?: TaskBrowserViewState,
+      scope?: TaskBrowserDatasetScope,
+      header?: string,
+    ): void => {
       if (liveAgent === undefined) return
+      // PR2 plan §10.5/§10.8: an EXPLICIT scope (a Workflow phase/run
+      // dataset) becomes the browser's dataset scope; a transition
+      // (Quick→Full / Full→Quick) without one keeps the current scope; a
+      // fresh ordinary open after a close always starts from `all` (the
+      // close paths reset it). The scope applies at EVERY runtime commit.
+      if (scope !== undefined) taskBrowserScope = scope
+      taskRuntime?.setScope(taskBrowserScope)
       // The destructive-intent fence is captured at OPEN time: a Stop
       // confirmed later belongs to THIS surface's session. Comparing the
       // generation/session AT dispatch against values captured AT dispatch
@@ -6141,11 +6160,14 @@ export function apply(ctx: Context, config: Config): void {
         taskPanelItems(taskBrowserRows),
         // Selection closes the overlay (the app closes it before invoking the
         // callback): drop the active-handle reference so a later runtime
-        // refresh cannot repaint a closed browser.
-        (value) => { activeTaskBrowser = undefined; selectRow(value) },
+        // refresh cannot repaint a closed browser. The dataset scope resets
+        // with the close (PR2 plan §10.8 — the next ordinary Task Center
+        // must see the global dataset).
+        (value) => { activeTaskBrowser = undefined; resetTaskBrowserScope(); selectRow(value) },
         () => {
           const current = activeTaskBrowser?.getViewState?.()
           activeTaskBrowser = undefined
+          resetTaskBrowserScope()
           if (viewMode === 'full' && restoreState !== undefined) {
             // Esc from a promoted full view returns to Quick with the latest
             // shared context, not the state from the promotion moment.
@@ -6154,7 +6176,7 @@ export function apply(ctx: Context, config: Config): void {
           }
         },
         {
-          header: 'Tasks',
+          header: header ?? 'Tasks',
           enableSearch: true,
           mode: viewMode,
           openedFrom: viewMode === 'full' && restoreState !== undefined ? 'quick' : 'command',
@@ -6217,6 +6239,68 @@ export function apply(ctx: Context, config: Config): void {
           diag,
           sessionId: () => liveAgent?.session.id,
         })
+      }
+    }
+
+    /** Reset the task-browser dataset scope to the global dataset (PR2
+     * plan §10.8): every close path (Esc, row selection) clears the scope
+     * so the next ordinary `/tasks` / ↓ Task Center sees `all` again. */
+    const resetTaskBrowserScope = (): void => {
+      taskBrowserScope = { kind: 'all' }
+      taskRuntime?.setScope({ kind: 'all' })
+    }
+
+    /** The Workflow card action sink (PR2 plan §9/§10/§14.5): the TUI
+     * emits semantic intents; THIS handler resolves them against the real
+     * Task Center / Subagent catalog and opens the existing surfaces —
+     * never a Workflow-specific viewer or browser. */
+    const handleWorkflowAction = (action: WorkflowAction): void => {
+      if (liveAgent === undefined) return
+      switch (action.kind) {
+        case 'open-member': {
+          // Direct member navigation (plan §9.2): the SINGLE authority
+          // resolver checks the catalog facts (row exists, subagent,
+          // direct child of the current session, driver running) — the
+          // model-side `member.status === running` was already verified by
+          // the app at click time. A missing catalog row (agent-start
+          // before the listing) or any failed condition is a no-op — the
+          // row simply does not open (plan §9.5).
+          const row = taskBrowserRows.find(candidate =>
+            candidate.kind === 'subagent' && candidate.childId === action.childId)
+          const target = workflowMemberViewerTarget(
+            { status: 'running', childId: action.childId },
+            row,
+            liveAgent.session.id,
+          )
+          if (target === undefined) return
+          runOwned('workflow member view', () => enterView(
+            target.childSessionId as SessionId,
+            target.label,
+            target.mode,
+            target.parentSessionId as SessionId,
+            target.activity,
+            target.depth,
+          ), {
+            diag,
+            sessionId: () => liveAgent?.session.id,
+            onError: (error) => app.notify(`could not open the subagent view: ${safeErrorMessage(error)}`, 'error'),
+          })
+          return
+        }
+        case 'open-phase-agents':
+        case 'open-run-agents': {
+          // Scoped Task Viewer (plan §10): the EXACT workflow child-id set
+          // becomes the browser's dataset scope; the existing Task Center
+          // provides search/filter/browse and the existing cold-view
+          // semantics for terminal children (plan §10.7).
+          if (taskRuntime === undefined) return
+          const count = action.childIds.length
+          const header = action.kind === 'open-phase-agents'
+            ? `Workflow · ${action.name} · ${action.phaseLabel} · ${count} agent${count === 1 ? '' : 's'}`
+            : `Workflow · ${action.name} · ${count} agent${count === 1 ? '' : 's'}`
+          openTasksBrowser('full', undefined, { kind: 'subagents', childIds: action.childIds }, header)
+          return
+        }
       }
     }
 
@@ -6716,6 +6800,11 @@ export function apply(ctx: Context, config: Config): void {
     let activeTaskBrowser: TaskBrowserHandle | undefined
     let taskBrowserRows: TaskBrowserRow[] = []
     let taskRuntime: TaskBrowserRuntime | undefined
+    /** The dataset scope of the OPEN task browser (PR2 plan §10.5): `all`
+     * for the ordinary Task Center, an exact child-id set for a Workflow
+     * phase/run scope. Reset to `all` on every close (see
+     * resetTaskBrowserScope) and on session switch. */
+    let taskBrowserScope: TaskBrowserDatasetScope = { kind: 'all' }
     /** Context retained only while the full center was promoted from Quick. */
     let quickTaskState: TaskBrowserViewState | undefined
     const jobs = ctx.get('jobs')

--- a/src/task-browser-runtime.ts
+++ b/src/task-browser-runtime.ts
@@ -48,6 +48,15 @@ export interface TaskBrowserSummary {
   readonly failedTotal: number
 }
 
+/** The generic dataset scope of the OPEN task browser (PR2 plan §10.2):
+ * `all` is the ordinary Task Center; `subagents` restricts the browser to
+ * an EXACT child-id set (a Workflow phase/run scope). The scope is generic
+ * — the Task Browser never knows what a Workflow is, and the Workflow
+ * presentation never reaches into the browser's runtime. */
+export type TaskBrowserDatasetScope =
+  | { readonly kind: 'all' }
+  | { readonly kind: 'subagents'; readonly childIds: readonly string[] }
+
 /** The runtime hooks the coordinator drives (wired by the runner). */
 export interface TaskBrowserRuntimeHooks {
   /** Session-identity key of the CURRENT live root (undefined = no live
@@ -117,6 +126,11 @@ export class TaskBrowserRuntime {
    * (it never advances the committed epoch), while a successful newer
    * commit still supersedes every older in-flight response. */
   private committedEpoch = 0
+  /** The dataset scope of the OPEN browser (PR2 plan §10.5): applied at
+   * EVERY row commit — a refresh after the scope was set must never leak
+   * the global rows back into a scoped browser. Reset to `all` on close
+   * (the runner) and on session switch (reset). */
+  private scope: TaskBrowserDatasetScope = { kind: 'all' }
 
   constructor(hooks: TaskBrowserRuntimeHooks) {
     this.hooks = hooks
@@ -136,6 +150,16 @@ export class TaskBrowserRuntime {
    * any stale post-switch event) never repaint. */
   has(childId: string): boolean {
     return this.catalog.some(entry => entry.id === childId)
+  }
+
+  /** Set the dataset scope of the OPEN browser and re-commit the cached
+   * rows through it (PR2 plan §10.5/§10.8): the scope applies at EVERY
+   * commit, so a later refresh/status update can never leak global rows
+   * into a scoped browser. The runner resets to `all` when the browser
+   * closes. */
+  setScope(scope: TaskBrowserDatasetScope): void {
+    this.scope = scope
+    this.apply(this.catalog)
   }
 
   /** A CATALOG refresh: re-list the descendants, then — if the session
@@ -210,13 +234,16 @@ export class TaskBrowserRuntime {
    * re-reads from the new root, and stale-session status flips find no
    * membership. Every in-flight request is invalidated too (the fence
    * jumps past them), so an old-session listing can never commit even
-   * if its key check were somehow satisfied. */
+   * if its key check were somehow satisfied. The dataset scope resets to
+   * `all` with it (a switched-in session must never inherit a scoped
+   * browser). */
   reset(): void {
     this.committedEpoch = ++this.requestEpoch
     this.catalog = []
     this.lastRows = []
     this.acknowledgedFailures.clear()
     this.previousFailureIds = new Set()
+    this.scope = { kind: 'all' }
     // Invalidates any pending refresh-state token: the old session's
     // in-flight promises are state-silent (their key check fails against
     // the new session), and the new session's requests mint a fresh token.
@@ -240,6 +267,17 @@ export class TaskBrowserRuntime {
     const projected = projectSubagentActivity(entries, (childId) => this.hooks.agentStatusOf(childId))
     const jobs = this.hooks.readJobs()
     const rawRows = buildTaskRows(jobs, projected)
+    // The dataset scope (PR2 plan §10.5/§10.6): a scoped browser shows
+    // EXACTLY the scope's child ids — unrelated subagents and every job
+    // row are excluded, on EVERY commit (never just the first frame).
+    // The scope filters ONLY the visible rows: the failure-attention
+    // ledger and the summary stay GLOBAL, so opening and closing a scoped
+    // viewer never re-arms previously acknowledged unrelated failures
+    // (review finding).
+    const scope = this.scope
+    const scopedRows = scope.kind === 'all'
+      ? rawRows
+      : rawRows.filter(row => row.kind === 'subagent' && scope.childIds.includes(row.childId))
     const currentFailureIds = new Set(rawRows
       .filter(row => row.kind === 'job' && (row.status === 'failed' || row.status === 'timed_out' || row.status === 'lost'))
       .map(row => row.value))
@@ -253,7 +291,7 @@ export class TaskBrowserRuntime {
     }
     this.previousFailureIds = currentFailureIds
     const attentionIds = new Set([...currentFailureIds].filter(id => !this.acknowledgedFailures.has(id)))
-    const rows = rawRows.map(row => row.kind === 'job'
+    const rows = scopedRows.map(row => row.kind === 'job'
       ? { ...row, attention: attentionIds.has(row.value) }
       : row)
     this.lastRows = rows

--- a/src/tasks-browser.ts
+++ b/src/tasks-browser.ts
@@ -38,6 +38,8 @@
  * @module @xmoon76/dsh-pi-tui/tasks-browser
  */
 
+import type { WorkflowRunStatus } from './transcript.ts'
+
 /** Picker-value prefix for a subagent row. */
 export const AGENT_ROW_PREFIX = 'agent:'
 /** Picker-value prefix for a job row. */
@@ -340,4 +342,43 @@ export function subagentInterruptParent(
   rootSessionId: string,
 ): string {
   return row.parentId !== '' ? row.parentId : rootSessionId
+}
+
+/** The direct-navigation authority for one Workflow member row (PR2 plan
+ * §9.2/§14.6): the SINGLE resolver both the Workflow card action and its
+ * tests use — the 5 authority conditions are never copied twice. The
+ * member must still be RUNNING (the model-side fact), the catalog row
+ * must exist and be a subagent, the child must be a DIRECT child of the
+ * current root session (depth 1 + exact durable parent), and the child's
+ * Agent driver must be running right now. Returns the viewer-open facts
+ * (the same shape `enterView` consumes) or undefined when any condition
+ * fails — a terminal member, a missing catalog row, a wrong parent or a
+ * nested child never cold-opens from the Workflow card (plan §9.4/§9.5). */
+export function workflowMemberViewerTarget(
+  member: { readonly status: WorkflowRunStatus; readonly childId: string },
+  row: TaskBrowserRow | undefined,
+  rootSessionId: string,
+): { parentSessionId: string; childSessionId: string; label: string; mode: 'one-shot' | 'continuable'; activity: 'running' | 'inactive'; depth: number } | undefined {
+  if (member.status !== 'running') return undefined
+  if (row === undefined || row.kind !== 'subagent') return undefined
+  // The row must BE the member's row: a mismatched row would combine one
+  // child's label/mode/parent with another child's identity (review
+  // finding). Workflow `agent()` children are one-shot by contract (plan
+  // §2.6/§9.3) — a continuable catalog row is never a Workflow member
+  // target, so the viewer can never accidentally grant an interactive
+  // continuable editor.
+  if (row.childId !== member.childId) return undefined
+  if (row.mode !== 'one-shot') return undefined
+  if (row.activity !== 'running') return undefined
+  if (row.depth !== 1) return undefined
+  const parentSessionId = row.parentId !== '' ? row.parentId : rootSessionId
+  if (parentSessionId !== rootSessionId) return undefined
+  return {
+    parentSessionId,
+    childSessionId: member.childId,
+    label: row.label,
+    mode: row.mode,
+    activity: row.activity,
+    depth: row.depth,
+  }
 }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -192,6 +192,16 @@ export function workflowPhaseKey(phase: string | null): string {
   return phase === null ? 'missing' : `value:${phase.length}:${phase}`
 }
 
+/** The human-readable phase label (Web WorkflowRunPanel parity, plan §2.4):
+ * `null` (absent) and `''` (explicit empty) stay DISTINCT identities with
+ * distinct readable labels — the renderer and the search corpus share this
+ * single mapping so the two can never drift. */
+export function workflowReadablePhase(phase: string | null): string {
+  if (phase === null) return 'Unassigned'
+  if (phase === '') return 'Empty'
+  return phase
+}
+
 /** Strict member-outcome mapping (plan §6.3): exhaustive so a new official
  * union variant fails typecheck instead of collapsing into a generic error. */
 function workflowMemberStatus(outcome: 'completed' | 'failed' | 'cancelled'): WorkflowRunStatus {
@@ -311,7 +321,8 @@ export class WorkflowProjection {
   /** One member published: fold it into the run card (Web WorkflowRunPanel
    * parity). A member starting after its owner closed is interrupted from
    * birth (plan §6.2 — the projection comes from the current fold facts, no
-   * invented recovery flow). */
+   * invented recovery flow). The member's label/phase/status entered the
+   * search corpus (PR2 plan §13.3): the onChange hook marks it dirty. */
   onAgentStart(runId: WorkflowRunId, seq: number, label: string, phase: string | null, childId: WorkflowChildSessionId): void {
     const state = this.runs.get(runId)
     if (state === undefined) return
@@ -325,10 +336,13 @@ export class WorkflowProjection {
     // Replace the members array reference so render caches observe the live
     // append (plan §6.2 — never rely on in-place push).
     state.message.members = [...state.message.members, member]
+    this.onChange?.(runId)
   }
 
   /** One member settled: only the started member with the matching runId +
-   * seq settles (plan §6.3 — never infer a member outcome from run-end). */
+   * seq settles (plan §6.3 — never infer a member outcome from run-end).
+   * The member's status word changed in the search corpus (PR2 plan
+   * §13.3): the onChange hook marks it dirty. */
   onAgentEnd(runId: WorkflowRunId, seq: number, outcome: 'completed' | 'failed' | 'cancelled'): void {
     const state = this.runs.get(runId)
     if (state === undefined) return
@@ -340,6 +354,7 @@ export class WorkflowProjection {
     state.message.members = state.message.members.map(member =>
       member === target ? { ...member, status } : member,
     )
+    this.onChange?.(runId)
   }
 
   /** One run settled: set the terminal status, notify, and drop the fold
@@ -481,11 +496,18 @@ export function transcriptSearchText(message: TranscriptMessage, depth = 0): str
     return `${own} ${message.subCalls.map(child => transcriptSearchText(child, depth + 1)).join(' ')}`
   }
   if (message.kind === 'workflow') {
-    // The run's stable search identity: the kind, the run name, and the
-    // current status (the terminal reason's presentation equivalent — plan
-    // §7.3). Members are deliberately not indexed (PR1 keeps the legacy
-    // tool-card search surface; member/session search is PR2).
-    return `workflow ${message.name} ${message.status}`
+    // The run's search identity (PR2 plan §13): the kind, the run name, the
+    // current status, every phase's readable label (Unassigned/Empty stay
+    // distinct) and every member's label + status. Machine identities
+    // (childId/runId) are deliberately NOT indexed. A member hidden inside
+    // a large phase's summary still hits its Workflow card (plan §13.1).
+    const phases = new Set<string>()
+    const members: string[] = []
+    for (const member of message.members) {
+      phases.add(workflowReadablePhase(member.phase))
+      members.push(`${member.label} ${member.status}`)
+    }
+    return `workflow ${message.name} ${message.status} ${[...phases].join(' ')} ${members.join(' ')}`
   }
   return message.text ?? ''
 }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7220,11 +7220,17 @@ export class TuiApp {
     }
     let changed = false
     if (state.abnormalOpened === false && runHasAbnormal) {
-      // First abnormal edge: drop the user's prior choice and let the
-      // current facts (abnormal → open) show the exception (plan §7.5).
+      // First abnormal edge: override ONLY a prior user CLOSE so the
+      // exception is not hidden behind an earlier fold (plan §7.5). A
+      // user who explicitly OPENED the run keeps their choice — clearing
+      // it here would let a later late-terminal completion (PR1's
+      // interrupted → completed recovery) snap the run shut against the
+      // user's explicit open (review finding).
       state.abnormalOpened = true
-      state.userOpen = undefined
-      changed = true
+      if (state.userOpen === false) {
+        state.userOpen = undefined
+        changed = true
+      }
     }
     // Phase-level facts over the CURRENT phase groups. A phase that
     // disappears (impossible today — members are append-only) simply keeps
@@ -7238,10 +7244,14 @@ export class TuiApp {
         continue
       }
       if (phaseState.abnormalOpened === false && phaseHasAbnormal) {
-        // First abnormal edge: same one-shot override as the run level.
+        // First abnormal edge: same one-shot override as the run level —
+        // only a prior user CLOSE is lifted, an explicit user OPEN is
+        // preserved (review finding).
         phaseState.abnormalOpened = true
-        phaseState.userOpen = undefined
-        changed = true
+        if (phaseState.userOpen === false) {
+          phaseState.userOpen = undefined
+          changed = true
+        }
       }
     }
     if (changed) this.workflowDisclosureRevision += 1

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -278,37 +278,30 @@ function workflowMemberMark(status: WorkflowRunStatus): string {
   }
 }
 
-/** One phase's disclosure state inside a Workflow run (PR2 plan §7): the
- * user's explicit choice wins forever once set; otherwise the status-driven
- * value after the one-shot transitions (first abnormal edge opens once,
- * completion closes once, a post-completion running member reopens once). */
+/** One phase's disclosure state inside a Workflow run (PR2 plan §7, Web
+ * advanceDisclosureState parity): the user's explicit choice wins forever
+ * once set; otherwise the CURRENT FACTS decide at every change — a clean
+ * phase (all members completed) closes, a running/abnormal phase opens.
+ * The only lifecycle flag is `abnormalOpened`: the FIRST abnormal edge
+ * overrides a prior user close exactly once (plan §7.5), so an exception
+ * is never hidden by an earlier toggle. */
 interface WorkflowPhaseDisclosureState {
-  /** The user's explicit open/closed choice (undefined = status-driven). */
+  /** The user's explicit open/closed choice (undefined = fact-driven). */
   userOpen?: boolean
-  /** The status-driven effective value after one-shot transitions. */
-  phaseOpen: boolean
-  /** Whether the first abnormal edge already auto-opened this phase. */
+  /** Whether the first abnormal edge already overrode the user choice. */
   abnormalOpened: boolean
-  /** Whether completion already auto-closed this phase. */
-  completionClosed: boolean
-  /** Whether a post-completion running member already reopened this phase. */
-  reopened: boolean
 }
 
 /** One Workflow run's disclosure state (PR2 plan §7). Keyed by the durable
  * `runId`; phase state is keyed by `workflowPhaseKey(phase)` — never the
- * display label, never an array index. */
+ * display label, never an array index. The run's open/closed value is
+ * derived from the CURRENT facts at render time (completed → closed,
+ * otherwise open) unless the user set an explicit choice. */
 interface WorkflowRunDisclosureState {
-  /** The user's explicit open/closed choice (undefined = status-driven). */
+  /** The user's explicit open/closed choice (undefined = fact-driven). */
   userOpen?: boolean
-  /** The status-driven effective value after one-shot transitions. */
-  runOpen: boolean
-  /** Whether the first abnormal edge already auto-opened this run. */
+  /** Whether the first abnormal edge already overrode the user choice. */
   abnormalOpened: boolean
-  /** Whether completion already auto-closed this run. */
-  completionClosed: boolean
-  /** Whether a post-completion running member already reopened this run. */
-  reopened: boolean
   /** Per-phase disclosure state by exact phase identity key. */
   phases: Map<string, WorkflowPhaseDisclosureState>
 }
@@ -7147,21 +7140,23 @@ export class TuiApp {
   }
 
   /** The effective Run disclosure of one Workflow card: the user's explicit
-   * choice wins forever once set; otherwise the status-driven value after
-   * the one-shot transitions (PR2 plan §7.4). */
+   * choice wins forever once set; otherwise the CURRENT FACTS decide —
+   * a completed run closes, every other status opens (PR2 plan §7.4/§7.6,
+   * Web advanceDisclosureState parity). */
   private workflowRunOpen(message: Extract<TranscriptMessage, { kind: 'workflow' }>): boolean {
     const state = this.workflowDisclosure.get(message.runId)
     if (state?.userOpen !== undefined) return state.userOpen
-    if (state !== undefined) return state.runOpen
     return message.status !== 'completed'
   }
 
   /** The effective Phase disclosure of one Workflow phase: user choice
-   * first, then the status-driven value after the one-shot transitions. */
+   * first, then the CURRENT FACTS — a clean phase (all members completed)
+   * closes, a running/abnormal phase opens. Re-derived at every change,
+   * so any number of running→clean cycles fold and unfold (Web
+   * advanceDisclosureState parity). */
   private workflowPhaseOpen(runId: string, phaseKey: string, phase: WorkflowPhasePresentation): boolean {
     const state = this.workflowDisclosure.get(runId)?.phases.get(phaseKey)
     if (state?.userOpen !== undefined) return state.userOpen
-    if (state !== undefined) return state.phaseOpen
     return phase.counts.completed !== phase.members.length
   }
 
@@ -7171,7 +7166,9 @@ export class TuiApp {
   private toggleWorkflowRun(runId: string): void {
     const state = this.workflowDisclosure.get(runId)
     if (state === undefined) return
-    state.userOpen = !(state.userOpen ?? state.runOpen)
+    const message = this.workflowMessageOf(runId)
+    if (message === undefined) return
+    state.userOpen = !(state.userOpen ?? this.workflowRunOpen(message))
     this.workflowDisclosureRevision += 1
     this.rebuildMessages()
   }
@@ -7182,99 +7179,69 @@ export class TuiApp {
   private toggleWorkflowPhase(runId: string, phaseKey: string): void {
     const state = this.workflowDisclosure.get(runId)?.phases.get(phaseKey)
     if (state === undefined) return
-    state.userOpen = !(state.userOpen ?? state.phaseOpen)
+    const message = this.workflowMessageOf(runId)
+    if (message === undefined) return
+    const phase = workflowPhasePresentations(message.members).find(candidate => candidate.key === phaseKey)
+    if (phase === undefined) return
+    state.userOpen = !(state.userOpen ?? this.workflowPhaseOpen(runId, phaseKey, phase))
     this.workflowDisclosureRevision += 1
     this.rebuildMessages()
   }
 
   /** Advance the Workflow disclosure state for one changed run (PR2 plan
-   * §7.5–§7.7): the one-shot transitions fire at most once per run/phase
-   * lifetime, and only while the user has not set an explicit choice —
-   * after a toggle the user's choice wins forever. The transition flags
-   * encode the history; the caller has already verified the run's content
-   * actually changed. */
+   * §7, Web advanceDisclosureState parity): the open/closed value is
+   * derived from the CURRENT FACTS at render time (completed/clean →
+   * closed, running/abnormal → open), so any number of running→clean
+   * cycles fold and unfold correctly. The ONLY transition stored here is
+   * the first abnormal edge: it overrides a prior user close exactly once
+   * (plan §7.5 — an exception must never stay hidden behind an earlier
+   * toggle); afterwards the user's choice wins forever. The caller has
+   * already verified the run's content actually changed. */
   private advanceWorkflowDisclosure(
     message: Extract<TranscriptMessage, { kind: 'workflow' }>,
   ): void {
     const runCounts = workflowStatusCounts(message.members)
     // The run's abnormal facts include the RUN status itself: a run can
     // settle failed/cancelled/interrupted with zero members or only
-    // completed members (review finding) — the abnormal edge must still
-    // open it once, and cold replay must pre-settle the flag.
+    // completed members — the abnormal edge must still open it once, and
+    // cold replay must pre-settle the flag.
     const runStatusAbnormal = message.status === 'failed'
       || message.status === 'cancelled'
       || message.status === 'interrupted'
     const runHasAbnormal = runCounts.failed + runCounts.cancelled + runCounts.interrupted > 0
       || runStatusAbnormal
-    const runHasRunning = runCounts.running > 0
-    const runFullyCompleted = message.status === 'completed'
     let state = this.workflowDisclosure.get(message.runId)
     if (state === undefined) {
-      // First sight: the initial state IS the status-driven default, and a
-      // run that already carries abnormal/completed facts at first sight
-      // has its one-shot transitions pre-settled (a cold-replayed terminal
-      // run must never be force-opened by a later update).
-      state = {
-        runOpen: message.status !== 'completed',
-        abnormalOpened: runHasAbnormal,
-        completionClosed: message.status === 'completed',
-        reopened: false,
-        phases: new Map(),
-      }
+      // First sight: a run that already carries abnormal facts has its
+      // abnormal edge pre-settled (a cold-replayed terminal run must never
+      // be force-opened by a later update).
+      state = { abnormalOpened: runHasAbnormal, phases: new Map() }
       this.workflowDisclosure.set(message.runId, state)
     }
     let changed = false
     if (state.abnormalOpened === false && runHasAbnormal) {
-      // First abnormal edge: open once so the exception is visible. This
-      // OVERRIDES a prior user close by returning the run to the
-      // status-driven default (plan §7.5 — the abnormal fact is a
-      // significant event); the flag makes it one-shot, so a later user
-      // close persists forever, and a later completion can still close it.
+      // First abnormal edge: drop the user's prior choice and let the
+      // current facts (abnormal → open) show the exception (plan §7.5).
       state.abnormalOpened = true
       state.userOpen = undefined
-      if (state.runOpen !== true) { state.runOpen = true; changed = true }
-    } else if (state.completionClosed === false && runFullyCompleted) {
-      // Normal completion: close once. A user's explicit open choice is
-      // respected (they asked to see the run; the close is a default).
-      state.completionClosed = true
-      if (state.runOpen !== false) { state.runOpen = false; changed = true }
-    } else if (state.reopened === false && state.completionClosed && runHasRunning) {
-      // A completed run with a new running member: reopen once.
-      state.reopened = true
-      if (state.runOpen !== true) { state.runOpen = true; changed = true }
+      changed = true
     }
-    // Phase-level transitions over the CURRENT phase groups. A phase that
+    // Phase-level facts over the CURRENT phase groups. A phase that
     // disappears (impossible today — members are append-only) simply keeps
     // its state; the renderer only consults present phases.
     for (const phase of workflowPhasePresentations(message.members)) {
       let phaseState = state.phases.get(phase.key)
+      const phaseHasAbnormal = phase.counts.failed + phase.counts.cancelled + phase.counts.interrupted > 0
       if (phaseState === undefined) {
-        const allCompleted = phase.counts.completed === phase.members.length
-        phaseState = {
-          phaseOpen: !allCompleted,
-          abnormalOpened: phase.counts.failed + phase.counts.cancelled + phase.counts.interrupted > 0,
-          completionClosed: allCompleted,
-          reopened: false,
-        }
+        phaseState = { abnormalOpened: phaseHasAbnormal }
         state.phases.set(phase.key, phaseState)
         continue
       }
-      const phaseHasAbnormal = phase.counts.failed + phase.counts.cancelled + phase.counts.interrupted > 0
-      const phaseHasRunning = phase.counts.running > 0
-      const phaseFullyCompleted = phase.counts.completed === phase.members.length
       if (phaseState.abnormalOpened === false && phaseHasAbnormal) {
-        // First abnormal edge: open once, overriding a prior user close
-        // by returning the phase to the status-driven default (plan §7.5);
-        // one-shot like the run-level flag.
+        // First abnormal edge: same one-shot override as the run level.
         phaseState.abnormalOpened = true
         phaseState.userOpen = undefined
-        if (phaseState.phaseOpen !== true) { phaseState.phaseOpen = true; changed = true }
-      } else if (phaseState.completionClosed === false && phaseFullyCompleted) {
-        phaseState.completionClosed = true
-        if (phaseState.phaseOpen !== false) { phaseState.phaseOpen = false; changed = true }
-      } else if (phaseState.reopened === false && phaseState.completionClosed && phaseHasRunning) {
-        phaseState.reopened = true
-        if (phaseState.phaseOpen !== true) { phaseState.phaseOpen = true; changed = true }
+        changed = true
       }
     }
     if (changed) this.workflowDisclosureRevision += 1

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -280,28 +280,29 @@ function workflowMemberMark(status: WorkflowRunStatus): string {
 
 /** One phase's disclosure state inside a Workflow run (PR2 plan §7, Web
  * advanceDisclosureState parity): the user's explicit choice wins forever
- * once set; otherwise the CURRENT FACTS decide at every change — a clean
- * phase (all members completed) closes, a running/abnormal phase opens.
- * The only lifecycle flag is `abnormalOpened`: the FIRST abnormal edge
- * overrides a prior user close exactly once (plan §7.5), so an exception
- * is never hidden by an earlier toggle. */
+ * once set — EXCEPT across a NEW CYCLE: a clean phase (all members
+ * completed) that gains a new running/abnormal member reopens (plan
+ * §7.7), overriding a prior user close. `previousMode` is the edge
+ * detector: running → running is an ordinary update (the user's close
+ * persists), clean → running is a new cycle (reopen). */
 interface WorkflowPhaseDisclosureState {
   /** The user's explicit open/closed choice (undefined = fact-driven). */
   userOpen?: boolean
-  /** Whether the first abnormal edge already overrode the user choice. */
-  abnormalOpened: boolean
+  /** The phase's mode at the last advance (edge detection). */
+  previousMode: 'clean' | 'running' | 'abnormal'
 }
 
 /** One Workflow run's disclosure state (PR2 plan §7). Keyed by the durable
  * `runId`; phase state is keyed by `workflowPhaseKey(phase)` — never the
  * display label, never an array index. The run's open/closed value is
  * derived from the CURRENT facts at render time (completed → closed,
- * otherwise open) unless the user set an explicit choice. */
+ * otherwise open) unless the user set an explicit choice; a phase starting
+ * a new cycle reopens a user-closed run (plan §7.7). */
 interface WorkflowRunDisclosureState {
   /** The user's explicit open/closed choice (undefined = fact-driven). */
   userOpen?: boolean
-  /** Whether the first abnormal edge already overrode the user choice. */
-  abnormalOpened: boolean
+  /** The run's mode at the last advance (edge detection). */
+  previousMode: 'clean' | 'running' | 'abnormal'
   /** Per-phase disclosure state by exact phase identity key. */
   phases: Map<string, WorkflowPhaseDisclosureState>
 }
@@ -7192,10 +7193,16 @@ export class TuiApp {
    * §7, Web advanceDisclosureState parity): the open/closed value is
    * derived from the CURRENT FACTS at render time (completed/clean →
    * closed, running/abnormal → open), so any number of running→clean
-   * cycles fold and unfold correctly. The ONLY transition stored here is
-   * the first abnormal edge: it overrides a prior user close exactly once
-   * (plan §7.5 — an exception must never stay hidden behind an earlier
-   * toggle); afterwards the user's choice wins forever. The caller has
+   * cycles fold and unfold correctly. The stored EDGES distinguish an
+   * ordinary update from a new cycle:
+   * - running → running (a new member joins a still-running phase): the
+   *   user's close persists (plan §7.4);
+   * - clean → running/abnormal (a completed phase gains a new member):
+   *   a NEW CYCLE — the phase reopens and the outer run reopens too
+   *   (plan §7.7), overriding a prior user close;
+   * - non-abnormal → abnormal: the first abnormal edge opens once
+   *   (plan §7.5), overriding a prior user close.
+   * An explicit user OPEN is never cleared by any edge. The caller has
    * already verified the run's content actually changed. */
   private advanceWorkflowDisclosure(
     message: Extract<TranscriptMessage, { kind: 'workflow' }>,
@@ -7204,55 +7211,68 @@ export class TuiApp {
     // The run's abnormal facts include the RUN status itself: a run can
     // settle failed/cancelled/interrupted with zero members or only
     // completed members — the abnormal edge must still open it once, and
-    // cold replay must pre-settle the flag.
+    // cold replay must pre-settle the mode.
     const runStatusAbnormal = message.status === 'failed'
       || message.status === 'cancelled'
       || message.status === 'interrupted'
-    const runHasAbnormal = runCounts.failed + runCounts.cancelled + runCounts.interrupted > 0
-      || runStatusAbnormal
+    const runHasAbnormalMembers = runCounts.failed + runCounts.cancelled + runCounts.interrupted > 0
+    const runMode: 'clean' | 'running' | 'abnormal' = message.status === 'completed'
+      ? 'clean'
+      : (runStatusAbnormal || runHasAbnormalMembers) ? 'abnormal' : 'running'
     let state = this.workflowDisclosure.get(message.runId)
     if (state === undefined) {
-      // First sight: a run that already carries abnormal facts has its
-      // abnormal edge pre-settled (a cold-replayed terminal run must never
-      // be force-opened by a later update).
-      state = { abnormalOpened: runHasAbnormal, phases: new Map() }
+      // First sight: the current mode is the pre-settled edge baseline (a
+      // cold-replayed terminal run never re-triggers an edge).
+      state = { previousMode: runMode, phases: new Map() }
       this.workflowDisclosure.set(message.runId, state)
     }
     let changed = false
-    if (state.abnormalOpened === false && runHasAbnormal) {
+    const previousRunMode = state.previousMode
+    state.previousMode = runMode
+    if (previousRunMode === 'clean' && runMode !== 'clean') {
+      // A completed run resumed (unreachable today — run-end is terminal —
+      // kept symmetric with the phase rule).
+      if (state.userOpen === false) { state.userOpen = undefined; changed = true }
+    } else if (previousRunMode !== 'abnormal' && runMode === 'abnormal') {
       // First abnormal edge: override ONLY a prior user CLOSE so the
-      // exception is not hidden behind an earlier fold (plan §7.5). A
-      // user who explicitly OPENED the run keeps their choice — clearing
-      // it here would let a later late-terminal completion (PR1's
-      // interrupted → completed recovery) snap the run shut against the
-      // user's explicit open (review finding).
-      state.abnormalOpened = true
-      if (state.userOpen === false) {
-        state.userOpen = undefined
-        changed = true
-      }
+      // exception is not hidden behind an earlier fold (plan §7.5). An
+      // explicit user OPEN is preserved (review finding).
+      if (state.userOpen === false) { state.userOpen = undefined; changed = true }
     }
-    // Phase-level facts over the CURRENT phase groups. A phase that
+    // Phase-level edges over the CURRENT phase groups. A phase that
     // disappears (impossible today — members are append-only) simply keeps
     // its state; the renderer only consults present phases.
+    let phaseStartedCycle = false
     for (const phase of workflowPhasePresentations(message.members)) {
-      let phaseState = state.phases.get(phase.key)
       const phaseHasAbnormal = phase.counts.failed + phase.counts.cancelled + phase.counts.interrupted > 0
+      const phaseMode: 'clean' | 'running' | 'abnormal' = phaseHasAbnormal
+        ? 'abnormal'
+        : phase.counts.completed === phase.members.length ? 'clean' : 'running'
+      let phaseState = state.phases.get(phase.key)
       if (phaseState === undefined) {
-        phaseState = { abnormalOpened: phaseHasAbnormal }
+        phaseState = { previousMode: phaseMode }
         state.phases.set(phase.key, phaseState)
         continue
       }
-      if (phaseState.abnormalOpened === false && phaseHasAbnormal) {
-        // First abnormal edge: same one-shot override as the run level —
-        // only a prior user CLOSE is lifted, an explicit user OPEN is
-        // preserved (review finding).
-        phaseState.abnormalOpened = true
-        if (phaseState.userOpen === false) {
-          phaseState.userOpen = undefined
-          changed = true
-        }
+      const previousPhaseMode = phaseState.previousMode
+      phaseState.previousMode = phaseMode
+      if (previousPhaseMode === 'clean' && phaseMode !== 'clean') {
+        // NEW CYCLE (plan §7.7): a completed phase gained a new running or
+        // abnormal member — reopen the phase and mark the run for reopen.
+        if (phaseState.userOpen === false) { phaseState.userOpen = undefined; changed = true }
+        phaseStartedCycle = true
+      } else if (previousPhaseMode !== 'abnormal' && phaseMode === 'abnormal') {
+        // First abnormal edge: same one-shot override as the run level.
+        if (phaseState.userOpen === false) { phaseState.userOpen = undefined; changed = true }
       }
+      // running → running: ordinary update — the user's choice persists.
+      // running → clean: status-driven close — the user's choice persists.
+    }
+    if (phaseStartedCycle && state.userOpen === false) {
+      // The outer run reopens with the new cycle (plan §7.7): a user who
+      // folded the whole run must not keep the second batch hidden.
+      state.userOpen = undefined
+      changed = true
     }
     if (changed) this.workflowDisclosureRevision += 1
   }

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -138,6 +138,7 @@ import { assistantPresentationRevision, PTC_MAX_DEPTH, recentTurnThreshold, text
 import {
   workflowCountsText,
   workflowPhasePresentations,
+  workflowRunMode,
   workflowRunSummaryText,
   workflowRunViewAllVisible,
   workflowStatusCounts,
@@ -7141,13 +7142,14 @@ export class TuiApp {
   }
 
   /** The effective Run disclosure of one Workflow card: the user's explicit
-   * choice wins forever once set; otherwise the CURRENT FACTS decide —
-   * a completed run closes, every other status opens (PR2 plan §7.4/§7.6,
-   * Web advanceDisclosureState parity). */
+   * choice wins forever once set; otherwise the CURRENT FACTS decide via
+   * the single {@link workflowRunMode} (Web runDisclosureFacts parity) —
+   * a clean run closes, a running/abnormal run opens. A completed run with
+   * a failed member is abnormal and stays open (PR2 goal: abnormal first). */
   private workflowRunOpen(message: Extract<TranscriptMessage, { kind: 'workflow' }>): boolean {
     const state = this.workflowDisclosure.get(message.runId)
     if (state?.userOpen !== undefined) return state.userOpen
-    return message.status !== 'completed'
+    return workflowRunMode(message.status, message.members) !== 'clean'
   }
 
   /** The effective Phase disclosure of one Workflow phase: user choice
@@ -7207,18 +7209,12 @@ export class TuiApp {
   private advanceWorkflowDisclosure(
     message: Extract<TranscriptMessage, { kind: 'workflow' }>,
   ): void {
-    const runCounts = workflowStatusCounts(message.members)
-    // The run's abnormal facts include the RUN status itself: a run can
-    // settle failed/cancelled/interrupted with zero members or only
-    // completed members — the abnormal edge must still open it once, and
-    // cold replay must pre-settle the mode.
-    const runStatusAbnormal = message.status === 'failed'
-      || message.status === 'cancelled'
-      || message.status === 'interrupted'
-    const runHasAbnormalMembers = runCounts.failed + runCounts.cancelled + runCounts.interrupted > 0
-    const runMode: 'clean' | 'running' | 'abnormal' = message.status === 'completed'
-      ? 'clean'
-      : (runStatusAbnormal || runHasAbnormalMembers) ? 'abnormal' : 'running'
+    // The run's disclosure mode is the SINGLE shared definition (Web
+    // runDisclosureFacts parity): abnormal when the run status OR any
+    // member is abnormal — a completed run with a failed member is
+    // abnormal, never clean. Cold replay pre-settles the mode so a
+    // terminal run never re-triggers an edge.
+    const runMode = workflowRunMode(message.status, message.members)
     let state = this.workflowDisclosure.get(message.runId)
     if (state === undefined) {
       // First sight: the current mode is the pre-settled edge baseline (a

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7199,17 +7199,18 @@ export class TuiApp {
    * §7, Web advanceDisclosureState parity): the open/closed value is
    * derived from the CURRENT FACTS at render time (completed/clean →
    * closed, running/abnormal → open), so any number of running→clean
-   * cycles fold and unfold correctly. The stored EDGES distinguish an
-   * ordinary update from a new cycle:
-   * - running → running (a new member joins a still-running phase): the
-   *   user's close persists (plan §7.4);
-   * - clean → running/abnormal (a completed phase gains a new member):
-   *   a NEW CYCLE — the phase reopens and the outer run reopens too
-   *   (plan §7.7), overriding a prior user close;
+   * cycles fold and unfold correctly. The stored EDGES consume the user's
+   * choice exactly like Web:
+   * - entering clean (running/abnormal → clean, or a clean phase whose
+   *   member count changed): the clean facts auto-close — the user's
+   *   choice is consumed (Web: new clean facts => close). Reopening AFTER
+   *   the card is already clean persists (no facts change);
+   * - clean → running/abnormal: a NEW CYCLE — the phase reopens and the
+   *   outer run reopens too (plan §7.7), overriding a prior user close;
    * - non-abnormal → abnormal: the first abnormal edge opens once
-   *   (plan §7.5), overriding a prior user close.
-   * An explicit user OPEN is never cleared by any edge. The caller has
-   * already verified the run's content actually changed. */
+   *   (plan §7.5), overriding a prior user close;
+   * - running → running: an ordinary update — the user's choice persists.
+   * The caller has already verified the run's content actually changed. */
   private advanceWorkflowDisclosure(
     message: Extract<TranscriptMessage, { kind: 'workflow' }>,
   ): void {
@@ -7229,7 +7230,15 @@ export class TuiApp {
     let changed = false
     const previousRunMode = state.previousMode
     state.previousMode = runMode
-    if (previousRunMode === 'clean' && runMode !== 'clean') {
+    if (runMode === 'clean' && previousRunMode !== 'clean') {
+      // Normal completion: the clean facts consume the user's choice — the
+      // run auto-closes (Web: new clean facts => close). A user who
+      // reopens AFTER the run is already clean keeps their choice.
+      if (state.userOpen !== undefined) {
+        state.userOpen = undefined
+        changed = true
+      }
+    } else if (previousRunMode === 'clean' && runMode !== 'clean') {
       // A completed run resumed (unreachable today — run-end is terminal —
       // kept symmetric with the phase rule).
       if (state.userOpen === false) { state.userOpen = undefined; changed = true }
@@ -7256,15 +7265,27 @@ export class TuiApp {
       }
       const previousPhaseMode = phaseState.previousMode
       const previousActivityCount = phaseState.previousActivityCount
+      const phaseFactsChanged = previousPhaseMode !== phaseMode
+        || previousActivityCount !== phase.members.length
       phaseState.previousMode = phaseMode
       phaseState.previousActivityCount = phase.members.length
-      // NEW CYCLE (Web `phaseStartedCycle` parity, plan §7.7): a clean
-      // phase gained a new member — either the mode left clean, or the
-      // member count changed while staying clean (a member that started
-      // and settled within one facts update). Reopen the phase and mark
-      // the run for reopen.
-      if (previousPhaseMode === 'clean'
-        && (phaseMode !== 'clean' || phase.members.length !== previousActivityCount)) {
+      if (phaseMode === 'clean' && phaseFactsChanged) {
+        // Normal completion (incl. clean→clean with a changed member
+        // count): the clean facts consume the user's choice — the phase
+        // auto-closes (Web: new clean facts => close). A clean phase
+        // whose member count changed is still a NEW CYCLE for the outer
+        // run (Web phaseStartedCycle: the run reopens, the phase stays
+        // folded).
+        if (phaseState.userOpen !== undefined) {
+          phaseState.userOpen = undefined
+          changed = true
+        }
+        if (previousPhaseMode === 'clean' && phase.members.length !== previousActivityCount) {
+          phaseStartedCycle = true
+        }
+      } else if (previousPhaseMode === 'clean' && phaseMode !== 'clean') {
+        // NEW CYCLE (plan §7.7): a completed phase gained a new running or
+        // abnormal member — reopen the phase and mark the run for reopen.
         if (phaseState.userOpen === false) { phaseState.userOpen = undefined; changed = true }
         phaseStartedCycle = true
       } else if (previousPhaseMode !== 'abnormal' && phaseMode === 'abnormal') {
@@ -7272,7 +7293,6 @@ export class TuiApp {
         if (phaseState.userOpen === false) { phaseState.userOpen = undefined; changed = true }
       }
       // running → running: ordinary update — the user's choice persists.
-      // running → clean: status-driven close — the user's choice persists.
     }
     if (phaseStartedCycle && runMode !== 'clean' && state.userOpen === false) {
       // The outer run reopens with the new cycle (Web parity, plan §7.7):

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -135,6 +135,14 @@ import { QuestionFlow } from './question.ts'
 import { SaveLocationPrompt, type SaveLocationDeps, type SaveLocationRequest, type SaveLocationResult } from './save-location.ts'
 import { MentionProvider } from './mentions.ts'
 import { assistantPresentationRevision, PTC_MAX_DEPTH, recentTurnThreshold, textWithAttachmentMarkers, type AssistantDisplayBlock, subCallDisplayStatus, type TranscriptMessage, type TurnActivity, type WorkflowMemberView, type WorkflowRunStatus, workflowPhaseKey } from './transcript.ts'
+import {
+  workflowCountsText,
+  workflowPhasePresentations,
+  workflowRunSummaryText,
+  workflowRunViewAllVisible,
+  workflowStatusCounts,
+  type WorkflowPhasePresentation,
+} from './workflow-presentation.ts'
 import { finalizedBlockFallbackText, fileAttachmentSummary, openOpaqueBlockFallbackText } from './content-block-presentation.ts'
 import type { TranscriptWindowState } from './transcript-window.ts'
 import { FocusActivityComponent, focusPreparingSummary, projectFocus, type FocusProjectedBlock } from './focus-activity.ts'
@@ -232,11 +240,12 @@ export interface TranscriptViewportAnchor {
 /** Whether a message is a Focus SECONDARY disclosure: a foldable process
  * card inside an expanded Thought that has its own compact/full two-state
  * renderer (plan §10). Shared by the render rule and the click handler —
- * never two different foldable sets. */
+ * never two different foldable sets. Workflow is deliberately NOT in the
+ * set (PR2 plan §7.1/§12.3): the Workflow card owns its own Run/Phase
+ * disclosure and must never be wrapped in a second generic fold. */
 function isFocusSecondaryDisclosure(message: TranscriptMessage): boolean {
   return message.kind === 'thinking'
     || message.kind === 'tool'
-    || message.kind === 'workflow'
     || message.kind === 'system'
     || message.kind === 'compaction'
 }
@@ -244,29 +253,75 @@ function isFocusSecondaryDisclosure(message: TranscriptMessage): boolean {
 /** The Workflow run header pill: the REAL status (plan §7.1 — the run's
  * state must be perceivable in the header). The old three-state
  * ok/error/running chrome is a generic-tool presentation; the Workflow card
- * is its own kind and never collapses cancelled/interrupted into error. */
+ * is its own kind and never collapses cancelled/interrupted into error
+ * (PR2 plan §8.2: failed → error, cancelled/interrupted → warning). */
 function workflowStatusPill(status: WorkflowRunStatus): string {
   switch (status) {
-    case 'running': return color.textDim('[running]')
+    case 'running': return color.primary('[running]')
     case 'completed': return color.success('[completed]')
-    case 'failed':
+    case 'failed': return color.error(`[${status}]`)
     case 'cancelled':
-    case 'interrupted': return color.error(`[${status}]`)
+    case 'interrupted': return color.warning(`[${status}]`)
   }
 }
 
 /** The Workflow member row mark: completed → success, running → primary,
- * failed/cancelled/interrupted → error (the old chrome mapping, kept only
- * at this presentation boundary — never written back into the model). */
+ * failed → error, cancelled/interrupted → warning (PR2 plan §8.3 — the
+ * warning category is no longer fused into error). */
 function workflowMemberMark(status: WorkflowRunStatus): string {
   switch (status) {
     case 'completed': return color.success('•')
     case 'running': return color.primary('●')
-    case 'failed':
+    case 'failed': return color.error('✗')
     case 'cancelled':
-    case 'interrupted': return color.error('✗')
+    case 'interrupted': return color.warning('!')
   }
 }
+
+/** One phase's disclosure state inside a Workflow run (PR2 plan §7): the
+ * user's explicit choice wins forever once set; otherwise the status-driven
+ * value after the one-shot transitions (first abnormal edge opens once,
+ * completion closes once, a post-completion running member reopens once). */
+interface WorkflowPhaseDisclosureState {
+  /** The user's explicit open/closed choice (undefined = status-driven). */
+  userOpen?: boolean
+  /** The status-driven effective value after one-shot transitions. */
+  phaseOpen: boolean
+  /** Whether the first abnormal edge already auto-opened this phase. */
+  abnormalOpened: boolean
+  /** Whether completion already auto-closed this phase. */
+  completionClosed: boolean
+  /** Whether a post-completion running member already reopened this phase. */
+  reopened: boolean
+}
+
+/** One Workflow run's disclosure state (PR2 plan §7). Keyed by the durable
+ * `runId`; phase state is keyed by `workflowPhaseKey(phase)` — never the
+ * display label, never an array index. */
+interface WorkflowRunDisclosureState {
+  /** The user's explicit open/closed choice (undefined = status-driven). */
+  userOpen?: boolean
+  /** The status-driven effective value after one-shot transitions. */
+  runOpen: boolean
+  /** Whether the first abnormal edge already auto-opened this run. */
+  abnormalOpened: boolean
+  /** Whether completion already auto-closed this run. */
+  completionClosed: boolean
+  /** Whether a post-completion running member already reopened this run. */
+  reopened: boolean
+  /** Per-phase disclosure state by exact phase identity key. */
+  phases: Map<string, WorkflowPhaseDisclosureState>
+}
+
+/** One Workflow card row hit target (PR2 plan §12.5): the minimal per-line
+ * metadata the fullscreen click map consumes — run header, phase header,
+ * inline running member, phase `View N agents`, run `View all N agents`. */
+export type WorkflowHit =
+  | { readonly kind: 'run'; readonly runId: string }
+  | { readonly kind: 'phase'; readonly runId: string; readonly phaseKey: string }
+  | { readonly kind: 'member'; readonly runId: string; readonly seq: number; readonly childId: string }
+  | { readonly kind: 'phase-agents'; readonly runId: string; readonly phaseKey: string }
+  | { readonly kind: 'run-agents'; readonly runId: string }
 
 /** The compaction lifecycle phase the working row advertises: idle (no
  * compaction), summarizing (compaction/start seen, the summary is being
@@ -1443,6 +1498,23 @@ export interface SubagentViewerSubmit {
   readonly text: string
 }
 
+/** One semantic Workflow card action (PR2 plan §12.5/§14.2): the TUI emits
+ * the intent, the HOST resolves it — member authority against the real
+ * Task Center / Subagent catalog, and the scoped Task Viewer opening. The
+ * app never queries a session service itself. The scoped-agent actions
+ * carry the display context (run name / readable phase label) so the host
+ * can title the scoped Task Viewer without re-deriving the model. */
+export type WorkflowAction =
+  | { readonly kind: 'open-member'; readonly runId: string; readonly seq: number; readonly childId: string }
+  | {
+    readonly kind: 'open-phase-agents'
+    readonly runId: string
+    readonly name: string
+    readonly phaseLabel: string
+    readonly childIds: readonly string[]
+  }
+  | { readonly kind: 'open-run-agents'; readonly runId: string; readonly name: string; readonly childIds: readonly string[] }
+
 /** The footer override while the subagent viewer is open: the footer shows
  * the VIEWED child's own identity instead of the parent session's (the
  * parent's permission/model/plan/task badges describe a session the user
@@ -2071,6 +2143,14 @@ export interface TuiAppOptions {
    * interval). */
   onTerminalResize?: () => void
   /**
+   * PR2: the semantic Workflow card action sink (plan §14.2). The app
+   * emits member-open / scoped-agent-browse intents; the HOST resolves
+   * them (member authority against the real Task Center / Subagent
+   * catalog, scoped Task Viewer opening). Optional — absent leaves the
+   * Workflow card display-only.
+   */
+  onWorkflowAction?: (action: WorkflowAction) => void
+  /**
    * M6: the plugin keybinding resolver (wired by the runner from the M5
    * KeybindingRegistry). Maps a NORMALIZED key (the InputRouter has
    * already decoded raw terminal input) → a plugin SEMANTIC action —
@@ -2309,6 +2389,9 @@ interface MessageComponentEntry {
   result?: string
   meta?: unknown
   members?: unknown
+  /** The Workflow disclosure revision the card was built at (PR2 plan
+   * §16.8): Run/Phase toggles and one-shot transitions rebuild the card. */
+  workflowDisclosureRev?: number
   /** PTC nested sub-calls (the parent card's `subCalls` tree). */
   subCalls?: unknown
   /** The sub-call disclosure revision at build time (cache key). */
@@ -2518,6 +2601,9 @@ export class TuiApp {
   private lastCommandWidth = 0
   /** M5: the terminal-resize callback (the command surface refresh). */
   private readonly onTerminalResize: (() => void) | undefined
+  /** PR2: the semantic Workflow card action sink (member open / scoped
+   * agent browse), resolved by the HOST. */
+  private readonly onWorkflowAction: ((action: WorkflowAction) => void) | undefined
 
   /** Whether the Ctrl+O expansion master switch is on. */
   isToolOutputExpanded(): boolean {
@@ -2761,6 +2847,20 @@ export class TuiApp {
   /** The block-relative sub-call hit rows recorded at render time, keyed by
    * the root message object (the renderer knows the exact layout). */
   private readonly subCallHitsByMessage = new Map<TranscriptMessage, { hits: ReadonlyArray<{ top: number; height: number; subCallId: string }>; total: number }>()
+  /** The block-relative Workflow card hit rows recorded at render time,
+   * keyed by the message object (the renderer owns the exact layout). */
+  private readonly workflowHitsByMessage = new Map<TranscriptMessage, { hits: ReadonlyArray<{ top: number; height: number; hit: WorkflowHit }>; total: number }>()
+  /** Per-run Workflow disclosure state (PR2 plan §7), keyed by the durable
+   * `runId`. Session-scoped: cleared on session switch. */
+  private readonly workflowDisclosure = new Map<string, WorkflowRunDisclosureState>()
+  /** The last-seen content snapshot per Workflow run: the members array
+   * reference + run status. The message OBJECT is mutated in place by the
+   * folder (plan §6.2 replaces the members array), so edge detection
+   * compares this snapshot, never the object identity. */
+  private readonly workflowSeen = new Map<string, { members: readonly WorkflowMemberView[]; status: WorkflowRunStatus }>()
+  /** Bumped on every Workflow disclosure change (toggle or one-shot
+   * transition): the render-cache identity for Workflow cards. */
+  private workflowDisclosureRevision = 0
   /**
    * Focus Mode (plan): the persisted preference is applied through
    * {@link setFocusMode}; while ON, the transcript projection replaces each
@@ -2830,6 +2930,10 @@ export class TuiApp {
     /** The row span (block-relative) of every PTC sub-call header's click
      * region, keyed by the durable subCallId. */
     subCallHits?: ReadonlyArray<{ top: number; height: number; subCallId: string }>
+    /** The row span (block-relative) of every Workflow card hit target
+     * (run/phase headers, running members, scoped-agent entries — PR2
+     * plan §12.5). */
+    workflowHits?: ReadonlyArray<{ top: number; height: number; hit: WorkflowHit }>
     /** Whether this entry's height includes the trailing inter-block
      * spacer (a blank visual row — the plan §9 blank-row collapse
      * target). Never set on the projection's LAST block or on skipped
@@ -2937,6 +3041,7 @@ export class TuiApp {
     this.iconStyle = options.iconStyle ?? 'emoji'
     this.extensionHost = options.extensionHost
     this.onTerminalResize = options.onTerminalResize
+    this.onWorkflowAction = options.onWorkflowAction
     // M0: the unified status projection store. The runner passes its own
     // store; without one the app keeps an internal projection so the
     // footer always composes from a snapshot (headless tests drive it
@@ -5467,6 +5572,9 @@ export class TuiApp {
     this.streamingToolPreviews = [...(streamingToolPreviews ?? [])]
     this.transcriptWindow = window
     this.refreshTranscriptWindowHint()
+    // The Workflow disclosure transitions fold BEFORE the rebuild: the
+    // renderer reads the advanced state (PR2 plan §7.5–§7.7).
+    this.updateWorkflowDisclosure(messages)
     // Repaints do NOT clear the transient notify line: an active session
     // repaints every frame (streaming chunks, tool cards), and clearing on
     // each repaint would make every notice — including error blocks like
@@ -5929,8 +6037,10 @@ export class TuiApp {
       this.messageComponents.delete(message)
       // The PTC sub-call hit map holds the same message objects: prune it
       // with the component so a long session never retains the sub-call
-      // trees of cards that left the live window.
+      // trees of cards that left the live window. The Workflow hit map is
+      // pruned with it for the same reason.
       this.subCallHitsByMessage.delete(message)
+      this.workflowHitsByMessage.delete(message)
       const component = entry.component as { dispose?: () => void } | undefined
       if (component?.dispose !== undefined) {
         try {
@@ -6170,6 +6280,7 @@ export class TuiApp {
       attachments: ReadonlyArray<{ imageIndex: number; start: number; end: number }>
       collapseFocusOwnerOnClick?: number
       subCallHits?: ReadonlyArray<{ top: number; height: number; subCallId: string }>
+      workflowHits?: ReadonlyArray<{ top: number; height: number; hit: WorkflowHit }>
       hasTrailingSpacer: boolean
     }> = []
     // One blank row separates consecutive blocks (pi/kimi Spacer parity), so
@@ -6183,6 +6294,7 @@ export class TuiApp {
       let truncatedMarker = false
       let attachments: ReadonlyArray<{ imageIndex: number; start: number; end: number }> = []
       let subCallHits: ReadonlyArray<{ top: number; height: number; subCallId: string }> | undefined
+      let workflowHits: ReadonlyArray<{ top: number; height: number; hit: WorkflowHit }> | undefined
       const collapseFocusOwnerOnClick = this.focusOwnerForRenderBlock(block)
       if (block.kind === 'activity') {
         // The live Thought disclosure; the hidden process rows (if any)
@@ -6214,6 +6326,10 @@ export class TuiApp {
         subCallHits = subCallInfo === undefined
           ? undefined
           : subCallInfo.hits.map(hit => ({ ...hit, top: hit.top + rendered.length - subCallInfo.total }))
+        const workflowInfo = this.workflowHitsByMessage.get(block.message)
+        workflowHits = workflowInfo === undefined
+          ? undefined
+          : workflowInfo.hits.map(hit => ({ ...hit, top: hit.top + rendered.length - workflowInfo.total }))
       }
       if (rendered.length === 0 && !truncatedMarker) {
         // A zero-row block must not occupy a spacer row: the image
@@ -6262,6 +6378,7 @@ export class TuiApp {
         height,
         attachments,
         ...(subCallHits === undefined ? {} : { subCallHits }),
+        ...(workflowHits === undefined ? {} : { workflowHits }),
         hasTrailingSpacer: index < blocks.length - 1,
       })
       if (index < blocks.length - 1) this.messagesView.addChild(new Spacer())
@@ -6384,6 +6501,8 @@ export class TuiApp {
       height: number
       attachments: ReadonlyArray<{ imageIndex: number; start: number; end: number }>
       collapseFocusOwnerOnClick?: number
+      subCallHits?: ReadonlyArray<{ top: number; height: number; subCallId: string }>
+      workflowHits?: ReadonlyArray<{ top: number; height: number; hit: WorkflowHit }>
       hasTrailingSpacer: boolean
     }> = []
     blocks.forEach((block, index) => {
@@ -6392,6 +6511,7 @@ export class TuiApp {
       let truncatedMarker = false
       let attachments: ReadonlyArray<{ imageIndex: number; start: number; end: number }> = []
       let subCallHits: ReadonlyArray<{ top: number; height: number; subCallId: string }> | undefined
+      let workflowHits: ReadonlyArray<{ top: number; height: number; hit: WorkflowHit }> | undefined
       const collapseFocusOwnerOnClick = this.focusOwnerForRenderBlock(block)
       if (block.kind === 'activity') {
         component = this.focusActivityComponentFor(
@@ -6415,6 +6535,10 @@ export class TuiApp {
         subCallHits = subCallInfo === undefined
           ? undefined
           : subCallInfo.hits.map(hit => ({ ...hit, top: hit.top + rendered.length - subCallInfo.total }))
+        const workflowInfo = this.workflowHitsByMessage.get(block.message)
+        workflowHits = workflowInfo === undefined
+          ? undefined
+          : workflowInfo.hits.map(hit => ({ ...hit, top: hit.top + rendered.length - workflowInfo.total }))
       }
       if (rendered.length === 0 && !truncatedMarker) {
         // Same zero-row rule as rebuildMessages: no spacer row, no height —
@@ -6443,6 +6567,7 @@ export class TuiApp {
         height,
         attachments,
         ...(subCallHits === undefined ? {} : { subCallHits }),
+        ...(workflowHits === undefined ? {} : { workflowHits }),
         hasTrailingSpacer: index < blocks.length - 1,
       })
     })
@@ -6922,6 +7047,19 @@ export class TuiApp {
             return
           }
         }
+        // Workflow card rows (PR2 plan §12.4/§12.5): the run/phase headers
+        // toggle their own disclosure, an eligible running member and the
+        // scoped-agent entries emit the semantic action. EVERY row of the
+        // card consumes the click — a click inside the Workflow card never
+        // falls through to the owning Focus collapse.
+        if (entry.workflowHits !== undefined) {
+          const hit = entry.workflowHits.find(candidate => inMessage >= candidate.top && inMessage < candidate.top + candidate.height)
+          if (hit !== undefined) {
+            this.handleWorkflowHit(hit.hit)
+            return
+          }
+          return
+        }
         // Attachment rows win FIRST (plan §8.3): a click on an image's
         // info bar or its image rows toggles THAT OCCURRENCE's display —
         // the identity stays, the picture collapses/expands, and a
@@ -7008,6 +7146,216 @@ export class TuiApp {
     this.rebuildMessages()
   }
 
+  /** The effective Run disclosure of one Workflow card: the user's explicit
+   * choice wins forever once set; otherwise the status-driven value after
+   * the one-shot transitions (PR2 plan §7.4). */
+  private workflowRunOpen(message: Extract<TranscriptMessage, { kind: 'workflow' }>): boolean {
+    const state = this.workflowDisclosure.get(message.runId)
+    if (state?.userOpen !== undefined) return state.userOpen
+    if (state !== undefined) return state.runOpen
+    return message.status !== 'completed'
+  }
+
+  /** The effective Phase disclosure of one Workflow phase: user choice
+   * first, then the status-driven value after the one-shot transitions. */
+  private workflowPhaseOpen(runId: string, phaseKey: string, phase: WorkflowPhasePresentation): boolean {
+    const state = this.workflowDisclosure.get(runId)?.phases.get(phaseKey)
+    if (state?.userOpen !== undefined) return state.userOpen
+    if (state !== undefined) return state.phaseOpen
+    return phase.counts.completed !== phase.members.length
+  }
+
+  /** Toggle one Workflow Run disclosure (click on the run header). The
+   * choice is explicit and persists: ordinary live updates never override
+   * it (PR2 plan §7.4). */
+  private toggleWorkflowRun(runId: string): void {
+    const state = this.workflowDisclosure.get(runId)
+    if (state === undefined) return
+    state.userOpen = !(state.userOpen ?? state.runOpen)
+    this.workflowDisclosureRevision += 1
+    this.rebuildMessages()
+  }
+
+  /** Toggle one Workflow Phase disclosure (click on the phase header). The
+   * choice is explicit and persists; closing and reopening the outer Run
+   * never clears it (PR2 plan §7.4/§16.3-12). */
+  private toggleWorkflowPhase(runId: string, phaseKey: string): void {
+    const state = this.workflowDisclosure.get(runId)?.phases.get(phaseKey)
+    if (state === undefined) return
+    state.userOpen = !(state.userOpen ?? state.phaseOpen)
+    this.workflowDisclosureRevision += 1
+    this.rebuildMessages()
+  }
+
+  /** Advance the Workflow disclosure state for one changed run (PR2 plan
+   * §7.5–§7.7): the one-shot transitions fire at most once per run/phase
+   * lifetime, and only while the user has not set an explicit choice —
+   * after a toggle the user's choice wins forever. The transition flags
+   * encode the history; the caller has already verified the run's content
+   * actually changed. */
+  private advanceWorkflowDisclosure(
+    message: Extract<TranscriptMessage, { kind: 'workflow' }>,
+  ): void {
+    const runCounts = workflowStatusCounts(message.members)
+    // The run's abnormal facts include the RUN status itself: a run can
+    // settle failed/cancelled/interrupted with zero members or only
+    // completed members (review finding) — the abnormal edge must still
+    // open it once, and cold replay must pre-settle the flag.
+    const runStatusAbnormal = message.status === 'failed'
+      || message.status === 'cancelled'
+      || message.status === 'interrupted'
+    const runHasAbnormal = runCounts.failed + runCounts.cancelled + runCounts.interrupted > 0
+      || runStatusAbnormal
+    const runHasRunning = runCounts.running > 0
+    const runFullyCompleted = message.status === 'completed'
+    let state = this.workflowDisclosure.get(message.runId)
+    if (state === undefined) {
+      // First sight: the initial state IS the status-driven default, and a
+      // run that already carries abnormal/completed facts at first sight
+      // has its one-shot transitions pre-settled (a cold-replayed terminal
+      // run must never be force-opened by a later update).
+      state = {
+        runOpen: message.status !== 'completed',
+        abnormalOpened: runHasAbnormal,
+        completionClosed: message.status === 'completed',
+        reopened: false,
+        phases: new Map(),
+      }
+      this.workflowDisclosure.set(message.runId, state)
+    }
+    let changed = false
+    if (state.abnormalOpened === false && runHasAbnormal) {
+      // First abnormal edge: open once so the exception is visible. This
+      // OVERRIDES a prior user close by returning the run to the
+      // status-driven default (plan §7.5 — the abnormal fact is a
+      // significant event); the flag makes it one-shot, so a later user
+      // close persists forever, and a later completion can still close it.
+      state.abnormalOpened = true
+      state.userOpen = undefined
+      if (state.runOpen !== true) { state.runOpen = true; changed = true }
+    } else if (state.completionClosed === false && runFullyCompleted) {
+      // Normal completion: close once. A user's explicit open choice is
+      // respected (they asked to see the run; the close is a default).
+      state.completionClosed = true
+      if (state.runOpen !== false) { state.runOpen = false; changed = true }
+    } else if (state.reopened === false && state.completionClosed && runHasRunning) {
+      // A completed run with a new running member: reopen once.
+      state.reopened = true
+      if (state.runOpen !== true) { state.runOpen = true; changed = true }
+    }
+    // Phase-level transitions over the CURRENT phase groups. A phase that
+    // disappears (impossible today — members are append-only) simply keeps
+    // its state; the renderer only consults present phases.
+    for (const phase of workflowPhasePresentations(message.members)) {
+      let phaseState = state.phases.get(phase.key)
+      if (phaseState === undefined) {
+        const allCompleted = phase.counts.completed === phase.members.length
+        phaseState = {
+          phaseOpen: !allCompleted,
+          abnormalOpened: phase.counts.failed + phase.counts.cancelled + phase.counts.interrupted > 0,
+          completionClosed: allCompleted,
+          reopened: false,
+        }
+        state.phases.set(phase.key, phaseState)
+        continue
+      }
+      const phaseHasAbnormal = phase.counts.failed + phase.counts.cancelled + phase.counts.interrupted > 0
+      const phaseHasRunning = phase.counts.running > 0
+      const phaseFullyCompleted = phase.counts.completed === phase.members.length
+      if (phaseState.abnormalOpened === false && phaseHasAbnormal) {
+        // First abnormal edge: open once, overriding a prior user close
+        // by returning the phase to the status-driven default (plan §7.5);
+        // one-shot like the run-level flag.
+        phaseState.abnormalOpened = true
+        phaseState.userOpen = undefined
+        if (phaseState.phaseOpen !== true) { phaseState.phaseOpen = true; changed = true }
+      } else if (phaseState.completionClosed === false && phaseFullyCompleted) {
+        phaseState.completionClosed = true
+        if (phaseState.phaseOpen !== false) { phaseState.phaseOpen = false; changed = true }
+      } else if (phaseState.reopened === false && phaseState.completionClosed && phaseHasRunning) {
+        phaseState.reopened = true
+        if (phaseState.phaseOpen !== true) { phaseState.phaseOpen = true; changed = true }
+      }
+    }
+    if (changed) this.workflowDisclosureRevision += 1
+  }
+
+  /** Fold the Workflow disclosure transitions for the CURRENT transcript
+   * snapshot (called from {@link setTranscript}): each run's content
+   * snapshot is compared against the last-seen one, and only a real
+   * change (members array reference or run status) advances the state. */
+  private updateWorkflowDisclosure(messages: readonly TranscriptMessage[]): void {
+    for (const message of messages) {
+      if (message.kind !== 'workflow') continue
+      const previous = this.workflowSeen.get(message.runId)
+      if (previous !== undefined && previous.members === message.members && previous.status === message.status) continue
+      this.workflowSeen.set(message.runId, { members: message.members, status: message.status })
+      this.advanceWorkflowDisclosure(message)
+    }
+  }
+
+  /** Dispatch one Workflow card hit (PR2 plan §12.4/§12.5): run/phase
+   * headers toggle their disclosure; a running inline member and the
+   * scoped-agent entries emit the semantic action for the HOST to resolve
+   * (authority + viewer/task-browser opening). */
+  private handleWorkflowHit(hit: WorkflowHit): void {
+    switch (hit.kind) {
+      case 'run':
+        this.toggleWorkflowRun(hit.runId)
+        return
+      case 'phase':
+        this.toggleWorkflowPhase(hit.runId, hit.phaseKey)
+        return
+      case 'member': {
+        const message = this.workflowMessageOf(hit.runId)
+        if (message === undefined) return
+        // The model-side authority re-check at CLICK time: the member must
+        // still be running (it may have settled since the row rendered),
+        // and the hit's child identity must still match the member's — a
+        // stale hit must never open a different child (review finding).
+        const member = message.members.find(candidate => candidate.seq === hit.seq)
+        if (member === undefined || member.status !== 'running') return
+        if (String(member.childId) !== hit.childId) return
+        this.onWorkflowAction?.({ kind: 'open-member', runId: hit.runId, seq: hit.seq, childId: hit.childId })
+        return
+      }
+      case 'phase-agents': {
+        const message = this.workflowMessageOf(hit.runId)
+        if (message === undefined) return
+        const phase = workflowPhasePresentations(message.members).find(candidate => candidate.key === hit.phaseKey)
+        if (phase === undefined) return
+        this.onWorkflowAction?.({
+          kind: 'open-phase-agents',
+          runId: hit.runId,
+          name: message.name,
+          phaseLabel: phase.label,
+          childIds: phase.members.map(member => String(member.childId)),
+        })
+        return
+      }
+      case 'run-agents': {
+        const message = this.workflowMessageOf(hit.runId)
+        if (message === undefined) return
+        this.onWorkflowAction?.({
+          kind: 'open-run-agents',
+          runId: hit.runId,
+          name: message.name,
+          childIds: message.members.map(member => String(member.childId)),
+        })
+        return
+      }
+    }
+  }
+
+  /** The current Workflow message for one runId (the click-time source of
+   * the member/child identities — never a stale render snapshot). */
+  private workflowMessageOf(runId: string): Extract<TranscriptMessage, { kind: 'workflow' }> | undefined {
+    for (const message of this.messages) {
+      if (message.kind === 'workflow' && message.runId === runId) return message
+    }
+    return undefined
+  }
+
   /** Drop all per-message expansion overrides (session-scoped state: a
    * session switch must not leak the old session's click toggles). */
   clearSessionOverrides(): void {
@@ -7032,6 +7380,13 @@ export class TuiApp {
     this.subCallExpanded.clear()
     this.subCallHitsByMessage.clear()
     this.subCallExpandedRevision += 1
+    // The Workflow disclosure state, its seen-snapshots and its render-time
+    // hit map are session-scoped too: a switched-in session must never
+    // inherit the old session's run/phase choices or retain its messages.
+    this.workflowDisclosure.clear()
+    this.workflowSeen.clear()
+    this.workflowHitsByMessage.clear()
+    this.workflowDisclosureRevision += 1
     // The per-message render cache is session-scoped too: old messages are
     // unreachable after a switch, so drop their cached components — with
     // disposal so thumbnail loader subscriptions never leak (round-2
@@ -8774,7 +9129,7 @@ export class TuiApp {
       }
       return this.toolOutputExpanded || this.expandedOverride.get(message) === true
     }
-    return (message.kind === 'system' || message.kind === 'tool' || message.kind === 'workflow' || message.kind === 'compaction')
+    return (message.kind === 'system' || message.kind === 'tool' || message.kind === 'compaction')
       && (message.turn >= boundary || this.expandedOverride.get(message) === true)
   }
 
@@ -8906,13 +9261,17 @@ export class TuiApp {
    * contract, plan §23).
    */
   private bakesFoldedWidth(message: TranscriptMessage, expanded: boolean): boolean {
+    // The Workflow card bakes EVERY row to the content width (run header,
+    // summary, phase/member rows) — a resize must rebuild it at the new
+    // width (PR2 plan §16.8).
+    if (message.kind === 'workflow') return true
     if (expanded) {
       // An expanded Edit bakes its diff; an expanded PTC root bakes its
       // sub-call rows (truncateToWidth at build time) — both must rebuild
       // on a resize.
       return message.kind === 'tool' && (message.name === 'edit' || (message.subCalls?.length ?? 0) > 0)
     }
-    return message.kind === 'system' || message.kind === 'compaction' || message.kind === 'workflow'
+    return message.kind === 'system' || message.kind === 'compaction'
       || (message.kind === 'tool' && !isCompactActionTool(message.name, message.args))
   }
 
@@ -8949,8 +9308,12 @@ export class TuiApp {
     if (!hostBuilt) {
       // An extension renderer owns the whole card: the host sub-call tree
       // is not rendered, so its render-time hit map must not survive (a
-      // ghost click target could toggle an invisible child).
+      // ghost click target could toggle an invisible child). The Workflow
+      // hit map is cleared with it — a plugin-rendered workflow card must
+      // never dispatch host workflow actions against stale geometry
+      // (review finding).
       this.subCallHitsByMessage.delete(message)
+      this.workflowHitsByMessage.delete(message)
     }
     return {
       // The EFFECTIVE expansion (the surface-adaptive rule) drives the
@@ -9005,9 +9368,12 @@ export class TuiApp {
       case 'workflow':
         // The run status and the members array reference (replaced on every
         // visible member/status change — plan §6.2) drive the staleness
-        // check; the run name is durable and never changes.
+        // check; the run name is durable and never changes. The disclosure
+        // revision covers Run/Phase toggles and one-shot transitions (PR2
+        // plan §16.8 — the rendered rows depend on the disclosure state).
         entry.status = message.status
         entry.members = message.members
+        entry.workflowDisclosureRev = this.workflowDisclosureRevision
         break
       case 'summary':
         break
@@ -9045,8 +9411,11 @@ export class TuiApp {
       case 'workflow':
         // The members array reference is replaced on every visible change
         // (plan §6.2), so reference comparison is the reliable invalidation
-        // evidence — never an in-place-mutation coincidence.
+        // evidence — never an in-place-mutation coincidence. The disclosure
+        // revision invalidates on Run/Phase toggles and one-shot
+        // transitions (PR2 plan §16.8).
         return entry.status !== message.status || entry.members !== message.members
+          || entry.workflowDisclosureRev !== this.workflowDisclosureRevision
       case 'summary':
         return false
       case 'compaction':
@@ -9365,7 +9734,9 @@ export class TuiApp {
       return card
     }
     if (message.kind === 'workflow') {
-      return this.renderWorkflowCard(message, expanded, width)
+      // The Workflow card owns its Run/Phase disclosure (PR2 plan §7.1) —
+      // the generic secondary `expanded` never applies to it.
+      return this.renderWorkflowCard(message, width)
     }
     // Tool card: the Web row-model header (design title + relativized args
     // summary + status pill), with the result body when expanded. The whole
@@ -9830,49 +10201,89 @@ export class TuiApp {
   }
 
   /**
-   * Render one Workflow run card (plan §7.1): the run header with the REAL
-   * status pill (running/completed/failed/cancelled/interrupted), and the
-   * member tree grouped by phase identity — `null` (absent) and `''`
-   * (explicit empty) are distinct groups via {@link workflowPhaseKey}, never
-   * merged by `phase ?? ''`. PR1 keeps the single-card disclosure shape;
-   * nested Run/Phase disclosure and child navigation are PR2.
+   * Render one Workflow run card (PR2 plan §5/§7): the run header IS the
+   * Run disclosure owner (never a second generic fold — plan §7.1), with
+   * the REAL status pill (running/completed/failed/cancelled/interrupted).
+   * When open: the run summary line, then each phase's own disclosure —
+   * a small phase (<= 5 members) renders every member inline, a large
+   * phase renders aggregate counts + a capped abnormal preview + a
+   * `View N agents` scoped Task Viewer entry. `null` (absent) and `''`
+   * (explicit empty) phases stay distinct groups with distinct readable
+   * labels (plan §6.2). Every row is width-baked and recorded as a hit
+   * target for the fullscreen click map.
    */
   private renderWorkflowCard(
     message: Extract<TranscriptMessage, { kind: 'workflow' }>,
-    expanded: boolean,
     width: number,
   ): Component {
     const card = new Container()
+    const runId = message.runId
+    const runOpen = this.workflowRunOpen(message)
     const icon = iconPrefix('workflow', this.iconStyle)
-    const head = `${color.textDim(`${icon}Workflow ${message.name}`)} ${workflowStatusPill(message.status)}`
-    if (expanded) {
-      card.addChild(new Text(head, 0, 0))
-      // Phase grouping over the durable arrival-ordered rows (Web
-      // WorkflowRunPanel parity). The phase identity key keeps absent and
-      // explicit-empty phases in separate groups (plan §4.2).
-      const groups = new Map<string, WorkflowMemberView[]>()
-      for (const member of message.members) {
-        const key = workflowPhaseKey(member.phase)
-        const list = groups.get(key)
-        if (list === undefined) groups.set(key, [member])
-        else list.push(member)
-      }
-      for (const members of groups.values()) {
-        const phase = members[0]?.phase
-        if (phase !== null && phase !== '') card.addChild(new Text(color.textMuted(`  ${phase}`), 0, 0))
-        for (const member of members) {
-          card.addChild(new Text(
-            `  ${workflowMemberMark(member.status)} ${member.label} — ${color.textDim(member.status)}`,
-            0,
-            0,
-          ))
+    const disclosure = runOpen ? '▼' : '▶'
+    const head = `${color.textDim(`${disclosure} ${icon}Workflow ${message.name}`)} ${workflowStatusPill(message.status)}`
+    const rows: string[] = []
+    const hits: Array<{ top: number; height: number; hit: WorkflowHit }> = []
+    rows.push(truncateToWidth(head, width, '…'))
+    hits.push({ top: 0, height: 1, hit: { kind: 'run', runId } })
+    // The aggregate summary renders in BOTH states (plan §5.6: a compact
+    // completed run still shows `126 agents · completed` — the phases and
+    // members stay hidden, the aggregate never does).
+    const runSummary = workflowRunSummaryText(workflowStatusCounts(message.members))
+    if (runSummary !== '') {
+      rows.push(truncateToWidth(color.textDim(`  ${runSummary}`), width, '…'))
+    }
+    if (runOpen) {
+      const phases = workflowPhasePresentations(message.members)
+      for (const phase of phases) {
+        const phaseOpen = this.workflowPhaseOpen(runId, phase.key, phase)
+        const phaseDisclosure = phaseOpen ? '▼' : '▶'
+        const countLabel = phase.members.length === 1 ? '1 agent' : `${phase.members.length} agents`
+        rows.push(truncateToWidth(
+          `${color.textDim(`  ${phaseDisclosure} ${phase.label}`)} ${color.textMuted(countLabel)}`,
+          width,
+          '…',
+        ))
+        hits.push({ top: rows.length - 1, height: 1, hit: { kind: 'phase', runId, phaseKey: phase.key } })
+        if (!phaseOpen) continue
+        if (phase.mode === 'inline') {
+          // Small phase: every member in durable seq order. Only a RUNNING
+          // member is a direct navigation target (plan §9.1/§9.4 — terminal
+          // members stay visible but never cold-open from the card).
+          for (const member of phase.members) {
+            rows.push(truncateToWidth(
+              `    ${workflowMemberMark(member.status)} ${member.label} — ${color.textDim(member.status)}`,
+              width,
+              '…',
+            ))
+            if (member.status === 'running') {
+              hits.push({ top: rows.length - 1, height: 1, hit: { kind: 'member', runId, seq: member.seq, childId: String(member.childId) } })
+            }
+          }
+        } else {
+          // Large phase: aggregate + capped abnormal preview + scoped
+          // viewer entry — never a dynamic running top-N (plan §5.3).
+          const counts = workflowCountsText(phase.counts)
+          if (counts !== '') {
+            rows.push(truncateToWidth(color.textDim(`    ${counts}`), width, '…'))
+          }
+          for (const member of phase.anomalyPreview) {
+            rows.push(truncateToWidth(`    ${workflowMemberMark(member.status)} ${member.label}`, width, '…'))
+          }
+          if (phase.hiddenAnomalyCount > 0) {
+            rows.push(truncateToWidth(color.textDim(`    … ${phase.hiddenAnomalyCount} more abnormal`), width, '…'))
+          }
+          rows.push(truncateToWidth(`    ${color.textDim('›')} View ${phase.members.length} agents`, width, '…'))
+          hits.push({ top: rows.length - 1, height: 1, hit: { kind: 'phase-agents', runId, phaseKey: phase.key } })
         }
       }
-    } else {
-      // The folded row truncates to the content width (same rule as the
-      // folded tool cards — the width-baking cache contract).
-      card.addChild(new Text(truncateToWidth(head, width, '…'), 0, 0))
+      if (workflowRunViewAllVisible(message.members.length, phases.length)) {
+        rows.push(truncateToWidth(`  ${color.textDim('›')} View all ${message.members.length} agents`, width, '…'))
+        hits.push({ top: rows.length - 1, height: 1, hit: { kind: 'run-agents', runId } })
+      }
     }
+    card.addChild(new Text(rows.join('\n'), 0, 0))
+    this.workflowHitsByMessage.set(message, { hits, total: rows.length })
     return card
   }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -283,14 +283,18 @@ function workflowMemberMark(status: WorkflowRunStatus): string {
  * advanceDisclosureState parity): the user's explicit choice wins forever
  * once set — EXCEPT across a NEW CYCLE: a clean phase (all members
  * completed) that gains a new running/abnormal member reopens (plan
- * §7.7), overriding a prior user close. `previousMode` is the edge
- * detector: running → running is an ordinary update (the user's close
- * persists), clean → running is a new cycle (reopen). */
+ * §7.7), overriding a prior user close. `previousMode` +
+ * `previousActivityCount` are the edge detectors (Web's
+ * `phaseStartedCycle`): running → running is an ordinary update (the
+ * user's close persists), clean → anything (or a clean phase whose
+ * member count changed) is a new cycle (reopen). */
 interface WorkflowPhaseDisclosureState {
   /** The user's explicit open/closed choice (undefined = fact-driven). */
   userOpen?: boolean
   /** The phase's mode at the last advance (edge detection). */
   previousMode: 'clean' | 'running' | 'abnormal'
+  /** The phase's member count at the last advance (edge detection). */
+  previousActivityCount: number
 }
 
 /** One Workflow run's disclosure state (PR2 plan §7). Keyed by the durable
@@ -7246,15 +7250,21 @@ export class TuiApp {
         : phase.counts.completed === phase.members.length ? 'clean' : 'running'
       let phaseState = state.phases.get(phase.key)
       if (phaseState === undefined) {
-        phaseState = { previousMode: phaseMode }
+        phaseState = { previousMode: phaseMode, previousActivityCount: phase.members.length }
         state.phases.set(phase.key, phaseState)
         continue
       }
       const previousPhaseMode = phaseState.previousMode
+      const previousActivityCount = phaseState.previousActivityCount
       phaseState.previousMode = phaseMode
-      if (previousPhaseMode === 'clean' && phaseMode !== 'clean') {
-        // NEW CYCLE (plan §7.7): a completed phase gained a new running or
-        // abnormal member — reopen the phase and mark the run for reopen.
+      phaseState.previousActivityCount = phase.members.length
+      // NEW CYCLE (Web `phaseStartedCycle` parity, plan §7.7): a clean
+      // phase gained a new member — either the mode left clean, or the
+      // member count changed while staying clean (a member that started
+      // and settled within one facts update). Reopen the phase and mark
+      // the run for reopen.
+      if (previousPhaseMode === 'clean'
+        && (phaseMode !== 'clean' || phase.members.length !== previousActivityCount)) {
         if (phaseState.userOpen === false) { phaseState.userOpen = undefined; changed = true }
         phaseStartedCycle = true
       } else if (previousPhaseMode !== 'abnormal' && phaseMode === 'abnormal') {
@@ -7264,9 +7274,11 @@ export class TuiApp {
       // running → running: ordinary update — the user's choice persists.
       // running → clean: status-driven close — the user's choice persists.
     }
-    if (phaseStartedCycle && state.userOpen === false) {
-      // The outer run reopens with the new cycle (plan §7.7): a user who
-      // folded the whole run must not keep the second batch hidden.
+    if (phaseStartedCycle && runMode !== 'clean' && state.userOpen === false) {
+      // The outer run reopens with the new cycle (Web parity, plan §7.7):
+      // a user who folded the whole run must not keep the second batch
+      // hidden. A clean run is never force-reopened (Web's
+      // `runFacts.mode !== 'clean'` guard).
       state.userOpen = undefined
       changed = true
     }

--- a/src/workflow-presentation.ts
+++ b/src/workflow-presentation.ts
@@ -81,6 +81,36 @@ export function workflowAggregateStatus(members: readonly WorkflowMemberView[]):
   return 'completed'
 }
 
+/** The run's disclosure mode (Web WorkflowRunPanel `runDisclosureFacts`
+ * parity): the run is ABNORMAL when its own status OR any member is
+ * abnormal; RUNNING when its own status or any member is still running;
+ * CLEAN only when the run and every member completed normally. A completed
+ * run with a failed member (the script handled the child's `null` and
+ * returned successfully — an ordinary child failure never fails the run)
+ * is therefore abnormal, so the exception stays visible (PR2 goal:
+ * abnormal first). The durable `message.status` is untouched — the pill
+ * still reads `[completed]`. */
+export function workflowRunMode(
+  status: WorkflowRunStatus,
+  members: readonly WorkflowMemberView[],
+): 'clean' | 'running' | 'abnormal' {
+  const counts = workflowStatusCounts(members)
+  if (
+    status === 'failed'
+    || status === 'cancelled'
+    || status === 'interrupted'
+    || counts.failed > 0
+    || counts.cancelled > 0
+    || counts.interrupted > 0
+  ) {
+    return 'abnormal'
+  }
+  if (status === 'running' || counts.running > 0) {
+    return 'running'
+  }
+  return 'clean'
+}
+
 /** The adaptive phase presentations of one run's member rows, grouped by
  * exact phase identity and ordered by first appearance (durable arrival
  * order). A phase with `<= 5` members is `inline`; a larger phase is

--- a/src/workflow-presentation.ts
+++ b/src/workflow-presentation.ts
@@ -1,0 +1,154 @@
+/**
+ * Workflow run presentation projection (PR2 plan §6): the pure, bounded
+ * presentation of one `TranscriptWorkflowMessage` for the TUI transcript.
+ *
+ * The durable lifecycle model lives in `transcript.ts` (PR1) and is NEVER
+ * touched here: this module only derives counts, phase groups, aggregate
+ * statuses and the adaptive inline/summary mode from the member rows. No
+ * TUI component, no session service, no Task Browser, no mutation, no
+ * cache — the renderer feeds the projection and renders what it returns.
+ *
+ * The adaptive rule (plan §5): a phase with `<= WORKFLOW_INLINE_MEMBER_LIMIT`
+ * members renders every member inline; a larger phase renders aggregate
+ * counts + a capped abnormal preview + a scoped Task Viewer entry, so a
+ * 100+ agent run never grows the transcript linearly.
+ * @module @xmoon76/dsh-pi-tui/workflow-presentation
+ */
+
+import {
+  workflowPhaseKey,
+  workflowReadablePhase,
+  type WorkflowMemberView,
+  type WorkflowRunStatus,
+} from './transcript.ts'
+
+/** A phase with at most this many members renders every member inline. */
+export const WORKFLOW_INLINE_MEMBER_LIMIT = 5
+
+/** A large phase previews at most this many abnormal (failed / cancelled /
+ * interrupted) members, in durable `seq` order. */
+export const WORKFLOW_ANOMALY_PREVIEW_LIMIT = 3
+
+/** Exact per-status member counts of one run or phase. */
+export interface WorkflowStatusCounts {
+  running: number
+  completed: number
+  failed: number
+  cancelled: number
+  interrupted: number
+}
+
+/** The adaptive presentation of ONE phase group. */
+export interface WorkflowPhasePresentation {
+  /** The collision-free phase identity key (`workflowPhaseKey`). */
+  key: string
+  /** The exact durable phase identity (`null` and `''` stay distinct). */
+  phase: string | null
+  /** The human-readable phase label (`Unassigned` / `Empty` / the raw name). */
+  label: string
+  /** The phase's member rows in durable `seq` / arrival order. */
+  members: readonly WorkflowMemberView[]
+  counts: WorkflowStatusCounts
+  /** The visual summary precedence of the phase's members. */
+  aggregateStatus: WorkflowRunStatus
+  /** `inline` = every member renders; `summary` = aggregate + preview. */
+  mode: 'inline' | 'summary'
+  /** The capped abnormal preview (large phases only; `seq` order). */
+  anomalyPreview: readonly WorkflowMemberView[]
+  /** Abnormal members beyond the preview cap (large phases only). */
+  hiddenAnomalyCount: number
+}
+
+/** Exact status counts of one member list. */
+export function workflowStatusCounts(members: readonly WorkflowMemberView[]): WorkflowStatusCounts {
+  const counts: WorkflowStatusCounts = { running: 0, completed: 0, failed: 0, cancelled: 0, interrupted: 0 }
+  for (const member of members) {
+    counts[member.status] += 1
+  }
+  return counts
+}
+
+/** The deterministic visual summary precedence of a member list (plan §6.1):
+ * `failed > interrupted > cancelled > running > completed`. Presentation
+ * only — the exact counts are always preserved; no durable phase status is
+ * ever written back. */
+export function workflowAggregateStatus(members: readonly WorkflowMemberView[]): WorkflowRunStatus {
+  const counts = workflowStatusCounts(members)
+  if (counts.failed > 0) return 'failed'
+  if (counts.interrupted > 0) return 'interrupted'
+  if (counts.cancelled > 0) return 'cancelled'
+  if (counts.running > 0) return 'running'
+  return 'completed'
+}
+
+/** The adaptive phase presentations of one run's member rows, grouped by
+ * exact phase identity and ordered by first appearance (durable arrival
+ * order). A phase with `<= 5` members is `inline`; a larger phase is
+ * `summary` with a capped abnormal preview — never a dynamic running
+ * top-N (plan §5.3: 100 concurrent settles must not jitter the rows). */
+export function workflowPhasePresentations(
+  members: readonly WorkflowMemberView[],
+): WorkflowPhasePresentation[] {
+  const groups = new Map<string, WorkflowMemberView[]>()
+  for (const member of members) {
+    const key = workflowPhaseKey(member.phase)
+    const list = groups.get(key)
+    if (list === undefined) groups.set(key, [member])
+    else list.push(member)
+  }
+  const presentations: WorkflowPhasePresentation[] = []
+  for (const [key, phaseMembers] of groups) {
+    const phase = phaseMembers[0]?.phase ?? null
+    const counts = workflowStatusCounts(phaseMembers)
+    const mode = phaseMembers.length > WORKFLOW_INLINE_MEMBER_LIMIT ? 'summary' : 'inline'
+    const abnormal = phaseMembers.filter(member =>
+      member.status === 'failed' || member.status === 'cancelled' || member.status === 'interrupted')
+    presentations.push({
+      key,
+      phase,
+      label: workflowReadablePhase(phase),
+      members: phaseMembers,
+      counts,
+      aggregateStatus: workflowAggregateStatus(phaseMembers),
+      mode,
+      anomalyPreview: mode === 'summary' ? abnormal.slice(0, WORKFLOW_ANOMALY_PREVIEW_LIMIT) : [],
+      hiddenAnomalyCount: mode === 'summary' ? Math.max(0, abnormal.length - WORKFLOW_ANOMALY_PREVIEW_LIMIT) : 0,
+    })
+  }
+  return presentations
+}
+
+/** The run summary line: `N agents · running · completed · failed ·
+ * cancelled · interrupted`, only non-zero counts, stable order (plan §5.4).
+ * Empty when the run has no members. */
+export function workflowRunSummaryText(counts: WorkflowStatusCounts): string {
+  const total = counts.running + counts.completed + counts.failed + counts.cancelled + counts.interrupted
+  if (total === 0) return ''
+  const parts = [`${total} agent${total === 1 ? '' : 's'}`]
+  if (counts.running > 0) parts.push(`${counts.running} running`)
+  if (counts.completed > 0) parts.push(`${counts.completed} completed`)
+  if (counts.failed > 0) parts.push(`${counts.failed} failed`)
+  if (counts.cancelled > 0) parts.push(`${counts.cancelled} cancelled`)
+  if (counts.interrupted > 0) parts.push(`${counts.interrupted} interrupted`)
+  return parts.join(' · ')
+}
+
+/** The phase aggregate line: `running · completed · failed · cancelled ·
+ * interrupted`, only non-zero counts, stable order (plan §5.4). */
+export function workflowCountsText(counts: WorkflowStatusCounts): string {
+  const parts: string[] = []
+  if (counts.running > 0) parts.push(`${counts.running} running`)
+  if (counts.completed > 0) parts.push(`${counts.completed} completed`)
+  if (counts.failed > 0) parts.push(`${counts.failed} failed`)
+  if (counts.cancelled > 0) parts.push(`${counts.cancelled} cancelled`)
+  if (counts.interrupted > 0) parts.push(`${counts.interrupted} interrupted`)
+  return parts.join(' · ')
+}
+
+/** Whether a run-level `View all N agents` entry is useful (plan §5.5):
+ * a run with `<= 5` agents needs no entry, and a single phase group's own
+ * `View N agents` already covers the whole run — the run-level entry only
+ * appears when the run spans at least two phase groups. */
+export function workflowRunViewAllVisible(totalAgents: number, phaseGroupCount: number): boolean {
+  return totalAgents > WORKFLOW_INLINE_MEMBER_LIMIT && phaseGroupCount >= 2
+}

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -2824,7 +2824,7 @@ test('minimal hides decorative icons with no dangling whitespace', async (t) => 
   assert.ok(read !== undefined, `minimal read header missing or space-prefixed:\n${view}`)
   const subagent = lines.find(line => line.startsWith('Subagent'))
   assert.ok(subagent !== undefined, `minimal subagent header missing or space-prefixed:\n${view}`)
-  const workflow = lines.find(line => line.startsWith('Workflow'))
+  const workflow = lines.find(line => line.replace(/^[▶▼] /, '').startsWith('Workflow'))
   assert.ok(workflow !== undefined, `minimal workflow header missing or space-prefixed:\n${view}`)
   const slash = lines.find(line => line.startsWith('compact [ok]'))
   assert.ok(slash !== undefined, `minimal slash header missing or space-prefixed:\n${view}`)
@@ -3681,7 +3681,7 @@ test('workflow runs expand into a phase-grouped member tree', async () => {
     turn: 0,
     runId: 'run-1' as WorkflowRunId,
     name: 'audit',
-    status: 'completed',
+    status: 'running',
     members: [
       { seq: 0, label: 'checker', phase: 'review', childId: 'session-x' as never, status: 'completed' },
       { seq: 1, label: 'patcher', phase: 'review', childId: 'session-y' as never, status: 'failed' },
@@ -3690,12 +3690,15 @@ test('workflow runs expand into a phase-grouped member tree', async () => {
     ],
   }])
   const view = await viewport(vt)
-  assert.ok(view.includes('Workflow audit [completed]'), `run header missing:\n${view}`)
-  assert.ok(view.includes('  review'), `phase header missing:\n${view}`)
+  assert.ok(view.includes('Workflow audit [running]'), `run header missing:\n${view}`)
+  assert.ok(view.includes('▼ review 2 agents'), `phase header missing:\n${view}`)
   assert.ok(view.includes('checker — completed'), `completed member missing:\n${view}`)
   assert.ok(view.includes('patcher — failed'), `failed member missing:\n${view}`)
-  assert.ok(view.includes('  report'), `second phase missing:\n${view}`)
-  assert.ok(view.includes('reporter — completed'), `report member missing:\n${view}`)
+  // A fully-completed phase auto-closes (PR2 plan §7.6): the header stays,
+  // the members fold.
+  assert.ok(view.includes('▶ report 1 agent'), `second phase missing:\n${view}`)
+  assert.ok(!view.includes('reporter — completed'), `closed phase must not leak members:\n${view}`)
+  assert.ok(view.includes('▼ Unassigned 1 agent'), `null phase readable label missing:\n${view}`)
   assert.ok(view.includes('live-agent — running'), `running member missing:\n${view}`)
 })
 
@@ -3739,7 +3742,8 @@ test('workflow live member/status updates invalidate the cached card (plan §8.1
   assert.notStrictEqual(secondComponent, firstComponent, 'agent-start must invalidate the cached workflow card')
   view = await viewport(vt)
   assert.ok(view.includes('checker — running'), `live member row missing:\n${view}`)
-  // agent-end: the member status changes → rebuild.
+  // agent-end: the member status changes → rebuild. The phase is now fully
+  // completed, so the PR2 completion auto-close folds it (plan §7.6).
   folder.apply([
     { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
   ])
@@ -3747,7 +3751,8 @@ test('workflow live member/status updates invalidate the cached card (plan §8.1
   const thirdComponent = cache.get(first)?.component
   assert.notStrictEqual(thirdComponent, secondComponent, 'agent-end must invalidate the cached workflow card')
   view = await viewport(vt)
-  assert.ok(view.includes('checker — completed'), `live member status missing:\n${view}`)
+  assert.ok(view.includes('▶ Unassigned 1 agent'), `completed phase must auto-close:\n${view}`)
+  assert.ok(!view.includes('checker — completed'), `closed phase must not leak members:\n${view}`)
   // An unchanged re-render keeps the component.
   app.setTranscript(folder.messages())
   assert.strictEqual(cache.get(first)?.component, thirdComponent, 'an unchanged workflow card must not churn the component')

--- a/test/task-browser-runtime.test.ts
+++ b/test/task-browser-runtime.test.ts
@@ -22,7 +22,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { SubagentDescendantListEntry } from '@deepseek-ai/dsh-subagent'
 import { SessionId } from '@deepseek-ai/dsh-session'
-import { TaskBrowserRuntime, type TaskBrowserRuntimeHooks } from '../src/task-browser-runtime.ts'
+import { TaskBrowserRuntime, type TaskBrowserRuntimeHooks, type TaskBrowserSummary } from '../src/task-browser-runtime.ts'
 import { AGENT_ROW_PREFIX, type TaskBrowserJobInput, type TaskBrowserRow } from '../src/tasks-browser.ts'
 
 const child = (overrides: Partial<SubagentDescendantListEntry> = {}): SubagentDescendantListEntry => ({
@@ -65,6 +65,7 @@ function makeHarness(): {
   commits(): readonly TaskBrowserRow[][]
   preferreds(): readonly (string | undefined)[]
   badges(): readonly ReadonlyArray<{ id: string; label: string }>[]
+  summaries(): readonly TaskBrowserSummary[]
   refreshStates(): readonly { state: 'loading' | 'ready' | 'stale'; error?: string }[]
   setKey(key: string | undefined): void
   setStatus(id: string, status: string | undefined): void
@@ -84,6 +85,7 @@ function makeHarness(): {
   const preferreds: (string | undefined)[] = []
   const badges: ReadonlyArray<{ id: string; label: string }>[] = []
   const refreshStates: { state: 'loading' | 'ready' | 'stale'; error?: string }[] = []
+  const summaries: TaskBrowserSummary[] = []
   const runtime = new TaskBrowserRuntime({
     currentKey: () => key,
     listDescendants: () => {
@@ -100,6 +102,7 @@ function makeHarness(): {
       preferreds.push(preferred)
     },
     commitBadge: (running) => badges.push([...running]),
+    commitSummary: (summary) => summaries.push(summary),
     commitRefreshState: (state, error) => refreshStates.push({ state, ...(error === undefined ? {} : { error }) }),
   })
   return {
@@ -108,6 +111,7 @@ function makeHarness(): {
     commits: () => commits,
     preferreds: () => preferreds,
     badges: () => badges,
+    summaries: () => summaries,
     refreshStates: () => refreshStates,
     setKey: (next) => { key = next },
     setStatus: (id, status) => { if (status === undefined) statuses.delete(id); else statuses.set(id, status) },
@@ -480,8 +484,8 @@ test('Task Center dispatch re-validates session, driver and job state at confirm
   // real protection is binding the intent to the opening surface.
   assert.ok(handler.includes("sessionGeneration !== browserGeneration || liveAgent !== browserSession"),
     'the dispatch must compare the current generation/session against the OPEN-time capture')
-  const openMarker = 'const openTasksBrowser = (viewMode: \'quick\' | \'full\' = \'full\', restoreState?: TaskBrowserViewState): void => {'
-  const openHead = indexSource.slice(indexSource.indexOf(openMarker), indexSource.indexOf(openMarker) + 900)
+  const openMarker = 'const openTasksBrowser = ('
+  const openHead = indexSource.slice(indexSource.indexOf(openMarker), indexSource.indexOf(openMarker) + 1200)
   assert.ok(openHead.includes('const browserGeneration = sessionGeneration'),
     'the browser must capture the generation at open')
   assert.ok(openHead.includes('const browserSession = liveAgent'),
@@ -499,7 +503,7 @@ test('Task Center dispatch re-validates session, driver and job state at confirm
 })
 
 test('Esc from a promoted full view returns to Quick ONLY for the quick-opener stack (review round)', () => {
-  const marker = 'const openTasksBrowser = (viewMode: \'quick\' | \'full\' = \'full\', restoreState?: TaskBrowserViewState): void => {'
+  const marker = 'const openTasksBrowser = ('
   const open = indexSource.slice(indexSource.indexOf(marker), indexSource.indexOf('// M3: attach the extension host'))
   const cancelBlock = open.slice(open.indexOf("() => {"), open.indexOf('},', open.indexOf('() => {')) + 3)
   assert.ok(cancelBlock.includes("viewMode === 'full' && restoreState !== undefined"),
@@ -511,7 +515,7 @@ test('Esc from a promoted full view returns to Quick ONLY for the quick-opener s
 })
 
 test('the Task Center surface never calls the consuming jobs read API (review round)', () => {
-  const marker = 'const openTasksBrowser = (viewMode: \'quick\' | \'full\' = \'full\', restoreState?: TaskBrowserViewState): void => {'
+  const marker = 'const openTasksBrowser = ('
   const open = indexSource.slice(indexSource.indexOf(marker), indexSource.indexOf('// M3: attach the extension host'))
   assert.ok(!open.includes('jobs.read('),
     'the browser must never consume the model-owned job output cursor')
@@ -551,7 +555,7 @@ test('Case E2: the SAME session listing failure still surfaces stale (the fenced
 })
 
 test('the runner never sets refresh state outside the runtime fence (PR review P1)', () => {
-  const marker = 'const openTasksBrowser = (viewMode: \'quick\' | \'full\' = \'full\', restoreState?: TaskBrowserViewState): void => {'
+  const marker = 'const openTasksBrowser = ('
   const open = indexSource.slice(indexSource.indexOf(marker), indexSource.indexOf('// M3: attach the extension host'))
   // The open-browser body is the ONLY owner of the panel: an unfenced
   // onError calling activeTaskBrowser.setRefreshState would let a stale
@@ -564,7 +568,7 @@ test('the runner never sets refresh state outside the runtime fence (PR review P
 })
 
 test('viewport exposure drives acknowledgement continuously, never whole-projection (PR review P1/P2)', () => {
-  const marker = 'const openTasksBrowser = (viewMode: \'quick\' | \'full\' = \'full\', restoreState?: TaskBrowserViewState): void => {'
+  const marker = 'const openTasksBrowser = ('
   const open = indexSource.slice(indexSource.indexOf(marker), indexSource.indexOf('// M3: attach the extension host'))
   // The runner wires the panel's first-time-viewport callback into the
   // coordinator's acknowledge — not a one-shot whole-projection read.
@@ -594,4 +598,155 @@ test('Case F: a cross-session overlap cannot strand the NEW session in loading (
   assert.equal(h.runtime.has('child-old'), false, 'A never lands on B')
   assert.equal(h.refreshStates()[h.refreshStates().length - 1]!.state, 'ready',
     'A settling late must not move B off ready (never a stuck loading)')
+})
+
+// ---------------------------------------------------------------------------
+// PR2: the generic dataset scope (plan §16.6)
+// ---------------------------------------------------------------------------
+
+test('PR2 scope: a subagents scope commits EXACTLY the scope child ids, jobs excluded', async () => {
+  const h = makeHarness()
+  h.setJobs([])
+  const listing = h.runtime.refreshCatalog()
+  h.settleListing(0, [
+    child({ id: 'child-1' as SessionId, label: 'phase-a-1', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-2' as SessionId, label: 'phase-a-2', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-3' as SessionId, label: 'phase-b', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-x' as SessionId, label: 'unrelated', mode: 'one-shot', depth: 1 }),
+  ])
+  await listing
+  h.setJobs([job({ id: 'job-y', label: 'unrelated job' })])
+  h.runtime.setScope({ kind: 'subagents', childIds: ['child-1', 'child-2'] })
+  const rows = h.commits().at(-1)!
+  assert.deepEqual(rowValue(rows), ['agent:child-1', 'agent:child-2'],
+    `the scoped browser must show exactly the scope child ids:\n${JSON.stringify(rows)}`)
+  assert.ok(!rows.some(row => row.kind === 'job'), 'jobs must never leak into a subagents scope')
+})
+
+test('PR2 scope: a live refresh keeps the scope (never a global leak)', async () => {
+  const h = makeHarness()
+  h.setJobs([])
+  const listing = h.runtime.refreshCatalog()
+  h.settleListing(0, [
+    child({ id: 'child-1' as SessionId, label: 'a', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-2' as SessionId, label: 'b', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-3' as SessionId, label: 'c', mode: 'one-shot', depth: 1 }),
+  ])
+  await listing
+  h.runtime.setScope({ kind: 'subagents', childIds: ['child-1', 'child-2'] })
+  // A runtime refresh (agent/status) and a CATALOG refresh (new global
+  // child arrives) must both commit through the scope.
+  h.setStatus('child-1', 'running')
+  h.runtime.refreshRuntime()
+  assert.deepEqual(rowValue(h.commits().at(-1)!), ['agent:child-1', 'agent:child-2'],
+    'a runtime refresh must keep the scope')
+  const refreshListing = h.runtime.refreshCatalog()
+  h.settleListing(1, [
+    child({ id: 'child-1' as SessionId, label: 'a', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-2' as SessionId, label: 'b', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-3' as SessionId, label: 'c', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-4' as SessionId, label: 'new-global', mode: 'one-shot', depth: 1 }),
+  ])
+  await refreshListing
+  assert.deepEqual(rowValue(h.commits().at(-1)!), ['agent:child-1', 'agent:child-2'],
+    'a catalog refresh must keep the scope (the new global child must not leak)')
+})
+
+test('PR2 scope: resetting to all restores the global dataset', async () => {
+  const h = makeHarness()
+  h.setJobs([])
+  const listing = h.runtime.refreshCatalog()
+  h.settleListing(0, [
+    child({ id: 'child-1' as SessionId, label: 'a', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-2' as SessionId, label: 'b', mode: 'one-shot', depth: 1 }),
+  ])
+  await listing
+  h.runtime.setScope({ kind: 'subagents', childIds: ['child-1'] })
+  assert.deepEqual(rowValue(h.commits().at(-1)!), ['agent:child-1'])
+  // The close path (the runner) resets to all: the next ordinary Task
+  // Center sees the global dataset again.
+  h.runtime.setScope({ kind: 'all' })
+  assert.deepEqual(rowValue(h.commits().at(-1)!), ['agent:child-1', 'agent:child-2'],
+    'the global dataset must be restored after the scope reset')
+})
+
+test('PR2 scope: reset() (session switch) clears the scope with the catalog', async () => {
+  const h = makeHarness()
+  h.setJobs([])
+  const listing = h.runtime.refreshCatalog()
+  h.settleListing(0, [
+    child({ id: 'child-1' as SessionId, label: 'a', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-2' as SessionId, label: 'b', mode: 'one-shot', depth: 1 }),
+  ])
+  await listing
+  h.runtime.setScope({ kind: 'subagents', childIds: ['child-1'] })
+  h.runtime.reset()
+  h.setKey('g2:sess-b')
+  const secondListing = h.runtime.refreshCatalog()
+  h.settleListing(1, [
+    child({ id: 'child-1' as SessionId, label: 'a', mode: 'one-shot', depth: 1 }),
+    child({ id: 'child-2' as SessionId, label: 'b', mode: 'one-shot', depth: 1 }),
+  ])
+  await secondListing
+  assert.deepEqual(rowValue(h.commits().at(-1)!), ['agent:child-1', 'agent:child-2'],
+    'a switched-in session must start from the global dataset')
+})
+
+// ---------------------------------------------------------------------------
+// PR2 review round 1: runner-level wiring regressions
+// ---------------------------------------------------------------------------
+
+test('PR2 review: the runner wires onWorkflowAction through the single authority resolver', () => {
+  assert.ok(indexSource.includes('onWorkflowAction: (action) => handleWorkflowAction(action)'),
+    'the app options must wire the workflow action sink')
+  const marker = 'const handleWorkflowAction = (action: WorkflowAction): void => {'
+  const start = indexSource.indexOf(marker)
+  assert.ok(start >= 0, 'the runner must define handleWorkflowAction')
+  const handler = indexSource.slice(start, start + 3000)
+  // The authority conditions live in ONE resolver — never copied in the runner.
+  assert.ok(handler.includes('workflowMemberViewerTarget('),
+    'the member open path must use the single authority resolver')
+  assert.ok(!handler.replace(/\/\/.*$/gm, '').includes("row.depth !== 1"),
+    'the runner must not re-implement the authority conditions')
+  assert.ok(handler.includes("openTasksBrowser('full', undefined, { kind: 'subagents', childIds: action.childIds }"),
+    'the scoped-agent actions must open the existing Task Browser with the exact child-id scope')
+})
+
+test('PR2 review: every task-browser close path resets the dataset scope', () => {
+  const marker = 'const openTasksBrowser = ('
+  const open = indexSource.slice(indexSource.indexOf(marker), indexSource.indexOf('// M3: attach the extension host'))
+  // Both close paths (row selection and Esc) must reset the scope so the
+  // next ordinary Task Center sees the global dataset (plan §10.8).
+  const selectBlock = open.slice(open.indexOf('(value) => {'), open.indexOf('},', open.indexOf('(value) => {')) + 3)
+  assert.ok(selectBlock.includes('resetTaskBrowserScope()'),
+    'the selection close path must reset the dataset scope')
+  const cancelBlock = open.slice(open.indexOf('() => {'), open.indexOf('},', open.indexOf('() => {')) + 3)
+  assert.ok(cancelBlock.includes('resetTaskBrowserScope()'),
+    'the Esc close path must reset the dataset scope')
+  // The Quick→Full transition must NOT reset the scope (it preserves it).
+  const viewFullBlock = open.slice(open.indexOf('onViewFull:'), open.indexOf('onStop:'))
+  assert.ok(!viewFullBlock.includes('resetTaskBrowserScope'),
+    'the Quick→Full promotion must preserve the dataset scope')
+})
+
+test('PR2 review: a scoped viewer never re-arms acknowledged global failures (review P2)', async () => {
+  const h = makeHarness()
+  h.setJobs([job({ id: 'j1', label: 'failed job', status: 'failed' })])
+  const listing = h.runtime.refreshCatalog()
+  h.settleListing(0, [
+    child({ id: 'child-1' as SessionId, label: 'a', mode: 'one-shot', depth: 1 }),
+  ])
+  await listing
+  // The user sees the failed job in the global browser and acknowledges it.
+  h.runtime.acknowledge(['job:j1'])
+  assert.equal(h.summaries().at(-1)!.failedAttention, 0, 'the acknowledged failure must be quiet')
+  // A workflow-scoped viewer opens (jobs are filtered out of the rows) and closes.
+  h.runtime.setScope({ kind: 'subagents', childIds: ['child-1'] })
+  assert.ok(!h.commits().at(-1)!.some(row => row.kind === 'job'), 'scoped rows must exclude jobs')
+  h.runtime.setScope({ kind: 'all' })
+  // The global browser returns: the previously acknowledged failure stays
+  // acknowledged — never re-armed by the scoped round-trip.
+  assert.equal(h.summaries().at(-1)!.failedAttention, 0,
+    'a scoped round-trip must not re-arm acknowledged global failures')
+  assert.equal(h.summaries().at(-1)!.failedTotal, 1, 'the global failure total stays intact')
 })

--- a/test/transcript-search-index.test.ts
+++ b/test/transcript-search-index.test.ts
@@ -15,7 +15,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { MessageId, ToolCallId } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
-import { TranscriptFolder, transcriptSearchText, type TranscriptMessage, type TranscriptSearchMatch } from '../src/transcript.ts'
+import { TranscriptFolder, transcriptSearchText, workflowReadablePhase, type TranscriptMessage, type TranscriptSearchMatch } from '../src/transcript.ts'
 import { refreshedSearchState, steppedSearchOverlayState } from '../src/search-overlay.ts'
 import type { AssistantLiveChunk, AssistantLiveInput } from '../src/runtime/assistant-stream-port.ts'
 
@@ -141,8 +141,21 @@ function compactionEvent(type: 'compaction/start' | 'compaction/summary' | 'comp
 function cardText(message: TranscriptMessage | undefined): string {
   if (message === undefined) return ''
   if (message.kind === 'tool') return `${message.name} ${message.args} ${message.result}`
-  if (message.kind === 'workflow') return `workflow ${message.name} ${message.status}`
+  if (message.kind === 'workflow') return workflowCorpus(message)
   return message.text ?? ''
+}
+
+/** The PR2 workflow search corpus (plan §13): kind + run name + run status +
+ * every phase's readable label + every member's label/status. Machine
+ * identities (childId/runId) are never indexed. */
+function workflowCorpus(message: Extract<TranscriptMessage, { kind: 'workflow' }>): string {
+  const phases = new Set<string>()
+  const members: string[] = []
+  for (const member of message.members) {
+    phases.add(workflowReadablePhase(member.phase))
+    members.push(`${member.label} ${member.status}`)
+  }
+  return `workflow ${message.name} ${message.status} ${[...phases].join(' ')} ${members.join(' ')}`
 }
 
 /**
@@ -155,7 +168,7 @@ function legacySearchForTest(folder: TranscriptFolder, query: string): Transcrip
   if (needle === '') return []
   return folder.messages().filter(message => {
     const text = message.kind === 'tool' ? `${message.name} ${message.args} ${message.result}`
-      : message.kind === 'workflow' ? `workflow ${message.name} ${message.status}`
+      : message.kind === 'workflow' ? workflowCorpus(message)
         : message.text
     return text.toLowerCase().includes(needle)
   })
@@ -631,6 +644,45 @@ test('workflow search text follows the live run status (plan §8.12)', () => {
   folder.apply([rawEvent('tool-workflow/run-end', { runId: 'run1', stopReason: 'completed' }, 2)])
   assertCorpusParity(folder, ['workflow', 'audit', 'completed'])
   assert.equal(folder.search('running').length, 0, 'the settled run must not keep the start-time status in the corpus')
+})
+
+test('workflow search indexes phase labels and member labels/statuses (PR2 plan §13)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run1', name: 'audit' }, 1),
+    rawEvent('tool-workflow/agent-start', { runId: 'run1', seq: 0, label: 'dependency-scan', phase: 'Research', childId: 'session-x' }, 2),
+    rawEvent('tool-workflow/agent-start', { runId: 'run1', seq: 1, label: 'schema-check', phase: '', childId: 'session-y' }, 3),
+    rawEvent('tool-workflow/agent-start', { runId: 'run1', seq: 2, label: 'orphan', phase: null, childId: 'session-z' }, 4),
+  ])
+  assertCorpusParity(folder, ['audit', 'Research', 'dependency-scan', 'running'])
+  // The readable phase labels are indexed: Unassigned (null) and Empty ('')
+  // are distinct searchable words.
+  assert.equal(folder.search('unassigned').length, 1, 'the null phase readable label must be searchable')
+  assert.equal(folder.search('empty').length, 1, 'the empty phase readable label must be searchable')
+  assert.equal(folder.search('schema-check').length, 1, 'a member label must be searchable')
+  // Machine identities are never indexed.
+  assert.equal(folder.search('session-x').length, 0, 'childId must never be indexed')
+  assert.equal(folder.search('run1').length, 0, 'runId must never be indexed')
+  // Member status words are indexed.
+  folder.apply([rawEvent('tool-workflow/agent-end', { runId: 'run1', seq: 0, outcome: 'failed' }, 5)])
+  assertCorpusParity(folder, ['failed'])
+  assert.equal(folder.search('failed').length, 1, 'a member status must be searchable')
+})
+
+test('a member hidden inside a large phase summary still hits its Workflow card (PR2 plan §13.1)', () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    turnStart(0, 0),
+    rawEvent('tool-workflow/run-start', { runId: 'run1', name: 'audit' }, 1),
+    // 6 members: the phase renders as a summary; member 5 is never inline.
+    ...Array.from({ length: 6 }, (_, i) =>
+      rawEvent('tool-workflow/agent-start', { runId: 'run1', seq: i, label: `shard-${i}`, phase: 'Migration', childId: `session-${i}` }, 2 + i)),
+  ])
+  const matches = folder.search('shard-5')
+  assert.equal(matches.length, 1, 'the hidden member must still hit the card')
+  assert.equal(folder.resolveSearchMatch(matches[0]!)?.kind, 'workflow', 'the hit must locate the Workflow card')
+  assertCorpusParity(folder, ['shard-5', 'Migration'])
 })
 
 test('a settled assistant message created WITHOUT chunks stays searchable after replacement', () => {

--- a/test/workflow-presentation.test.ts
+++ b/test/workflow-presentation.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure presentation projection tests for the scalable Workflow UI (PR2 plan
+ * §16.1): phase identity, adaptive thresholds, the capped abnormal preview,
+ * aggregate precedence and the run-level View-all rule. The combinatorics
+ * live HERE — the renderer tests only assert structural output.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  WORKFLOW_ANOMALY_PREVIEW_LIMIT,
+  WORKFLOW_INLINE_MEMBER_LIMIT,
+  workflowAggregateStatus,
+  workflowCountsText,
+  workflowPhasePresentations,
+  workflowRunSummaryText,
+  workflowRunViewAllVisible,
+  workflowStatusCounts,
+} from '../src/workflow-presentation.ts'
+import { workflowPhaseKey, workflowReadablePhase, type WorkflowMemberView, type WorkflowRunStatus } from '../src/transcript.ts'
+
+const member = (seq: number, label: string, phase: string | null, status: WorkflowRunStatus): WorkflowMemberView =>
+  ({ seq, label, phase, childId: `child-${seq}` as never, status })
+
+test('phase identity: null, empty and named phases stay distinct with distinct readable labels', () => {
+  const presentations = workflowPhasePresentations([
+    member(0, 'a', null, 'completed'),
+    member(1, 'b', '', 'completed'),
+    member(2, 'c', 'Research', 'completed'),
+  ])
+  assert.equal(presentations.length, 3, 'null / empty / named must be three groups')
+  const keys = new Set(presentations.map(p => p.key))
+  assert.equal(keys.size, 3, 'phase keys must be collision-free')
+  assert.notEqual(workflowPhaseKey(null), workflowPhaseKey(''))
+  assert.notEqual(workflowReadablePhase(null), workflowReadablePhase(''))
+  assert.equal(workflowReadablePhase(null), 'Unassigned')
+  assert.equal(workflowReadablePhase(''), 'Empty')
+  assert.equal(workflowReadablePhase('Research'), 'Research')
+  const labels = presentations.map(p => p.label)
+  assert.ok(labels.includes('Unassigned') && labels.includes('Empty') && labels.includes('Research'),
+    `readable labels must distinguish the identities: ${labels.join(', ')}`)
+})
+
+test('phase grouping preserves durable arrival order and first-appearance order', () => {
+  const presentations = workflowPhasePresentations([
+    member(0, 'a', 'Research', 'completed'),
+    member(1, 'b', 'Verify', 'completed'),
+    member(2, 'c', 'Research', 'running'),
+  ])
+  assert.deepEqual(presentations.map(p => p.label), ['Research', 'Verify'])
+  assert.deepEqual(presentations[0]!.members.map(m => m.seq), [0, 2], 'members keep durable seq order')
+})
+
+test('adaptive threshold: <=5 members inline, >5 summary', () => {
+  // 0 members: no phase groups at all (a group exists only via its members).
+  assert.deepEqual(workflowPhasePresentations([]), [])
+  for (const count of [1, WORKFLOW_INLINE_MEMBER_LIMIT]) {
+    const members = Array.from({ length: count }, (_, i) => member(i, `m${i}`, 'Research', 'completed'))
+    const [phase] = workflowPhasePresentations(members)
+    assert.equal(phase?.mode, 'inline', `${count} members must be inline`)
+  }
+  for (const count of [WORKFLOW_INLINE_MEMBER_LIMIT + 1, 100]) {
+    const members = Array.from({ length: count }, (_, i) => member(i, `m${i}`, 'Research', 'completed'))
+    const [phase] = workflowPhasePresentations(members)
+    assert.equal(phase?.mode, 'summary', `${count} members must be summary`)
+  }
+})
+
+test('large phase preview: exact counts, abnormal-only, capped, seq-stable, hidden count', () => {
+  const members: WorkflowMemberView[] = [
+    ...Array.from({ length: 10 }, (_, i) => member(i, `done-${i}`, 'Migration', 'completed')),
+    ...Array.from({ length: 5 }, (_, i) => member(10 + i, `run-${i}`, 'Migration', 'running')),
+    member(15, 'fail-1', 'Migration', 'failed'),
+    member(16, 'cancel-1', 'Migration', 'cancelled'),
+    member(17, 'interrupt-1', 'Migration', 'interrupted'),
+    member(18, 'fail-2', 'Migration', 'failed'),
+  ]
+  const [phase] = workflowPhasePresentations(members)
+  assert.ok(phase !== undefined)
+  assert.equal(phase.mode, 'summary')
+  assert.deepEqual(phase.counts, { running: 5, completed: 10, failed: 2, cancelled: 1, interrupted: 1 })
+  // Preview: abnormal only, in seq order, capped at 3 — never a running/completed top-N.
+  assert.deepEqual(phase.anomalyPreview.map(m => m.seq), [15, 16, 17])
+  assert.equal(phase.anomalyPreview.length, WORKFLOW_ANOMALY_PREVIEW_LIMIT)
+  assert.equal(phase.hiddenAnomalyCount, 1, 'the 4th abnormal (seq 18) stays hidden')
+  assert.ok(!phase.anomalyPreview.some(m => m.status === 'running' || m.status === 'completed'),
+    'preview must never inline running/completed members')
+})
+
+test('aggregate status precedence: failed > interrupted > cancelled > running > completed', () => {
+  const cases: Array<[WorkflowRunStatus[], WorkflowRunStatus]> = [
+    [['completed'], 'completed'],
+    [['running', 'completed'], 'running'],
+    [['cancelled', 'running'], 'cancelled'],
+    [['interrupted', 'cancelled'], 'interrupted'],
+    [['failed', 'interrupted'], 'failed'],
+    [['failed', 'cancelled', 'running', 'completed'], 'failed'],
+  ]
+  for (const [statuses, expected] of cases) {
+    const members = statuses.map((status, i) => member(i, `m${i}`, 'P', status))
+    assert.equal(workflowAggregateStatus(members), expected, `${statuses.join(',')} -> ${expected}`)
+  }
+})
+
+test('run summary and phase counts text: non-zero only, stable order', () => {
+  assert.equal(workflowRunSummaryText({ running: 0, completed: 0, failed: 0, cancelled: 0, interrupted: 0 }), '')
+  assert.equal(workflowRunSummaryText({ running: 18, completed: 103, failed: 5, cancelled: 0, interrupted: 0 }),
+    '126 agents · 18 running · 103 completed · 5 failed')
+  assert.equal(workflowRunSummaryText({ running: 0, completed: 1, failed: 0, cancelled: 0, interrupted: 0 }), '1 agent · 1 completed')
+  assert.equal(workflowCountsText({ running: 8, completed: 32, failed: 2, cancelled: 0, interrupted: 0 }),
+    '8 running · 32 completed · 2 failed')
+  assert.equal(workflowCountsText({ running: 0, completed: 0, failed: 0, cancelled: 0, interrupted: 0 }), '')
+})
+
+test('run-level View all rule (plan §5.5)', () => {
+  // total <= 5: never.
+  assert.equal(workflowRunViewAllVisible(0, 1), false)
+  assert.equal(workflowRunViewAllVisible(5, 2), false)
+  // single phase group (large or small): the phase entry covers the run.
+  assert.equal(workflowRunViewAllVisible(6, 1), false)
+  assert.equal(workflowRunViewAllVisible(100, 1), false)
+  // multiple phase groups with total > 5: useful.
+  assert.equal(workflowRunViewAllVisible(6, 2), true)
+  assert.equal(workflowRunViewAllVisible(126, 3), true)
+})
+
+test('status counts are exact for every vocabulary member', () => {
+  const members = [
+    member(0, 'a', null, 'running'),
+    member(1, 'b', null, 'completed'),
+    member(2, 'c', null, 'failed'),
+    member(3, 'd', null, 'cancelled'),
+    member(4, 'e', null, 'interrupted'),
+  ]
+  assert.deepEqual(workflowStatusCounts(members), { running: 1, completed: 1, failed: 1, cancelled: 1, interrupted: 1 })
+})

--- a/test/workflow-ui.test.ts
+++ b/test/workflow-ui.test.ts
@@ -676,3 +676,51 @@ test('a phase folds and unfolds across ANY number of running→clean cycles (rev
   const view = await viewport(vt)
   assert.ok(view.includes('▼ Unassigned'), `the third cycle must open the phase again:\n${view}`)
 })
+
+test('an explicit user open survives the interrupted edge and late terminal facts (review P2)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-x' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  // The user closes and reopens the PHASE, then the RUN: both choices are
+  // now explicit opens (userOpen = true).
+  const phaseRow = rowOf(view, '▼ Unassigned 1 agent')
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  const runRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, runRow)
+  view = await viewport(vt)
+  await clickCell(vt, 10, runRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `the run must be explicitly open:\n${view}`)
+  assert.ok(view.includes('▼ Unassigned 1 agent'), `the phase must be explicitly open:\n${view}`)
+  // The owner closes without terminal facts: run + member project
+  // interrupted (PR1). The first abnormal edge must NOT clear the user's
+  // explicit opens.
+  folder.apply([
+    { type: 'turn/end', seq: 3, time: 1_700_000_000_003, data: { turn: 0, reason: { kind: 'completed' } } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `the interrupted edge must keep the explicit run open:\n${view}`)
+  assert.ok(view.includes('▼ Unassigned 1 agent'), `the interrupted edge must keep the explicit phase open:\n${view}`)
+  // Late durable terminal facts recover completed (PR1 late-terminal
+  // contract): the user's explicit opens still win over the fact-driven
+  // completed → closed default.
+  folder.apply([
+    { type: 'tool-workflow/agent-end', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+    { type: 'tool-workflow/run-end', seq: 5, time: 1_700_000_000_005, data: { runId: 'run-1', stopReason: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `late completion must not snap the explicitly opened run shut:\n${view}`)
+  assert.ok(view.includes('▼ Unassigned 1 agent'), `late completion must not snap the explicitly opened phase shut:\n${view}`)
+})

--- a/test/workflow-ui.test.ts
+++ b/test/workflow-ui.test.ts
@@ -713,16 +713,24 @@ test('an explicit user open survives the interrupted edge and late terminal fact
   assert.equal(runChevron(view), '▼', `the interrupted edge must keep the explicit run open:\n${view}`)
   assert.ok(view.includes('▼ Unassigned 1 agent'), `the interrupted edge must keep the explicit phase open:\n${view}`)
   // Late durable terminal facts recover completed (PR1 late-terminal
-  // contract): the user's explicit opens still win over the fact-driven
-  // completed → closed default.
+  // contract). The final facts are ALL clean, so the completion edge
+  // auto-closes both the run and the phase (Web: new clean facts =>
+  // close) — the explicit opens were consumed by the clean transition.
   folder.apply([
     { type: 'tool-workflow/agent-end', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
     { type: 'tool-workflow/run-end', seq: 5, time: 1_700_000_000_005, data: { runId: 'run-1', stopReason: 'completed' } } as SessionEvent,
   ])
   app.setTranscript(folder.messages())
   view = await viewport(vt)
-  assert.equal(runChevron(view), '▼', `late completion must not snap the explicitly opened run shut:\n${view}`)
-  assert.ok(view.includes('▼ Unassigned 1 agent'), `late completion must not snap the explicitly opened phase shut:\n${view}`)
+  assert.equal(runChevron(view), '▶', `all-clean late completion must auto-close the run:\n${view}`)
+  // Reopen the run: the phase's clean transition already consumed the
+  // explicit open, so the phase is folded too (Web: new clean facts =>
+  // close).
+  const closedRunRow = rowOf(view, 'Workflow audit [completed]')
+  await clickCell(vt, 10, closedRunRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `the run must reopen on click:\n${view}`)
+  assert.ok(view.includes('▶ Unassigned 1 agent'), `all-clean late completion must auto-close the phase:\n${view}`)
 })
 
 test('a new running cycle reopens a user-closed run and phase (review P2, plan §7.7)', async () => {
@@ -864,4 +872,34 @@ test('a clean phase whose member count changed reopens a user-closed run (Web ph
   app.setTranscript(folder.messages())
   view = await viewport(vt)
   assert.equal(runChevron(view), '▼', `a clean phase with a changed member count must reopen the run:\n${view}`)
+})
+
+test('a clean phase manually opened then batch-grown closes while the run reopens (Web parity)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-a' } } as SessionEvent,
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  // The user manually opens the clean phase (userOpen = true).
+  const phaseRow = rowOf(view, '▶ Unassigned 1 agent')
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  assert.ok(view.includes('▼ Unassigned 1 agent'), `the phase must be explicitly open:\n${view}`)
+  // B starts AND settles within one facts update: the phase stays clean
+  // but its member count changed. Web: the clean facts consume the user's
+  // open (phase folds) while the outer run reopens (new clean cycle).
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 1, label: 'b', childId: 'session-b' } } as SessionEvent,
+    { type: 'tool-workflow/agent-end', seq: 5, time: 1_700_000_000_005, data: { runId: 'run-1', seq: 1, outcome: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `a new clean cycle must reopen the run:\n${view}`)
+  assert.ok(view.includes('▶ Unassigned 2 agents'), `the clean phase must fold despite the explicit open:\n${view}`)
 })

--- a/test/workflow-ui.test.ts
+++ b/test/workflow-ui.test.ts
@@ -1,0 +1,641 @@
+/**
+ * Headless tests for the scalable Workflow UI (PR2 plan §16.2–§16.6): the
+ * adaptive renderer, the Run/Phase disclosure state machine, Focus
+ * integration, direct member navigation authority, and the scoped Task
+ * Viewer dataset. The pure projection combinatorics live in
+ * workflow-presentation.test.ts; these tests assert structural output and
+ * interaction behavior.
+ * @module @xmoon76/dsh-pi-tui/workflow-ui.test
+ */
+
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { stripTerminalSequences } from '@xmoon76/pi-tui'
+import { TuiApp, type WorkflowAction } from '../src/tui-app.ts'
+import { TranscriptFolder, type TranscriptMessage, type WorkflowMemberView, type WorkflowRunId, type WorkflowRunStatus } from '../src/transcript.ts'
+import { workflowMemberViewerTarget, type TaskBrowserRow } from '../src/tasks-browser.ts'
+import { VirtualTerminal } from './virtual-terminal.ts'
+
+const startedApps = new Set<TuiApp>()
+afterEach(() => {
+  for (const app of [...startedApps]) {
+    startedApps.delete(app)
+    if (app.isDisposed()) continue
+    try { app.dispose() } catch {}
+  }
+})
+
+process.env.NO_COLOR = ''
+process.env.FORCE_COLOR = ''
+process.env.CI = ''
+
+function startApp(options: ConstructorParameters<typeof TuiApp>[2] = {}): { vt: VirtualTerminal; app: TuiApp } {
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, options)
+  app.start()
+  startedApps.add(app)
+  return { vt, app }
+}
+
+async function viewport(vt: VirtualTerminal): Promise<string> {
+  await vt.waitForRender()
+  return vt.getViewport().join('\n')
+}
+
+const member = (seq: number, label: string, phase: string | null, status: WorkflowRunStatus): WorkflowMemberView =>
+  ({ seq, label, phase, childId: `child-${seq}` as never, status })
+
+const workflow = (overrides: Partial<Extract<TranscriptMessage, { kind: 'workflow' }>> = {}): Extract<TranscriptMessage, { kind: 'workflow' }> => ({
+  kind: 'workflow',
+  turn: 0,
+  runId: 'run-1' as WorkflowRunId,
+  name: 'audit',
+  status: 'running',
+  members: [],
+  ...overrides,
+})
+
+/** Send an SGR primary-button press+release (1-based coords) at a screen
+ * row. A short delay precedes every click: the fork's terminal decodes two
+ * rapid same-position clicks as a DOUBLE-CLICK (word selection), which
+ * would swallow the second toggle. */
+async function clickCell(vt: { sendInput: (data: string) => void }, x: number, y: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 600))
+  vt.sendInput(`\x1b[<0;${x + 1};${y + 1}M`)
+  vt.sendInput(`\x1b[<0;${x + 1};${y + 1}m`)
+}
+
+/** The 0-based viewport row of the first line containing `needle`. */
+function rowOf(view: string, needle: string): number {
+  const lines = view.split('\n')
+  const index = lines.findIndex(line => stripTerminalSequences(line).includes(needle))
+  assert.ok(index >= 0, `row ${needle} missing:\n${view}`)
+  return index
+}
+
+/** The disclosure chevron of the Workflow run header (the icon sits between
+ * the chevron and the title, so substring matches must not assume adjacency). */
+function runChevron(view: string): string {
+  const line = view.split('\n').find(l => stripTerminalSequences(l).includes('Workflow audit'))
+  assert.ok(line !== undefined, `workflow run header missing:\n${view}`)
+  const match = stripTerminalSequences(line).match(/^[▶▼]/)
+  assert.ok(match !== null && match !== undefined, `workflow run header must start with a chevron:\n${view}`)
+  return match[0]
+}
+
+// ---------------------------------------------------------------------------
+// Renderer: adaptive small/large phases (plan §16.2)
+// ---------------------------------------------------------------------------
+
+test('small phase renders every member inline with no View entry', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({ members: [
+    member(0, 'a', 'Research', 'running'),
+    member(1, 'b', 'Research', 'completed'),
+    member(2, 'c', 'Research', 'completed'),
+  ] })])
+  const view = await viewport(vt)
+  assert.ok(view.includes('▼ Research 3 agents'), `phase header missing:\n${view}`)
+  assert.ok(view.includes('a — running') && view.includes('b — completed') && view.includes('c — completed'),
+    `all 3 members must be inline:\n${view}`)
+  assert.ok(!view.includes('View 3 agents'), `small phase must not show a View entry:\n${view}`)
+})
+
+test('5-member phase stays inline; the 6th member flips it to summary', async () => {
+  const { vt, app } = startApp()
+  // One running member keeps the phase open (a fully-completed phase
+  // auto-closes — plan §7.6).
+  app.setTranscript([workflow({ members: [
+    ...Array.from({ length: 4 }, (_, i) => member(i, `m${i}`, 'P', 'completed')),
+    member(4, 'm4', 'P', 'running'),
+  ] })])
+  let view = await viewport(vt)
+  assert.ok(view.includes('m4 — running'), `5 members must all be inline:\n${view}`)
+  assert.ok(!view.includes('View 5 agents'), `5-member phase must not summarize:\n${view}`)
+  app.setTranscript([workflow({ members: [
+    ...Array.from({ length: 5 }, (_, i) => member(i, `m${i}`, 'P', 'completed')),
+    member(5, 'm5', 'P', 'running'),
+  ] })])
+  view = await viewport(vt)
+  assert.ok(view.includes('▼ P 6 agents'), `phase header missing:\n${view}`)
+  assert.ok(view.includes('View 6 agents'), `6-member phase must show the scoped entry:\n${view}`)
+  assert.ok(!view.includes('m4 — completed'), `summary mode must not inline ordinary members:\n${view}`)
+})
+
+test('100-agent phase stays bounded: aggregate + capped abnormal preview only', async () => {
+  const { vt, app } = startApp()
+  const members: WorkflowMemberView[] = [
+    ...Array.from({ length: 90 }, (_, i) => member(i, `done-${i}`, 'Migration', 'completed')),
+    ...Array.from({ length: 5 }, (_, i) => member(90 + i, `run-${i}`, 'Migration', 'running')),
+    member(95, 'fail-1', 'Migration', 'failed'),
+    member(96, 'cancel-1', 'Migration', 'cancelled'),
+    member(97, 'interrupt-1', 'Migration', 'interrupted'),
+    member(98, 'fail-2', 'Migration', 'failed'),
+    member(99, 'fail-3', 'Migration', 'failed'),
+  ]
+  app.setTranscript([workflow({ members })])
+  const view = await viewport(vt)
+  assert.ok(view.includes('100 agents · 5 running · 90 completed · 3 failed · 1 cancelled · 1 interrupted'),
+    `run summary missing:\n${view}`)
+  assert.ok(view.includes('5 running · 90 completed · 3 failed · 1 cancelled · 1 interrupted'),
+    `phase counts missing:\n${view}`)
+  // The preview shows exactly the first 3 abnormal in seq order — never a
+  // running/completed top-N, never the 4th/5th abnormal.
+  assert.ok(view.includes('fail-1') && view.includes('cancel-1') && view.includes('interrupt-1'),
+    `abnormal preview missing:\n${view}`)
+  assert.ok(!view.includes('fail-2') && !view.includes('fail-3'), `preview must cap at 3:\n${view}`)
+  assert.ok(view.includes('2 more abnormal'), `hidden abnormal count missing:\n${view}`)
+  assert.ok(!view.includes('done-0') && !view.includes('run-0'), `ordinary members must not inline:\n${view}`)
+  assert.ok(view.includes('View 100 agents'), `scoped entry missing:\n${view}`)
+  // Bounded: the card is ~10 rows, never 100 member rows.
+  const lines = view.split('\n')
+  assert.ok(lines.length < 30, `transcript must stay bounded (${lines.length} rows):\n${view}`)
+})
+
+test('null and empty phase labels render distinctly', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({ members: [
+    member(0, 'a', null, 'running'),
+    member(1, 'b', '', 'running'),
+  ] })])
+  const view = await viewport(vt)
+  assert.ok(view.includes('▼ Unassigned 1 agent'), `null phase label missing:\n${view}`)
+  assert.ok(view.includes('▼ Empty 1 agent'), `empty phase label missing:\n${view}`)
+})
+
+test('failed uses the error glyph; cancelled/interrupted use the warning glyph', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({ members: [
+    member(0, 'f', 'P', 'failed'),
+    member(1, 'c', 'P', 'cancelled'),
+    member(2, 'i', 'P', 'interrupted'),
+  ] })])
+  const view = await viewport(vt)
+  assert.ok(view.includes('✗ f'), `failed must render the error mark:\n${view}`)
+  assert.ok(view.includes('! c') && view.includes('! i'), `cancelled/interrupted must render the warning mark:\n${view}`)
+})
+
+test('run-level View all appears only for multi-phase runs over the limit', async () => {
+  const { vt, app } = startApp()
+  // Single large phase: the phase entry covers the run — no run-level entry.
+  app.setTranscript([workflow({ members: [
+    ...Array.from({ length: 5 }, (_, i) => member(i, `m${i}`, 'P', 'completed')),
+    member(5, 'm5', 'P', 'running'),
+  ] })])
+  let view = await viewport(vt)
+  assert.ok(view.includes('View 6 agents'), `phase entry missing:\n${view}`)
+  assert.ok(!view.includes('View all 6 agents'), `single-phase run must not repeat the entry:\n${view}`)
+  // Two phase groups, total > 5: the run-level entry is useful.
+  app.setTranscript([workflow({ members: [
+    ...Array.from({ length: 4 }, (_, i) => member(i, `a${i}`, 'A', 'completed')),
+    ...Array.from({ length: 3 }, (_, i) => member(4 + i, `b${i}`, 'B', 'completed')),
+  ] })])
+  view = await viewport(vt)
+  assert.ok(view.includes('View all 7 agents'), `run-level entry missing:\n${view}`)
+})
+
+// ---------------------------------------------------------------------------
+// Disclosure state machine (plan §16.3)
+// ---------------------------------------------------------------------------
+
+test('initial disclosure: running/abnormal runs open, completed runs closed', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({ status: 'running', members: [member(0, 'a', 'P', 'running')] })])
+  let view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `running run must open:\n${view}`)
+  assert.ok(view.includes('a — running'), `open run must show members:\n${view}`)
+  for (const status of ['failed', 'cancelled', 'interrupted'] as const) {
+    app.setTranscript([workflow({ status, members: [member(0, 'a', 'P', status)] })])
+    view = await viewport(vt)
+    assert.equal(runChevron(view), '▼', `${status} run must open:\n${view}`)
+  }
+  app.setTranscript([workflow({ status: 'completed', members: [member(0, 'a', 'P', 'completed')] })])
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `completed run must close:\n${view}`)
+  assert.ok(!view.includes('a — completed'), `closed run must not leak members:\n${view}`)
+})
+
+test('fully completed phase closes; active/abnormal phase opens', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({ members: [
+    member(0, 'done', 'A', 'completed'),
+    member(1, 'live', 'B', 'running'),
+  ] })])
+  const view = await viewport(vt)
+  assert.ok(view.includes('▶ A 1 agent'), `completed phase must close:\n${view}`)
+  assert.ok(!view.includes('done — completed'), `closed phase must not leak members:\n${view}`)
+  assert.ok(view.includes('▼ B 1 agent'), `active phase must open:\n${view}`)
+  assert.ok(view.includes('live — running'), `active phase members visible:\n${view}`)
+})
+
+test('user close persists across ordinary live updates', async () => {
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript([workflow({ members: [member(0, 'a', 'P', 'running')] })])
+  let view = await viewport(vt)
+  const headerRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `user close must fold the run:\n${view}`)
+  // A normal live update (new member, still running) must not reopen it.
+  app.setTranscript([workflow({ members: [member(0, 'a', 'P', 'running'), member(1, 'b', 'P', 'running')] })])
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `ordinary updates must not override the user choice:\n${view}`)
+  assert.ok(!view.includes('a — running'), `closed run must stay closed:\n${view}`)
+})
+
+test('first abnormal edge auto-opens once; a later user close persists', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-x' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `running run must open:\n${view}`)
+  // The first abnormal edge (a member fails) keeps the run open — the
+  // exception stays visible.
+  folder.apply([
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'failed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.ok(view.includes('a — failed'), `abnormal member must stay visible:\n${view}`)
+  // The user closes the run; a further abnormal update must not reopen it.
+  const headerRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `user close must fold the run:\n${view}`)
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 1, label: 'b', childId: 'session-y' } } as SessionEvent,
+    { type: 'tool-workflow/agent-end', seq: 5, time: 1_700_000_000_005, data: { runId: 'run-1', seq: 1, outcome: 'cancelled' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `abnormal updates must not reopen a user-closed run:\n${view}`)
+})
+
+test('completion auto-closes once; a new running member reopens the phase', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-x' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  assert.ok(view.includes('▼ Unassigned 1 agent'), `active phase must open:\n${view}`)
+  // Completion: the phase auto-closes once.
+  folder.apply([
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.ok(view.includes('▶ Unassigned 1 agent'), `completed phase must auto-close:\n${view}`)
+  // A new running member in the SAME phase reopens it (plan §7.7).
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 1, label: 'b', childId: 'session-y' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.ok(view.includes('▼ Unassigned 2 agents'), `phase must reopen for the new running member:\n${view}`)
+  assert.ok(view.includes('b — running'), `new member visible:\n${view}`)
+  // The outer run stays open too (it is still running — the reopen never
+  // folds it; plan §7.7 "phase + run reopen").
+  assert.equal(runChevron(view), '▼', `the outer run must stay open:\n${view}`)
+})
+
+test('outer run close/open never clears the phase user choice', async () => {
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript([workflow({ members: [member(0, 'a', 'P', 'running')] })])
+  let view = await viewport(vt)
+  // Close the phase by hand.
+  const phaseRow = rowOf(view, '▼ P 1 agent')
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  assert.ok(view.includes('▶ P 1 agent'), `phase must fold on click:\n${view}`)
+  // Close and reopen the outer run.
+  const headerRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `run must fold:\n${view}`)
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  // The phase stays closed — the user's choice survives the run round-trip.
+  assert.ok(view.includes('▶ P 1 agent'), `phase choice must survive the run toggle:\n${view}`)
+  assert.ok(!view.includes('a — running'), `closed phase must not leak members:\n${view}`)
+})
+
+// ---------------------------------------------------------------------------
+// Focus integration (plan §16.4)
+// ---------------------------------------------------------------------------
+
+test('collapsed Focus hides the Workflow card; expanded Focus shows one Run disclosure', async () => {
+  const { vt, app } = startApp()
+  app.setFocusMode(true)
+  app.setTranscript([workflow({ members: [member(0, 'a', 'P', 'running')] })])
+  let view = await viewport(vt)
+  assert.ok(!view.includes('Workflow audit'), `collapsed Focus must hide the workflow card:\n${view}`)
+  app.expandFocusTurn(0)
+  view = await viewport(vt)
+  assert.ok(view.includes('Workflow audit [running]'), `expanded Focus must show the workflow card:\n${view}`)
+  // Exactly ONE run disclosure — never a generic fold wrapped around it.
+  const chevrons = view.split('\n').filter(line => stripTerminalSequences(line).includes('Workflow audit')).length
+  assert.equal(chevrons, 1, `exactly one workflow run row:\n${view}`)
+})
+
+test('workflow card clicks never collapse the owning Focus turn', async () => {
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setFocusMode(true)
+  app.setTranscript([workflow({ members: [member(0, 'a', 'P', 'running')] })])
+  app.expandFocusTurn(0)
+  let view = await viewport(vt)
+  assert.ok(view.includes('Workflow audit [running]'), `workflow card must be visible:\n${view}`)
+  // Click the run header (toggle), the phase header (toggle), and a member
+  // row — none may collapse the Focus turn.
+  const headerRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `run header click must toggle the run:\n${view}`)
+  assert.ok(view.includes('Workflow audit'), `Focus must stay expanded after a run click:\n${view}`)
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  const phaseRow = rowOf(view, '▼ P 1 agent')
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  assert.ok(view.includes('▶ P 1 agent'), `phase header click must toggle the phase:\n${view}`)
+  assert.ok(view.includes('Workflow audit'), `Focus must stay expanded after a phase click:\n${view}`)
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  const memberRow = rowOf(view, 'a — running')
+  await clickCell(vt, 10, memberRow)
+  view = await viewport(vt)
+  assert.ok(view.includes('Workflow audit'), `Focus must stay expanded after a member click:\n${view}`)
+})
+
+// ---------------------------------------------------------------------------
+// Direct member navigation (plan §16.5)
+// ---------------------------------------------------------------------------
+
+test('workflowMemberViewerTarget: the full authority matrix', () => {
+  const root = 'session-main'
+  const directRunning: TaskBrowserRow = {
+    kind: 'subagent', value: 'agent:child-1', childId: 'child-1', label: 'checker',
+    mode: 'one-shot', activity: 'running', hasChildren: false, parentId: '', depth: 1,
+  }
+  const runningMember = { status: 'running' as const, childId: 'child-1' }
+  // running + direct + exact parent + running driver → target.
+  const target = workflowMemberViewerTarget(runningMember, directRunning, root)
+  assert.ok(target !== undefined)
+  assert.equal(target.parentSessionId, root)
+  assert.equal(target.childSessionId, 'child-1')
+  assert.equal(target.label, 'checker')
+  assert.equal(target.mode, 'one-shot')
+  assert.equal(target.activity, 'running')
+  // Terminal member → no direct opener.
+  assert.equal(workflowMemberViewerTarget({ status: 'completed', childId: 'child-1' }, directRunning, root), undefined)
+  assert.equal(workflowMemberViewerTarget({ status: 'failed', childId: 'child-1' }, directRunning, root), undefined)
+  assert.equal(workflowMemberViewerTarget({ status: 'cancelled', childId: 'child-1' }, directRunning, root), undefined)
+  assert.equal(workflowMemberViewerTarget({ status: 'interrupted', childId: 'child-1' }, directRunning, root), undefined)
+  // Missing catalog row (agent-start before the listing) → noninteractive.
+  assert.equal(workflowMemberViewerTarget(runningMember, undefined, root), undefined)
+  // Wrong parent → noninteractive.
+  const wrongParent: TaskBrowserRow = { ...directRunning, parentId: 'session-other' }
+  assert.equal(workflowMemberViewerTarget(runningMember, wrongParent, root), undefined)
+  // Nested (depth 2) → noninteractive.
+  const nested: TaskBrowserRow = { ...directRunning, parentId: 'session-mid', depth: 2 }
+  assert.equal(workflowMemberViewerTarget(runningMember, nested, root), undefined)
+  // Inactive driver → noninteractive.
+  const inactive: TaskBrowserRow = { ...directRunning, activity: 'inactive' }
+  assert.equal(workflowMemberViewerTarget(runningMember, inactive, root), undefined)
+  // A job row is never a member target.
+  const jobRow: TaskBrowserRow = {
+    kind: 'job', value: 'job:j1', jobId: 'j1', jobKind: 'bash', label: 'job', status: 'running', startedAt: 1,
+  }
+  assert.equal(workflowMemberViewerTarget(runningMember, jobRow, root), undefined)
+})
+
+test('running member click emits open-member; terminal member rows have no hit', async () => {
+  const actions: WorkflowAction[] = []
+  const { vt, app } = startApp({ onWorkflowAction: action => actions.push(action) })
+  app.setFullscreen(true)
+  app.setTranscript([workflow({ members: [
+    member(0, 'live', 'P', 'running'),
+    member(1, 'done', 'P', 'completed'),
+  ] })])
+  let view = await viewport(vt)
+  const liveRow = rowOf(view, 'live — running')
+  await clickCell(vt, 10, liveRow)
+  await vt.waitForRender()
+  assert.deepEqual(actions, [{ kind: 'open-member', runId: 'run-1', seq: 0, childId: 'child-0' }],
+    `running member click must emit the semantic action`)
+  // A terminal member row consumes the click but emits nothing.
+  actions.length = 0
+  view = await viewport(vt)
+  const doneRow = rowOf(view, 'done — completed')
+  await clickCell(vt, 10, doneRow)
+  await vt.waitForRender()
+  assert.deepEqual(actions, [], `terminal member must never emit open-member`)
+})
+
+test('View N agents clicks emit the scoped phase/run actions', async () => {
+  const actions: WorkflowAction[] = []
+  const { vt, app } = startApp({ onWorkflowAction: action => actions.push(action) })
+  app.setFullscreen(true)
+  app.setTranscript([workflow({ name: 'audit', members: [
+    ...Array.from({ length: 5 }, (_, i) => member(i, `a${i}`, 'A', 'completed')),
+    member(5, 'a5', 'A', 'running'),
+    ...Array.from({ length: 2 }, (_, i) => member(6 + i, `b${i}`, 'B', 'completed')),
+    member(8, 'b2', 'B', 'running'),
+  ] })])
+  let view = await viewport(vt)
+  const phaseRow = rowOf(view, 'View 6 agents')
+  await clickCell(vt, 10, phaseRow)
+  await vt.waitForRender()
+  assert.deepEqual(actions, [{
+    kind: 'open-phase-agents', runId: 'run-1', name: 'audit', phaseLabel: 'A',
+    childIds: ['child-0', 'child-1', 'child-2', 'child-3', 'child-4', 'child-5'],
+  }], `phase View click must emit the scoped action`)
+  actions.length = 0
+  view = await viewport(vt)
+  const runRow = rowOf(view, 'View all 9 agents')
+  await clickCell(vt, 10, runRow)
+  await vt.waitForRender()
+  assert.deepEqual(actions, [{
+    kind: 'open-run-agents', runId: 'run-1', name: 'audit',
+    childIds: ['child-0', 'child-1', 'child-2', 'child-3', 'child-4', 'child-5', 'child-6', 'child-7', 'child-8'],
+  }], `run View-all click must emit the scoped action`)
+})
+
+// ---------------------------------------------------------------------------
+// Review round 1 fixes (P1/P2 regressions)
+// ---------------------------------------------------------------------------
+
+test('a run settling abnormal with only completed members reopens once after user close (review P1)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-x' } } as SessionEvent,
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  // The user closes the run while it is still running with a completed member.
+  const headerRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `user close must fold the run:\n${view}`)
+  // The run settles FAILED with only completed members: the abnormal RUN
+  // status is an abnormal edge — it must reopen once.
+  folder.apply([
+    { type: 'tool-workflow/run-end', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', stopReason: 'error' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `an abnormal run status must reopen the run once:\n${view}`)
+  assert.ok(view.includes('Workflow audit [failed]'), `failed run status missing:\n${view}`)
+})
+
+test('a cold-replayed abnormal run with zero members opens by default (review P1)', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({ status: 'failed', members: [] })])
+  const view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `a zero-member failed run must open:\n${view}`)
+  assert.ok(view.includes('Workflow audit [failed]'), `failed run status missing:\n${view}`)
+})
+
+test('a closed completed run still shows the aggregate summary (review P1, plan §5.6)', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({
+    status: 'completed',
+    members: Array.from({ length: 100 }, (_, i) => member(i, `m${i}`, 'P', 'completed')),
+  })])
+  const view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `completed run must close:\n${view}`)
+  assert.ok(view.includes('100 agents · 100 completed'), `closed run must keep the aggregate summary:\n${view}`)
+  assert.ok(!view.includes('m0 — completed'), `closed run must not leak members:\n${view}`)
+})
+
+test('workflowMemberViewerTarget rejects a mismatched row and a continuable row (review P2)', () => {
+  const root = 'session-main'
+  const runningMember = { status: 'running' as const, childId: 'child-1' }
+  // A row for a DIFFERENT child must never combine with the member identity.
+  const mismatched: TaskBrowserRow = {
+    kind: 'subagent', value: 'agent:child-9', childId: 'child-9', label: 'other',
+    mode: 'one-shot', activity: 'running', hasChildren: false, parentId: '', depth: 1,
+  }
+  assert.equal(workflowMemberViewerTarget(runningMember, mismatched, root), undefined,
+    'a mismatched row must never resolve')
+  // A continuable catalog row is never a Workflow member target (one-shot
+  // authority — the viewer must never grant an interactive editor).
+  const continuable: TaskBrowserRow = {
+    kind: 'subagent', value: 'agent:child-1', childId: 'child-1', label: 'checker',
+    mode: 'continuable', activity: 'running', hasChildren: false, parentId: '', depth: 1,
+  }
+  assert.equal(workflowMemberViewerTarget(runningMember, continuable, root), undefined,
+    'a continuable row must never resolve as a Workflow member target')
+})
+
+test('the running run pill uses the primary semantic color (review P2, plan §8.2)', async () => {
+  const { vt, app } = startApp()
+  app.setTranscript([workflow({ status: 'running', members: [] })])
+  const view = await viewport(vt)
+  // The pill cell must carry the PRIMARY truecolor (0x4FA8FF), never the
+  // dim gray (0x888888) of the old textDim pill (plan §8.2: running →
+  // active/primary).
+  const row = rowOf(view, '[running]')
+  const col = stripTerminalSequences(view.split('\n')[row]!).indexOf('[running]')
+  assert.equal(vt.getCellFgRgb(row, col), 0x4FA8FF,
+    `running pill must use the primary semantic color:\n${view}`)
+  assert.notEqual(vt.getCellFgRgb(row, col), 0x888888,
+    `running pill must not use the dim color:\n${view}`)
+})
+
+test('workflow cards stay host-owned under a message renderer registry (review P2)', async () => {
+  const { RendererRegistry } = await import('../src/renderer-registry.ts')
+  const registry = new RendererRegistry()
+  registry.registerMessageRenderer({
+    id: 'workflow-plugin',
+    render: () => ({ kind: 'text', spans: [{ text: 'PLUGIN WORKFLOW' }] }),
+  }, 'test-owner')
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} }, { renderers: registry })
+  app.start()
+  startedApps.add(app)
+  app.setTranscript([workflow({ members: [member(0, 'a', 'P', 'running')] })])
+  const view = await viewport(vt)
+  // Workflow records are HOST-owned (semanticSnapshotOf returns undefined):
+  // a message renderer registry never takes the card over, so the host hit
+  // map stays authoritative (the !hostBuilt cleanup is defensive for the
+  // future, unreachable for workflow today).
+  assert.ok(view.includes('Workflow audit [running]'), `host must render the workflow card:\n${view}`)
+  assert.ok(!view.includes('PLUGIN WORKFLOW'), `a plugin must never own the workflow card:\n${view}`)
+  const hits = (app as unknown as { workflowHitsByMessage: Map<object, unknown> }).workflowHitsByMessage
+  assert.equal(hits.size, 1, `the host-rendered card must record its hit rows`)
+})
+
+test('View-agent clicks inside an expanded Focus never collapse the owning turn (review P2)', async () => {
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setFocusMode(true)
+  app.setTranscript([workflow({ name: 'audit', members: [
+    ...Array.from({ length: 5 }, (_, i) => member(i, `a${i}`, 'A', 'completed')),
+    member(5, 'a5', 'A', 'running'),
+    ...Array.from({ length: 2 }, (_, i) => member(6 + i, `b${i}`, 'B', 'completed')),
+    member(8, 'b2', 'B', 'running'),
+  ] })])
+  app.expandFocusTurn(0)
+  let view = await viewport(vt)
+  assert.ok(view.includes('Workflow audit [running]'), `workflow card must be visible:\n${view}`)
+  // Phase View N agents click: the scoped action fires, Focus stays expanded.
+  const phaseRow = rowOf(view, 'View 6 agents')
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  assert.ok(view.includes('Workflow audit'), `Focus must stay expanded after a phase View click:\n${view}`)
+  // Run View all click: same protection.
+  const runRow = rowOf(view, 'View all 9 agents')
+  await clickCell(vt, 10, runRow)
+  view = await viewport(vt)
+  assert.ok(view.includes('Workflow audit'), `Focus must stay expanded after a run View-all click:\n${view}`)
+})
+
+test('a running run auto-closes once on run-end completed; an explicit user open persists (review P2)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-x' } } as SessionEvent,
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `a running run must open:\n${view}`)
+  // run-end completed: the OUTER run auto-closes once (plan §7.6).
+  folder.apply([
+    { type: 'tool-workflow/run-end', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', stopReason: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `a completed run must auto-close once:\n${view}`)
+  // The user explicitly reopens it: the choice persists (no second
+  // auto-close can fire — the transition is one-shot).
+  const headerRow = rowOf(view, 'Workflow audit [completed]')
+  await clickCell(vt, 10, headerRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `the explicit user open must persist:\n${view}`)
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `an unchanged re-render must keep the user choice:\n${view}`)
+})

--- a/test/workflow-ui.test.ts
+++ b/test/workflow-ui.test.ts
@@ -639,3 +639,40 @@ test('a running run auto-closes once on run-end completed; an explicit user open
   view = await viewport(vt)
   assert.equal(runChevron(view), '▼', `an unchanged re-render must keep the user choice:\n${view}`)
 })
+
+test('a phase folds and unfolds across ANY number of running→clean cycles (review P2)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setTranscript(folder.messages())
+  const cycle = async (seq: number, label: string): Promise<string> => {
+    folder.apply([
+      { type: 'tool-workflow/agent-start', seq, time: 1_700_000_000_000 + seq, data: { runId: 'run-1', seq: seq - 2, label, childId: `session-${label}` } } as SessionEvent,
+    ])
+    app.setTranscript(folder.messages())
+    let view = await viewport(vt)
+    assert.ok(view.includes('▼ Unassigned'), `${label} start must open the phase:\n${view}`)
+    folder.apply([
+      { type: 'tool-workflow/agent-end', seq: seq + 1, time: 1_700_000_000_000 + seq + 1, data: { runId: 'run-1', seq: seq - 2, outcome: 'completed' } } as SessionEvent,
+    ])
+    app.setTranscript(folder.messages())
+    view = await viewport(vt)
+    assert.ok(view.includes('▶ Unassigned'), `${label} completion must close the phase again:\n${view}`)
+    return view
+  }
+  // A start -> open, A complete -> close.
+  await cycle(2, 'a')
+  // B start -> open, B complete -> close (the SECOND cycle — the old
+  // one-shot completionClosed/reopened flags would leave it stuck open).
+  await cycle(4, 'b')
+  // C start -> open (a THIRD cycle still works).
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 6, time: 1_700_000_000_006, data: { runId: 'run-1', seq: 4, label: 'c', childId: 'session-c' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  const view = await viewport(vt)
+  assert.ok(view.includes('▼ Unassigned'), `the third cycle must open the phase again:\n${view}`)
+})

--- a/test/workflow-ui.test.ts
+++ b/test/workflow-ui.test.ts
@@ -836,3 +836,32 @@ test('a run stays abnormal/open after run-end completed when a member failed (re
   assert.ok(view.includes('Workflow audit [completed]'), `the durable status pill stays completed:\n${view}`)
   assert.ok(view.includes('a — failed'), `the failed member stays visible:\n${view}`)
 })
+
+test('a clean phase whose member count changed reopens a user-closed run (Web phaseStartedCycle parity)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-a' } } as SessionEvent,
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  // The user folds the run while the phase is clean.
+  const runRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, runRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `the run must be user-closed:\n${view}`)
+  // B starts AND settles within one facts update: the phase stays clean
+  // but its member count changed — Web's phaseStartedCycle still fires
+  // (facts.activityCount !== previous.activityCount) and reopens the run.
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 1, label: 'b', childId: 'session-b' } } as SessionEvent,
+    { type: 'tool-workflow/agent-end', seq: 5, time: 1_700_000_000_005, data: { runId: 'run-1', seq: 1, outcome: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `a clean phase with a changed member count must reopen the run:\n${view}`)
+})

--- a/test/workflow-ui.test.ts
+++ b/test/workflow-ui.test.ts
@@ -724,3 +724,70 @@ test('an explicit user open survives the interrupted edge and late terminal fact
   assert.equal(runChevron(view), '▼', `late completion must not snap the explicitly opened run shut:\n${view}`)
   assert.ok(view.includes('▼ Unassigned 1 agent'), `late completion must not snap the explicitly opened phase shut:\n${view}`)
 })
+
+test('a new running cycle reopens a user-closed run and phase (review P2, plan §7.7)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-a' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  // The user folds the phase and the whole run.
+  const phaseRow = rowOf(view, '▼ Unassigned 1 agent')
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  const runRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, runRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `the run must be user-closed:\n${view}`)
+  // A completes: the phase is clean — the user's close persists.
+  folder.apply([
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `a clean phase must keep the user close:\n${view}`)
+  // B starts in the SAME phase: a NEW CYCLE — the phase AND the run reopen
+  // (plan §7.7), overriding the prior user close.
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 1, label: 'b', childId: 'session-b' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `a new cycle must reopen the run:\n${view}`)
+  assert.ok(view.includes('▼ Unassigned 2 agents'), `a new cycle must reopen the phase:\n${view}`)
+})
+
+test('a new member in a still-running phase is an ordinary update, not a new cycle (review P2)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-a' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 1, label: 'b', childId: 'session-b' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setFullscreen(true)
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  // The user folds the phase and the run while both are still running.
+  const phaseRow = rowOf(view, '▼ Unassigned 2 agents')
+  await clickCell(vt, 10, phaseRow)
+  view = await viewport(vt)
+  const runRow = rowOf(view, 'Workflow audit [running]')
+  await clickCell(vt, 10, runRow)
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `the run must be user-closed:\n${view}`)
+  // C starts while the phase is STILL running: an ordinary update — the
+  // user's close persists (plan §7.4).
+  folder.apply([
+    { type: 'tool-workflow/agent-start', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', seq: 2, label: 'c', childId: 'session-c' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▶', `an ordinary update must keep the user close:\n${view}`)
+})

--- a/test/workflow-ui.test.ts
+++ b/test/workflow-ui.test.ts
@@ -791,3 +791,48 @@ test('a new member in a still-running phase is an ordinary update, not a new cyc
   view = await viewport(vt)
   assert.equal(runChevron(view), '▶', `an ordinary update must keep the user close:\n${view}`)
 })
+
+test('a completed run with a failed member is abnormal and opens by default (review P2, Web parity)', async () => {
+  const { vt, app } = startApp()
+  // Cold replay: the script handled the child's null and returned
+  // successfully — run-end completed, member failed. Web runDisclosureFacts
+  // says abnormal (any phase abnormal) → the run and the phase open.
+  app.setTranscript([workflow({ status: 'completed', members: [
+    member(0, 'a', 'P', 'failed'),
+  ] })])
+  const view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `a completed run with a failed member must open:\n${view}`)
+  assert.ok(view.includes('Workflow audit [completed]'), `the durable status pill stays completed:\n${view}`)
+  assert.ok(view.includes('▼ P 1 agent'), `the failed phase must open:\n${view}`)
+  assert.ok(view.includes('a — failed'), `the failed member must be visible:\n${view}`)
+})
+
+test('a run stays abnormal/open after run-end completed when a member failed (review P2)', async () => {
+  const folder = new TranscriptFolder()
+  folder.apply([
+    { type: 'turn/start', seq: 0, time: 1_700_000_000_000, data: { turn: 0 } } as SessionEvent,
+    { type: 'tool-workflow/run-start', seq: 1, time: 1_700_000_000_001, data: { runId: 'run-1', name: 'audit' } } as SessionEvent,
+    { type: 'tool-workflow/agent-start', seq: 2, time: 1_700_000_000_002, data: { runId: 'run-1', seq: 0, label: 'a', childId: 'session-a' } } as SessionEvent,
+  ])
+  const { vt, app } = startApp()
+  app.setTranscript(folder.messages())
+  let view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `a running run must open:\n${view}`)
+  // The member fails: the run becomes abnormal (still open).
+  folder.apply([
+    { type: 'tool-workflow/agent-end', seq: 3, time: 1_700_000_000_003, data: { runId: 'run-1', seq: 0, outcome: 'failed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `an abnormal run must stay open:\n${view}`)
+  // run-end completed: the run is STILL abnormal (member failed) — it must
+  // NOT collapse to the clean default.
+  folder.apply([
+    { type: 'tool-workflow/run-end', seq: 4, time: 1_700_000_000_004, data: { runId: 'run-1', stopReason: 'completed' } } as SessionEvent,
+  ])
+  app.setTranscript(folder.messages())
+  view = await viewport(vt)
+  assert.equal(runChevron(view), '▼', `run-end completed must not collapse an abnormal run:\n${view}`)
+  assert.ok(view.includes('Workflow audit [completed]'), `the durable status pill stays completed:\n${view}`)
+  assert.ok(view.includes('a — failed'), `the failed member stays visible:\n${view}`)
+})


### PR DESCRIPTION
## Summary

- add Run/Phase disclosure for Workflow transcript nodes
- keep small phases (<=5 agents) directly inspectable in the transcript
- summarize large phases with aggregate state and bounded abnormal previews
- reuse Task Center as a Workflow-scoped agent browser for large runs
- reuse the existing read-only Subagent Viewer for eligible live Workflow children
- align cancelled/interrupted warning semantics and exact phase labels with DSH Web

## Scalability

Large Workflow phases no longer render every member inline. The transcript stays bounded while the existing Task Viewer provides searchable access to the full child set.

## DSH Web parity

Lifecycle/status/phase identity/direct-child authority follow current dsh@0.1.5-alpha.1 Web semantics. The bounded large-phase presentation is an intentional TUI-specific divergence.

Intentional interaction difference (plan §7.8): the TUI has no DOM-focus equivalent, so completion auto-close fires immediately (one-shot) instead of being delayed while the user is inside the disclosure content.

## Validation

- pnpm typecheck:bundle
- pnpm test:product
- pnpm gate:boundary
- pnpm build:bundle
