### PR TITLE
fix(focus/input): surface injected turn foundation; keep host commands out of the busy policy; stop older paging at the oldest turn

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -55,12 +55,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Compatibility
 
-- **Plugin command `execution: 'submission'` changed meaning (breaking).** It now declares a SUBMISSION
-  LINE rather than a command execution: the TUI delivers `/name args` verbatim with the resolved busy
-  mode (steer / queue) and **no longer runs the commands-service handler** — the web composer's
-  unclaimed-line semantics — leaving line expansion to the plugin's own pre-step. A plugin that needs
-  handler execution declares `execution: 'local'`; `submission` combined with `sessionless: true` is now
-  rejected at registration.
+- **Plugin command contributions now follow the DSH client command model (breaking).** The
+  `execution: 'local' | 'submission'` ownership metadata is REMOVED: a contribution IS a client-owned
+  command (a required `handler`, no host descriptor) that joins the `/` menu and executes locally, never
+  steered. A name that collides with the current host catalog FAILS the candidate synthesis as a whole
+  (no menu rows are installed, the collision is recorded on the contribution's health and surfaced once)
+  while the host command keeps its claim — it can never be downgraded to a model prompt. A contribution
+  used to advertise a prompt-style name should simply not be registered (an unclaimed `/name args` line
+  is already a prompt; the host-side skill owns discovery). `sessionless: true` runs the command before a
+  session exists; the default `false` resolves/creates the session first.
 
 ## [0.4.3-alpha.2] - 2026-09-08
 

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -45,6 +45,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Updated builtin default Footer layout.** The default statusline (no custom Footer) now uses two rows: row 1 keeps permission, model, tasks, cwd, branch and extension items on the left, with plan state and Focus Mode on the right; row 2 composes token usage, cache hit, TTFB, throughput and the turn/step counters on the left (the semantic decomposition of the stats line), with the full context pressure (`used/window (percent)`) on the right. Users with a saved custom `footerLayout` are unaffected.
 
+### Improved
+
+- **Ctrl+Enter now follows the web submission semantics.** While the agent is running, Ctrl+Enter takes
+  the **opposite** of the busy-Enter behavior: it steers under the default `busyEnter=queue` and queues
+  under `busyEnter=steer` (an idle agent always queues). The old `app.input.queue` action is kept as a
+  deprecated, key-less action, so a stored remap still means "queue" instead of being silently turned
+  into the opposite behavior; the new `app.input.submitAccelerated` owns Ctrl+Enter.
+
+### Compatibility
+
+- **Plugin command `execution: 'submission'` changed meaning (breaking).** It now declares a SUBMISSION
+  LINE rather than a command execution: the TUI delivers `/name args` verbatim with the resolved busy
+  mode (steer / queue) and **no longer runs the commands-service handler** — the web composer's
+  unclaimed-line semantics — leaving line expansion to the plugin's own pre-step. A plugin that needs
+  handler execution declares `execution: 'local'`; `submission` combined with `sessionless: true` is now
+  rejected at registration.
+
 ## [0.4.3-alpha.2] - 2026-09-08
 
 ### Installation and version pairing

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -71,12 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wire. The policy follows the FINAL authority: an unknown `/name [image #1]` line whose command only appears
   with the session (a session-scoped host command) is checked again after the session resolves — an undeclared
   command refuses it instead of running with an empty payload and consuming the draft.
-- **An attachment-bearing client command no longer refuses before the deferred authority resolves.**
-  Before the first session exists, a line such as `/deploy [image #1]` first resolves the session-keyed
-  authority: a host command or skill wrapper that appears with the session takes the line **with its
-  attachment**; only when the client command keeps it does the attachment refusal fire, returning the
-  draft (placeholder intact) for a re-attach decision. The referenced drafts are reserved across the
-  deferred window, so a concurrent attach-time prune cannot drop them.
+- **An attachment-bearing `/name args` line is no longer treated as a client command.** A client command
+  contribution claims the BARE `/name` token only, so a line such as `/deploy [image #1]` (an attachment
+  always brings input with it) was never a contribution invocation: it is an ordinary multimodal submission
+  that reaches the model — the plugin handler does not run and no "local command" attachment refusal is
+  raised.
 - **A plugin reload during a deferred start never runs the next generation.** If the contribution is
   unloaded/replaced while the first submission resolves its session (even under the same owner and id),
   the submitted command does **not** run the new handler and is **never** downgraded to a model prompt:
@@ -89,6 +88,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Compatibility
 
+- **Client command contributions are bare-token invocations only (breaking).** DSH `matchEnter`
+  parity: a contribution is a slash-MENU entry, so it claims the BARE `/name` token only — `/name args`
+  is not an invocation. It is an ordinary submission that reaches the model (busy policy and
+  attachments included), and the plugin `handler` never runs for it. Previously `/deploy prod` ran the
+  plugin handler. A plugin that needs arguments should open its own picker from the bare command, or
+  expose the capability to the model as a tool.
 - **The extension API version is now 2 (breaking).** `api().apiVersion` reports `2` because the
   plugin command contribution contract below is a breaking change to the STABLE surface (removed
   `execution`/`argumentProvider`, required `handler`); `1` stays the M0–M3 foundation, so a plugin

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+- **Commands are decided by the whole LINE, not by the command name.** The DSH decision table
+  (`CommandDescriptor.input`) distinguishes a `leadingInput` command (e.g. `/goal`), whose arguments are part of the
+  invocation, from an execute-kind one (e.g. `/compact`), where only the BARE token is an invocation. Previously any
+  name present in the command catalog sent the whole line to the command plane — `/compact anything` executed the
+  command, ignored the busy queue/steer policy while running, and was even refused by the command attachment rule when
+  it carried an image. Such a line now behaves exactly like an ordinary prompt: it follows the busy policy
+  (queue/steer, and Ctrl+Enter takes the opposite), and its image is delivered to the model as a multimodal prompt.
+  Real invocations — `/compact`, `/goal <objective>`, `/plan <message>` — still execute through the command plane, and
+  the attachment rule only applies to a line a command actually claims.
 - **`!`/`!!` shell lines refuse attachments instead of passing the placeholder to the shell.** The local shell never
   admitted or consumed drafts, so `!echo [image #1]` used to run with the placeholder as ordinary shell arguments and
   leave the image staged. The line is now refused like any other local command, and the draft comes back with its

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+- **`!`/`!!` shell lines refuse attachments instead of passing the placeholder to the shell.** The local shell never
+  admitted or consumed drafts, so `!echo [image #1]` used to run with the placeholder as ordinary shell arguments and
+  leave the image staged. The line is now refused like any other local command, and the draft comes back with its
+  attachment intact.
 - **Command attachments follow the command's own declaration.** A command may be invoked with attachments
   only when its descriptor declares `input.attachments`; anything else refuses the line up front
   (`/<name> does not accept attachments; remove them first`) instead of handing the host a placeholder with
@@ -172,6 +176,9 @@ commands are in the README's “Install into a DSH profile” section.
 
 ### Fixed
 
+- **A stale command handle can no longer remove a newer registration.** A dispose handle names ONE registration:
+  a repeated or late `dispose()` (a fiber cleanup arriving after an HMR reload re-registered the same id) no longer
+  removes the newer contribution or drops its health record.
 - **Text-input keyboard ownership is corrected.** Free-text editing no
   longer loses its line-editing keys to the parent: in Question's “Type
   something.” edit, `←/→` are the text cursor (previously they could

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -47,6 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+- **An attachment-bearing client command no longer refuses before the deferred authority resolves.**
+  Before the first session exists, a line such as `/deploy [image #1]` first resolves the session-keyed
+  authority: a host command or skill wrapper that appears with the session takes the line **with its
+  attachment**; only when the client command keeps it does the attachment refusal fire, returning the
+  draft (placeholder intact) for a re-attach decision. The referenced drafts are reserved across the
+  deferred window, so a concurrent attach-time prune cannot drop them.
+- **A plugin reload during a deferred start never runs the next generation.** If the contribution is
+  unloaded/replaced while the first submission resolves its session (even under the same owner and id),
+  the submitted command does **not** run the new handler and is **never** downgraded to a model prompt:
+  the submission is aborted with `/<name> is no longer available` and the draft is restored for a retry.
 - **Ctrl+Enter now follows the web submission semantics.** While the agent is running, Ctrl+Enter takes
   the **opposite** of the busy-Enter behavior: it steers under the default `busyEnter=queue` and queues
   under `busyEnter=steer` (an idle agent always queues). The old `app.input.queue` action is kept as a
@@ -55,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Compatibility
 
+- **The extension API version is now 2 (breaking).** `api().apiVersion` reports `2` because the
+  plugin command contribution contract below is a breaking change to the STABLE surface (removed
+  `execution`/`argumentProvider`, required `handler`); `1` stays the M0–M3 foundation, so a plugin
+  can tell the two schemas apart. A plugin still declaring the removed v1 shape is rejected at
+  registration instead of being silently reinterpreted.
 - **Plugin command contributions now follow the DSH client command model (breaking).** The
   `execution: 'local' | 'submission'` ownership metadata is REMOVED: a contribution IS a client-owned
   command (a required `handler`, no host descriptor) that joins the `/` menu and executes locally, never

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -55,7 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   draft WITH its attachments. File attachments are refused for commands (the host expects an upload receipt
   this client cannot produce yet). Skill invocations are unaffected: an explicit `/skill <name> [image #1]`
   and a skill wrapper stay agent-facing, so their images ride the delivered prompt instead of the command
-  wire.
+  wire. The policy follows the FINAL authority: an unknown `/name [image #1]` line whose command only appears
+  with the session (a session-scoped host command) is checked again after the session resolves — an undeclared
+  command refuses it instead of running with an empty payload and consuming the draft.
 - **An attachment-bearing client command no longer refuses before the deferred authority resolves.**
   Before the first session exists, a line such as `/deploy [image #1]` first resolves the session-keyed
   authority: a host command or skill wrapper that appears with the session takes the line **with its

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -53,7 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no payload. A declaring command receives the submitted images as encoded attachments on the host command
   call, and a command submission consumes them only after handler success — a failed command restores the
   draft WITH its attachments. File attachments are refused for commands (the host expects an upload receipt
-  this client cannot produce yet).
+  this client cannot produce yet). Skill invocations are unaffected: an explicit `/skill <name> [image #1]`
+  and a skill wrapper stay agent-facing, so their images ride the delivered prompt instead of the command
+  wire.
 - **An attachment-bearing client command no longer refuses before the deferred authority resolves.**
   Before the first session exists, a line such as `/deploy [image #1]` first resolves the session-keyed
   authority: a host command or skill wrapper that appears with the session takes the line **with its

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+- **Command attachments follow the command's own declaration.** A command may be invoked with attachments
+  only when its descriptor declares `input.attachments`; anything else refuses the line up front
+  (`/<name> does not accept attachments; remove them first`) instead of handing the host a placeholder with
+  no payload. A declaring command receives the submitted images as encoded attachments on the host command
+  call, and a command submission consumes them only after handler success — a failed command restores the
+  draft WITH its attachments. File attachments are refused for commands (the host expects an upload receipt
+  this client cannot produce yet).
 - **An attachment-bearing client command no longer refuses before the deferred authority resolves.**
   Before the first session exists, a line such as `/deploy [image #1]` first resolves the session-keyed
   authority: a host command or skill wrapper that appears with the session takes the line **with its

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -63,7 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while the host command keeps its claim — it can never be downgraded to a model prompt. A contribution
   used to advertise a prompt-style name should simply not be registered (an unclaimed `/name args` line
   is already a prompt; the host-side skill owns discovery). `sessionless: true` runs the command before a
-  session exists; the default `false` resolves/creates the session first.
+  session exists; the default `false` resolves/creates the session first. A collision with the SESSION's
+  host catalog fails the whole candidate pass at synthesis time (upstream `source-failed` parity: the
+  source's command rows are withdrawn until a synthesis succeeds again) while the host claims stay
+  refreshed — input authority is never lost — and the collision is recorded on the contribution's health
+  and surfaced once per identity/failure generation; a collision with the TUI's own static command names
+  is rejected at registration. The never-wired `argumentProvider` field is removed too (use
+  `registerAutocomplete`).
 
 ## [0.4.3-alpha.2] - 2026-09-08
 

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -59,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `execution: 'local' | 'submission'` ownership metadata is REMOVED: a contribution IS a client-owned
   command (a required `handler`, no host descriptor) that joins the `/` menu and executes locally, never
   steered. A name that collides with the current host catalog FAILS the candidate synthesis as a whole
-  (no menu rows are installed, the collision is recorded on the contribution's health and surfaced once)
+  (no menu rows are installed, the collision is recorded on the contribution's health and surfaced once,
+  naming every colliding contribution of that failed pass)
   while the host command keeps its claim — it can never be downgraded to a model prompt. A contribution
   used to advertise a prompt-style name should simply not be registered (an unclaimed `/name args` line
   is already a prompt; the host-side skill owns discovery). `sessionless: true` runs the command before a
@@ -67,7 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   host catalog fails the whole candidate pass at synthesis time (upstream `source-failed` parity: the
   source's command rows are withdrawn until a synthesis succeeds again) while the host claims stay
   refreshed — input authority is never lost — and the collision is recorded on the contribution's health
-  and surfaced once per identity/failure generation; a collision with the TUI's own static command names
+  and surfaced once per identity/failure generation (the notice names every collision of that pass); a
+  collision with the TUI's own static command names
   is rejected at registration. The never-wired `argumentProvider` field is removed too (use
   `registerAutocomplete`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,13 @@
 
 ### 兼容性
 
-- **插件命令 `execution: 'submission'` 语义变更（破坏性）。** 它现在表示"提交行"而不是"执行命令"：
-  TUI 把 `/name args` 原样按解析出的模式投递给会话（steer / 入队），**不再调用 commands service 的
-  handler**（与 Web composer 未 claim 行的语义一致），行内展开交给插件自己的 pre-step。需要 handler
-  执行的插件请改声明 `execution: 'local'`；`submission` 与 `sessionless: true` 的组合现在会在注册时
-  被拒绝。
+- **插件命令 contribution 对齐 DSH 客户端命令模型（破坏性）。** `execution: 'local' | 'submission'`
+  已**移除**：contribution 就是"客户端自有的命令"（必有 `handler`，无 host descriptor），会进入 `/`
+  命令菜单并本地执行、永不 steer；名字与当前 host catalog 冲突时**候选合成整体失败**（不安装任何菜单
+  行、记录扩展健康并在界面提示一次），host 命令始终保留自己的 claim，**绝不会被降级成模型 prompt**。
+  用于广告 prompt 型名字的 `submission` 请直接不要注册 contribution（未 claim 的 `/name args` 本来就
+  是 prompt，发现渠道是 host 侧 skill）。`sessionless: true` 表示可在没有 session 时执行；默认
+  `false` 会先解析/创建 session 再执行。
 
 ## [0.4.3-alpha.2] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@
 
 ### 改进
 
+- **命令与普通输入按"整行"判定，不再按命令名判定。** DSH 的命令判定表
+  （`CommandDescriptor.input`）区分两类命令：`leadingInput` 命令（如 `/goal`）把参数一起当作调用，
+  无参数命令（如 `/compact`）只有**裸命令**才是调用。此前只要名字出现在命令表里，整行就会走命令
+  通道——`/compact 任意内容` 会被当成命令执行，运行中也不跟随 queue/steer 策略，带图片时还会被按
+  命令附件规则拒绝。现在这类"带参数的无参数命令"与普通提示完全一致：跟随忙碌策略（queue/steer、
+  Ctrl+Enter 取反），图片作为多模态提示进入模型；而 `/compact`、`/goal <objective>`、`/plan <message>`
+  等真正的调用仍然走命令通道，附件规则也只在"这一行确实被命令接管"时生效。
 - **`!`/`!!` 本地 shell 行不再把占位符带进 shell。** 本地 shell 本来就不 admit/consume 草稿，`!echo [image #1]`
   会把占位符当普通 shell 参数执行、图片留在 store 里。现在与其它本地命令一致：直接拒绝，并把草稿（含附件）退回。
 - **命令附件按命令自身的声明处理。** 只有 descriptor 声明了 `input.attachments` 的命令才允许带附件调用；

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,9 @@
   仍属 agent-facing，图片随投递的 prompt 进入模型，而不是走命令通道。策略按**最终 authority** 复核：
   未知的 `/name [image #1]` 若其命令在 session 建立后才出现（session 级 host 命令），会在 session 解析后
   再判一次——未声明的命令会被拒绝，而不是带着空 payload 执行并把草稿 consume 掉。
-- **带附件的 client 命令在 deferred start 下不再提前拒绝。** 首次输入前没有 session 时，`/deploy [image #1]`
-  这类命令先完成 session 级 authority 解析：随 session 出现的 host 命令或 skill wrapper 会**带着附件**接管
-  该行；只有最终归属仍是 client 命令时才拒绝附件，并把草稿（附件占位符保留）原样退回。延迟窗口内的附件由
-  reservation 保护，不会被并发的 attach 清理删掉。
+- **带附件的 `/name args` 行不再被当成 client 命令。** client 命令 contribution 只 claim **裸 `/name`**，
+  所以 `/deploy [image #1]` 这类带参数（附件必然引入参数）的行本来就**不是** contribution 调用：它作为
+  普通多模态提交进入模型，插件 handler 不执行、也不会再报 "local command" 附件拒绝。
 - **deferred start 期间插件重载不会串代执行。** 首次输入触发的 session 解析过程中，如果该 contribution
   被卸载/重载（即使 owner 与 id 相同），已提交的命令**不会**执行新一代的 handler，也**不会**降级成模型
   prompt：提交被中止、提示 `/<name> is no longer available`，草稿还原后可直接重试。
@@ -65,6 +64,10 @@
 
 ### 兼容性
 
+- **客户端命令 contribution 改为"仅裸命令"调用（破坏性）。** 对齐 DSH `matchEnter`：contribution 是
+  斜杠**菜单项**，只 claim **裸 `/name`**；`/name args` 不是调用——它作为普通提交进入模型（跟随忙碌
+  策略、附件照常投递），插件的 handler 完全不执行。此前 `/deploy prod` 会执行插件 handler。需要参数的
+  插件应在裸命令里自行打开面板/选择器，或把该能力做成模型可用的工具。
 - **扩展 API 版本升到 2（破坏性）。** `api().apiVersion` 现在返回 `2`：下面的插件命令 contribution
   契约对 STABLE 面是破坏性变更（移除 `execution`/`argumentProvider`、`handler` 变为必填）；`1` 仍是
   M0–M3 基础版，插件可据此区分两套 schema。仍声明旧 v1 shape 的插件会在注册时**直接报错**，不会

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@
   其余命令在派发前直接拒绝（`/<name> does not accept attachments; remove them first`），不再把"只有占位符、
   没有内容"的行交给 host。声明过的命令会在 host 命令调用上收到编码后的图片附件；命令提交**只在 handler
   成功后才 consume 附件**——失败的命令会连同附件一起还原草稿。文件附件对命令一律拒绝（host 需要上传
-  receipt，本 client 尚无该通道）。
+  receipt，本 client 尚无该通道）。skill 调用不受影响：显式 `/skill <name> [image #1]` 与 skill wrapper
+  仍属 agent-facing，图片随投递的 prompt 进入模型，而不是走命令通道。
 - **带附件的 client 命令在 deferred start 下不再提前拒绝。** 首次输入前没有 session 时，`/deploy [image #1]`
   这类命令先完成 session 级 authority 解析：随 session 出现的 host 命令或 skill wrapper 会**带着附件**接管
   该行；只有最终归属仍是 client 命令时才拒绝附件，并把草稿（附件占位符保留）原样退回。延迟窗口内的附件由

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@
 
 ### 改进
 
+- **带附件的 client 命令在 deferred start 下不再提前拒绝。** 首次输入前没有 session 时，`/deploy [image #1]`
+  这类命令先完成 session 级 authority 解析：随 session 出现的 host 命令或 skill wrapper 会**带着附件**接管
+  该行；只有最终归属仍是 client 命令时才拒绝附件，并把草稿（附件占位符保留）原样退回。延迟窗口内的附件由
+  reservation 保护，不会被并发的 attach 清理删掉。
+- **deferred start 期间插件重载不会串代执行。** 首次输入触发的 session 解析过程中，如果该 contribution
+  被卸载/重载（即使 owner 与 id 相同），已提交的命令**不会**执行新一代的 handler，也**不会**降级成模型
+  prompt：提交被中止、提示 `/<name> is no longer available`，草稿还原后可直接重试。
 - **Ctrl+Enter 与 Web 提交语义对齐。** 运行中按 Ctrl+Enter 现在取"忙碌提交行为"的**相反值**：默认
   `busyEnter=queue` 时它 steer，`busyEnter=steer` 时它入队（空闲时一律入队）。旧的
   `app.input.queue` 动作保留为 deprecated、无默认键，已有自定义绑定仍然是"入队"，不会被悄悄改成
@@ -41,6 +48,10 @@
 
 ### 兼容性
 
+- **扩展 API 版本升到 2（破坏性）。** `api().apiVersion` 现在返回 `2`：下面的插件命令 contribution
+  契约对 STABLE 面是破坏性变更（移除 `execution`/`argumentProvider`、`handler` 变为必填）；`1` 仍是
+  M0–M3 基础版，插件可据此区分两套 schema。仍声明旧 v1 shape 的插件会在注册时**直接报错**，不会
+  被静默重新解释。
 - **插件命令 contribution 对齐 DSH 客户端命令模型（破坏性）。** `execution: 'local' | 'submission'`
   已**移除**：contribution 就是"客户端自有的命令"（必有 `handler`，无 host descriptor），会进入 `/`
   命令菜单并本地执行、永不 steer；名字与当前 host catalog 冲突时**候选合成整体失败**（不安装任何菜单

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@
   没有内容"的行交给 host。声明过的命令会在 host 命令调用上收到编码后的图片附件；命令提交**只在 handler
   成功后才 consume 附件**——失败的命令会连同附件一起还原草稿。文件附件对命令一律拒绝（host 需要上传
   receipt，本 client 尚无该通道）。skill 调用不受影响：显式 `/skill <name> [image #1]` 与 skill wrapper
-  仍属 agent-facing，图片随投递的 prompt 进入模型，而不是走命令通道。
+  仍属 agent-facing，图片随投递的 prompt 进入模型，而不是走命令通道。策略按**最终 authority** 复核：
+  未知的 `/name [image #1]` 若其命令在 session 建立后才出现（session 级 host 命令），会在 session 解析后
+  再判一次——未声明的命令会被拒绝，而不是带着空 payload 执行并把草稿 consume 掉。
 - **带附件的 client 命令在 deferred start 下不再提前拒绝。** 首次输入前没有 session 时，`/deploy [image #1]`
   这类命令先完成 session 级 authority 解析：随 session 出现的 host 命令或 skill wrapper 会**带着附件**接管
   该行；只有最终归属仍是 client 命令时才拒绝附件，并把草稿（附件占位符保留）原样退回。延迟窗口内的附件由

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 ### 改进
 
+- **`!`/`!!` 本地 shell 行不再把占位符带进 shell。** 本地 shell 本来就不 admit/consume 草稿，`!echo [image #1]`
+  会把占位符当普通 shell 参数执行、图片留在 store 里。现在与其它本地命令一致：直接拒绝，并把草稿（含附件）退回。
 - **命令附件按命令自身的声明处理。** 只有 descriptor 声明了 `input.attachments` 的命令才允许带附件调用；
   其余命令在派发前直接拒绝（`/<name> does not accept attachments; remove them first`），不再把"只有占位符、
   没有内容"的行交给 host。声明过的命令会在 host 命令调用上收到编码后的图片附件；命令提交**只在 handler
@@ -132,6 +134,8 @@ dsh --profile pi-tui
 
 ### 修复
 
+- **过期的命令 handle 不再删除新一代注册。** handle 只代表**一次**注册：重复或迟到的 `dispose()`（HMR 重载后
+  才到达的 fiber cleanup）不会删掉同 id 的新 contribution，也不会误清新一代的健康记录。
 - **文本输入态的键盘所有权修正。** 自由输入编辑不再被父层抢走行编辑键:
   Question 的“Type something.”自由输入里 `←/→` 现在是文本光标(此前会误
   提交或翻页),`Home/End/Ctrl+A/E/B/F/Delete` 等编辑键统一进入共享输入;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
 
 ### 改进
 
+- **命令附件按命令自身的声明处理。** 只有 descriptor 声明了 `input.attachments` 的命令才允许带附件调用；
+  其余命令在派发前直接拒绝（`/<name> does not accept attachments; remove them first`），不再把"只有占位符、
+  没有内容"的行交给 host。声明过的命令会在 host 命令调用上收到编码后的图片附件；命令提交**只在 handler
+  成功后才 consume 附件**——失败的命令会连同附件一起还原草稿。文件附件对命令一律拒绝（host 需要上传
+  receipt，本 client 尚无该通道）。
 - **带附件的 client 命令在 deferred start 下不再提前拒绝。** 首次输入前没有 session 时，`/deploy [image #1]`
   这类命令先完成 session 级 authority 解析：随 session 出现的 host 命令或 skill wrapper 会**带着附件**接管
   该行；只有最终归属仍是 client 命令时才拒绝附件，并把草稿（附件占位符保留）原样退回。延迟窗口内的附件由

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,11 @@
   行、记录扩展健康并在界面提示一次），host 命令始终保留自己的 claim，**绝不会被降级成模型 prompt**。
   用于广告 prompt 型名字的 `submission` 请直接不要注册 contribution（未 claim 的 `/name args` 本来就
   是 prompt，发现渠道是 host 侧 skill）。`sessionless: true` 表示可在没有 session 时执行；默认
-  `false` 会先解析/创建 session 再执行。
+  `false` 会先解析/创建 session 再执行。与 **session 级 host catalog 同名**属于合成期冲突：整轮候选
+  合成失败（对齐上游 `source-failed`，该 source 的命令行全部撤下，直到下一次成功合成），但 host claim
+  已先行刷新，输入归属不受影响，冲突记录在该 contribution 的健康上并按 identity/失败代次提示一次；
+  TUI 静态命令名冲突则在注册时直接抛错。另外从未接线的 `argumentProvider` 字段一并移除（请用
+  `registerAutocomplete`）。
 
 ## [0.4.3-alpha.2] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,12 @@
 - **插件命令 contribution 对齐 DSH 客户端命令模型（破坏性）。** `execution: 'local' | 'submission'`
   已**移除**：contribution 就是"客户端自有的命令"（必有 `handler`，无 host descriptor），会进入 `/`
   命令菜单并本地执行、永不 steer；名字与当前 host catalog 冲突时**候选合成整体失败**（不安装任何菜单
-  行、记录扩展健康并在界面提示一次），host 命令始终保留自己的 claim，**绝不会被降级成模型 prompt**。
+  行、记录扩展健康并在界面提示一次，提示中列出该轮全部冲突的 contribution），host 命令始终保留自己的 claim，**绝不会被降级成模型 prompt**。
   用于广告 prompt 型名字的 `submission` 请直接不要注册 contribution（未 claim 的 `/name args` 本来就
   是 prompt，发现渠道是 host 侧 skill）。`sessionless: true` 表示可在没有 session 时执行；默认
   `false` 会先解析/创建 session 再执行。与 **session 级 host catalog 同名**属于合成期冲突：整轮候选
   合成失败（对齐上游 `source-failed`，该 source 的命令行全部撤下，直到下一次成功合成），但 host claim
-  已先行刷新，输入归属不受影响，冲突记录在该 contribution 的健康上并按 identity/失败代次提示一次；
+  已先行刷新，输入归属不受影响，冲突记录在该 contribution 的健康上并按 identity/失败代次提示一次（提示列出该轮全部冲突）；
   TUI 静态命令名冲突则在注册时直接抛错。另外从未接线的 `argumentProvider` 字段一并移除（请用
   `registerAutocomplete`）。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@
 
 - **内置 Footer 默认布局更新。** 未自定义 Footer 的默认 statusline 现在是两行:第一行左侧为权限、Model、Tasks、目录、分支与扩展条目,右侧为 Plan 状态和 Focus Mode;第二行左侧为 token 用量、cache 命中、TTFB、吞吐与 turn/step 计数(stats-line 的语义拆解),右侧为完整 Context 用量(`已用/窗口 (百分比)`)。已保存自定义 `footerLayout` 的用户不受影响。
 
+### 改进
+
+- **Ctrl+Enter 与 Web 提交语义对齐。** 运行中按 Ctrl+Enter 现在取"忙碌提交行为"的**相反值**：默认
+  `busyEnter=queue` 时它 steer，`busyEnter=steer` 时它入队（空闲时一律入队）。旧的
+  `app.input.queue` 动作保留为 deprecated、无默认键，已有自定义绑定仍然是"入队"，不会被悄悄改成
+  相反行为；新的 `app.input.submitAccelerated` 独立拥有 Ctrl+Enter。
+
+### 兼容性
+
+- **插件命令 `execution: 'submission'` 语义变更（破坏性）。** 它现在表示"提交行"而不是"执行命令"：
+  TUI 把 `/name args` 原样按解析出的模式投递给会话（steer / 入队），**不再调用 commands service 的
+  handler**（与 Web composer 未 claim 行的语义一致），行内展开交给插件自己的 pre-step。需要 handler
+  执行的插件请改声明 `execution: 'local'`；`submission` 与 `sessionless: true` 的组合现在会在注册时
+  被拒绝。
+
 ## [0.4.3-alpha.2] - 2026-09-08
 
 ### 安装与版本对应

--- a/README.en.md
+++ b/README.en.md
@@ -300,7 +300,7 @@ For the full `/footer` workflow, Custom Text / Command items, YAML reference, se
 | Key           | Action                                              |
 | ------------- | --------------------------------------------------- |
 | `Enter`       | Submit input                                        |
-| `Ctrl+Enter`  | Queue the draft while the agent is busy (the opposite of Enter while busy) |
+| `Ctrl+Enter`  | Submit with the OPPOSITE busy behavior (steers by default; queues when `busyEnter=steer`) |
 | `Shift+Enter` | Insert newline                                      |
 | `Esc`         | Cancel current interaction / interrupt running work |
 | `Esc Esc`     | Open Rewind while idle                              |

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ TUI 使用 DSH 提供的模型和设置服务。
 | 按键            | 功能                     |
 | ------------- | ---------------------- |
 | `Enter`       | 提交输入                   |
-| `Ctrl+Enter`  | Agent 忙碌时把草稿入队(与 Enter 相反) |
+| `Ctrl+Enter`  | 与 Enter 的忙碌行为相反(默认 steer,`busyEnter=steer` 时入队) |
 | `Shift+Enter` | 换行                     |
 | `Esc`         | 取消当前交互 / 中断运行          |
 | `Esc Esc`     | 空闲时打开 Rewind           |

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ knows where the rest lives.
 | `perf-baseline.md` | contributors | Measured rendering performance before/after the incremental read grouping + render-cache optimization, and how to re-run it |
 | `tmux-testing.md` | contributors | When to test in tmux instead of headless, the manual verification flows, and every trap hit while real-testing |
 | `footer-customization.md` | users | User guide for `/footer`: builtin items and styles, Custom Text, trusted Custom Command Items, whole-footer commands, extension items, responsive behavior, raw settings reference, and troubleshooting |
-| `extension-api.md` | plugin authors | The extension API v1 author guide: import rules, the surface table, lifecycle/render contracts, deprecation policy, stability |
+| `extension-api.md` | plugin authors | The extension API v2 author guide: import rules, the surface table, lifecycle/render contracts, deprecation policy, stability |
 | `extension-advanced.md` | plugin authors | The ADVANCED tier author guide (Phase 2/4): normalized input capture, focused interactive surfaces, advanced editor control, the imperative UI broker, custom UI and the host-state facade — the Host-mediated contract and the capture ladder position |
 | `extension-capability-matrix.md` | plugin authors | The Pi capability reference: Pi capability → dsh equivalent → tier → status (roadmap, not a hash gate) |
 | `plugin-authoring.md` | plugin authors | The "which tier should I use?" decision tree and the authoring checklist |

--- a/docs/dsh-compatibility.md
+++ b/docs/dsh-compatibility.md
@@ -140,6 +140,14 @@ removed with the temporary validation workspace and must never be committed to
   until a `pi2dsh` release declares and runs on DSH `>= 0.1.2-alpha.4`; the
   official-preset gate above keeps the real preset coverage meanwhile. The
   local driver (`pnpm smoke:pi2dsh`) remains available for manual runs.
+- **Second, independent Gate B blocker (extension API v2).** The published
+  `pi2dsh@0.24.0` bridge hard-gates the host API version
+  (`api().apiVersion !== 1` ⇒ it refuses to host Pi components), and the
+  candidate now reports **API v2** (`docs/extension-api.md`). The pinned
+  consumer therefore also needs a v2-aware release; its manifest
+  (`test/compat/pi2dsh.json`) keeps recording `apiVersion=1` because that is
+  the consumer's own requirement — never silently rewritten to match this
+  host. Re-enabling Gate B requires a `pi2dsh` release that accepts API v2.
 - The runtime-boundary smoke intentionally runs the 0.4 candidate against DSH
   0.1.1 and requires a nonzero unsupported-runtime outcome. Friendly startup
   guidance is asserted when emitted, but raw import failure is accepted because

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -1,10 +1,16 @@
-# Extension API v1 — Stable author guide and stability contract
+# Extension API v2 — Stable author guide and stability contract
 
 The dsh-pi-tui STABLE extension surface (`@xmoon76/dsh-pi-tui/extensions`)
 is the compatibility-oriented public seam for third-party plugins. This
 document is the STABLE API author guide and stability record (plan §16 —
-M11 API v1 hardening). Advanced and Unstable tiers are documented in
-`docs/extension-tiers.md`.
+M11 hardening, now at **API v2**). Advanced and Unstable tiers are
+documented in `docs/extension-tiers.md`.
+
+`api().apiVersion` reports **2**. The version was bumped with the breaking
+client-command contribution contract below; a plugin that must support both
+schemas branches on `api().apiVersion` (`1` = the M0–M3 foundation), and a
+plugin that declared the removed v1 ownership shape is rejected loudly at
+registration instead of being silently reinterpreted.
 
 ## Import rules (hard gate — Stable)
 
@@ -183,10 +189,16 @@ locally, never steered.
   (pure client commands: an overlay toggle, a picker). `false` (default)
   resolves/creates the session first — the host command surface is
   session-keyed — and only then runs the handler.
+- **Deferred reloads.** A `sessionless: false` contribution submitted before
+  the first session exists resolves the session first; if the plugin unloads
+  or replaces it during that window, the submission is aborted with a
+  `/<name> is no longer available` notice and the draft is restored — the new
+  generation's handler never runs, and the line never reaches the model.
 - **`handler`** receives `invocation.rawInput` verbatim, like every other
   command surface.
 
-**Breaking change (Unreleased).** The previous `execution: 'local' |
+**Breaking change (Unreleased) — API v1 → v2.** `api().apiVersion` reports
+`2` from this release on. The previous `execution: 'local' |
 'submission'` ownership metadata is REMOVED, and the never-wired
 `argumentProvider` field is gone with it (use `registerAutocomplete` for
 plugin suggestions — it was a dead public surface). A contribution is a client

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -155,6 +155,39 @@ construction or restore failure leaves the old seat available.
 Always `service.api().capabilities.has(...)` before relying on a
 capability — never parse the package version.
 
+## Command ownership (M5)
+
+`registerCommand(contribution)` declares ownership over an EXISTING slash
+command (register the command itself through the commands service). The
+bridge never executes anything — `execution` decides the route the TUI
+takes for a submitted `/<name> args` line, mirroring the web composer's
+claim-vs-prompt split:
+
+- `execution: 'local'` — the command executes whenever it is submitted,
+  with or without a live session: the contribution's `handler` (the bridge
+  handler) runs locally with the raw input verbatim, and the
+  commands-service definition handler is only the fallback when no bridge
+  handler is declared. The busy-Enter policy never applies and the line is
+  never steered, so a local command is never sent to the model. Use it for
+  UI/control commands; `sessionless: true` additionally lets it run before
+  any session exists.
+- `execution: 'submission'` — the command is a SUBMISSION LINE, not a
+  command execution: the TUI delivers the raw line to the session with the
+  busy-Enter-policy mode (steered into the running turn, or queued), like a
+  skill invocation, and does NOT run the commands-service handler. The
+  plugin's own pre-step owns any expansion of the line. A submission needs
+  a session, so `sessionless: true` with `submission` is rejected at
+  registration.
+
+**Breaking change (Unreleased).** `submission` used to keep the
+commands-service handler authoritative: the handler ran in every non-steer
+mode while only the steer mode delivered a bare line — an asymmetry no
+other client shared. Migration: a contribution that needs handler execution
+declares `execution: 'local'`; a contribution that wants the line delivered
+as agent input keeps `submission` and expands the line in its own pre-step.
+Busy Enter classifies by the EFFECTIVE ownership (a dynamic local command is
+local while registered, submission after unload).
+
 ## Theme registry (M5)
 
 `registerTheme(contribution)` registers a named color palette into the

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -169,6 +169,16 @@ entirely on the client (no host descriptor), carried by the required
 `handler`. It is merged into the `/` menu with the host catalog and runs
 locally, never steered.
 
+- **Bare-token invocation.** A contribution is a slash-MENU entry, so it
+  claims the BARE `/name` token only — the DSH decision table
+  (`ui-commands` `matchEnter`) checks a contribution with `if (!bare) return
+  undefined`. `/deploy` runs the handler; `/deploy explain` is NOT an
+  invocation: it is an ordinary submission that reaches the model (with its
+  attachments), and the handler never runs for it. A contribution therefore
+  receives an `invocation.rawInput` with no non-whitespace input (trailing
+  whitespace is preserved verbatim, like every other command surface), and one
+  can never be invoked with a composer attachment (any attachment makes the line
+  argued).
 - **Host authority.** A LINE the current host catalog CLAIMS is a host
   command: it executes through the command plane and a contribution can
   never shadow it — not in the dispatch, and not in the attachment gate (a
@@ -212,20 +222,30 @@ locally, never steered.
   name without claiming the line (an argued line of an execute-kind command)
   makes the submission an ordinary one — the contribution does not run for it.
 - **`handler`** receives `invocation.rawInput` verbatim, like every other
-  command surface.
+  command surface — for a contribution that is the bare token's remainder,
+  which carries no non-whitespace input (only the bare `/name` line invokes
+  one).
 
 **Breaking change (Unreleased) — API v1 → v2.** `api().apiVersion` reports
 `2` from this release on. The previous `execution: 'local' |
 'submission'` ownership metadata is REMOVED, and the never-wired
 `argumentProvider` field is gone with it (use `registerAutocomplete` for
 plugin suggestions — it was a dead public surface). A contribution is a client
-command, full stop: a `/name args` line that is not a command is an
-unclaimed prompt (the host pre-step owns skill expansion, and the inline
-skill lexicon owns its discovery), so a contribution no longer needs to
-declare that. Migration: drop `execution` (and declare `handler`, now
-required); a contribution that used `submission` to advertise a
-prompt-style name should instead not register a contribution at all — its
-line reaches the model as an ordinary prompt.
+command, full stop: the `'submission'` variant is gone, and an unclaimed slash
+line is an ordinary prompt (the host pre-step owns skill expansion, and the
+inline skill lexicon owns its discovery). Migration: drop `execution` (and
+declare `handler`, now required); a contribution that used `submission` to
+advertise a prompt-style name should instead not register a contribution at all
+— its line reaches the model as an ordinary prompt.
+
+The bare-token invocation is part of the same alignment and is itself a
+behaviour change for plugins that declared arguments before: `/name args` no
+longer reaches `handler` (the line is an ordinary submission, and its
+`rawInput` was never a stable argument channel to begin with — the handler is
+the CLI-entered *bare* command gesture on the web too, where a contribution
+opens its popup). A plugin that needs arguments should own them client-side
+(a picker/overlay opened by the bare command) or expose the capability to the
+MODEL as a tool instead.
 
 ## Theme registry (M5)
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -165,11 +165,17 @@ locally, never steered.
 
 - **Host authority.** A name the current host catalog resolves is a HOST
   command: it executes through the command plane and a contribution can
-  never shadow it. Upstream's candidate synthesis throws on a
-  host/contribution name collision; here the synthesis pass FAILS (nothing
-  is installed, the collision is recorded on the contribution's health and
-  surfaced once) while the host command keeps its claim — the input can
-  never be downgraded to a model prompt.
+  never shadow it — not in the dispatch, and not in the attachment gate
+  (the host handler owns its own attachment policy).
+- **Two collision mechanisms.** A name owned by the TUI's OWN static catalog
+  (`/status`, `/kill`, ...) is rejected at REGISTRATION: `registerCommand`
+  throws and the plugin fails to load loudly. A name the SESSION's host
+  catalog resolves (a preset/plugin command that may appear only after the
+  session exists) is a SYNTHESIS-time collision: the candidate pass fails as
+  a whole — upstream `source-failed` parity, so its command rows are removed
+  until a synthesis succeeds again — while the host claims stay refreshed
+  (input authority is never lost) and the collision is recorded on the
+  contribution's health and surfaced once.
 - **`sessionless`.** `true` lets the command run before a session exists
   (pure client commands: an overlay toggle, a picker). `false` (default)
   resolves/creates the session first — the host command surface is
@@ -178,7 +184,9 @@ locally, never steered.
   command surface.
 
 **Breaking change (Unreleased).** The previous `execution: 'local' |
-'submission'` ownership metadata is REMOVED. A contribution is a client
+'submission'` ownership metadata is REMOVED, and the never-wired
+`argumentProvider` field is gone with it (use `registerAutocomplete` for
+plugin suggestions — it was a dead public surface). A contribution is a client
 command, full stop: a `/name args` line that is not a command is an
 unclaimed prompt (the host pre-step owns skill expansion, and the inline
 skill lexicon owns its discovery), so a contribution no longer needs to
@@ -187,7 +195,6 @@ required); a contribution that used `submission` to advertise a
 prompt-style name should instead not register a contribution at all — its
 line reaches the model as an ordinary prompt.
 
-## Theme registry (M5)
 ## Theme registry (M5)
 
 `registerTheme(contribution)` registers a named color palette into the

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -169,11 +169,17 @@ entirely on the client (no host descriptor), carried by the required
 `handler`. It is merged into the `/` menu with the host catalog and runs
 locally, never steered.
 
-- **Host authority.** A name the current host catalog resolves is a HOST
+- **Host authority.** A LINE the current host catalog CLAIMS is a host
   command: it executes through the command plane and a contribution can
-  never shadow it — not in the dispatch, and not in the attachment gate
-  (a host command's own `input.attachments` declaration decides whether the
-  composer may attach anything).
+  never shadow it — not in the dispatch, and not in the attachment gate (a
+  host command's own `input.attachments` declaration decides whether the
+  composer may attach anything). The claim belongs to the line, exactly like
+  the DSH decision table: every host command claims its BARE token, and a
+  `leadingInput` descriptor claims its argued line too. An argued line of an
+  execute-kind command (`/compact now`) is not an invocation at all — it is an
+  ordinary submission. A name the host catalog RESOLVES is host territory in
+  both states: the contribution of that name never runs for such a line, and
+  the line is never classified as a local client command.
 - **Two collision mechanisms.** A name owned by the TUI's OWN static catalog
   (`/status`, `/kill`, ...) is rejected at REGISTRATION: `registerCommand`
   throws and the plugin fails to load loudly. A name the SESSION's host
@@ -186,6 +192,12 @@ locally, never steered.
   failed pass. That health record is a best-effort diagnostic: a handler
   failure overlapping a live collision can be masked or cleared by it (see
   the diagnostic-limitation note in `docs/surface-decisions.md`).
+  "The host keeps its claim" is a claim on the LINES its descriptor owns: the
+  bare token for every command, plus the argued line for a `leadingInput` one.
+  A contribution colliding with an execute-kind host command therefore loses
+  that command's ARGUED line as well — the host never claimed it, so neither
+  the host nor the colliding contribution runs it: the line falls through to an
+  ordinary submission.
 - **`sessionless`.** `true` lets the command run before a session exists
   (pure client commands: an overlay toggle, a picker). `false` (default)
   resolves/creates the session first — the host command surface is
@@ -195,6 +207,10 @@ locally, never steered.
   or replaces it during that window, the submission is aborted with a
   `/<name> is no longer available` notice and the draft is restored — the new
   generation's handler never runs, and the line never reaches the model.
+  The session's own catalog is consulted first, in both directions: a command
+  that appears and CLAIMS the line executes it, and a command that resolves the
+  name without claiming the line (an argued line of an execute-kind command)
+  makes the submission an ordinary one — the contribution does not run for it.
 - **`handler`** receives `invocation.rawInput` verbatim, like every other
   command surface.
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -157,37 +157,37 @@ capability — never parse the package version.
 
 ## Command ownership (M5)
 
-`registerCommand(contribution)` declares ownership over an EXISTING slash
-command (register the command itself through the commands service). The
-bridge never executes anything — `execution` decides the route the TUI
-takes for a submitted `/<name> args` line, mirroring the web composer's
-claim-vs-prompt split:
+`registerCommand(contribution)` declares a CLIENT-OWNED command — the DSH
+client command contribution shape: a slash name whose behavior lives
+entirely on the client (no host descriptor), carried by the required
+`handler`. It is merged into the `/` menu with the host catalog and runs
+locally, never steered.
 
-- `execution: 'local'` — the command executes whenever it is submitted,
-  with or without a live session: the contribution's `handler` (the bridge
-  handler) runs locally with the raw input verbatim, and the
-  commands-service definition handler is only the fallback when no bridge
-  handler is declared. The busy-Enter policy never applies and the line is
-  never steered, so a local command is never sent to the model. Use it for
-  UI/control commands; `sessionless: true` additionally lets it run before
-  any session exists.
-- `execution: 'submission'` — the command is a SUBMISSION LINE, not a
-  command execution: the TUI delivers the raw line to the session with the
-  busy-Enter-policy mode (steered into the running turn, or queued), like a
-  skill invocation, and does NOT run the commands-service handler. The
-  plugin's own pre-step owns any expansion of the line. A submission needs
-  a session, so `sessionless: true` with `submission` is rejected at
-  registration.
+- **Host authority.** A name the current host catalog resolves is a HOST
+  command: it executes through the command plane and a contribution can
+  never shadow it. Upstream's candidate synthesis throws on a
+  host/contribution name collision; here the synthesis pass FAILS (nothing
+  is installed, the collision is recorded on the contribution's health and
+  surfaced once) while the host command keeps its claim — the input can
+  never be downgraded to a model prompt.
+- **`sessionless`.** `true` lets the command run before a session exists
+  (pure client commands: an overlay toggle, a picker). `false` (default)
+  resolves/creates the session first — the host command surface is
+  session-keyed — and only then runs the handler.
+- **`handler`** receives `invocation.rawInput` verbatim, like every other
+  command surface.
 
-**Breaking change (Unreleased).** `submission` used to keep the
-commands-service handler authoritative: the handler ran in every non-steer
-mode while only the steer mode delivered a bare line — an asymmetry no
-other client shared. Migration: a contribution that needs handler execution
-declares `execution: 'local'`; a contribution that wants the line delivered
-as agent input keeps `submission` and expands the line in its own pre-step.
-Busy Enter classifies by the EFFECTIVE ownership (a dynamic local command is
-local while registered, submission after unload).
+**Breaking change (Unreleased).** The previous `execution: 'local' |
+'submission'` ownership metadata is REMOVED. A contribution is a client
+command, full stop: a `/name args` line that is not a command is an
+unclaimed prompt (the host pre-step owns skill expansion, and the inline
+skill lexicon owns its discovery), so a contribution no longer needs to
+declare that. Migration: drop `execution` (and declare `handler`, now
+required); a contribution that used `submission` to advertise a
+prompt-style name should instead not register a contribution at all — its
+line reaches the model as an ordinary prompt.
 
+## Theme registry (M5)
 ## Theme registry (M5)
 
 `registerTheme(contribution)` registers a named color palette into the

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -175,7 +175,8 @@ locally, never steered.
   a whole — upstream `source-failed` parity, so its command rows are removed
   until a synthesis succeeds again — while the host claims stay refreshed
   (input authority is never lost) and the collision is recorded on the
-  contribution's health and surfaced once.
+  contribution's health and surfaced once, naming every collision of that
+  failed pass.
 - **`sessionless`.** `true` lets the command run before a session exists
   (pure client commands: an overlay toggle, a picker). `false` (default)
   resolves/creates the session first — the host command surface is

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -176,7 +176,9 @@ locally, never steered.
   until a synthesis succeeds again — while the host claims stay refreshed
   (input authority is never lost) and the collision is recorded on the
   contribution's health and surfaced once, naming every collision of that
-  failed pass.
+  failed pass. That health record is a best-effort diagnostic: a handler
+  failure overlapping a live collision can be masked or cleared by it (see
+  the diagnostic-limitation note in `docs/surface-decisions.md`).
 - **`sessionless`.** `true` lets the command run before a session exists
   (pure client commands: an overlay toggle, a picker). `false` (default)
   resolves/creates the session first — the host command surface is

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -336,7 +336,10 @@ shell, or keyboard focus — the host owns all of it.
 
 - Every registration is FIBER-BOUND: the host disposes it when the
   plugin's Cordis fiber unloads (HMR, disable). Explicit `dispose()` is
-  idempotent.
+  idempotent, and a handle names ONE registration: a repeated or LATE
+  `dispose()` (a fiber cleanup arriving after an HMR reload re-registered the
+  same id) never removes the newer registration, and it never drops that
+  registration's health record.
 - Registrations may happen BEFORE any surface exists; the host renders
   them when the surface attaches.
 - The surface GENERATION is stable across start/stop/fullscreen/

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -172,7 +172,8 @@ locally, never steered.
 - **Host authority.** A name the current host catalog resolves is a HOST
   command: it executes through the command plane and a contribution can
   never shadow it — not in the dispatch, and not in the attachment gate
-  (the host handler owns its own attachment policy).
+  (a host command's own `input.attachments` declaration decides whether the
+  composer may attach anything).
 - **Two collision mechanisms.** A name owned by the TUI's OWN static catalog
   (`/status`, `/kill`, ...) is rejected at REGISTRATION: `registerCommand`
   throws and the plugin fails to load loudly. A name the SESSION's host

--- a/docs/footer-customization.md
+++ b/docs/footer-customization.md
@@ -7,7 +7,7 @@ builtin status items, create your own text or command items, and place
 plugin-provided items without editing YAML by hand.
 
 This guide covers the user-facing Footer surface. Plugin authors should also
-read [Extension API v1](extension-api.md).
+read [Extension API v2](extension-api.md).
 
 ## Quick start
 
@@ -503,7 +503,7 @@ terminal ownership, arbitrary ANSI, cursor control, shell execution, or
 keyboard focus through this slot.
 
 Plugin authors should use the full contract in
-[Extension API v1](extension-api.md) rather than copying internal TUI code.
+[Extension API v2](extension-api.md) rather than copying internal TUI code.
 
 ## Responsive and narrow-terminal behavior
 
@@ -672,5 +672,5 @@ Use the Stable package boundary:
 and feature-detect the configurable Footer item capability before relying on
 it.
 
-See [Extension API v1](extension-api.md) for the authoritative registration,
+See [Extension API v2](extension-api.md) for the authoritative registration,
 ownership, lifecycle, HMR identity, sanitization, and compatibility contract.

--- a/docs/input-and-card-polish.md
+++ b/docs/input-and-card-polish.md
@@ -454,7 +454,8 @@ pre-mode behavior).
 
 **Boundaries** (the compatibility contract):
 
-- **Submission** — Enter, Ctrl+Enter (queue), Ctrl+S (steer), the plugin
+- **Submission** — Enter, the accelerated chord (Ctrl+Enter: the OPPOSITE of
+  the busy-Enter preference), Ctrl+S (steer), the plugin
   action sink and the subagent submit path all serialize the mode into the
   wire form before the text leaves the app; the mode resets to `prompt`
   BEFORE the dispatch (a synchronous rejection restores the serialized text

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -492,6 +492,34 @@ name collision **fails loud — it never shadows**.
   attributing a host execution to the contribution), which is deliberately
   out of scope here.
 
+## Command attachments follow the descriptor declaration
+
+The composer's attachment policy is the DSH client contract
+(`ui-commands` `CommandInputDescriptor.attachments` +
+`CommandUiRuntime`/leading-claim submit), not a TUI-local guess:
+
+- A command may be invoked with attachments ONLY when its descriptor declares
+  `input.attachments: true`. An attachment-bearing line for any other command
+  is refused before dispatch (`/<name> does not accept attachments; remove
+  them first`) and the draft — attachment placeholder included — comes back.
+  The host executor re-enforces the same declaration at admission.
+- A DECLARING command receives the submitted IMAGES as encoded
+  `CommandSubmitAttachment`s on `commands.execute`; the host admits them
+  through its own attachment store (the client never saves them locally for a
+  command invocation).
+- A FILE attachment is refused even for a declaring command: the host
+  contract carries files as upload receipts, and this client has no seam to
+  produce one — fail closed rather than hand the host a placeholder with no
+  payload (`/<name> cannot receive file attachments in this client; remove
+  them first`).
+- A command submission CONSUMES its attachments only after handler success
+  (web parity): an error outcome restores the draft and KEEPS the staged
+  attachments, so a failed command never swallows the user's image.
+- TUI/core local commands and client contributions keep refusing attachments
+  outright: their line is a UI control, never agent-facing input. A skill
+  wrapper, a `/skill <name>` invocation and a plain prompt stay agent-facing
+  and deliver their attachments to the model.
+
 ## Focus is surface-adaptive
 
 Two surfaces, two consistent detail paths — no mouse hit-map in regular

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -416,29 +416,27 @@ then only executed:
   command plane driven from outside the submit boundary) has no gesture to
   honor and delivers queued.
 
-## Advertised is not Host-owned
+## Host commands outrank client contributions
 
-The busy queue/steer policy is skipped only for a confirmed HOST command —
-a slash name the current effective catalog advertises and that neither the
-TUI nor an extension owns. Ownership, not advertising, decides:
+The command surface follows the DSH client contribution contract
+(`ui-commands` `CommandUiRuntime.candidates`): the host catalog is merged
+with the live CLIENT command contributions by name, and a host/contribution
+name collision **fails loud — it never shadows**.
 
-- a TUI-owned skill wrapper (agent-facing input built by `loadSkill`),
-- an extension contribution (`TuiCommandContribution.execution`): a
-  `submission` command is a SUBMISSION LINE (the web composer's
-  unclaimed-line semantics) — its line is delivered with the resolved mode
-  (steer / queue) and the commands-service handler is NOT run for it; a
-  `local` one always executes and never steers. A submission needs a live
-  session, so `submission + sessionless` is rejected at registration
-  (fail fast at the extension boundary). `submission` is a DELIBERATE
-  BREAKING ownership change (Unreleased): the handler used to stay
-  authoritative in every non-steer mode — see the migration note in
-  `docs/extension-api.md` and `TuiCommandContribution.execution`,
-- the TUI-local set (`LOCAL_COMMANDS` plus dynamic local contributions).
-
-Everything else that is advertised resolves through the command plane
-without consulting the busy policy (e.g. `/compact`), and a claimed
-command the real session then lacks is consumed by the advertised-miss
-gate — never a plain model message.
+- A name the current effective host catalog resolves is a HOST command: it
+  executes through the command plane, and neither a TUI nor an extension
+  contribution can remove that claim. A claimed command the real session
+  then lacks is consumed by the advertised-miss gate — never a plain model
+  message.
+- A contribution is a client-owned command (menu row + client handler); it
+  executes locally and never steers. `sessionless: true` runs it before a
+  session exists, otherwise the session resolves first.
+- A colliding contribution is NOT installed: the candidate synthesis pass
+  fails as a whole (no partial menu), the collision is recorded against the
+  contribution's health and surfaced once, and the previous list stays.
+- Everything unclaimed is an ordinary prompt; TUI-local commands
+  (`LOCAL_COMMANDS`) and TUI-owned skill wrappers keep their own routes
+  (local execution, `loadSkill`).
 
 ## Focus is surface-adaptive
 

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -525,6 +525,15 @@ The composer's attachment policy is the DSH client contract
   outright: their line is a UI control, never agent-facing input. A skill
   wrapper, a `/skill <name>` invocation and a plain prompt stay agent-facing
   and deliver their attachments to the model.
+- The policy is applied against the FINAL authority, not only at submit time.
+  A deferred start may commit a session-scoped host command the standing view
+  could not see, so the dispatch RE-APPLIES the policy after
+  `ensureSession()` and before `commands.execute` (the host executor only
+  validates the payload it is handed — an empty one would run the handler with
+  the placeholder as a plain argument and then consume the draft). An unknown
+  `/name [image #1]` line that becomes an undeclared host command is refused,
+  a late declaring command receives its images, and a late declaring command
+  still refuses a file.
 
 ## Focus is surface-adaptive
 

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -445,6 +445,30 @@ name collision **fails loud — it never shadows**.
 - Everything unclaimed is an ordinary prompt; TUI-local commands
   (`LOCAL_COMMANDS`) and TUI-owned skill wrappers keep their own routes
   (local execution, `loadSkill`).
+- **Known diagnostic limitation — the health record is lossy.** One
+  contribution identity has THREE writers of its single extension-health
+  record: the candidate synthesis above, the client handler's settlement,
+  and the session command path that reports the HOST command executing under
+  a colliding name. The ledger keeps ONE failure generation per record and
+  deduplicates a repeat (the first message wins), so the record is not an
+  authoritative summary of every unrecovered failure:
+  - a client handler that fails while its name is colliding keeps its
+    failure out of the record (the collision message wins), and the
+    collision recovery then clears the record although the handler never
+    recovered;
+  - a client handler that succeeds while its name is colliding clears the
+    still-active collision record;
+  - a HOST command's own settlement under a colliding name is attributed to
+    the contribution's health record.
+
+  The user-visible behavior is unaffected and is asserted alongside: the
+  handler failure is notified and logged when it happens, the collision is
+  notified and withdraws the menu rows, and dispatch, claims and the menu
+  never consult health. The three flows are pinned by the `known limitation`
+  regressions in `test/submit-hot-path.test.ts`. Making the record
+  authoritative requires separating the failure SOURCES (and no longer
+  attributing a host execution to the contribution), which is deliberately
+  out of scope here.
 
 ## Focus is surface-adaptive
 

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -503,10 +503,16 @@ The composer's attachment policy is the DSH client contract
   is refused before dispatch (`/<name> does not accept attachments; remove
   them first`) and the draft — attachment placeholder included — comes back.
   The host executor re-enforces the same declaration at admission.
-- A DECLARING command receives the submitted IMAGES as encoded
+- A DECLARING **HOST** command receives the submitted IMAGES as encoded
   `CommandSubmitAttachment`s on `commands.execute`; the host admits them
   through its own attachment store (the client never saves them locally for a
-  command invocation).
+  command invocation). A TUI-owned command never carries a payload on that
+  wire: `/skill <name> ...` is itself a registered TUI command and a live
+  skill wrapper is TUI-owned, and neither declares `input.attachments` — the
+  host executor would reject the invocation before `loadSkill` ran. Their
+  placeholder line is delivered as-is and the images are admitted by the
+  delivery path (`loadSkill` → `prepareUserMessage`), which is what makes an
+  explicit `/skill <name> [image #1]` multimodal.
 - A FILE attachment is refused even for a declaring command: the host
   contract carries files as upload receipts, and this client has no seam to
   produce one — fail closed rather than hand the host a placeholder with no

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -434,6 +434,14 @@ name collision **fails loud — it never shadows**.
   (busy policy included) and the command plane is never asked to run it. A
   claimed command the real session then lacks is consumed by the
   advertised-miss gate — never a plain model message.
+- **A contribution is a slash-MENU entry: it claims the BARE token only.**
+  Upstream checks a contribution with `if (!bare) return undefined`, so
+  `/deploy` runs the client handler while `/deploy explain` is an ordinary
+  submission that reaches the model (busy policy and attachments included),
+  and the handler never runs for it. A contribution can therefore never be
+  invoked with a composer attachment — an attachment makes the line argued —
+  and its `handler` only ever sees `rawInput` without non-whitespace input
+  (trailing whitespace stays verbatim, like every other command surface).
 - **A name the host catalog RESOLVES is host territory in BOTH states.** The
   catalog's view of a line has three outcomes: it CLAIMS the line, it resolves
   the name but does not claim THIS line (an argued line of an execute-kind
@@ -475,28 +483,20 @@ name collision **fails loud — it never shadows**.
   could not see): a host claim or skill wrapper that appears with it takes the
   line, otherwise the client handler runs. A name the committed catalog
   resolves — claimed or not — ends the contribution's ownership of the line.
-  Three rules follow, all regression-pinned:
-  - **Attachments defer with the authority.** An attachment-bearing line is
-    refused as "local" only once the local classification is FINAL. For a
-    provisional session-backed contribution the refusal waits for the same
-    resolution, with the referenced drafts RESERVED across the window (a
-    concurrent attach-time prune must not drop them). A late host claim or
-    skill wrapper takes the line WITH its attachment; if the contribution
-    keeps it, the refusal fires after the session resolves and the draft —
-    placeholder intact — comes back for a re-attach decision.
+  Two rules follow, both regression-pinned (the deferred line is always the
+  BARE token, so there is no attachment to carry across the window and no
+  deferred refusal to fire):
   - **The captured registration is fenced.** The deferred resolution runs the
     EXACT contribution the user submitted. A dispose + reload during the
     window (even under the same owner and id) is a NEW generation that must
     never run in place of the submitted one, and a vanished name must never
     fall through to the command plane or the MODEL. The submission is aborted
     with a `/<name> is no longer available` notice and the draft is restored.
-  - **The line's final owner is re-asked, in both directions.** A late host
-    descriptor that CLAIMS the argued line takes it (the plane executes the
-    command even though the standing view had classified the line as
-    unclaimed), and a late descriptor that resolves the name WITHOUT claiming
-    the line takes it away from the contribution: the submission becomes an
-    ordinary delivery. The plane's ownership and the advertised-miss gate are
-    resolved from that same final answer.
+  - **The line's final owner is re-asked.** A late host descriptor that
+    resolves the name owns the bare line (the plane executes it, or — for a
+    name resolved without claiming the line, which can only be an argued
+    line — the submission becomes an ordinary delivery). The plane's ownership
+    and the advertised-miss gate are resolved from that same final answer.
 - A colliding contribution fails the candidate synthesis as a whole: the
   command SOURCE is marked failed (upstream `source-failed` parity — the
   source's whole group is removed), so no command row, client or host, is
@@ -579,13 +579,15 @@ The composer's attachment policy is the DSH client contract
 - A command submission CONSUMES its attachments only after handler success
   (web parity): an error outcome restores the draft and KEEPS the staged
   attachments, so a failed command never swallows the user's image.
-- TUI/core local commands, client contributions AND `!`/`!!` local shell
-  lines keep refusing attachments outright: their line is a UI control, never
-  agent-facing input. The shell has no attachment delivery path
-  (`runLocalShell` neither admits nor consumes drafts), so the refusal is
-  what keeps a placeholder from becoming shell arguments. A skill
-  wrapper, a `/skill <name>` invocation and a plain prompt stay agent-facing
-  and deliver their attachments to the model.
+- TUI/core local commands AND `!`/`!!` local shell lines keep refusing
+  attachments outright: their line is a UI control, never agent-facing input.
+  The shell has no attachment delivery path (`runLocalShell` neither admits nor
+  consumes drafts), so the refusal is what keeps a placeholder from becoming
+  shell arguments. A client command contribution needs no refusal: its
+  invocation is the BARE token only, so an attachment-bearing `/deploy [image
+  #1]` line is never its invocation — it is an ordinary multimodal submission.
+  A skill wrapper, a `/skill <name>` invocation and a plain prompt stay
+  agent-facing and deliver their attachments to the model.
 - The policy is applied against the FINAL authority, not only at submit time.
   A deferred start may commit a session-scoped host command the standing view
   could not see, so the dispatch RE-APPLIES the policy after

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -341,17 +341,40 @@ The 2026-08-24 UX plan's Focus click behavior is fullscreen-only:
   switches reset it. The old `hideThinking` / `focusThinkingVisible`
   visibility pair is deleted.
 - **Focus separates turn foundation from process chronology
-  (projection-only)**: a LEADING injected/system context prefix that
-  wakes a turn is persistent input context and renders before the
-  Thought — expanded and collapsed. Only the leading prefix counts;
-  mid-turn injected context stays process content at its real position.
-  Collapsed Focus summarizes inputs: opening injected context + ALL
-  human user rows precede the Thought, even when a user row was a
-  same-turn steer. Expanded Focus preserves process chronology after
-  the foundation: later steers and mid-turn injected context return to
-  their real positions. The durable `steer`/source facts are never
-  rewritten, and injected context still does not occupy Think/Tool/
-  Message slots and never counts as a tool.
+  (projection-only)**: a LEADING injected-context prefix that wakes a
+  turn is persistent input context and renders before the Thought —
+  expanded and collapsed. Only the leading prefix counts; mid-turn
+  injected context stays process content at its real position. Collapsed
+  Focus summarizes inputs: opening injected context + ALL human user rows
+  precede the Thought, even when a user row was a same-turn steer.
+  Expanded Focus preserves process chronology after the foundation: later
+  steers and mid-turn injected context return to their real positions.
+  The durable `steer`/source facts are never rewritten, and injected
+  context still does not occupy Think/Tool/Message slots and never counts
+  as a tool.
+- **The foundation is identified by a source-derived `context` marker,
+  never by bare `kind: 'system'`**: the fold writes `context: true` only
+  on injected-context rows (the non-user `user/message` path); llm/retry
+  and max-tokens rows are also `kind: 'system'` but are orchestration and
+  stay inside the expanded process (owner-marked) and hidden under the
+  collapsed Thought. The original leading-`kind` heuristic was falsified
+  by the retry-before-any-visible-output case, so the presentation-only
+  marker was added to the system row (a plan deviation from
+  "projection-only": the marker is not a durable field and no new session
+  event, and the icon stays a display field, never a semantic signal).
+
+## Skill invocation delivery follows the busy-Enter preference
+
+A human skill invocation (`/skill <name>` or a per-skill wrapper) is an
+agent-facing prompt, not a Host command: while the agent is running it
+follows the busy-Enter preference like a plain prompt — `steer` steers
+into the turn, `queue` (and idle) queues. The queue delivery is only
+used when the HOST injects the skill body (the dsh-tool-skill pre-step
+listener): the TUI's fallback body injection rides next-step, so a
+followup would let the body arrive before the user's words (the driver
+claims next-step first). Without the host loader the invocation keeps
+the steer path to preserve the original-line-before-body order — the
+documented exception, confined to compositions without the loader.
 
 ## Focus is surface-adaptive
 

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -440,7 +440,8 @@ name collision **fails loud — it never shadows**.
   costs a host command its input authority; the collision is recorded on the
   contribution's health (cleared only when it merges cleanly again, and never
   over a handler-failure record in the same slot) and surfaced once per
-  contribution identity and failure generation.
+  contribution identity and failure generation — one failed pass states EVERY
+  collision it found in the single notice slot.
 - Everything unclaimed is an ordinary prompt; TUI-local commands
   (`LOCAL_COMMANDS`) and TUI-owned skill wrappers keep their own routes
   (local execution, `loadSkill`).

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -438,8 +438,10 @@ name collision **fails loud — it never shadows**.
   displayed row can never execute a different command than it shows. The
   HOST CLAIMS are refreshed before the merge, so a failed synthesis never
   costs a host command its input authority; the collision is recorded on the
-  contribution's health (cleared only when it merges cleanly again, and never
-  over a handler-failure record in the same slot) and surfaced once per
+  contribution's health (cleared when it merges cleanly again, and only while
+  the record still shows that very collision message — so a handler failure
+  that OPENED the record is preserved; see the limitation note below for the
+  failure order that is not protected) and surfaced once per
   contribution identity and failure generation — one failed pass states EVERY
   collision it found in the single notice slot.
 - Everything unclaimed is an ordinary prompt; TUI-local commands
@@ -451,7 +453,8 @@ name collision **fails loud — it never shadows**.
   and the session command path that reports the HOST command executing under
   a colliding name. The ledger keeps ONE failure generation per record and
   deduplicates a repeat (the first message wins), so the record is not an
-  authoritative summary of every unrecovered failure:
+  authoritative summary of every unrecovered failure. The recovery rule above
+  is message-based, which protects one failure order only:
   - a client handler that fails while its name is colliding keeps its
     failure out of the record (the collision message wins), and the
     collision recovery then clears the record although the handler never

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -424,10 +424,15 @@ TUI nor an extension owns. Ownership, not advertising, decides:
 
 - a TUI-owned skill wrapper (agent-facing input built by `loadSkill`),
 - an extension contribution (`TuiCommandContribution.execution`): a
-  `submission` command flows through the busy policy like a skill
-  invocation — its LINE is delivered (steer / queue) and the plugin's
-  command handler is never run ahead of the queue it asked to join; a
-  `local` one always executes and never steers,
+  `submission` command is a SUBMISSION LINE (the web composer's
+  unclaimed-line semantics) — its line is delivered with the resolved mode
+  (steer / queue) and the commands-service handler is NOT run for it; a
+  `local` one always executes and never steers. A submission needs a live
+  session, so `submission + sessionless` is rejected at registration
+  (fail fast at the extension boundary). `submission` is a DELIBERATE
+  BREAKING ownership change (Unreleased): the handler used to stay
+  authoritative in every non-steer mode — see the migration note in
+  `docs/extension-api.md` and `TuiCommandContribution.execution`,
 - the TUI-local set (`LOCAL_COMMANDS` plus dynamic local contributions).
 
 Everything else that is advertised resolves through the command plane

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -423,19 +423,59 @@ The command surface follows the DSH client contribution contract
 with the live CLIENT command contributions by name, and a host/contribution
 name collision **fails loud — it never shadows**.
 
-- A name the current effective host catalog resolves is a HOST command: it
+- A LINE the current effective host catalog CLAIMS is a host command: it
   executes through the command plane, and neither a TUI nor an extension
-  contribution can remove that claim. A claimed command the real session
-  then lacks is consumed by the advertised-miss gate — never a plain model
-  message.
+  contribution can remove that claim. The claim belongs to the LINE, not to
+  the name — the DSH decision table (`ui-commands` `matchEnter`) claims the
+  BARE token of every host command and, for a `leadingInput` descriptor
+  (`CommandDescriptor.input !== undefined`: `/goal <objective>`, `/plan`),
+  its argued line as well. An argued line of an execute-kind command
+  (`/compact now`) is not a command invocation: it is an ordinary submission
+  (busy policy included) and the command plane is never asked to run it. A
+  claimed command the real session then lacks is consumed by the
+  advertised-miss gate — never a plain model message.
+- **A name the host catalog RESOLVES is host territory in BOTH states.** The
+  catalog's view of a line has three outcomes: it CLAIMS the line, it resolves
+  the name but does not claim THIS line (an argued line of an execute-kind
+  command), or it does not resolve the name at all. The LAST outcome leaves the
+  name to the client layers — an unknown slash line, or a live client
+  contribution, which may then run locally. The other two are host territory:
+  such a line is never classified as a local client command for the attachment
+  gate, a same-named contribution never runs for it, and the middle state is an
+  ordinary submission (`/compact <args>`). A contribution can only coexist with
+  a resolved host name in the failed-source collision state, so the middle
+  state's contribution rule is the shape that state takes.
+- **The claim is resolved against the FINAL catalog, and submit-time
+  NON-invocations are sticky.** On a deferred start the standing view cannot
+  see the session-scoped catalog, so the plane's ownership of the line is asked
+  AGAIN after `ensureSession()` and the advertised-miss gate follows that same
+  answer: a name the committed catalog resolves without claiming the line is
+  delivered as an ordinary submission (never consumed as an "advertised miss"),
+  and a name the committed catalog DOES claim on this line is executed by the
+  plane even when the standing view had classified the line as unclaimed.
+  A line the catalog already resolved WITHOUT claiming it when it was submitted
+  can never become an invocation afterwards: if that name disappears from the
+  final catalog, the line stays an ordinary submission (the plane is not asked,
+  and the submit-time name claim does not consume it as a miss), and the
+  attachment gate keeps treating it as host territory — it never falls back to
+  a same-named client contribution that the submit-time routing had already
+  excluded.
+  The CLIENT-LOCAL eligibility is sticky in the same way: only a line whose
+  initial route was a LIVE client contribution keeps the client-local
+  classification under the final authority (that is the deferral case above),
+  so a contribution that appears DURING the deferred window never reclassifies
+  a generic line as a UI control — the routing already decided, its handler
+  never runs for that submission, and an attachment on the line is delivered
+  as an ordinary multimodal prompt.
 - A contribution is a client-owned command (menu row + client handler); it
   executes locally and never steers. `sessionless: true` runs it before a
   session exists, otherwise the session resolves first.
 - A **deferred start** settles a session-backed contribution's authority only
   AFTER the session exists (the session commits the catalog the standing view
   could not see): a host claim or skill wrapper that appears with it takes the
-  line, otherwise the client handler runs. Two rules follow, both
-  regression-pinned:
+  line, otherwise the client handler runs. A name the committed catalog
+  resolves — claimed or not — ends the contribution's ownership of the line.
+  Three rules follow, all regression-pinned:
   - **Attachments defer with the authority.** An attachment-bearing line is
     refused as "local" only once the local classification is FINAL. For a
     provisional session-backed contribution the refusal waits for the same
@@ -450,6 +490,13 @@ name collision **fails loud — it never shadows**.
     never run in place of the submitted one, and a vanished name must never
     fall through to the command plane or the MODEL. The submission is aborted
     with a `/<name> is no longer available` notice and the draft is restored.
+  - **The line's final owner is re-asked, in both directions.** A late host
+    descriptor that CLAIMS the argued line takes it (the plane executes the
+    command even though the standing view had classified the line as
+    unclaimed), and a late descriptor that resolves the name WITHOUT claiming
+    the line takes it away from the contribution: the submission becomes an
+    ordinary delivery. The plane's ownership and the advertised-miss gate are
+    resolved from that same final answer.
 - A colliding contribution fails the candidate synthesis as a whole: the
   command SOURCE is marked failed (upstream `source-failed` parity — the
   source's whole group is removed), so no command row, client or host, is
@@ -465,7 +512,9 @@ name collision **fails loud — it never shadows**.
   collision it found in the single notice slot.
 - Everything unclaimed is an ordinary prompt; TUI-local commands
   (`LOCAL_COMMANDS`) and TUI-owned skill wrappers keep their own routes
-  (local execution, `loadSkill`).
+  (local execution, `loadSkill`) — they are the one thing the line-level host
+  claim must not steal, because the dispatch excludes them from the host
+  route in the same way.
 - **Known diagnostic limitation — the health record is lossy.** One
   contribution identity has THREE writers of its single extension-health
   record: the candidate synthesis above, the client handler's settlement,
@@ -498,11 +547,20 @@ The composer's attachment policy is the DSH client contract
 (`ui-commands` `CommandInputDescriptor.attachments` +
 `CommandUiRuntime`/leading-claim submit), not a TUI-local guess:
 
-- A command may be invoked with attachments ONLY when its descriptor declares
-  `input.attachments: true`. An attachment-bearing line for any other command
-  is refused before dispatch (`/<name> does not accept attachments; remove
-  them first`) and the draft — attachment placeholder included — comes back.
-  The host executor re-enforces the same declaration at admission.
+- A command may be invoked with attachments ONLY when the descriptor that
+  CLAIMS the line declares `input.attachments: true`. An attachment-bearing
+  line for any other CLAIMED command is refused before dispatch
+  (`/<name> does not accept attachments; remove them first`) and the draft —
+  attachment placeholder included — comes back. The host executor re-enforces
+  the same declaration at admission.
+- The claim is asked for the LINE, never for the name
+  (`CommandDescriptor.input`, upstream `matchEnter`): a `leadingInput`
+  command (`/goal <objective>`) claims its argued line, while an execute-kind
+  command (`/compact`) claims the BARE token only. `/compact <anything>` is
+  therefore no command invocation at all — it is an ordinary submission that
+  keeps its attachments and follows the busy policy — and the command plane
+  is never asked to run it (the host registry resolves by NAME, so handing it
+  over would run the command anyway).
 - A DECLARING **HOST** command receives the submitted IMAGES as encoded
   `CommandSubmitAttachment`s on `commands.execute`; the host admits them
   through its own attachment store (the client never saves them locally for a

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -431,9 +431,16 @@ name collision **fails loud — it never shadows**.
 - A contribution is a client-owned command (menu row + client handler); it
   executes locally and never steers. `sessionless: true` runs it before a
   session exists, otherwise the session resolves first.
-- A colliding contribution is NOT installed: the candidate synthesis pass
-  fails as a whole (no partial menu), the collision is recorded against the
-  contribution's health and surfaced once, and the previous list stays.
+- A colliding contribution fails the candidate synthesis as a whole: the
+  command SOURCE is marked failed (upstream `source-failed` parity — the
+  source's whole group is removed), so no command row, client or host, is
+  offered until a synthesis succeeds again. Nothing stale survives: a
+  displayed row can never execute a different command than it shows. The
+  HOST CLAIMS are refreshed before the merge, so a failed synthesis never
+  costs a host command its input authority; the collision is recorded on the
+  contribution's health (cleared only when it merges cleanly again, and never
+  over a handler-failure record in the same slot) and surfaced once per
+  contribution identity and failure generation.
 - Everything unclaimed is an ordinary prompt; TUI-local commands
   (`LOCAL_COMMANDS`) and TUI-owned skill wrappers keep their own routes
   (local execution, `loadSkill`).

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -521,8 +521,11 @@ The composer's attachment policy is the DSH client contract
 - A command submission CONSUMES its attachments only after handler success
   (web parity): an error outcome restores the draft and KEEPS the staged
   attachments, so a failed command never swallows the user's image.
-- TUI/core local commands and client contributions keep refusing attachments
-  outright: their line is a UI control, never agent-facing input. A skill
+- TUI/core local commands, client contributions AND `!`/`!!` local shell
+  lines keep refusing attachments outright: their line is a UI control, never
+  agent-facing input. The shell has no attachment delivery path
+  (`runLocalShell` neither admits nor consumes drafts), so the refusal is
+  what keeps a placeholder from becoming shell arguments. A skill
   wrapper, a `/skill <name>` invocation and a plain prompt stay agent-facing
   and deliver their attachments to the model.
 - The policy is applied against the FINAL authority, not only at submit time.

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -340,6 +340,18 @@ The 2026-08-24 UX plan's Focus click behavior is fullscreen-only:
   state, and neither Focus ON/OFF nor fullscreen ON/OFF nor session
   switches reset it. The old `hideThinking` / `focusThinkingVisible`
   visibility pair is deleted.
+- **Focus separates turn foundation from process chronology
+  (projection-only)**: a LEADING injected/system context prefix that
+  wakes a turn is persistent input context and renders before the
+  Thought — expanded and collapsed. Only the leading prefix counts;
+  mid-turn injected context stays process content at its real position.
+  Collapsed Focus summarizes inputs: opening injected context + ALL
+  human user rows precede the Thought, even when a user row was a
+  same-turn steer. Expanded Focus preserves process chronology after
+  the foundation: later steers and mid-turn injected context return to
+  their real positions. The durable `steer`/source facts are never
+  rewritten, and injected context still does not occupy Think/Tool/
+  Message slots and never counts as a tool.
 
 ## Focus is surface-adaptive
 

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -363,35 +363,57 @@ The 2026-08-24 UX plan's Focus click behavior is fullscreen-only:
   "projection-only": the marker is not a durable field and no new session
   event, and the icon stays a display field, never a semantic signal).
 
-## Skill invocation delivery follows the busy-Enter preference
+## The composer submission policy is the WEB policy
+
+The busy-Enter preference (`busyEnter`, default `queue`) is owned by the
+gesture, not by the command: the boundary applies the WEB
+`ComposerSubmissionPolicy.resolve()` contract (baseline
+`dsh-v0.1.3-alpha.2`) verbatim and resolves ONCE per submission.
+
+```text
+!running              -> queue
+gesture === 'enter'   -> the preferred mode (busyEnter)
+accelerated           -> the OPPOSITE of the preferred mode
+```
+
+The Cmd/Ctrl-accelerated chord (Ctrl+Enter) is therefore "the other
+behavior", never a fixed queue: with the DEFAULT `busyEnter=queue` it
+STEERS, and under `busyEnter=steer` it queues. The public `queue-draft` /
+`submit-draft` extension actions and the replacement editor's
+`queue-submit` are EXPLICIT delivery commands, not gestures — they deliver
+exactly what they say (the app raises `explicit-queue`). Those two
+semantics must never be merged again: a fixed-queue chord gets the default
+configuration backwards.
+
+## Skill invocation delivery follows the resolved mode
 
 A human skill invocation (`/skill <name>` or a per-skill wrapper) is an
-agent-facing prompt, not a Host command: while the agent is running it
-follows the busy-Enter preference like a plain prompt — `steer` steers
-into the turn, `queue` (and idle) queues. The queue delivery is only
-used when the HOST injects the skill body (the dsh-tool-skill pre-step
-listener): the TUI's fallback body injection rides next-step, so a
-followup would let the body arrive before the user's words (the driver
-claims next-step first). Without the host loader the invocation keeps
-the steer path to preserve the original-line-before-body order — the
-documented exception, confined to compositions without the loader.
+agent-facing prompt, not a Host command: it follows the resolved mode.
+`loadSkill` owns the delivery in BOTH modes — it builds the NORMALIZED
+`/<name> <args>` line, steers or queues it, and injects the body whenever
+the HOST's `dsh-tool-skill` pre-step listener does not (a composition
+without that loader, where the TUI fallback rides next-step). Without the
+loader the invocation keeps the order-preserving steer even under a queue
+mode: a followup would let the body arrive before the user's words (the
+driver claims next-step first) — the documented exception, confined to
+compositions without the loader.
 
-The mode is resolved ONCE, at the submitting gesture's own boundary, and
+The mode is resolved once, at the submitting gesture's own boundary, and
 then only executed:
 
-- The dispatch boundary resolves `queue | steer` from the agent's liveness,
-  the persisted preference, and the one-shot Ctrl+Enter force-queue chord,
-  and binds it for the command execution that launches the delivery
+- The dispatch boundary resolves `queue | steer` (the policy above) and
+  binds it for the command execution that launches the delivery
   (`withDelivery`). The skill delivery accepts that value; it never
-  re-reads `busyEnter` or `agent.status`, because a chord is a property of
-  the gesture that settings cannot reconstruct — and an async draft
+  re-reads `busyEnter` or `agent.status` — a gesture is a property of the
+  dispatch that settings cannot reconstruct, and an async draft
   preparation must not let a concurrent settings edit or status change
   re-decide the mode.
 - The `/skill` picker (a modal selection with no dispatcher above it) is
-  its own boundary: it resolves the same preference rule at picker open
-  (`prefersSteer`) and hands the result to the delivery.
+  its own boundary, and its SELECTION is the boundary moment: the mode is
+  resolved when a row is chosen, never when the modal opened (the agent
+  may have gone idle, or busy, while it was up).
 - A TUI-owned skill command executed with no submission behind it (the
-  command plane driven from outside the submit boundary) has no chord to
+  command plane driven from outside the submit boundary) has no gesture to
   honor and delivers queued.
 
 ## Advertised is not Host-owned
@@ -403,7 +425,9 @@ TUI nor an extension owns. Ownership, not advertising, decides:
 - a TUI-owned skill wrapper (agent-facing input built by `loadSkill`),
 - an extension contribution (`TuiCommandContribution.execution`): a
   `submission` command flows through the busy policy like a skill
-  invocation, a `local` one never steers,
+  invocation — its LINE is delivered (steer / queue) and the plugin's
+  command handler is never run ahead of the queue it asked to join; a
+  `local` one always executes and never steers,
 - the TUI-local set (`LOCAL_COMMANDS` plus dynamic local contributions).
 
 Everything else that is advertised resolves through the command plane

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -376,6 +376,41 @@ claims next-step first). Without the host loader the invocation keeps
 the steer path to preserve the original-line-before-body order — the
 documented exception, confined to compositions without the loader.
 
+The mode is resolved ONCE, at the submitting gesture's own boundary, and
+then only executed:
+
+- The dispatch boundary resolves `queue | steer` from the agent's liveness,
+  the persisted preference, and the one-shot Ctrl+Enter force-queue chord,
+  and binds it for the command execution that launches the delivery
+  (`withDelivery`). The skill delivery accepts that value; it never
+  re-reads `busyEnter` or `agent.status`, because a chord is a property of
+  the gesture that settings cannot reconstruct — and an async draft
+  preparation must not let a concurrent settings edit or status change
+  re-decide the mode.
+- The `/skill` picker (a modal selection with no dispatcher above it) is
+  its own boundary: it resolves the same preference rule at picker open
+  (`prefersSteer`) and hands the result to the delivery.
+- A TUI-owned skill command executed with no submission behind it (the
+  command plane driven from outside the submit boundary) has no chord to
+  honor and delivers queued.
+
+## Advertised is not Host-owned
+
+The busy queue/steer policy is skipped only for a confirmed HOST command —
+a slash name the current effective catalog advertises and that neither the
+TUI nor an extension owns. Ownership, not advertising, decides:
+
+- a TUI-owned skill wrapper (agent-facing input built by `loadSkill`),
+- an extension contribution (`TuiCommandContribution.execution`): a
+  `submission` command flows through the busy policy like a skill
+  invocation, a `local` one never steers,
+- the TUI-local set (`LOCAL_COMMANDS` plus dynamic local contributions).
+
+Everything else that is advertised resolves through the command plane
+without consulting the busy policy (e.g. `/compact`), and a claimed
+command the real session then lacks is consumed by the advertised-miss
+gate — never a plain model message.
+
 ## Focus is surface-adaptive
 
 Two surfaces, two consistent detail paths — no mouse hit-map in regular

--- a/docs/surface-decisions.md
+++ b/docs/surface-decisions.md
@@ -431,6 +431,25 @@ name collision **fails loud — it never shadows**.
 - A contribution is a client-owned command (menu row + client handler); it
   executes locally and never steers. `sessionless: true` runs it before a
   session exists, otherwise the session resolves first.
+- A **deferred start** settles a session-backed contribution's authority only
+  AFTER the session exists (the session commits the catalog the standing view
+  could not see): a host claim or skill wrapper that appears with it takes the
+  line, otherwise the client handler runs. Two rules follow, both
+  regression-pinned:
+  - **Attachments defer with the authority.** An attachment-bearing line is
+    refused as "local" only once the local classification is FINAL. For a
+    provisional session-backed contribution the refusal waits for the same
+    resolution, with the referenced drafts RESERVED across the window (a
+    concurrent attach-time prune must not drop them). A late host claim or
+    skill wrapper takes the line WITH its attachment; if the contribution
+    keeps it, the refusal fires after the session resolves and the draft —
+    placeholder intact — comes back for a re-attach decision.
+  - **The captured registration is fenced.** The deferred resolution runs the
+    EXACT contribution the user submitted. A dispose + reload during the
+    window (even under the same owner and id) is a NEW generation that must
+    never run in place of the submitted one, and a vanished name must never
+    fall through to the command plane or the MODEL. The submission is aborted
+    with a `/<name> is no longer available` notice and the draft is restored.
 - A colliding contribution fails the candidate synthesis as a whole: the
   command SOURCE is marked failed (upstream `source-failed` parity — the
   source's whole group is removed), so no command row, client or host, is

--- a/examples/plugins/interactive-shell/src/index.ts
+++ b/examples/plugins/interactive-shell/src/index.ts
@@ -123,7 +123,6 @@ export function apply(ctx: Context): void {
     id: 'example-interactive-shell',
     name: 'shell',
     description: 'Run the Phase-5 interactive-shell example (Unstable raw seam).',
-    execution: 'local',
     handler: runShell,
   })
 }

--- a/examples/plugins/questionnaire/src/index.ts
+++ b/examples/plugins/questionnaire/src/index.ts
@@ -70,7 +70,6 @@ export function apply(ctx: Context): void {
     id: 'example-questionnaire',
     name: 'questionnaire',
     description: 'Run the Phase-5 questionnaire example (imperative UI broker).',
-    execution: 'local',
     handler: runQuestionnaire,
   })
 }

--- a/scripts/advanced-plugin-smoke.mjs
+++ b/scripts/advanced-plugin-smoke.mjs
@@ -232,7 +232,7 @@ function main() {
           }
           return {
             api: () => ({
-              apiVersion: 1,
+              apiVersion: 2,
               hostVersion: 'test',
               capabilities: new Set(['advanced.input.capture', 'advanced.ui.interactive', 'advanced.editor.control']),
               deprecations: new Map(),

--- a/scripts/examples-plugin-smoke.mjs
+++ b/scripts/examples-plugin-smoke.mjs
@@ -234,7 +234,7 @@ function main() {
             const makeHandle = () => ({ id: 'x', invalidate: () => {}, replace: () => {}, dispose: () => {} })
             return {
               api: () => ({
-                apiVersion: 1,
+                apiVersion: 2,
                 hostVersion: 'test',
                 capabilities: new Set([
                   'slot.chrome.header.badge', 'slot.input.dock.item', 'slot.chrome.footer.status',

--- a/scripts/phase4-plugin-smoke.mjs
+++ b/scripts/phase4-plugin-smoke.mjs
@@ -236,7 +236,7 @@ function main() {
           }
           return {
             api: () => ({
-              apiVersion: 1,
+              apiVersion: 2,
               hostVersion: 'test',
               capabilities: new Set(['advanced.input.capture', 'advanced.ui.interactive', 'advanced.editor.control']),
               deprecations: new Map(),

--- a/scripts/unstable-plugin-smoke.mjs
+++ b/scripts/unstable-plugin-smoke.mjs
@@ -231,7 +231,7 @@ function main() {
           }
           return {
             api: () => ({
-              apiVersion: 1,
+              apiVersion: 2,
               hostVersion: 'test',
               capabilities: new Set(['unstable.input.raw', 'unstable.surface.handle']),
               deprecations: new Map(),

--- a/scripts/vim-plugin-smoke.mjs
+++ b/scripts/vim-plugin-smoke.mjs
@@ -232,7 +232,7 @@ function main() {
         function mockService() {
           const makeHandle = () => ({ id: 'x', invalidate: () => {}, replace: () => {}, dispose: () => {} })
           return {
-            api: () => ({ apiVersion: 1, hostVersion: 'test', capabilities: new Set(['slot.input.widget', 'slot.input.dock.item', 'slot.chrome.header.badge', 'slot.chrome.footer.status']) }),
+            api: () => ({ apiVersion: 2, hostVersion: 'test', capabilities: new Set(['slot.input.widget', 'slot.input.dock.item', 'slot.chrome.header.badge', 'slot.chrome.footer.status']) }),
             register: () => makeHandle(),
             registerCommand: () => makeHandle(),
             registerTheme: () => makeHandle(),

--- a/src/attachment/placeholder.ts
+++ b/src/attachment/placeholder.ts
@@ -76,3 +76,14 @@ export function draftHasAttachments(
 ): boolean {
   return expandAttachmentPlaceholders(text, imageStore, fileStore).some(segment => segment.type !== 'text')
 }
+
+/** Whether text contains a currently live GENERIC-FILE placeholder (a
+ * command invocation cannot carry one: the host expects an upload receipt
+ * this client has no seam to produce). */
+export function draftHasFiles(
+  text: string,
+  imageStore: DraftImageStoreLike,
+  fileStore?: DraftFileStoreLike,
+): boolean {
+  return expandAttachmentPlaceholders(text, imageStore, fileStore).some(segment => segment.type === 'file')
+}

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -57,6 +57,9 @@ interface Contribution {
    * empty snapshot in between). */
   readonly generation: number
   readonly handler: TuiLocalCommandHandler
+  /** The handle minted for THIS registration (identity for the caller's
+   * generation-aware cleanup). */
+  handle?: TuiCommandHandle
   disposed: boolean
 }
 
@@ -162,24 +165,38 @@ export class CommandBridge {
       handler: spec.handler,
       disposed: false,
     }
+    // IDENTITY-bound handle: a handle captured before a re-registration under
+    // the same id must never remove the NEWER registration (a repeated or
+    // late fiber cleanup would otherwise kill a live contribution —
+    // `dispose(id)` cannot tell the generations apart).
+    const handle: TuiCommandHandle = {
+      id: spec.id,
+      dispose: () => this.disposeContribution(contribution),
+    }
+    contribution.handle = handle
     this.contributions.set(spec.id, contribution)
     this.revision += 1
     this.onInvalidate()
-    return {
-      kind: 'registered',
-      handle: {
-        id: spec.id,
-        dispose: () => this.dispose(spec.id),
-      },
-    }
+    return { kind: 'registered', handle }
   }
 
   /** Remove one contribution by id (idempotent). */
   dispose(id: string): void {
     const contribution = this.contributions.get(id)
     if (contribution === undefined || contribution.disposed) return
+    this.disposeContribution(contribution)
+  }
+
+  /** Remove ONE registration by identity (the handle's own record).
+   * Idempotent, and a no-op for an entry the map no longer holds: the id may
+   * already belong to a NEWER registration (a dispose + re-register under the
+   * same id is a new generation, and a late cleanup of the old handle must
+   * leave it alive). */
+  private disposeContribution(contribution: Contribution): void {
+    if (contribution.disposed) return
     contribution.disposed = true
-    this.contributions.delete(id)
+    if (this.contributions.get(contribution.id) !== contribution) return
+    this.contributions.delete(contribution.id)
     this.revision += 1
     this.onInvalidate()
   }
@@ -189,6 +206,16 @@ export class CommandBridge {
     for (const [id, contribution] of [...this.contributions]) {
       if (contribution.owner === owner) this.dispose(id)
     }
+  }
+
+  /** Whether one handle still names the LIVE registration for its id. The
+   * caller's cleanup consults it before touching state that is keyed by id
+   * alone — the extension ledger's health record is (slot, owner, id), so a
+   * STALE handle's cleanup would otherwise untrack a NEWER generation's
+   * record. */
+  isCurrent(handle: TuiCommandHandle): boolean {
+    const contribution = this.contributions.get(handle.id)
+    return contribution !== undefined && !contribution.disposed && contribution.handle === handle
   }
 
   /** The owning fiber of one contribution id (the runner-facing health

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -15,8 +15,9 @@
  * - `/name args...` ALWAYS keeps `invocation.rawInput` verbatim — the
  *   bridge never re-parses or rewrites arguments (the skill rawInput
  *   regression gate);
- * - busy Enter keeps classifying by the EFFECTIVE ownership: a dynamic
- *   local command is local while registered, submission after unload;
+ * - a contribution is CLIENT-OWNED while registered; after unload the name
+ *   returns to the ordinary routes (a host claim, or an unclaimed prompt —
+ *   never a lingering client route);
  * - dynamic unload removes the contribution (fiber-bound, like every
  *   extension registration);
  * - near-synonym command conflicts keep the AGENTS hard rule: the bridge
@@ -48,8 +49,7 @@ interface Contribution {
   readonly description: string
   readonly sessionless: boolean
   readonly owner: string
-  readonly argumentProvider: TuiAutocompleteProvider | undefined
-  readonly handler: TuiLocalCommandHandler | undefined
+  readonly handler: TuiLocalCommandHandler
   disposed: boolean
 }
 
@@ -89,6 +89,20 @@ export class CommandBridge {
       throw new Error(`duplicate command contribution id "${spec.id}" (owner "${this.contributions.get(spec.id)?.owner}")`)
     }
     if (spec.name === '') throw new Error('command contribution name must not be empty')
+    // A contribution IS its client behavior: a caller that bypasses the
+    // public types (plain JS, a stale compiled plugin) must fail LOUD at the
+    // boundary rather than install a menu row that can never run.
+    if (typeof spec.handler !== 'function') {
+      throw new Error(`command contribution "${spec.name}" must declare its handler (the client behavior)`)
+    }
+    // The removed `execution` ownership metadata must never be SILENTLY
+    // reinterpreted: a stale plugin still declaring it is rejected loudly
+    // (breaking API, explicit migration — see docs/extension-api.md).
+    if ('execution' in spec) {
+      throw new Error(
+        `command contribution "${spec.name}" declares the removed 'execution' ownership metadata — a contribution is a client-owned command now; drop 'execution' and declare 'handler' (see docs/extension-api.md)`,
+      )
+    }
     // P1-04: the host-owned catalog is authoritative — an EXACT collision
     // with a host command is rejected loudly (a plugin can never shadow
     // /status, /sessions, ...). Near-synonyms of host names are rejected
@@ -132,7 +146,6 @@ export class CommandBridge {
       description: spec.description,
       sessionless: spec.sessionless ?? false,
       owner,
-      argumentProvider: spec.argumentProvider,
       handler: spec.handler,
       disposed: false,
     }
@@ -184,17 +197,6 @@ export class CommandBridge {
     return false
   }
 
-  /** Whether a command name is sessionless (static set OR a live dynamic
-   * sessionless contribution). */
-  isSessionless(name: string, staticSessionless: ReadonlySet<string>): boolean {
-    if (staticSessionless.has(name)) return true
-    for (const contribution of this.contributions.values()) {
-      if (contribution.disposed) continue
-      if (contribution.name === name && contribution.sessionless) return true
-    }
-    return false
-  }
-
   /** The live contribution for one name, or undefined. */
   find(name: string): Contribution | undefined {
     for (const contribution of this.contributions.values()) {
@@ -215,11 +217,6 @@ export class CommandBridge {
    * back to the commands service for TUI-owned sessionless names). */
   handlerFor(name: string): TuiLocalCommandHandler | undefined {
     return this.find(name)?.handler
-  }
-
-  /** The argument autocomplete provider for one name, or undefined. */
-  argumentProviderFor(name: string): TuiAutocompleteProvider | undefined {
-    return this.find(name)?.argumentProvider
   }
 
   /** An immutable snapshot (diagnostics + /status). */

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -1,23 +1,17 @@
 /**
- * The CommandBridge (M5, plan §10): the extension seam over the host's
- * slash-command execution. The bridge itself never executes a command — it
- * carries the TUI's OWNERSHIP metadata, and the runner decides the route
- * from it:
- *
- * - `execution: 'local'` — the command ALWAYS executes locally (TUI
- *   control commands like /status, /settings), never steered, regardless of
- *   the busyEnter preference: the contribution's own bridge handler when one
- *   is declared, otherwise the `ctx.commands` definition handler. This is
- *   exactly the semantic of the static LOCAL_COMMANDS set, now extensible by
- *   plugins.
- * - `execution: 'submission'` — the command is a SUBMISSION LINE, not a
- *   command execution: it flows through the session submission policy
- *   (steer/queue) like any skill invocation, the commands-service handler
- *   is NOT run for it, and the plugin's own pre-step owns any expansion —
- *   the web composer's unclaimed-line semantics. BREAKING (Unreleased): the
- *   handler used to stay authoritative in every non-steer mode.
+ * The CommandBridge (M5, plan §10): the extension seam for CLIENT-OWNED
+ * commands. A contribution is exactly the DSH client command contribution
+ * (`ui-commands` CommandContribution): a slash name whose behavior lives
+ * entirely on the client (no host descriptor) and which is merged into the
+ * `/` menu with the host catalog. The bridge itself never executes
+ * anything — the runner runs the contribution's own handler locally, never
+ * steered, exactly like the static LOCAL_COMMANDS set (the TUI's own
+ * /status, /settings). A contribution whose name is a host command FAILS
+ * LOUD at candidate synthesis and never shadows it.
  *
  * Contract (plan §10):
+ * - a contribution needs a declared handler (its client behavior) and needs
+ *   no commands-service definition;
  * - `/name args...` ALWAYS keeps `invocation.rawInput` verbatim — the
  *   bridge never re-parses or rewrites arguments (the skill rawInput
  *   regression gate);
@@ -39,25 +33,19 @@
 import type { TuiAutocompleteProvider } from './extension/public-types.ts'
 import type { TuiCommandContribution, TuiCommandHandle, TuiLocalCommandHandler, TuiCommandBridgeSnapshot } from './extension/public-types.ts'
 
-/**
- * One command contribution: ownership metadata over a slash name — either a
- * locally executed command (`local`) or an agent-facing submission line
- * (`submission`).
- */
+/** One client command contribution: a slash name the client owns. */
 
 
 /** Registration outcome for a new contribution. */
 type RegisterOutcome =
   | { kind: 'registered'; handle: TuiCommandHandle }
   | { kind: 'conflict'; existingOwner: string; nearSynonym?: string }
-  | { kind: 'invalid'; reason: string }
 
 /** The bridge's internal registration record. */
 interface Contribution {
   readonly id: string
   readonly name: string
   readonly description: string
-  readonly execution: 'local' | 'submission'
   readonly sessionless: boolean
   readonly owner: string
   readonly argumentProvider: TuiAutocompleteProvider | undefined
@@ -101,19 +89,6 @@ export class CommandBridge {
       throw new Error(`duplicate command contribution id "${spec.id}" (owner "${this.contributions.get(spec.id)?.owner}")`)
     }
     if (spec.name === '') throw new Error('command contribution name must not be empty')
-    // A submission contribution is an AGENT-FACING line: it needs a live
-    // session to be delivered to, so `sessionless` (which lets a LOCAL
-    // command run before any session exists) is not a valid combination —
-    // accepting it would let the line fall into the local path and execute a
-    // handler the submission ownership explicitly does not run. Rejected at
-    // registration: fail fast at the extension boundary, never a silent
-    // reinterpretation at dispatch time.
-    if (spec.execution === 'submission' && spec.sessionless === true) {
-      return {
-        kind: 'invalid',
-        reason: 'a submission command is delivered to the session, so it cannot be sessionless — declare execution: \'local\' if the command must run without a live session',
-      }
-    }
     // P1-04: the host-owned catalog is authoritative — an EXACT collision
     // with a host command is rejected loudly (a plugin can never shadow
     // /status, /sessions, ...). Near-synonyms of host names are rejected
@@ -155,7 +130,6 @@ export class CommandBridge {
       id: spec.id,
       name: spec.name,
       description: spec.description,
-      execution: spec.execution,
       sessionless: spec.sessionless ?? false,
       owner,
       argumentProvider: spec.argumentProvider,
@@ -198,14 +172,14 @@ export class CommandBridge {
     return this.contributions.get(id)?.owner
   }
 
-  /** Whether a command name is EFFECTIVELY local (static core set OR a
-   * live dynamic local contribution). The static set stays the baseline —
-   * the bridge only ADDS dynamic ownership. */
+  /** Whether a command name is a CLIENT-OWNED local command (static core
+   * set OR a live contribution). The static set stays the baseline — the
+   * bridge only ADDS client-owned names. */
   isLocal(name: string, staticLocal: ReadonlySet<string>): boolean {
     if (staticLocal.has(name)) return true
     for (const contribution of this.contributions.values()) {
       if (contribution.disposed) continue
-      if (contribution.name === name && contribution.execution === 'local') return true
+      if (contribution.name === name) return true
     }
     return false
   }
@@ -237,20 +211,10 @@ export class CommandBridge {
     return this.find(name)?.id
   }
 
-  /** The handler for one name, or undefined (dispatch falls back to the
-   * commands service). */
+  /** The client handler for one name, or undefined (the dispatch falls
+   * back to the commands service for TUI-owned sessionless names). */
   handlerFor(name: string): TuiLocalCommandHandler | undefined {
     return this.find(name)?.handler
-  }
-
-  /** The LOCAL handler for one name: the bridge handler of a contribution
-   * whose EFFECTIVE ownership is `local`, or undefined. This is the
-   * implementation the TUI runs locally — a `submission` contribution's
-   * handler is never executed by the TUI, and a handler-less local
-   * contribution falls back to the commands-service definition. */
-  localHandlerFor(name: string): TuiLocalCommandHandler | undefined {
-    const contribution = this.find(name)
-    return contribution !== undefined && contribution.execution === 'local' ? contribution.handler : undefined
   }
 
   /** The argument autocomplete provider for one name, or undefined. */
@@ -267,7 +231,6 @@ export class CommandBridge {
         id: contribution.id,
         name: contribution.name,
         description: contribution.description,
-        execution: contribution.execution,
         sessionless: contribution.sessionless,
         owner: contribution.owner,
       }))

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -1,17 +1,21 @@
 /**
  * The CommandBridge (M5, plan §10): the extension seam over the host's
- * slash-command execution. It does NOT re-implement command execution —
- * actual execution continues through the existing `ctx.commands` service
- * (register + execute). The bridge adds the TUI's OWNERSHIP metadata:
+ * slash-command execution. The bridge itself never executes a command — it
+ * carries the TUI's OWNERSHIP metadata, and the runner decides the route
+ * from it:
  *
  * - `execution: 'local'` — the command ALWAYS executes locally (TUI
- *   control commands like /status, /settings), never steered, regardless
- *   of the busyEnter preference. This is exactly the semantic of the
- *   static LOCAL_COMMANDS set, now extensible by plugins.
- * - `execution: 'submission'` — the command is AGENT-FACING input: its LINE
- *   flows through the session submission policy (steer/queue) like any skill
- *   invocation, and the TUI never runs the commands-service handler ahead of
- *   that delivery (the plugin's own pre-step owns any expansion).
+ *   control commands like /status, /settings), never steered, regardless of
+ *   the busyEnter preference: the contribution's own bridge handler when one
+ *   is declared, otherwise the `ctx.commands` definition handler. This is
+ *   exactly the semantic of the static LOCAL_COMMANDS set, now extensible by
+ *   plugins.
+ * - `execution: 'submission'` — the command is a SUBMISSION LINE, not a
+ *   command execution: it flows through the session submission policy
+ *   (steer/queue) like any skill invocation, the commands-service handler
+ *   is NOT run for it, and the plugin's own pre-step owns any expansion —
+ *   the web composer's unclaimed-line semantics. BREAKING (Unreleased): the
+ *   handler used to stay authoritative in every non-steer mode.
  *
  * Contract (plan §10):
  * - `/name args...` ALWAYS keeps `invocation.rawInput` verbatim — the
@@ -35,13 +39,18 @@
 import type { TuiAutocompleteProvider } from './extension/public-types.ts'
 import type { TuiCommandContribution, TuiCommandHandle, TuiLocalCommandHandler, TuiCommandBridgeSnapshot } from './extension/public-types.ts'
 
-/** One command contribution: ownership metadata over an existing command. */
+/**
+ * One command contribution: ownership metadata over a slash name — either a
+ * locally executed command (`local`) or an agent-facing submission line
+ * (`submission`).
+ */
 
 
-/** Conflict-detection outcome for a new registration. */
+/** Registration outcome for a new contribution. */
 type RegisterOutcome =
   | { kind: 'registered'; handle: TuiCommandHandle }
   | { kind: 'conflict'; existingOwner: string; nearSynonym?: string }
+  | { kind: 'invalid'; reason: string }
 
 /** The bridge's internal registration record. */
 interface Contribution {
@@ -92,6 +101,19 @@ export class CommandBridge {
       throw new Error(`duplicate command contribution id "${spec.id}" (owner "${this.contributions.get(spec.id)?.owner}")`)
     }
     if (spec.name === '') throw new Error('command contribution name must not be empty')
+    // A submission contribution is an AGENT-FACING line: it needs a live
+    // session to be delivered to, so `sessionless` (which lets a LOCAL
+    // command run before any session exists) is not a valid combination —
+    // accepting it would let the line fall into the local path and execute a
+    // handler the submission ownership explicitly does not run. Rejected at
+    // registration: fail fast at the extension boundary, never a silent
+    // reinterpretation at dispatch time.
+    if (spec.execution === 'submission' && spec.sessionless === true) {
+      return {
+        kind: 'invalid',
+        reason: 'a submission command is delivered to the session, so it cannot be sessionless — declare execution: \'local\' if the command must run without a live session',
+      }
+    }
     // P1-04: the host-owned catalog is authoritative — an EXACT collision
     // with a host command is rejected loudly (a plugin can never shadow
     // /status, /sessions, ...). Near-synonyms of host names are rejected
@@ -219,6 +241,16 @@ export class CommandBridge {
    * commands service). */
   handlerFor(name: string): TuiLocalCommandHandler | undefined {
     return this.find(name)?.handler
+  }
+
+  /** The LOCAL handler for one name: the bridge handler of a contribution
+   * whose EFFECTIVE ownership is `local`, or undefined. This is the
+   * implementation the TUI runs locally — a `submission` contribution's
+   * handler is never executed by the TUI, and a handler-less local
+   * contribution falls back to the commands-service definition. */
+  localHandlerFor(name: string): TuiLocalCommandHandler | undefined {
+    const contribution = this.find(name)
+    return contribution !== undefined && contribution.execution === 'local' ? contribution.handler : undefined
   }
 
   /** The argument autocomplete provider for one name, or undefined. */

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -23,11 +23,14 @@
  * - near-synonym command conflicts keep the AGENTS hard rule: the bridge
  *   reports a conflicting registration loudly instead of guessing;
  * - P1-04: a dynamic command can NEVER shadow a host-owned command. The
- *   authoritative static catalog (TUI-registered commands + the
- *   LOCAL_COMMANDS/SESSIONLESS_COMMANDS ownership sets) is validated at
+ *   STATIC ownership catalog (the LOCAL_COMMANDS/SESSIONLESS_COMMANDS sets
+ *   plus `/plan`, handed over by the extension host) is validated at
  *   register time — an exact-name or near-synonym collision with a
- *   host-owned command name is rejected loudly, never silently overriding
- *   the built-in behavior.
+ *   TUI-owned command name is rejected loudly, never silently overriding
+ *   the built-in behavior. A name the CURRENT (session-scoped) host catalog
+ *   owns is NOT visible here: that collision is caught at candidate
+ *   synthesis, which fails the whole pass (see `mergeContributions` in
+ *   commands.ts).
  * @module @xmoon76/dsh-pi-tui/command-bridge
  */
 
@@ -60,12 +63,15 @@ interface Contribution {
 export class CommandBridge {
   /** Contributions by id (diagnostic identity; also the registry key). */
   private readonly contributions = new Map<string, Contribution>()
-  /** The AUTHORITATIVE host-owned command names (P1-04): TUI-registered
-   * commands + the LOCAL_COMMANDS/SESSIONLESS_COMMANDS ownership sets. A
-   * dynamic contribution colliding with this catalog (exact or
-   * near-synonym) is rejected at register time — a plugin can never
-   * shadow a built-in command. Defaults to empty for standalone tests
-   * that exercise the dynamic-vs-dynamic rules only. */
+  /** The STATIC host-owned command names (P1-04): the
+   * LOCAL_COMMANDS/SESSIONLESS_COMMANDS ownership sets plus `/plan` — the
+   * names the TUI owns and registers itself. A dynamic contribution
+   * colliding with this catalog (exact or near-synonym) is rejected at
+   * register time — a plugin can never shadow a built-in command. Dynamic
+   * and session-scoped host names are NOT in this catalog (it is a fixed
+   * set); those collisions surface at candidate synthesis instead.
+   * Defaults to empty for standalone tests that exercise the
+   * dynamic-vs-dynamic rules only. */
   private readonly staticCatalog: ReadonlySet<string>
   /** Local names, derived on demand (never stored twice). */
   private revision = 0

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -51,6 +51,11 @@ interface Contribution {
   readonly description: string
   readonly sessionless: boolean
   readonly owner: string
+  /** Monotonic registration generation: a dispose + re-register under the
+   * same id/owner is a NEW generation (the consumer's notice/de-duplication
+   * identity must follow it — a coalesced invalidate batch never exposes the
+   * empty snapshot in between). */
+  readonly generation: number
   readonly handler: TuiLocalCommandHandler
   disposed: boolean
 }
@@ -75,6 +80,8 @@ export class CommandBridge {
   private readonly staticCatalog: ReadonlySet<string>
   /** Local names, derived on demand (never stored twice). */
   private revision = 0
+  /** Per-registration generation counter (see {@link Contribution.generation}). */
+  private nextGeneration = 0
   private readonly onInvalidate: () => void
 
   constructor(onInvalidate: () => void = () => {}, staticCatalog: ReadonlySet<string> = new Set()) {
@@ -151,6 +158,7 @@ export class CommandBridge {
       description: spec.description,
       sessionless: spec.sessionless ?? false,
       owner,
+      generation: this.nextGeneration += 1,
       handler: spec.handler,
       disposed: false,
     }
@@ -235,6 +243,7 @@ export class CommandBridge {
         description: contribution.description,
         sessionless: contribution.sessionless,
         owner: contribution.owner,
+        generation: contribution.generation,
       }))
     return { entries, revision: this.revision }
   }

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -12,9 +12,12 @@
  * Contract (plan §10):
  * - a contribution needs a declared handler (its client behavior) and needs
  *   no commands-service definition;
- * - `/name args...` ALWAYS keeps `invocation.rawInput` verbatim — the
- *   bridge never re-parses or rewrites arguments (the skill rawInput
- *   regression gate);
+ * - a contribution is a slash-MENU entry, so it claims the BARE `/name`
+ *   token only (DSH `matchEnter`: `if (!bare) return undefined`). An argued
+ *   line (`/deploy explain`) is an ordinary submission that reaches the
+ *   model — the handler never runs for it. A handler therefore always sees
+ *   `invocation.rawInput` with no non-whitespace input (trailing whitespace is
+ *   preserved verbatim, exactly like every other command surface);
  * - a contribution is CLIENT-OWNED while registered; after unload the name
  *   returns to the ordinary routes (a host claim, or an unclaimed prompt —
  *   never a lingering client route);

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -31,7 +31,6 @@
  * @module @xmoon76/dsh-pi-tui/command-bridge
  */
 
-import type { TuiAutocompleteProvider } from './extension/public-types.ts'
 import type { TuiCommandContribution, TuiCommandHandle, TuiLocalCommandHandler, TuiCommandBridgeSnapshot } from './extension/public-types.ts'
 
 /** One client command contribution: a slash name the client owns. */

--- a/src/command-bridge.ts
+++ b/src/command-bridge.ts
@@ -8,8 +8,10 @@
  *   control commands like /status, /settings), never steered, regardless
  *   of the busyEnter preference. This is exactly the semantic of the
  *   static LOCAL_COMMANDS set, now extensible by plugins.
- * - `execution: 'submission'` — the command flows through the session
- *   submission policy (steer/queue) like any skill invocation.
+ * - `execution: 'submission'` — the command is AGENT-FACING input: its LINE
+ *   flows through the session submission policy (steer/queue) like any skill
+ *   invocation, and the TUI never runs the commands-service handler ahead of
+ *   that delivery (the plugin's own pre-step owns any expansion).
  *
  * Contract (plan §10):
  * - `/name args...` ALWAYS keeps `invocation.rawInput` verbatim — the

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2869,6 +2869,12 @@ export function registerTuiCommands(
     // and the draft consumption — so a concurrent /image prune can never
     // delete images this invocation is still admitting (review finding 1).
     const releasePin = pinDraftAttachments(line, runner.imageStore, runner.fileStore)
+    // The host's pre-step listener (dsh-tool-skill) injects the rendered
+    // body only when ITS tool registration is visible to this agent — the
+    // same visibility test the listener itself uses. Probed BEFORE the
+    // delivery: the queue path below depends on it, and the fallback body
+    // injection after the write needs it too.
+    const hostLoadsSkillBody = runner.catalog.skills.hostLoadsSkillBody(agent.session.id)
     let userMessage: import('@deepseek-ai/dsh-llm').UserMessage
     try {
       userMessage = await runner.prepareDraftMessage(line)
@@ -2894,7 +2900,22 @@ export function registerTuiCommands(
       try {
         await runner.withSessionWriter(agent.session.id, async () => {
           skillSignal.throwIfAborted()
-          agent.steer(userMessage)
+          // Web parity (busyEnter): a skill invocation is an agent-facing
+          // prompt — while the agent is running with busyEnter=queue (or
+          // idle), it QUEUES like a plain prompt (web: session.prompt with
+          // the policy-resolved mode). The queue delivery is only safe when
+          // the HOST injects the skill body: the fallback body injection
+          // below rides next-step, so a followup would let the body arrive
+          // before the user's words (the driver claims next-step FIRST).
+          // Without the host loader the invocation keeps the steer path to
+          // preserve the original-line-before-body order.
+          const busyEnter = runner.tuiSettings?.get().busyEnter
+          const queueDelivery = hostLoadsSkillBody && (agent.status !== 'running' || busyEnter !== 'steer')
+          if (queueDelivery) {
+            agent.followup(userMessage)
+          } else {
+            agent.steer(userMessage)
+          }
         })
       } catch (error) {
         if (error instanceof TransitionInProgressError) {
@@ -2932,7 +2953,6 @@ export function registerTuiCommands(
     // would not inject for it either, so the TUI's fallback must cover it.
     // The probe is a SEMANTIC catalog operation now (migration M1.8) — the
     // raw tools service never crosses into the command surface.
-    const hostLoadsSkillBody = runner.catalog.skills.hostLoadsSkillBody(agent.session.id)
     // Deliver the batch through the steer path (and unlike
     // agent.inject alone, which queues for the next pre-step WITHOUT waking
     // the driver): the ORIGINAL line is steered — a running turn takes it
@@ -2946,12 +2966,18 @@ export function registerTuiCommands(
     // body lands as step 2 of the same turn (the loop only ends when
     // next-step drains). Either way the original line reaches the model
     // before the body, exactly like the web's message order.
-    // Never follow-up the original line here: followup parks the line in
-    // next-turn while the body sits in next-step, and the driver's first
-    // step boundary claims next-step FIRST — the body would arrive BEFORE
-    // the user's words, inverting the web's message order. (A second
-    // follow-up would not help either: a turn boundary claims ONE next-turn
-    // message, so the pair would split across two turns.)
+    // The queue delivery (chosen above when the HOST injects the body) is
+    // the web-parity busyEnter path: followup parks the line in next-turn
+    // and the host's pre-step listener injects the body at the next model
+    // request — the same order the web's queued session.prompt produces.
+    // The fallback body injection below is INCOMPATIBLE with followup:
+    // the body would sit in next-step while the line waits in next-turn,
+    // and the driver's first step boundary claims next-step FIRST — the
+    // body would arrive BEFORE the user's words, inverting the web's
+    // message order. (A second follow-up would not help either: a turn
+    // boundary claims ONE next-turn message, so the pair would split
+    // across two turns.) That is why the queue path requires
+    // hostLoadsSkillBody.
     if (!hostLoadsSkillBody) {
       const body = typeof skill.content === 'string' && skill.content !== '' ? skill.content : skill.description
       // Forward the resource base too, so the fallback rendering matches

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -359,6 +359,33 @@ export interface DefaultIntentRecord {
   readonly selection: ModelSelection
 }
 
+/**
+ * The effective mode ONE submission resolved at the submit boundary: whether
+ * an agent-facing delivery steers into the running turn or queues behind it
+ * (web `ComposerSubmissionPolicy` parity — the boundary resolves 'queue' for
+ * a non-running agent, for `busyEnter=queue`, and for the Ctrl+Enter
+ * force-queue chord).
+ *
+ * It is a property of the GESTURE, not of the persisted settings: a one-shot
+ * chord exists only inside the dispatch that resolved it, so every
+ * downstream consumer (the TUI skill delivery) accepts this value instead of
+ * re-deriving the mode from `busyEnter`.
+ */
+export type SubmitDelivery = 'steer' | 'queue'
+
+/**
+ * Whether an agent-facing delivery steers under the busy-Enter preference:
+ * the agent is RUNNING and the preference says 'steer'. The submit gate adds
+ * the local-command and one-shot-chord terms on top; the `/skill` picker — a
+ * gesture with no dispatcher above it — resolves with this same rule, so the
+ * preference has exactly ONE implementation.
+ * @param running - whether the live agent reports running.
+ * @param busyEnter - the persisted preference value (''/undefined = queue).
+ */
+export function prefersSteer(running: boolean, busyEnter: string | undefined): boolean {
+  return running && busyEnter === 'steer'
+}
+
 /** Everything the TUI-owned commands read from the runner. */
 export interface TuiCommandRunner {
   ctx: Context
@@ -1172,12 +1199,15 @@ export function registerTuiCommands(
 ): {
   wasAdvertised(name: string): boolean
   /** Whether one slash name is a HOST command in the current effective
-   * catalog (advertised, not a TUI-owned skill wrapper). */
+   * catalog (advertised, owned by neither the TUI nor an extension). */
   isHostCommand(name: string): boolean
   /** One synchronous catalog commit (the coordinator's install hook). */
   installSnapshot(snapshot: SurfaceCatalogSnapshot): void
   /** The revalidating transition (the coordinator's target-change hook). */
   enterTransition(): void
+  /** Bind one submission's resolved delivery mode for the synchronous window
+   * that launches a command execution (see the TUI skill handlers). */
+  withDelivery<T>(delivery: SubmitDelivery, run: () => T): T
 } {
   const { ctx, app } = runner
   const cwd = runner.cwd
@@ -1189,6 +1219,46 @@ export function registerTuiCommands(
   // The commands service is part of the base layer; its absence means the
   // TUI commands cannot be registered at all — the caller surfaces this.
   if (commands === undefined) throw new Error('commands service unavailable')
+
+  // ── submit-resolved delivery binding ────────────────────────────────────
+  /**
+   * The delivery mode bound to the command execution launched in the CURRENT
+   * synchronous window (`withDelivery`). `commands.execute` invokes a
+   * resolved handler in the SAME call stack as the dispatch (the TUI submits
+   * no attachments), so a TUI-owned skill handler captures its invocation's
+   * mode before any await and passes it to the delivery — never re-deriving
+   * the mode from the persisted preference, which cannot reconstruct a
+   * one-shot force-queue chord.
+   */
+  let boundDelivery: SubmitDelivery | undefined
+  /**
+   * Bind `delivery` for one synchronous window and run the launch. Commands
+   * that own their own busy semantics (Host commands, local UI commands)
+   * simply never consume it.
+   * @param delivery - the mode the submit boundary resolved for this gesture.
+   * @param run - the launch (the command execution) to run inside the window.
+   */
+  const withDelivery = <T>(delivery: SubmitDelivery, run: () => T): T => {
+    const previous = boundDelivery
+    boundDelivery = delivery
+    try {
+      return run()
+    } finally {
+      // Reentrancy-safe: a nested execution restores the outer window.
+      boundDelivery = previous
+    }
+  }
+  /**
+   * Consume the delivery mode bound for the execution launching in this call
+   * stack. `undefined` means no TUI submission launched it (the command
+   * plane driven from outside the submit boundary): there is no chord to
+   * honor, so the skill delivery falls back to the safe queue mode.
+   */
+  const takeDelivery = (): SubmitDelivery | undefined => {
+    const delivery = boundDelivery
+    boundDelivery = undefined
+    return delivery
+  }
 
   /** The EFFECTIVE key label for user-facing descriptions (plan §18): a
    * remap updates every row; a disabled action shows a neutral dash. */
@@ -2833,12 +2903,15 @@ export function registerTuiCommands(
    * here — a summary that passed the cold/live filter is never execution
    * authorization. A model-only skill is refused with an explicit error and
    * never injected.
+   * @param delivery - the delivery mode the caller's boundary resolved for
+   *   this gesture, or undefined when no TUI submission launched it.
    */
   const loadSkill = async (
     agent: Agent,
     name: string,
     args = '',
     signal: AbortSignal = runner.signal,
+    delivery: SubmitDelivery | undefined,
   ): Promise<{ kind: 'success'; text: string } | { kind: 'error'; text: string }> => {
     const skillSignal = signal === runner.signal ? runner.signal : AbortSignal.any([runner.signal, signal])
     skillSignal.throwIfAborted()
@@ -2901,17 +2974,19 @@ export function registerTuiCommands(
         await runner.withSessionWriter(agent.session.id, async () => {
           skillSignal.throwIfAborted()
           // Web parity (busyEnter): a skill invocation is an agent-facing
-          // prompt — while the agent is running with busyEnter=queue (or
-          // idle), it QUEUES like a plain prompt (web: session.prompt with
-          // the policy-resolved mode). The queue delivery is only safe when
-          // the HOST injects the skill body: the fallback body injection
-          // below rides next-step, so a followup would let the body arrive
-          // before the user's words (the driver claims next-step FIRST).
-          // Without the host loader the invocation keeps the steer path to
-          // preserve the original-line-before-body order.
-          const busyEnter = runner.tuiSettings?.get().busyEnter
-          const queueDelivery = hostLoadsSkillBody && (agent.status !== 'running' || busyEnter !== 'steer')
-          if (queueDelivery) {
+          // prompt — under the queue mode it QUEUES like a plain prompt
+          // (web: session.prompt with the policy-resolved mode). The mode
+          // was resolved ONCE at the gesture's own boundary and handed in;
+          // re-deriving it here from the persisted preference would lose
+          // the one-shot Ctrl+Enter force-queue chord, which exists only in
+          // the dispatch that resolved it.
+          // The queue delivery is only safe when the HOST injects the skill
+          // body: the fallback body injection below rides next-step, so a
+          // followup would let the body arrive before the user's words (the
+          // driver claims next-step FIRST). Without the host loader the
+          // invocation keeps the steer path to preserve the
+          // original-line-before-body order — the documented exception.
+          if (delivery !== 'steer' && hostLoadsSkillBody) {
             agent.followup(userMessage)
           } else {
             agent.steer(userMessage)
@@ -3043,8 +3118,12 @@ export function registerTuiCommands(
           // line, never carved out or dropped — the wrapper's own name is
           // the skill name, everything after it is args).
           handler: async (invocation) => {
+            // The FIRST synchronous statement: the submit boundary bound this
+            // invocation's delivery mode for exactly this call stack (see
+            // withDelivery). Everything below may await.
+            const delivery = takeDelivery()
             const agent = await requireAgent()
-            return loadSkill(agent, skill.name, invocation?.rawInput ?? '', invocation?.signal ?? runner.signal)
+            return loadSkill(agent, skill.name, invocation?.rawInput ?? '', invocation?.signal ?? runner.signal, delivery)
           },
         })
         skillDisposers.set(skill.name, dispose)
@@ -3103,8 +3182,10 @@ export function registerTuiCommands(
             name,
             description: `[skill: revalidating] ${name}`,
             handler: async (invocation) => {
+              // Captured before any await, exactly like the direct wrapper.
+              const delivery = takeDelivery()
               const agent = await requireAgent()
-              return loadSkill(agent, name, invocation?.rawInput ?? '', invocation?.signal ?? runner.signal)
+              return loadSkill(agent, name, invocation?.rawInput ?? '', invocation?.signal ?? runner.signal, delivery)
             },
           })
           skillDisposers.set(name, dispose)
@@ -3119,13 +3200,18 @@ export function registerTuiCommands(
    * (the claim captured at submit time, before any session creation). */
   const wasAdvertised = (name: string): boolean => claims.has(name)
   /** Whether one slash name is a HOST command in the CURRENT effective
-   * catalog: advertised by the completion list but NOT a TUI-owned skill
-   * wrapper. A skill wrapper is a thin agent-facing invocation (loadSkill
-   * builds a prompt), so it must keep the ordinary submission semantics —
-   * only real Host commands (e.g. /compact) execute through the command
-   * plane regardless of the busy-Enter policy. */
+   * catalog: advertised by the completion list, NOT a TUI-owned skill
+   * wrapper, and NOT an extension contribution. A skill wrapper is a thin
+   * agent-facing invocation (loadSkill builds a prompt), and an extension
+   * contribution's `execution` metadata owns its classification
+   * ('submission' flows through the busy queue/steer policy like a skill
+   * invocation; 'local' never steers) — so both keep the ordinary
+   * submission semantics. Only real Host commands (e.g. /compact) execute
+   * through the command plane regardless of the busy-Enter policy: being
+   * advertised never proves Host ownership. */
   const isHostCommand = (name: string): boolean => {
     if (skillDisposers.has(name)) return false
+    if (runner.extensions?.commands.find(name) !== undefined) return false
     return claims.has(name)
   }
 
@@ -3134,6 +3220,8 @@ export function registerTuiCommands(
     description: 'Load a skill into the session context',
     input: { hint: '<name>' },
     handler: async (invocation) => {
+      // Captured before any await: the submit boundary's resolved mode.
+      const delivery = takeDelivery()
       const liveAgent = await requireAgent()
       // `/skill <name> [args...]`: the first whitespace token is the skill
       // name, the remainder its arguments (forwarded verbatim on the
@@ -3141,7 +3229,7 @@ export function registerTuiCommands(
       // invocation line is normalized to `/name args` so the host's pre-step
       // gesture (dsh-tool-skill) also recognizes it when visible.
       const [name, ...args] = splitSkillLine(invocation.rawInput)
-      if (name !== '') return loadSkill(liveAgent, name, args.join(' '), invocation.signal ?? runner.signal)
+      if (name !== '') return loadSkill(liveAgent, name, args.join(' '), invocation.signal ?? runner.signal, delivery)
       // No argument: pick from the catalog — the same validated, policy-
       // filtered, sorted view the collector builds (the catalog port's
       // live read), so hostile or model-only entries never reach the
@@ -3149,6 +3237,15 @@ export function registerTuiCommands(
       const catalog = await runner.catalog.skills.listHumanSkills(liveAgent.session.id)
       if (catalog === undefined) return { kind: 'error', text: 'skill service unavailable' }
       if (catalog.skills.length === 0) return { kind: 'error', text: 'no skills available' }
+      // A picker selection is its OWN delivery boundary (no dispatcher above
+      // it): choosing a row submits the skill like a plain Enter on the
+      // completed `/<name>` line, so the busy-Enter preference is resolved
+      // here — the one-shot Ctrl+Enter chord cannot exist for a modal
+      // selection. The resolved mode is handed to the delivery, which never
+      // re-derives it.
+      const pickerDelivery: SubmitDelivery = prefersSteer(liveAgent.status === 'running', runner.tuiSettings?.get().busyEnter)
+        ? 'steer'
+        : 'queue'
       // SettingsList rows: Enter cycles the value, which fires onChange.
       app.openSettings(
         catalog.skills.map(skill => ({
@@ -3159,7 +3256,7 @@ export function registerTuiCommands(
           values: ['✓'],
         })),
         (id) => {
-          detach('skill load', () => loadSkill(liveAgent, id).then(result => {
+          detach('skill load', () => loadSkill(liveAgent, id, '', runner.signal, pickerDelivery).then(result => {
             if (result.kind === 'error') app.notify(result.text)
           }), { notify: true })
         },
@@ -4411,14 +4508,14 @@ export function registerTuiCommands(
     /** The claim test for the dispatch: is /name advertised right now? */
     wasAdvertised,
     /** Whether one slash name is a HOST command in the CURRENT effective
-     * catalog: advertised by the completion list but NOT a TUI-owned skill
-     * wrapper (a skill invocation is agent-facing input, never a command
-     * claim). TUI-local commands are excluded by the dispatch caller
-     * (LOCAL_COMMANDS). */
+     * catalog: advertised by the completion list but owned by neither the
+     * TUI as a skill wrapper nor an extension contribution (the dispatch
+     * caller excludes TUI-local commands itself via LOCAL_COMMANDS). */
     isHostCommand,
     /** One synchronous catalog commit (the coordinator's install hook). */
     installSnapshot: (snapshot: SurfaceCatalogSnapshot): void => installSurfaceSnapshot(snapshot),
     /** The revalidating transition (the coordinator's target-change hook). */
     enterTransition: (): void => enterCatalogTransition(),
+    withDelivery,
   }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1223,6 +1223,10 @@ export function registerTuiCommands(
   isSkillWrapper(name: string): boolean
   /** One synchronous catalog commit (the coordinator's install hook). */
   installSnapshot(snapshot: SurfaceCatalogSnapshot): void
+  /** Re-synthesize the slash completions from the CURRENT host catalog plus
+   * the live client contributions (the extension-invalidate hook: a late
+   * contribution joins the menu without waiting for a session refresh). */
+  refreshCommandCompletions(): void
   /** The revalidating transition (the coordinator's target-change hook). */
   enterTransition(): void
   /** Bind one submission's resolved delivery mode for the synchronous window
@@ -1409,17 +1413,57 @@ export function registerTuiCommands(
    * Host session cwd remains reserved for `@` via HostFilePort. */
   const PATH_ARGUMENT_COMMANDS = FILE_ARGUMENT_COMMANDS
   /**
+   * Candidate synthesis (the DSH `CommandUiRuntime.candidates` parity): the
+   * host catalog merged with the live CLIENT command contributions by name.
+   * A contribution whose name is already a host command (or a TUI-owned
+   * name) is a COLLISION: this pass FAILS — nothing is installed, the
+   * previous list stays, the collision is recorded against the contribution
+   * and surfaced once. Never a silent shadow, never a partial list.
+   * @param host - the host catalog rows for the current scope.
+   * @throws when a contribution collides with a host name.
+   */
+  const mergeContributions = (host: readonly SurfaceCommandSummary[]): readonly SurfaceCommandSummary[] => {
+    const bridge = runner.extensions?.commands
+    if (bridge === undefined) return host
+    const contributions = bridge.snapshot().entries
+    if (contributions.length === 0) return host
+    const byName = new Map(host.map(entry => [entry.name, entry] as const))
+    for (const contribution of contributions) {
+      if (!byName.has(contribution.name)) continue
+      const collision = new Error(`command contribution /${contribution.name} collides with a host command`)
+      recordExtensionError?.({ slot: 'command', id: contribution.id, owner: contribution.owner }, collision)
+      throw collision
+    }
+    for (const contribution of contributions) {
+      byName.set(contribution.name, { name: contribution.name, description: contribution.description })
+    }
+    return [...byName.values()]
+  }
+  /** One collision notice per contribution name (never a per-refresh spam). */
+  const notifiedCollisions = new Set<string>()
+  /**
    * Install one completion list (sorted, claims refreshed). The single
    * synchronous seam every catalog commit funnels through.
+   * @param entries - the HOST catalog rows; the client contributions are
+   *   merged in by {@link mergeContributions} (the installed DISPLAY list),
+   *   while `claims` stays host-only — a contribution is not a command-plane
+   *   claim.
    */
   const installCompletions = (entries: readonly SurfaceCommandSummary[]): void => {
     const sorted = [...entries].sort((left, right) => left.name < right.name ? -1 : 1)
+    // HOST CLAIMS first: the claim set is the host's AUTHORITY record (the
+    // dispatch consults it), so it must never depend on the client merge — a
+    // failed synthesis must not cost a host command its claim.
+    claims = new Set(sorted.map(command => command.name))
+    // The display list carries the client contributions too; the CLAIM set
+    // never does (see the parameter doc).
+    const display = [...mergeContributions(sorted)].sort((left, right) => left.name < right.name ? -1 : 1)
     // M5: the plugin autocomplete chain (AutocompleteRegistry) is consulted
     // after the host's own provider returns null. The registry's suggest()
     // handles cancellation (latest-only commit) and per-provider isolation.
     const extensionAutocomplete = runner.extensions?.autocomplete
     app.setCommandCompletions(
-      sorted.map(command => ({
+      display.map(command => ({
         name: command.name,
         description: command.description,
         argumentHint: command.input?.hint,
@@ -1460,7 +1504,6 @@ export function registerTuiCommands(
       // list, never from the command registry.
       currentSkillReferences,
     )
-    claims = new Set(sorted.map(command => command.name))
   }
   /** The saved probed scoped overrides (see installSurfaceSnapshot). */
   let savedScopedCommands: readonly SurfaceCommandSummary[] = []
@@ -1485,9 +1528,35 @@ export function registerTuiCommands(
    * `commands.list(undefined)` safely returns the global layer only (the
    * remote RPC path's lookup guard does not apply in-process).
    */
+  /**
+   * The CONTAINING seam every catalog commit funnels through: a failed
+   * candidate synthesis (a contribution/host name collision) installs
+   * NOTHING — the previous completion list stays live, exactly like
+   * upstream's throwing candidate pass — while the collision is already
+   * recorded on the contribution's health and surfaced once to the user.
+   * The HOST CLAIMS were refreshed before the merge, so a collision never
+   * costs a host command its claim.
+   * @param entries - the host catalog rows for the current scope.
+   */
+  const installCompletionsContained = (entries: readonly SurfaceCommandSummary[]): void => {
+    try {
+      installCompletions(entries)
+    } catch (error) {
+      const message = safeErrorMessage(error)
+      if (!notifiedCollisions.has(message)) {
+        notifiedCollisions.add(message)
+        app.notify(message, 'error')
+      }
+      try {
+        ctx.logger.error(`tui-runner: ${message}`)
+      } catch {
+        // The cordis logger must not block the submission path.
+      }
+    }
+  }
   const refreshCompletions = (): void => {
     const liveAgent = runner.liveAgent
-    installCompletions(liveAgent === undefined
+    installCompletionsContained(liveAgent === undefined
       ? mergeGlobalAndSavedScoped()
       : commands.list(liveAgent).map(commandSummaryOf))
   }
@@ -3186,7 +3255,7 @@ export function registerTuiCommands(
       // mergePartial already retained it in `snapshot.skills`).
       if (!skillsFailed) currentSkillReferences = snapshot.skills
       savedScopedCommands = snapshot.scopedCommands
-      installCompletions(mergeGlobalAndSavedScoped())
+      installCompletionsContained(mergeGlobalAndSavedScoped())
     })
   }
   /**
@@ -3223,25 +3292,22 @@ export function registerTuiCommands(
           // Registration raced with another plugin; the picker still works.
         }
       }
-      installCompletions(mergeGlobalAndSavedScoped())
+      installCompletionsContained(mergeGlobalAndSavedScoped())
     })
   }
   /** Whether one command name is advertised by the CURRENT completion list
    * (the claim captured at submit time, before any session creation). */
   const wasAdvertised = (name: string): boolean => claims.has(name)
   /** Whether one slash name is a HOST command in the CURRENT effective
-   * catalog: advertised by the completion list, NOT a TUI-owned skill
-   * wrapper, and NOT an extension contribution. A skill wrapper is a thin
-   * agent-facing invocation (loadSkill builds a prompt), and an extension
-   * contribution's `execution` metadata owns its classification
-   * ('submission' flows through the busy queue/steer policy like a skill
-   * invocation; 'local' never steers) — so both keep the ordinary
-   * submission semantics. Only real Host commands (e.g. /compact) execute
-   * through the command plane regardless of the busy-Enter policy: being
-   * advertised never proves Host ownership. */
+   * catalog: advertised by the host list and NOT a TUI-owned skill wrapper.
+   * HOST AUTHORITY: a client command contribution never removes a name from
+   * this claim — upstream's candidate synthesis merges contributions with
+   * the host catalog and FAILS LOUD on a collision instead of shadowing, so
+   * a resolved host command always keeps its execution. A skill wrapper is a
+   * thin agent-facing invocation (loadSkill builds the prompt), never a host
+   * claim. */
   const isHostCommand = (name: string): boolean => {
     if (skillDisposers.has(name)) return false
-    if (runner.extensions?.commands.find(name) !== undefined) return false
     return claims.has(name)
   }
 
@@ -4517,7 +4583,7 @@ export function registerTuiCommands(
       replaceSkillCommands(initial.skills!.skills, new Set())
       currentSkillReferences = initial.skills!.skills
       savedScopedCommands = []
-      installCompletions(mergeGlobalAndSavedScoped())
+      installCompletionsContained(mergeGlobalAndSavedScoped())
     })
   } else {
     refreshCompletions()
@@ -4550,6 +4616,7 @@ export function registerTuiCommands(
     isSkillWrapper: (name: string): boolean => skillDisposers.has(name),
     /** One synchronous catalog commit (the coordinator's install hook). */
     installSnapshot: (snapshot: SurfaceCatalogSnapshot): void => installSurfaceSnapshot(snapshot),
+    refreshCommandCompletions: (): void => refreshCompletions(),
     /** The revalidating transition (the coordinator's target-change hook). */
     enterTransition: (): void => enterCatalogTransition(),
     withDelivery,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,6 +30,7 @@ import type { CommandInvocation, CommandResult, CommandDescriptor, CommandDefini
 import { TransitionInProgressError } from './session-operation-barrier.ts'
 import { createForkedAgent } from './session-fork.ts'
 import { SettingsList, type SettingItem } from '@xmoon76/pi-tui'
+import type { ComposerSubmitGesture } from './tui-app.ts'
 import { mergeDraft } from './steer.ts'
 import { applyHomeEndKeyMode, homeEndKeysModeOf } from './home-end-keys.ts'
 import { parseNotificationMethod, parseNotificationMode } from './notification/settings.ts'
@@ -362,28 +363,43 @@ export interface DefaultIntentRecord {
 /**
  * The effective mode ONE submission resolved at the submit boundary: whether
  * an agent-facing delivery steers into the running turn or queues behind it
- * (web `ComposerSubmissionPolicy` parity — the boundary resolves 'queue' for
- * a non-running agent, for `busyEnter=queue`, and for the Ctrl+Enter
- * force-queue chord).
+ * (web `ComposerSubmissionPolicy` parity — an idle agent queues, plain Enter
+ * takes the preference, and the accelerated chord takes its OPPOSITE).
  *
  * It is a property of the GESTURE, not of the persisted settings: a one-shot
- * chord exists only inside the dispatch that resolved it, so every
+ * gesture exists only inside the dispatch that resolved it, so every
  * downstream consumer (the TUI skill delivery) accepts this value instead of
  * re-deriving the mode from `busyEnter`.
  */
 export type SubmitDelivery = 'steer' | 'queue'
 
 /**
- * Whether an agent-facing delivery steers under the busy-Enter preference:
- * the agent is RUNNING and the preference says 'steer'. The submit gate adds
- * the local-command and one-shot-chord terms on top; the `/skill` picker — a
- * gesture with no dispatcher above it — resolves with this same rule, so the
- * preference has exactly ONE implementation.
+ * Resolve one submission's delivery mode — the DSH WEB
+ * `ComposerSubmissionPolicy.resolve()` contract (baseline 0.1.3-alpha.2,
+ * shared by every UI client):
+ *
+ * ```text
+ * !running              -> queue
+ * gesture === 'enter'   -> the preferred mode (busyEnter)
+ * accelerated           -> the OPPOSITE of the preferred mode
+ * ```
+ *
+ * The accelerated chord is therefore "the other behavior", never a fixed
+ * queue: with the default preference ('queue') it steers. A non-steering
+ * transport always queues (the TUI's Direct surface always steers).
  * @param running - whether the live agent reports running.
- * @param busyEnter - the persisted preference value (''/undefined = queue).
+ * @param gesture - the composer gesture that raised the submission.
+ * @param busyEnter - the persisted preference (''/undefined = queue).
  */
-export function prefersSteer(running: boolean, busyEnter: string | undefined): boolean {
-  return running && busyEnter === 'steer'
+export function resolveComposerDelivery(
+  running: boolean,
+  gesture: ComposerSubmitGesture,
+  busyEnter: string | undefined,
+): SubmitDelivery {
+  if (!running) return 'queue'
+  const preferred: SubmitDelivery = busyEnter === 'steer' ? 'steer' : 'queue'
+  if (gesture === 'enter') return preferred
+  return preferred === 'queue' ? 'steer' : 'queue'
 }
 
 /** Everything the TUI-owned commands read from the runner. */
@@ -1201,6 +1217,10 @@ export function registerTuiCommands(
   /** Whether one slash name is a HOST command in the current effective
    * catalog (advertised, owned by neither the TUI nor an extension). */
   isHostCommand(name: string): boolean
+  /** Whether one slash name is a LIVE TUI-owned skill wrapper (an
+   * agent-facing invocation whose `/name` line the host may resolve into an
+   * injected skill body). */
+  isSkillWrapper(name: string): boolean
   /** One synchronous catalog commit (the coordinator's install hook). */
   installSnapshot(snapshot: SurfaceCatalogSnapshot): void
   /** The revalidating transition (the coordinator's target-change hook). */
@@ -1228,7 +1248,7 @@ export function registerTuiCommands(
    * no attachments), so a TUI-owned skill handler captures its invocation's
    * mode before any await and passes it to the delivery — never re-deriving
    * the mode from the persisted preference, which cannot reconstruct a
-   * one-shot force-queue chord.
+   * one-shot gesture (the accelerated chord's opposite mode).
    */
   let boundDelivery: SubmitDelivery | undefined
   /**
@@ -1735,7 +1755,7 @@ export function registerTuiCommands(
           {
             id: 'busy-enter',
             label: 'Submit while busy',
-            description: `Steer injects the draft into the running turn; ${keyHint('app.input.queue')} uses the other behavior`,
+            description: `Steer injects the draft into the running turn; ${keyHint('app.input.submitAccelerated')} uses the other behavior`,
             currentValue: settingsDoc?.busyEnter ?? 'queue',
             values: ['queue', 'steer'],
           },
@@ -2977,9 +2997,9 @@ export function registerTuiCommands(
           // prompt — under the queue mode it QUEUES like a plain prompt
           // (web: session.prompt with the policy-resolved mode). The mode
           // was resolved ONCE at the gesture's own boundary and handed in;
-          // re-deriving it here from the persisted preference would lose
-          // the one-shot Ctrl+Enter force-queue chord, which exists only in
-          // the dispatch that resolved it.
+          // re-deriving it here from the persisted preference would lose the
+          // accelerated chord's opposite mode, which exists only in the
+          // dispatch that resolved it.
           // The queue delivery is only safe when the HOST injects the skill
           // body: the fallback body injection below rides next-step, so a
           // followup would let the body arrive before the user's words (the
@@ -3237,15 +3257,6 @@ export function registerTuiCommands(
       const catalog = await runner.catalog.skills.listHumanSkills(liveAgent.session.id)
       if (catalog === undefined) return { kind: 'error', text: 'skill service unavailable' }
       if (catalog.skills.length === 0) return { kind: 'error', text: 'no skills available' }
-      // A picker selection is its OWN delivery boundary (no dispatcher above
-      // it): choosing a row submits the skill like a plain Enter on the
-      // completed `/<name>` line, so the busy-Enter preference is resolved
-      // here — the one-shot Ctrl+Enter chord cannot exist for a modal
-      // selection. The resolved mode is handed to the delivery, which never
-      // re-derives it.
-      const pickerDelivery: SubmitDelivery = prefersSteer(liveAgent.status === 'running', runner.tuiSettings?.get().busyEnter)
-        ? 'steer'
-        : 'queue'
       // SettingsList rows: Enter cycles the value, which fires onChange.
       app.openSettings(
         catalog.skills.map(skill => ({
@@ -3256,7 +3267,19 @@ export function registerTuiCommands(
           values: ['✓'],
         })),
         (id) => {
-          detach('skill load', () => loadSkill(liveAgent, id, '', runner.signal, pickerDelivery).then(result => {
+          // The SELECTION is the delivery boundary (choosing a row submits
+          // the skill like a plain Enter on the completed `/<name>` line), so
+          // the mode is resolved HERE — the picker may have been open while
+          // the agent went idle (or busy) and while the preference was
+          // edited; a mode frozen at picker-open time would be stale. The
+          // resolved mode is handed to the delivery, which never re-derives
+          // it.
+          const delivery = resolveComposerDelivery(
+            liveAgent.status === 'running',
+            'enter',
+            runner.tuiSettings?.get().busyEnter,
+          )
+          detach('skill load', () => loadSkill(liveAgent, id, '', runner.signal, delivery).then(result => {
             if (result.kind === 'error') app.notify(result.text)
           }), { notify: true })
         },
@@ -4324,7 +4347,7 @@ export function registerTuiCommands(
         return label === '' ? '—' : label
       }
       const rows: SettingItem[] = [        { id: 'k-enter', label: keysLabel('app.input.submit'), description: 'Submit the draft; while the agent is busy, delivery follows the "Submit while busy" preference (skill commands steer too, UI commands run locally)', currentValue: '' },
-        { id: 'k-queue', label: keysLabel('app.input.queue'), description: 'Queue the draft while the agent is busy (the opposite of "Submit while busy")', currentValue: '' },
+        { id: 'k-queue', label: keysLabel('app.input.submitAccelerated'), description: 'Submit with the OPPOSITE of the "Submit while busy" behavior (the web accelerated-submit chord)', currentValue: '' },
         { id: 'k-exit', label: keysLabel('app.exit.request'), description: 'Quit the TUI (flushes the session)', currentValue: '' },
         { id: 'k-cancel', label: keysLabel('app.agent.interrupt'), description: 'Cancel the active turn / tool / shell command (one interrupt while the agent is busy; press the interrupt action twice while idle — with an empty editor it opens the rewind picker)', currentValue: '' },
         { id: 'k-fold', label: keysLabel('app.transcript.toggleExpand'), description: `Expand/collapse recent tool and system output; in regular Focus it reveals the recent Thoughts; in fullscreen Focus it bulk-expands the recent Thoughts or collapses them all (per-card detail stays mouse-owned). Thinking detail is ${keysLabel('app.transcript.toggleThinking')}`, currentValue: '' },
@@ -4512,6 +4535,9 @@ export function registerTuiCommands(
      * TUI as a skill wrapper nor an extension contribution (the dispatch
      * caller excludes TUI-local commands itself via LOCAL_COMMANDS). */
     isHostCommand,
+    /** Whether one slash name is a LIVE TUI-owned skill wrapper (the
+     * revalidating transition wrappers included). */
+    isSkillWrapper: (name: string): boolean => skillDisposers.has(name),
     /** One synchronous catalog commit (the coordinator's install hook). */
     installSnapshot: (snapshot: SurfaceCatalogSnapshot): void => installSurfaceSnapshot(snapshot),
     /** The revalidating transition (the coordinator's target-change hook). */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1171,6 +1171,9 @@ export function registerTuiCommands(
   initial?: InitialCommandCatalog,
 ): {
   wasAdvertised(name: string): boolean
+  /** Whether one slash name is a HOST command in the current effective
+   * catalog (advertised, not a TUI-owned skill wrapper). */
+  isHostCommand(name: string): boolean
   /** One synchronous catalog commit (the coordinator's install hook). */
   installSnapshot(snapshot: SurfaceCatalogSnapshot): void
   /** The revalidating transition (the coordinator's target-change hook). */
@@ -3089,6 +3092,16 @@ export function registerTuiCommands(
   /** Whether one command name is advertised by the CURRENT completion list
    * (the claim captured at submit time, before any session creation). */
   const wasAdvertised = (name: string): boolean => claims.has(name)
+  /** Whether one slash name is a HOST command in the CURRENT effective
+   * catalog: advertised by the completion list but NOT a TUI-owned skill
+   * wrapper. A skill wrapper is a thin agent-facing invocation (loadSkill
+   * builds a prompt), so it must keep the ordinary submission semantics —
+   * only real Host commands (e.g. /compact) execute through the command
+   * plane regardless of the busy-Enter policy. */
+  const isHostCommand = (name: string): boolean => {
+    if (skillDisposers.has(name)) return false
+    return claims.has(name)
+  }
 
   commands.register({
     name: 'skill',
@@ -4371,6 +4384,12 @@ export function registerTuiCommands(
   return {
     /** The claim test for the dispatch: is /name advertised right now? */
     wasAdvertised,
+    /** Whether one slash name is a HOST command in the CURRENT effective
+     * catalog: advertised by the completion list but NOT a TUI-owned skill
+     * wrapper (a skill invocation is agent-facing input, never a command
+     * claim). TUI-local commands are excluded by the dispatch caller
+     * (LOCAL_COMMANDS). */
+    isHostCommand,
     /** One synchronous catalog commit (the coordinator's install hook). */
     installSnapshot: (snapshot: SurfaceCatalogSnapshot): void => installSurfaceSnapshot(snapshot),
     /** The revalidating transition (the coordinator's target-change hook). */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1416,9 +1416,11 @@ export function registerTuiCommands(
    * Candidate synthesis (the DSH `CommandUiRuntime.candidates` parity): the
    * host catalog merged with the live CLIENT command contributions by name.
    * A contribution whose name is already a host command (or a TUI-owned
-   * name) is a COLLISION: this pass FAILS — nothing is installed, the
-   * previous list stays, the collision is recorded against the contribution
-   * and surfaced once. Never a silent shadow, never a partial list.
+   * name) is a COLLISION: this pass FAILS — no merged list is installed, the
+   * command source is marked failed downstream (`source-failed` parity
+   * withdraws its rows), and EVERY collision of the pass is recorded against
+   * its contribution and reported. Never a silent shadow, never a partial
+   * list.
    * @param host - the host catalog rows for the current scope.
    * @throws when a contribution collides with a host name.
    */
@@ -1431,15 +1433,14 @@ export function registerTuiCommands(
     // Record EVERY collision of this pass before failing it: the health
     // surface must list all offenders, not only the first one scanned.
     const colliding = new Set<string>()
+    const collisions: { identity: string; message: string }[] = []
     let firstCollision: Error | undefined
     for (const contribution of contributions) {
       if (!byName.has(contribution.name)) continue
       const identity = contributionIdentity(contribution)
       colliding.add(identity)
-      const collision = Object.assign(
-        new Error(`command contribution /${contribution.name} collides with a host command`),
-        { contributionIdentity: identity },
-      )
+      const collision = new Error(`command contribution /${contribution.name} collides with a host command`)
+      collisions.push({ identity, message: collision.message })
       const ref = { slot: 'command', id: contribution.id, owner: contribution.owner }
       collisionHealth.set(identity, { ref, message: collision.message })
       recordExtensionError?.(ref, collision)
@@ -1468,7 +1469,7 @@ export function registerTuiCommands(
       if (current === undefined || current.state !== 'failed' || current.lastError !== recorded.message) continue
       clearExtensionError?.(recorded.ref)
     }
-    if (firstCollision !== undefined) throw firstCollision
+    if (firstCollision !== undefined) throw Object.assign(firstCollision, { collisions })
     for (const contribution of contributions) {
       byName.set(contribution.name, { name: contribution.name, description: contribution.description })
     }
@@ -1478,7 +1479,8 @@ export function registerTuiCommands(
    * One collision notice per contribution IDENTITY and failure GENERATION
    * (the key is dropped when the collision recovers): a new owner reusing a
    * released name, or the same contribution colliding again after the host
-   * descriptor went away and came back, is surfaced again.
+   * descriptor went away and came back, is surfaced again. A pass that finds
+   * a fresh collision anywhere re-states the WHOLE current collision set.
    */
   const notifiedCollisions = new Set<string>()
   /** The identity of one contribution across the bridge and the health
@@ -1577,12 +1579,11 @@ export function registerTuiCommands(
    */
   /**
    * The CONTAINING seam every catalog commit funnels through: a failed
-   * candidate synthesis (a contribution/host name collision) installs
-   * NOTHING — the previous completion list stays live, exactly like
-   * upstream's throwing candidate pass — while the collision is already
-   * recorded on the contribution's health and surfaced once to the user.
-   * The HOST CLAIMS were refreshed before the merge, so a collision never
-   * costs a host command its claim.
+   * candidate synthesis (a contribution/host name collision) installs no
+   * merged list — the source's rows are withdrawn downstream — while every
+   * collision is already recorded on its contribution's health and reported
+   * to the user. The HOST CLAIMS were refreshed before the merge, so a
+   * collision never costs a host command its claim.
    * @param entries - the host catalog rows for the current scope.
    */
   const installCompletionsContained = (entries: readonly SurfaceCommandSummary[]): void => {
@@ -1597,14 +1598,19 @@ export function registerTuiCommands(
       // input authority of a host command is never lost while the menu is
       // empty.
       const message = safeErrorMessage(error)
-      // The notice identity is the FAILING contribution (the error carries
-      // its name; the health ref carries the owner) — a re-used name by a
-      // new owner notifies again.
-      const collision = error as { contributionIdentity?: string }
-      const noticeKey = collision.contributionIdentity ?? message
-      if (!notifiedCollisions.has(noticeKey)) {
-        notifiedCollisions.add(noticeKey)
-        app.notify(message, 'error')
+      // A failed pass surfaces EVERY collision it found, not only the first:
+      // with one notice slot, the aggregated text names all offenders. It
+      // notifies only while at least one identity is FRESH (per identity and
+      // failure generation), so a refresh re-failing on the same collisions
+      // stays silent instead of re-raising the notice. A throw carrying no
+      // collision list (a core bug, not a contribution) falls back to its own
+      // message as the notice identity.
+      const reported = (error as { collisions?: readonly { identity: string; message: string }[] })
+        .collisions ?? [{ identity: message, message }]
+      const fresh = reported.filter(entry => !notifiedCollisions.has(entry.identity))
+      if (fresh.length > 0) {
+        for (const entry of fresh) notifiedCollisions.add(entry.identity)
+        app.notify(reported.map(entry => entry.message).join(' · '), 'error')
       }
       try {
         ctx.logger.error(`tui-runner: ${message}`)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1446,10 +1446,13 @@ export function registerTuiCommands(
       recordExtensionError?.(ref, collision)
       firstCollision ??= collision
     }
-    // HEALTH RECOVERY, scoped to COLLISION records only: a contribution that
-    // merges cleanly again is no longer failed — even while another
-    // contribution keeps this pass failing. A handler-failure record in the
-    // same health slot is NEVER touched (this synthesis did not write it).
+    // HEALTH RECOVERY, scoped to the COLLISION records this synthesis wrote: a
+    // contribution that merges cleanly again is no longer failed — even while
+    // another contribution keeps this pass failing. A handler failure that
+    // OPENED the record is protected by the message guard below (the ledger
+    // deduplicates into it, keeping the handler message); one deduplicated
+    // INTO a live collision record is not — the documented diagnostic
+    // limitation (docs/surface-decisions.md).
     for (const contribution of contributions) {
       const identity = contributionIdentity(contribution)
       if (colliding.has(identity)) continue
@@ -1462,7 +1465,9 @@ export function registerTuiCommands(
       // same slot also carries handler runtime failures, and the ledger
       // DEDUPLICATES a later failure into an already-failed record (keeping
       // the first message) — clearing blindly would erase a handler failure
-      // that this synthesis never wrote (and that has not recovered).
+      // that this synthesis never wrote (and that has not recovered). A
+      // failure deduplicated into OUR live collision record is
+      // indistinguishable here (documented limitation).
       const current = runner.extensions?.health?.().find(
         entry => entry.id === recorded.ref.id && entry.owner === recorded.ref.owner,
       )

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1505,9 +1505,13 @@ export function registerTuiCommands(
    * a fresh collision anywhere re-states the WHOLE current collision set.
    */
   const notifiedCollisions = new Set<string>()
-  /** The identity of one contribution across the bridge and the health
-   * ledger (the id alone is unique today, the owner keeps it honest). */
-  const contributionIdentity = (entry: { id: string; owner: string }): string => `${entry.id}\u0000${entry.owner}`
+  /** The identity of one contribution GENERATION (id + owner + registration
+   * generation): the owner keeps a reused id honest, and the generation keeps
+   * a dispose + re-register under the same id/owner apart — an HMR reload may
+   * coalesce both into ONE invalidate flush, so a purge that only observes
+   * absent identities can never see the gap. */
+  const contributionIdentity = (entry: { id: string; owner: string; generation: number }): string =>
+    `${entry.id}\u0000${entry.owner}\u0000${entry.generation}`
   /** The COLLISION records THIS synthesis wrote, by identity — the only
    * health entries a successful merge may clear, and only while the record
    * still shows that collision message (see the recovery loop). */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1217,6 +1217,10 @@ export function registerTuiCommands(
   /** Whether one slash name is a HOST command in the current effective
    * catalog (advertised, owned by neither the TUI nor an extension). */
   isHostCommand(name: string): boolean
+  /** Whether the current host catalog's command for one name declares
+   * `input.attachments` (the composer-side attachment gate — only a
+   * declaring command may be invoked with staged attachments). */
+  isHostCommandAcceptingAttachments(name: string): boolean
   /** Whether one slash name is a LIVE TUI-owned skill wrapper (an
    * agent-facing invocation whose `/name` line the host may resolve into an
    * injected skill body). */
@@ -1397,6 +1401,13 @@ export function registerTuiCommands(
   // lacks must be consumed with an explicit error, never sent to the model.
   /** The advertised names of the currently installed completion list. */
   let claims = new Set<string>()
+  /** The advertised HOST command names whose descriptor DECLARES
+   * `input.attachments` (DSH `CommandInputDescriptor.attachments`): the
+   * composer-side half of the attachment contract — only these may be
+   * invoked with staged attachments, everything else refuses before
+   * dispatch (the host executor re-enforces at admission). Contributions are
+   * never in this set: a contribution has no host descriptor. */
+  let hostAttachmentCommands = new Set<string>()
   /**
    * The detached human skill catalog for INLINE skill reference completion
    * (the plain-text `/name` lexicon). A Client presentation cache: it owns
@@ -1525,6 +1536,9 @@ export function registerTuiCommands(
     // dispatch consults it), so it must never depend on the client merge — a
     // failed synthesis must not cost a host command its claim.
     claims = new Set(sorted.map(command => command.name))
+    hostAttachmentCommands = new Set(sorted
+      .filter(command => command.input?.attachments === true)
+      .map(command => command.name))
     // The display list carries the client contributions too; the CLAIM set
     // never does (see the parameter doc). 'none' is the FAILED-SOURCE state
     // (upstream `source-failed` removes the source's group): no command rows
@@ -3407,6 +3421,14 @@ export function registerTuiCommands(
     if (skillDisposers.has(name)) return false
     return claims.has(name)
   }
+  /** Whether the CURRENT host catalog's command for one name DECLARES
+   * `input.attachments` (see {@link hostAttachmentCommands}): the composer
+   * consults it before letting an attachment-bearing line through. A skill
+   * wrapper is never an attachment-declaring host command. */
+  const isHostCommandAcceptingAttachments = (name: string): boolean => {
+    if (skillDisposers.has(name)) return false
+    return hostAttachmentCommands.has(name)
+  }
 
   commands.register({
     name: 'skill',
@@ -4708,6 +4730,9 @@ export function registerTuiCommands(
      * TUI as a skill wrapper nor an extension contribution (the dispatch
      * caller excludes TUI-local commands itself via LOCAL_COMMANDS). */
     isHostCommand,
+    /** Whether the current host catalog's command for one name declares
+     * `input.attachments` (the composer-side attachment gate). */
+    isHostCommandAcceptingAttachments,
     /** Whether one slash name is a LIVE TUI-owned skill wrapper (the
      * revalidating transition wrappers included). */
     isSkillWrapper: (name: string): boolean => skillDisposers.has(name),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1195,6 +1195,26 @@ function mergeFooterCustomItemsForSave(raw: unknown, saved: readonly FooterCusto
 }
 
 /**
+ * The CURRENT host catalog's view of ONE parsed line (the DSH client
+ * `CommandUiRuntime.matchEnter` decision table): whether the host CLAIMS the
+ * line, and — for a claimed line — the claiming descriptor's attachment
+ * declaration, so the dispatch can never consult two different catalog views
+ * for the claim and the declaration.
+ */
+export type HostCommandClaim =
+  | {
+    readonly claimed: true
+    /** The claiming descriptor's `input.attachments`
+     * (DSH `CommandInputDescriptor.attachments`): only a declaring command
+     * may be invoked with composer attachments. */
+    readonly attachments: boolean
+  }
+  // The catalog RESOLVES the name but this LINE is not an invocation (an
+  // argued line of an execute-kind command): the line is never handed to the
+  // command plane, and it is an ordinary submission.
+  | { readonly claimed: false }
+
+/**
  * Register the TUI-owned slash commands on the commands service. The
  * completion list is refreshed after every registration so TUI-owned
  * commands appear in the editor's tab list. Registration is sessionless:
@@ -1214,13 +1234,11 @@ export function registerTuiCommands(
   initial?: InitialCommandCatalog,
 ): {
   wasAdvertised(name: string): boolean
-  /** Whether one slash name is a HOST command in the current effective
-   * catalog (advertised, owned by neither the TUI nor an extension). */
-  isHostCommand(name: string): boolean
-  /** Whether the current host catalog's command for one name declares
-   * `input.attachments` (the composer-side attachment gate — only a
-   * declaring command may be invoked with staged attachments). */
-  isHostCommandAcceptingAttachments(name: string): boolean
+  /** The CURRENT host catalog's view of ONE parsed line (see
+   * {@link HostCommandClaim}): `undefined` when the catalog does not RESOLVE
+   * the name, `claimed: false` when it resolves the name without claiming
+   * this line. */
+  hostClaimOf(parsed: { name: string; rawInput?: string }): HostCommandClaim | undefined
   /** Whether one slash name is a LIVE TUI-owned skill wrapper (an
    * agent-facing invocation whose `/name` line the host may resolve into an
    * injected skill body). */
@@ -1399,15 +1417,13 @@ export function registerTuiCommands(
   // command. The dispatch captures the claim BEFORE any session creation
   // (wasAdvertised below); a probed command that the real session then
   // lacks must be consumed with an explicit error, never sent to the model.
-  /** The advertised names of the currently installed completion list. */
-  let claims = new Set<string>()
-  /** The advertised HOST command names whose descriptor DECLARES
-   * `input.attachments` (DSH `CommandInputDescriptor.attachments`): the
-   * composer-side half of the attachment contract — only these may be
-   * invoked with staged attachments, everything else refuses before
-   * dispatch (the host executor re-enforces at admission). Contributions are
-   * never in this set: a contribution has no host descriptor. */
-  let hostAttachmentCommands = new Set<string>()
+  /** The advertised HOST commands of the currently installed completion
+   * list, by name — the host's AUTHORITY record. A contribution never enters
+   * it, and the descriptor's INPUT KIND is kept with it (see
+   * {@link hostClaimOf}): the DSH command UI distinguishes a `leadingInput`
+   * command (`/goal <objective>`) from an execute-kind one (`/compact`) by
+   * `CommandDescriptor.input`, and only the former claims an argued line. */
+  let claims = new Map<string, { leadingInput: boolean; attachments: boolean }>()
   /**
    * The detached human skill catalog for INLINE skill reference completion
    * (the plain-text `/name` lexicon). A Client presentation cache: it owns
@@ -1534,11 +1550,15 @@ export function registerTuiCommands(
     const sorted = [...entries].sort((left, right) => left.name < right.name ? -1 : 1)
     // HOST CLAIMS first: the claim set is the host's AUTHORITY record (the
     // dispatch consults it), so it must never depend on the client merge — a
-    // failed synthesis must not cost a host command its claim.
-    claims = new Set(sorted.map(command => command.name))
-    hostAttachmentCommands = new Set(sorted
-      .filter(command => command.input?.attachments === true)
-      .map(command => command.name))
+    // failed synthesis must not cost a host command its claim. The INPUT KIND
+    // and the attachment DECLARATION (`CommandInputDescriptor`) ride in the
+    // same record: which line the command claims and whether that line may
+    // carry attachments are both descriptor facts, so they can never describe
+    // two different catalogs.
+    claims = new Map(sorted.map(command => [command.name, {
+      leadingInput: command.input !== undefined,
+      attachments: command.input?.attachments === true,
+    }]))
     // The display list carries the client contributions too; the CLAIM set
     // never does (see the parameter doc). 'none' is the FAILED-SOURCE state
     // (upstream `source-failed` removes the source's group): no command rows
@@ -3409,25 +3429,25 @@ export function registerTuiCommands(
   /** Whether one command name is advertised by the CURRENT completion list
    * (the claim captured at submit time, before any session creation). */
   const wasAdvertised = (name: string): boolean => claims.has(name)
-  /** Whether one slash name is a HOST command in the CURRENT effective
-   * catalog: advertised by the host list and NOT a TUI-owned skill wrapper.
+  /** The CURRENT host catalog's view of ONE parsed line (see
+   * {@link HostCommandClaim}): `undefined` when the catalog does not RESOLVE
+   * the name at all (a session-scoped command the standing view cannot see —
+   * the command plane decides), `claimed: false` when it resolves the name
+   * but this line is not an invocation (an argued line of an execute-kind
+   * command: a bare token is claimed by every host command, an argued line
+   * only by a `leadingInput` descriptor).
    * HOST AUTHORITY: a client command contribution never removes a name from
-   * this claim — upstream's candidate synthesis merges contributions with
+   * this catalog — upstream's candidate synthesis merges contributions with
    * the host catalog and FAILS LOUD on a collision instead of shadowing, so
    * a resolved host command always keeps its execution. A skill wrapper is a
    * thin agent-facing invocation (loadSkill builds the prompt), never a host
    * claim. */
-  const isHostCommand = (name: string): boolean => {
-    if (skillDisposers.has(name)) return false
-    return claims.has(name)
-  }
-  /** Whether the CURRENT host catalog's command for one name DECLARES
-   * `input.attachments` (see {@link hostAttachmentCommands}): the composer
-   * consults it before letting an attachment-bearing line through. A skill
-   * wrapper is never an attachment-declaring host command. */
-  const isHostCommandAcceptingAttachments = (name: string): boolean => {
-    if (skillDisposers.has(name)) return false
-    return hostAttachmentCommands.has(name)
+  const hostClaimOf = (parsed: { name: string; rawInput?: string }): HostCommandClaim | undefined => {
+    if (skillDisposers.has(parsed.name)) return undefined
+    const descriptor = claims.get(parsed.name)
+    if (descriptor === undefined) return undefined
+    if (!descriptor.leadingInput && (parsed.rawInput?.trim() ?? '') !== '') return { claimed: false }
+    return { claimed: true, attachments: descriptor.attachments }
   }
 
   commands.register({
@@ -4725,14 +4745,12 @@ export function registerTuiCommands(
   return {
     /** The claim test for the dispatch: is /name advertised right now? */
     wasAdvertised,
-    /** Whether one slash name is a HOST command in the CURRENT effective
-     * catalog: advertised by the completion list but owned by neither the
-     * TUI as a skill wrapper nor an extension contribution (the dispatch
-     * caller excludes TUI-local commands itself via LOCAL_COMMANDS). */
-    isHostCommand,
-    /** Whether the current host catalog's command for one name declares
-     * `input.attachments` (the composer-side attachment gate). */
-    isHostCommandAcceptingAttachments,
+    /** The host catalog's view of ONE parsed line (see
+     * {@link HostCommandClaim}): the name is advertised by the completion list
+     * and owned by neither the TUI as a skill wrapper nor an extension
+     * contribution (the dispatch caller excludes TUI-local commands itself via
+     * LOCAL_COMMANDS). */
+    hostClaimOf,
     /** Whether one slash name is a LIVE TUI-owned skill wrapper (the
      * revalidating transition wrappers included). */
     isSkillWrapper: (name: string): boolean => skillDisposers.has(name),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1253,8 +1253,18 @@ export function registerTuiCommands(
   let boundDelivery: SubmitDelivery | undefined
   /**
    * Bind `delivery` for one synchronous window and run the launch. Commands
-   * that own their own busy semantics (Host commands, local UI commands)
-   * simply never consume it.
+   * that own their own busy semantics (Host commands, dispatched without a
+   * binding) simply never consume it.
+   *
+   * The binding belongs to the dispatch that armed it: it is consumed by the
+   * TUI-owned handler launched in the SAME synchronous window (a handler
+   * that awaits still captures it, because capture is its first statement).
+   * KNOWN LIMITATION: a command handler that SYNCHRONOUSLY re-enters the
+   * command service (`ctx.commands.execute`) for a TUI skill wrapper would
+   * inherit this delivery instead of resolving as "no submission" (queued) —
+   * no in-tree caller does that, and the public `CommandRuntime.execute`
+   * contract has no channel for a per-invocation mode, so such a caller must
+   * pass its own explicit mode rather than rely on the ambient one.
    * @param delivery - the mode the submit boundary resolved for this gesture.
    * @param run - the launch (the command execution) to run inside the window.
    */
@@ -1264,7 +1274,7 @@ export function registerTuiCommands(
     try {
       return run()
     } finally {
-      // Reentrancy-safe: a nested execution restores the outer window.
+      // Restore the enclosing window (undefined at the top level).
       boundDelivery = previous
     }
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1428,6 +1428,19 @@ export function registerTuiCommands(
     const bridge = runner.extensions?.commands
     if (bridge === undefined) return host
     const contributions = bridge.snapshot().entries
+    // PURGE the bookkeeping of contributions that are GONE. A disposed
+    // contribution leaves the snapshot entirely — the recovery loop below
+    // only visits LIVE entries — while its notice key would survive and
+    // silence a RE-registration under the same id/owner (a plugin
+    // reload/HMR): that is a NEW failure generation, and its health record
+    // fails again. The registration's ledger record was untracked with it,
+    // so only these local records remain to drop.
+    const live = new Set(contributions.map(contribution => contributionIdentity(contribution)))
+    for (const identity of [...collisionHealth.keys()]) {
+      if (live.has(identity)) continue
+      collisionHealth.delete(identity)
+      notifiedCollisions.delete(identity)
+    }
     if (contributions.length === 0) return host
     const byName = new Map(host.map(entry => [entry.name, entry] as const))
     // Record EVERY collision of this pass before failing it: the health
@@ -1467,9 +1480,13 @@ export function registerTuiCommands(
       // the first message) — clearing blindly would erase a handler failure
       // that this synthesis never wrote (and that has not recovered). A
       // failure deduplicated into OUR live collision record is
-      // indistinguishable here (documented limitation).
+      // indistinguishable here (documented limitation). The record identity
+      // is (slot, owner, id): one plugin may legally reuse an id in another
+      // slot (a theme and a command), so the extension point MUST match too.
       const current = runner.extensions?.health?.().find(
-        entry => entry.id === recorded.ref.id && entry.owner === recorded.ref.owner,
+        entry => entry.extensionPoint === recorded.ref.slot
+          && entry.id === recorded.ref.id
+          && entry.owner === recorded.ref.owner,
       )
       if (current === undefined || current.state !== 'failed' || current.lastError !== recorded.message) continue
       clearExtensionError?.(recorded.ref)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1428,36 +1428,83 @@ export function registerTuiCommands(
     const contributions = bridge.snapshot().entries
     if (contributions.length === 0) return host
     const byName = new Map(host.map(entry => [entry.name, entry] as const))
+    // Record EVERY collision of this pass before failing it: the health
+    // surface must list all offenders, not only the first one scanned.
+    const colliding = new Set<string>()
+    let firstCollision: Error | undefined
     for (const contribution of contributions) {
       if (!byName.has(contribution.name)) continue
-      const collision = new Error(`command contribution /${contribution.name} collides with a host command`)
-      recordExtensionError?.({ slot: 'command', id: contribution.id, owner: contribution.owner }, collision)
-      throw collision
+      const identity = contributionIdentity(contribution)
+      colliding.add(identity)
+      const collision = Object.assign(
+        new Error(`command contribution /${contribution.name} collides with a host command`),
+        { contributionIdentity: identity },
+      )
+      const ref = { slot: 'command', id: contribution.id, owner: contribution.owner }
+      collisionHealth.set(identity, { ref, message: collision.message })
+      recordExtensionError?.(ref, collision)
+      firstCollision ??= collision
     }
+    // HEALTH RECOVERY, scoped to COLLISION records only: a contribution that
+    // merges cleanly again is no longer failed — even while another
+    // contribution keeps this pass failing. A handler-failure record in the
+    // same health slot is NEVER touched (this synthesis did not write it).
+    for (const contribution of contributions) {
+      const identity = contributionIdentity(contribution)
+      if (colliding.has(identity)) continue
+      const recorded = collisionHealth.get(identity)
+      if (recorded === undefined) continue
+      collisionHealth.delete(identity)
+      // A recovered collision may notify again in a later generation.
+      notifiedCollisions.delete(identity)
+      // Clear ONLY when the health record currently shows OUR collision: the
+      // same slot also carries handler runtime failures, and the ledger
+      // DEDUPLICATES a later failure into an already-failed record (keeping
+      // the first message) — clearing blindly would erase a handler failure
+      // that this synthesis never wrote (and that has not recovered).
+      const current = runner.extensions?.health?.().find(
+        entry => entry.id === recorded.ref.id && entry.owner === recorded.ref.owner,
+      )
+      if (current === undefined || current.state !== 'failed' || current.lastError !== recorded.message) continue
+      clearExtensionError?.(recorded.ref)
+    }
+    if (firstCollision !== undefined) throw firstCollision
     for (const contribution of contributions) {
       byName.set(contribution.name, { name: contribution.name, description: contribution.description })
     }
     return [...byName.values()]
   }
-  /** One collision notice per contribution name (never a per-refresh spam). */
-  const notifiedCollisions = new Set<string>()
   /**
-   * Install one completion list (sorted, claims refreshed). The single
-   * synchronous seam every catalog commit funnels through.
-   * @param entries - the HOST catalog rows; the client contributions are
-   *   merged in by {@link mergeContributions} (the installed DISPLAY list),
-   *   while `claims` stays host-only — a contribution is not a command-plane
-   *   claim.
+   * One collision notice per contribution IDENTITY and failure GENERATION
+   * (the key is dropped when the collision recovers): a new owner reusing a
+   * released name, or the same contribution colliding again after the host
+   * descriptor went away and came back, is surfaced again.
    */
-  const installCompletions = (entries: readonly SurfaceCommandSummary[]): void => {
+  const notifiedCollisions = new Set<string>()
+  /** The identity of one contribution across the bridge and the health
+   * ledger (the id alone is unique today, the owner keeps it honest). */
+  const contributionIdentity = (entry: { id: string; owner: string }): string => `${entry.id}\u0000${entry.owner}`
+  /** The COLLISION records THIS synthesis wrote, by identity — the only
+   * health entries a successful merge may clear, and only while the record
+   * still shows that collision message (see the recovery loop). */
+  const collisionHealth = new Map<string, { ref: { slot: string; id: string; owner: string }; message: string }>()
+  const installCompletions = (
+    entries: readonly SurfaceCommandSummary[],
+    options: { display?: 'merged' | 'none' } = {},
+  ): void => {
     const sorted = [...entries].sort((left, right) => left.name < right.name ? -1 : 1)
     // HOST CLAIMS first: the claim set is the host's AUTHORITY record (the
     // dispatch consults it), so it must never depend on the client merge — a
     // failed synthesis must not cost a host command its claim.
     claims = new Set(sorted.map(command => command.name))
     // The display list carries the client contributions too; the CLAIM set
-    // never does (see the parameter doc).
-    const display = [...mergeContributions(sorted)].sort((left, right) => left.name < right.name ? -1 : 1)
+    // never does (see the parameter doc). 'none' is the FAILED-SOURCE state
+    // (upstream `source-failed` removes the source's group): no command rows
+    // are offered until a synthesis succeeds again, while the claims above
+    // stay live.
+    const display = options.display === 'none'
+      ? []
+      : [...mergeContributions(sorted)].sort((left, right) => left.name < right.name ? -1 : 1)
     // M5: the plugin autocomplete chain (AutocompleteRegistry) is consulted
     // after the host's own provider returns null. The registry's suggest()
     // handles cancellation (latest-only commit) and per-provider isolation.
@@ -1542,15 +1589,33 @@ export function registerTuiCommands(
     try {
       installCompletions(entries)
     } catch (error) {
+      // The failed pass marks the command SOURCE failed (upstream
+      // `source-failed` parity: the source's whole group is removed): no
+      // command row — client OR host — is offered until a synthesis succeeds
+      // again, so no displayed row can ever execute a different command than
+      // it shows. The HOST CLAIMS were refreshed before the merge, so the
+      // input authority of a host command is never lost while the menu is
+      // empty.
       const message = safeErrorMessage(error)
-      if (!notifiedCollisions.has(message)) {
-        notifiedCollisions.add(message)
+      // The notice identity is the FAILING contribution (the error carries
+      // its name; the health ref carries the owner) — a re-used name by a
+      // new owner notifies again.
+      const collision = error as { contributionIdentity?: string }
+      const noticeKey = collision.contributionIdentity ?? message
+      if (!notifiedCollisions.has(noticeKey)) {
+        notifiedCollisions.add(noticeKey)
         app.notify(message, 'error')
       }
       try {
         ctx.logger.error(`tui-runner: ${message}`)
       } catch {
         // The cordis logger must not block the submission path.
+      }
+      try {
+        installCompletions(entries, { display: 'none' })
+      } catch {
+        // Clearing the display is plain work: a failure here is a core bug,
+        // not a contribution problem — leave the previous list in place.
       }
     }
   }

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -482,6 +482,10 @@ export interface TuiCommandBridgeSnapshot {
     readonly description: string
     readonly sessionless: boolean
     readonly owner: string
+    /** Monotonic per-registration generation (diagnostics + the notice
+     * identity): a dispose + re-register under the same id/owner is a NEW
+     * generation, even when both happen inside one coalesced flush. */
+    readonly generation: number
   }[]
   readonly revision: number
 }

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -420,49 +420,32 @@ export interface InputWidget {
 
 // ── M5: commands / themes / autocomplete / settings / keybindings ──────────
 
-/** One command contribution (plan §10): ownership metadata over a slash
- * name. The bridge itself never executes anything — the RUNNER routes from
- * `execution`: a local contribution runs its own bridge `handler` locally
- * (falling back to the commands-service definition handler when it declares
- * none), a submission contribution is delivered as an agent-facing line.
+/** One CLIENT-OWNED command contribution (plan §10) — the DSH client
+ * command contribution shape: a slash name whose behavior lives entirely on
+ * the client (no host descriptor). It appears in the `/` menu merged with
+ * the host catalog and executes through its own `handler`, never steered.
+ * A contribution whose name is a host command FAILS LOUD at candidate
+ * synthesis and never shadows it (the host command keeps its claim).
  * `/name args...` ALWAYS keeps `invocation.rawInput` verbatim. */
 export interface TuiCommandContribution {
   readonly id: string
   /** The slash-command name WITHOUT the leading slash. */
   readonly name: string
   readonly description: string
-  /** Execution ownership over an existing command (TUI-owned metadata; the
-   * bridge never executes).
-   * - `local` — the command ALWAYS executes locally, never steered: the
-   *   contribution's own bridge `handler` when one is declared (live session
-   *   or not), otherwise the commands-service definition handler; the busy
-   *   policy never applies and the line is never steered.
-   * - `submission` — the command is a SUBMISSION LINE, not a command
-   *   execution: the TUI delivers the raw `/<name> args` line to the session
-   *   with the busy-Enter-policy mode (steered into the running turn, or
-   *   queued), exactly like a skill invocation; the commands-service handler
-   *   is NOT run for that gesture (the plugin's own pre-step owns any
-   *   expansion of the line). It needs a live session — `sessionless: true`
-   *   with `submission` is rejected at registration.
-   *
-   * BREAKING (Unreleased): `submission` used to keep the commands-service
-   * handler authoritative, so the handler ran in every non-steer mode
-   * (`commands.execute`) while the steer mode delivered a bare line — an
-   * asymmetry no other client shared. It is now the web composer's
-   * unclaimed-line semantics on BOTH sides. A contribution that needs
-   * handler execution declares `local`. */
-  readonly execution: 'local' | 'submission'
-  /** Whether the command may run without a live session. */
+  /** Whether the command may run BEFORE a live session exists (default
+   * false). A sessionless contribution executes immediately; every other
+   * contribution resolves/creates the session first, then executes — the
+   * host command surface is session-keyed upstream, so this is an explicit
+   * TUI extension for pure client commands (an overlay toggle, a picker). */
   readonly sessionless?: boolean
+
   /** Optional autocomplete provider for this command's arguments
    * (the structural {@link TuiAutocompleteProvider}). */
   readonly argumentProvider?: TuiAutocompleteProvider
-  /** Optional LOCAL implementation. The TUI runs it whenever the EFFECTIVE
-   * ownership is `local` — with or without a live session — passing
-   * `invocation.rawInput` verbatim, and the commands-service definition is
-   * only the fallback when no bridge handler is declared. A `submission`
-   * contribution's handler is never run by the TUI. */
-  readonly handler?: TuiLocalCommandHandler
+  /** The command's client behavior (required): the TUI runs it locally,
+   * passing `invocation.rawInput` verbatim, with or without a live session
+   * according to {@link sessionless}. */
+  readonly handler: TuiLocalCommandHandler
 }
 
 /** The local command handler signature (invocation carries the VERBATIM
@@ -488,7 +471,6 @@ export interface TuiCommandBridgeSnapshot {
     readonly id: string
     readonly name: string
     readonly description: string
-    readonly execution: 'local' | 'submission'
     readonly sessionless: boolean
     readonly owner: string
   }[]

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -468,9 +468,13 @@ export interface TuiLocalCommandHandler {
     | Promise<{ readonly kind: 'success'; readonly text?: string; readonly sourceEventSeq?: number } | { readonly kind: 'error'; readonly text: string }>
 }
 
-/** A live handle on one command contribution. */
+/** A live handle on ONE command contribution REGISTRATION. */
 export interface TuiCommandHandle {
   readonly id: string
+  /** Dispose THIS registration (idempotent). A repeated or late call — e.g.
+   * a fiber disposer running after an HMR reload re-registered the same id —
+   * never removes a NEWER registration: the handle names one generation, not
+   * the id. */
   dispose(): void
 }
 

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -435,7 +435,10 @@ export interface InputWidget {
  * the host catalog and executes through its own `handler`, never steered.
  * A contribution whose name is a host command FAILS LOUD at candidate
  * synthesis and never shadows it (the host command keeps its claim).
- * `/name args...` ALWAYS keeps `invocation.rawInput` verbatim. */
+ * A contribution is a slash-MENU entry, so it claims the BARE `/name` token
+ * only (DSH `matchEnter`): `/name args...` is NOT an invocation — it is an
+ * ordinary submission that reaches the model, and `handler` never runs for
+ * it. */
 export interface TuiCommandContribution {
   readonly id: string
   /** The slash-command name WITHOUT the leading slash. */
@@ -451,15 +454,20 @@ export interface TuiCommandContribution {
   // REMOVED (Unreleased): `argumentProvider` was never wired to the
   // completion path (a dead public surface). Use the AutocompleteRegistry
   // (`registerAutocomplete`) for plugin suggestions.
-  /** The command's client behavior (required): the TUI runs it locally,
-   * passing `invocation.rawInput` verbatim, with or without a live session
+  /** The command's client behavior (required): the TUI runs it locally for the
+   * BARE `/name` line, passing `invocation.rawInput` verbatim (it carries no
+   * non-whitespace input, since an argued line is never an invocation, though
+   * trailing whitespace may be preserved), with or without a live session
    * according to {@link sessionless}. */
   readonly handler: TuiLocalCommandHandler
 }
 
 /** The local command handler signature (invocation carries the VERBATIM
- * raw input — never re-parsed or rewritten). Returns the commands
- * service's result shape (`{ kind: 'success' }` / `{ kind: 'error',
+ * raw input — never re-parsed or rewritten). A client command CONTRIBUTION is
+ * invoked by its bare token alone, so its `rawInput` never carries
+ * non-whitespace input (trailing whitespace is preserved verbatim); TUI-owned
+ * local commands (`/export json`) still receive their arguments here. Returns the
+ * commands service's result shape (`{ kind: 'success' }` / `{ kind: 'error',
  * text }`) so the runner's notify path is shared. */
 export interface TuiLocalCommandHandler {
   (invocation: { commandId: string; rawInput: string; signal: AbortSignal }):

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -439,9 +439,9 @@ export interface TuiCommandContribution {
    * TUI extension for pure client commands (an overlay toggle, a picker). */
   readonly sessionless?: boolean
 
-  /** Optional autocomplete provider for this command's arguments
-   * (the structural {@link TuiAutocompleteProvider}). */
-  readonly argumentProvider?: TuiAutocompleteProvider
+  // REMOVED (Unreleased): `argumentProvider` was never wired to the
+  // completion path (a dead public surface). Use the AutocompleteRegistry
+  // (`registerAutocomplete`) for plugin suggestions.
   /** The command's client behavior (required): the TUI runs it locally,
    * passing `invocation.rawInput` verbatim, with or without a live session
    * according to {@link sessionless}. */

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -428,20 +428,36 @@ export interface TuiCommandContribution {
   /** The slash-command name WITHOUT the leading slash. */
   readonly name: string
   readonly description: string
-  /** Execution ownership: `local` always runs the handler and never steers;
-   * `submission` is AGENT-FACING input — the command's LINE is delivered to
-   * the session in the busy-Enter-policy mode (steered or queued, like any
-   * skill invocation), and the commands-service handler is NOT run by the
-   * TUI ahead of that delivery. Busy Enter classifies by the EFFECTIVE
-   * ownership. */
+  /** Execution ownership over an existing command (TUI-owned metadata; the
+   * bridge never executes).
+   * - `local` — the command ALWAYS executes through the commands service
+   *   (its handler, or the bridge handler when one is declared); the busy
+   *   policy never applies and the line is never steered.
+   * - `submission` — the command is a SUBMISSION LINE, not a command
+   *   execution: the TUI delivers the raw `/<name> args` line to the session
+   *   with the busy-Enter-policy mode (steered into the running turn, or
+   *   queued), exactly like a skill invocation; the commands-service handler
+   *   is NOT run for that gesture (the plugin's own pre-step owns any
+   *   expansion of the line). It needs a live session — `sessionless: true`
+   *   with `submission` is rejected at registration.
+   *
+   * BREAKING (Unreleased): `submission` used to keep the commands-service
+   * handler authoritative, so the handler ran in every non-steer mode
+   * (`commands.execute`) while the steer mode delivered a bare line — an
+   * asymmetry no other client shared. It is now the web composer's
+   * unclaimed-line semantics on BOTH sides. A contribution that needs
+   * handler execution declares `local`. */
   readonly execution: 'local' | 'submission'
   /** Whether the command may run without a live session. */
   readonly sessionless?: boolean
   /** Optional autocomplete provider for this command's arguments
    * (the structural {@link TuiAutocompleteProvider}). */
   readonly argumentProvider?: TuiAutocompleteProvider
-  /** Optional local handler; absent = metadata-only ownership (the
-   * commands service handler runs). */
+  /** Optional LOCAL implementation. The TUI runs it whenever the EFFECTIVE
+   * ownership is `local` — with or without a live session — passing
+   * `invocation.rawInput` verbatim, and the commands-service definition is
+   * only the fallback when no bridge handler is declared. A `submission`
+   * contribution's handler is never run by the TUI. */
   readonly handler?: TuiLocalCommandHandler
 }
 

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -428,8 +428,12 @@ export interface TuiCommandContribution {
   /** The slash-command name WITHOUT the leading slash. */
   readonly name: string
   readonly description: string
-  /** Execution ownership: local (never steered) vs submission (session
-   * policy). Busy Enter classifies by the EFFECTIVE ownership. */
+  /** Execution ownership: `local` always runs the handler and never steers;
+   * `submission` is AGENT-FACING input — the command's LINE is delivered to
+   * the session in the busy-Enter-policy mode (steered or queued, like any
+   * skill invocation), and the commands-service handler is NOT run by the
+   * TUI ahead of that delivery. Busy Enter classifies by the EFFECTIVE
+   * ownership. */
   readonly execution: 'local' | 'submission'
   /** Whether the command may run without a live session. */
   readonly sessionless?: boolean

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -420,9 +420,12 @@ export interface InputWidget {
 
 // ── M5: commands / themes / autocomplete / settings / keybindings ──────────
 
-/** One command contribution (plan §10): ownership metadata over an
- * existing command. The bridge does NOT execute — the commands service
- * does. `/name args...` ALWAYS keeps `invocation.rawInput` verbatim. */
+/** One command contribution (plan §10): ownership metadata over a slash
+ * name. The bridge itself never executes anything — the RUNNER routes from
+ * `execution`: a local contribution runs its own bridge `handler` locally
+ * (falling back to the commands-service definition handler when it declares
+ * none), a submission contribution is delivered as an agent-facing line.
+ * `/name args...` ALWAYS keeps `invocation.rawInput` verbatim. */
 export interface TuiCommandContribution {
   readonly id: string
   /** The slash-command name WITHOUT the leading slash. */
@@ -430,8 +433,9 @@ export interface TuiCommandContribution {
   readonly description: string
   /** Execution ownership over an existing command (TUI-owned metadata; the
    * bridge never executes).
-   * - `local` — the command ALWAYS executes through the commands service
-   *   (its handler, or the bridge handler when one is declared); the busy
+   * - `local` — the command ALWAYS executes locally, never steered: the
+   *   contribution's own bridge `handler` when one is declared (live session
+   *   or not), otherwise the commands-service definition handler; the busy
    *   policy never applies and the line is never steered.
    * - `submission` — the command is a SUBMISSION LINE, not a command
    *   execution: the TUI delivers the raw `/<name> args` line to the session

--- a/src/extension/public-types.ts
+++ b/src/extension/public-types.ts
@@ -73,8 +73,16 @@ export interface TuiAutocompleteProvider {
   getSuggestions(query: TuiAutocompleteQuery): Promise<TuiAutocompleteSuggestions | null>
 }
 
-/** API version of the extension surface (bumped only on breaking changes). */
-export const API_VERSION = 1 as const
+/**
+ * API version of the extension surface (bumped only on breaking changes).
+ * `2` is the client-command contribution contract: `execution` and the
+ * never-wired `argumentProvider` are REMOVED, `handler` is required, and a
+ * stale plugin still declaring the removed ownership shape is rejected at
+ * registration. `1` was the M0–M3 foundation. A plugin branching on
+ * `api().apiVersion` can tell the two schemas apart — the host never reports
+ * a version it does not implement.
+ */
+export const API_VERSION = 2 as const
 
 /** Capability identifiers, feature-detected via {@link PiTuiApiInfo}. */
 export type PiTuiCapability =
@@ -126,7 +134,8 @@ export type UnstableCapability = `unstable.${string}`
 
 /** What a plugin may know about the host (M1: version + capabilities only). */
 export interface PiTuiApiInfo {
-  /** The extension API version; 1 for the M0–M3 foundation. */
+  /** The extension API version: 2 for the client-command contribution
+   * contract, 1 for the M0–M3 foundation (see {@link API_VERSION}). */
   readonly apiVersion: typeof API_VERSION
   /** The `@xmoon76/dsh-pi-tui` bundle version (semver string). */
   readonly hostVersion: string

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -23,6 +23,7 @@ import { Service, type Context } from '@deepseek-ai/cordis'
 import { ExtensionLedger } from './internal/ledger.ts'
 import { InvalidateBatcher } from './internal/batcher.ts'
 import { isSlotName, slotNames, slotSemantic } from './slot-map.ts'
+import { API_VERSION } from './public-types.ts'
 import type { PiTuiApiInfo, PiTuiCapability, PiTuiSlotName, RegistrationHandle, RegistrationSpec, SurfaceStateValues } from './public-types.ts'
 import type {
   AdvancedConfirmOptions,
@@ -526,12 +527,15 @@ export class PiTuiExtensionServiceImpl extends Service implements PiTuiExtension
     // attachment-gated: the snapshot contract only holds while a surface
     // is attached. The runner's attachSurface() adds the live set.
     return {
-      apiVersion: 1,
+      // The ONE source of truth for the reported version (`public-types`):
+      // never a literal, so a bump cannot leave the runtime behind.
+      apiVersion: API_VERSION,
       hostVersion: this.hostVersion,
       capabilities: new Set([...PiTuiExtensionServiceImpl.ADVERTISED_CAPABILITIES, ...this.liveCapabilities]),
       // M11 deprecation policy (plan §16): currently nothing is
       // deprecated — the map stays empty. When a surface is deprecated,
-      // its note lands here AND the capability/API is removed in API v2.
+      // its note lands here AND the capability/API is removed in the NEXT
+      // API version.
       deprecations: new Map(),
     }
   }

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -219,12 +219,12 @@ export interface PiTuiExtensionService {
    */
   subscribeState(listener: (state: SurfaceStateValues) => void): () => void
   /**
-   * Register a TUI command contribution (M5): execution ownership metadata
-   * over a slash name. The bridge itself never executes anything — the
-   * runner runs a local contribution's own bridge `handler` locally (the
-   * commands-service definition handler is the fallback), while a
-   * submission contribution is delivered as an agent-facing line. Owned by
-   * the calling fiber.
+   * Register a CLIENT-OWNED command contribution (M5): a slash name whose
+   * behavior lives entirely on the client (the DSH client command
+   * contribution shape). It joins the `/` menu merged with the host catalog
+   * and the runner executes its own `handler` locally; a name that is also a
+   * host command fails loud at candidate synthesis and never shadows it.
+   * Owned by the calling fiber.
    * @param contribution - the command contribution.
    */
   registerCommand(contribution: TuiCommandContribution): TuiCommandHandle
@@ -867,9 +867,6 @@ export class PiTuiExtensionServiceImpl extends Service implements PiTuiExtension
     const caller = this.ctx
     const owner = `${caller.fiber.uid}:${caller.fiber.name}`
     const outcome = this.commands.register(contribution, owner)
-    if (outcome.kind === 'invalid') {
-      throw new Error(`command contribution "${contribution.name}" is invalid: ${outcome.reason}`)
-    }
     if (outcome.kind === 'conflict') {
       const detail = outcome.nearSynonym === undefined
         ? `owner "${outcome.existingOwner}" already holds it`

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -864,6 +864,9 @@ export class PiTuiExtensionServiceImpl extends Service implements PiTuiExtension
     const caller = this.ctx
     const owner = `${caller.fiber.uid}:${caller.fiber.name}`
     const outcome = this.commands.register(contribution, owner)
+    if (outcome.kind === 'invalid') {
+      throw new Error(`command contribution "${contribution.name}" is invalid: ${outcome.reason}`)
+    }
     if (outcome.kind === 'conflict') {
       const detail = outcome.nearSynonym === undefined
         ? `owner "${outcome.existingOwner}" already holds it`

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -220,8 +220,11 @@ export interface PiTuiExtensionService {
   subscribeState(listener: (state: SurfaceStateValues) => void): () => void
   /**
    * Register a TUI command contribution (M5): execution ownership metadata
-   * over an existing command. The bridge does NOT execute — actual
-   * execution stays in the commands service. Owned by the calling fiber.
+   * over a slash name. The bridge itself never executes anything — the
+   * runner runs a local contribution's own bridge `handler` locally (the
+   * commands-service definition handler is the fallback), while a
+   * submission contribution is delivered as an agent-facing line. Owned by
+   * the calling fiber.
    * @param contribution - the command contribution.
    */
   registerCommand(contribution: TuiCommandContribution): TuiCommandHandle

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -878,22 +878,28 @@ export class PiTuiExtensionServiceImpl extends Service implements PiTuiExtension
       throw new Error(`command contribution "${contribution.name}" conflicts: ${detail} — resolve the conflict before registering`)
     }
     this.trackRegistryHealth('command', contribution.id, owner)
+    // The health record is keyed (slot, owner, id) — it cannot tell two
+    // registrations of the same id apart, so every cleanup asks the bridge
+    // whether THIS handle is still the live registration before untracking:
+    // a stale cleanup (a repeated explicit dispose, or a late fiber effect
+    // after an HMR re-registration) must never drop a newer generation's
+    // record.
+    const disposeOwn = (): void => {
+      const current = this.commands.isCurrent(outcome.handle)
+      outcome.handle.dispose()
+      if (current) this.untrackRegistryHealth('command', contribution.id, owner)
+    }
     let dispose: () => void
     try {
-      dispose = caller.fiber.effect(() => () => {
-        outcome.handle.dispose()
-        this.untrackRegistryHealth('command', contribution.id, owner)
-      }, 'piTuiExtensions.registerCommand()')
+      dispose = caller.fiber.effect(() => disposeOwn, 'piTuiExtensions.registerCommand()')
     } catch (error) {
-      outcome.handle.dispose()
-      this.untrackRegistryHealth('command', contribution.id, owner)
+      disposeOwn()
       throw error
     }
     return {
       id: outcome.handle.id,
       dispose: () => {
-        outcome.handle.dispose()
-        this.untrackRegistryHealth('command', contribution.id, owner)
+        disposeOwn()
         dispose()
       },
     }

--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -382,16 +382,21 @@ export class FocusActivityComponent {
  * The Focus presentation projection over one windowed transcript (plan
  * §12/§33): a turn with an initial prompt is grouped as
  * `user(s) → FocusActivity`; a turn with only same-turn steers starts with
- * `FocusActivity` and keeps those steers in process order. Expanded
- * process/final and compaction rows follow, so the raw TranscriptMessage
- * union is never polluted with a fake `focus-activity` kind and the session
- * data stays lossless.
+ * `FocusActivity` and keeps those steers in process order. A turn woken by
+ * injected/system context keeps that LEADING prefix as its foundation
+ * before the Thought (expanded and collapsed). Expanded process/final and
+ * compaction rows follow, so the raw TranscriptMessage union is never
+ * polluted with a fake `focus-activity` kind and the session data stays
+ * lossless.
  *
- * Collapsed turns HIDE thinking/tool/system/intermediate-assistant rows
- * entirely — they cannot leak through Ctrl+O/Alt+T because they are not in
- * the rendered list at all (plan §15.2). The final assistant only appears
- * after the authoritative `turn/end` (plan §13.1) and never duplicates in
- * the expanded view (it stays at its chronological position).
+ * Collapsed turns HIDE the process rows — thinking, tool, mid-turn
+ * system/inject and intermediate-assistant — entirely: they cannot leak
+ * through Ctrl+O/Alt+T because they are not in the rendered list at all
+ * (plan §15.2). The LEADING injected/system prefix (the turn foundation)
+ * and every human user row stay visible before the Thought. The final
+ * assistant only appears after the authoritative `turn/end` (plan §13.1)
+ * and never duplicates in the expanded view (it stays at its
+ * chronological position).
  * @param messages - the windowed transcript.
  * @param activities - the folder's per-turn activities (same fold state).
  * @param expandedTurns - the user's expansion choices (live running turns
@@ -458,19 +463,22 @@ export function projectFocus(
       // the final assistant held back and appended LAST (a max-tokens
       // turn's `max tokens reached` system row must never land after the
       // final: the settled order is User → Thought → process → final).
-      // The INITIAL-PROMPT boundary precedes the Thought: rows before the
+      // The THOUGHT-LEAD boundary precedes the Thought: rows before the
       // turn's FIRST non-steer user (injected/system context) stay in place
       // and that initial user itself stays above the Thought; every later
       // user/steer returns to its chronological position in the process
       // (plan: expanded chronology — the projection reorders, never the
       // session events). With a non-steer user, the first such row is the
-      // compatibility boundary; when every user is a steer, the boundary is 0.
-      // Consecutive users after the boundary stay in chronological
-      // order; they are not a multi-row initial prompt (plan: no adjacency guessing).
-      // Every revealed process row carries the owner-turn collapse mark; the
-      // user's rows and the FINAL assistant stay unmarked (clicking them
-      // must not collapse the Thought — review P2).
-      const boundary = initialPromptBoundary(group)
+      // compatibility boundary; when every user is a steer, the boundary
+      // falls back to the end of the LEADING injected/system prefix, so an
+      // inject-woken turn keeps its foundation before the Thought (never a
+      // scan of mid-process system rows). Consecutive users after the
+      // boundary stay in chronological order; they are not a multi-row
+      // initial prompt (plan: no adjacency guessing). Every revealed
+      // process row carries the owner-turn collapse mark; the user's rows,
+      // the lead foundation rows and the FINAL assistant stay unmarked
+      // (clicking them must not collapse the Thought — review P2).
+      const boundary = thoughtLeadBoundary(group)
       for (const member of group.slice(0, boundary)) {
         out.push({ kind: 'message', message: member })
       }
@@ -488,21 +496,20 @@ export function projectFocus(
       }
       continue
     }
-    // Collapsed: preserve the existing users-before-Thought summary when
-    // an initial prompt exists. A turn with no same-turn opening user row
-    // has its Thought lead, followed by the claimed mid-turn steers.
-    const hasInitialPrompt = initialPromptBoundary(group) > 0
-    if (hasInitialPrompt) {
-      for (const member of group) {
-        if (member.kind === 'user') out.push({ kind: 'message', message: member })
-      }
+    // Collapsed Focus summarizes the turn's INPUTS before the Thought: the
+    // leading injected/system prefix (the turn foundation) and EVERY human
+    // user row (same-turn steers included) precede the Thought; the process
+    // stays hidden inside it. This is a summary, not strict chronology — a
+    // steer-only turn still shows its user input above the Thought. Only
+    // the LEADING system prefix is lifted; mid-turn injected context stays
+    // process content, hidden under the collapsed Thought.
+    for (const member of group.slice(0, leadingSystemPrefixEnd(group))) {
+      out.push({ kind: 'message', message: member })
+    }
+    for (const member of group) {
+      if (member.kind === 'user') out.push({ kind: 'message', message: member })
     }
     if (activity !== undefined) out.push({ kind: 'activity', activity })
-    if (!hasInitialPrompt) {
-      for (const member of group) {
-        if (member.kind === 'user') out.push({ kind: 'message', message: member })
-      }
-    }
     // Compaction cards keep their existing lifecycle in the collapsed
     // view (plan §12.3 v1 — never hidden into the Thought).
     for (const member of group) {
@@ -530,19 +537,32 @@ function assistantForStep(
   return undefined
 }
 
-/** The initial-prompt boundary of one turn group: the index AFTER the
+/** The end of the turn's LEADING injected/system prefix: only consecutive
+ * `kind === 'system'` rows at the very start of the group count as the
+ * opening turn foundation. Mid-process system rows are never included, so a
+ * later inject can never be lifted before the Thought. */
+function leadingSystemPrefixEnd(group: readonly TranscriptMessage[]): number {
+  let end = 0
+  while (group[end]?.kind === 'system') end += 1
+  return end
+}
+
+/** The Thought-lead boundary of one turn group: the index AFTER the
  * turn's FIRST unmarked user row. Rows before it (injected/system context)
  * and the initial user itself stay above the Thought; every later row
  * (same-turn steers included) returns to its chronological position. A turn
- * whose user rows are all marked same-turn steers has no boundary, so the
- * Thought leads with chronology intact. Without steer metadata, the first
- * user remains the initial-prompt fallback; consecutive users are queue/steer
- * input, not a multi-row initial prompt. */
-function initialPromptBoundary(group: readonly TranscriptMessage[]): number {
+ * whose user rows are all marked same-turn steers has no opening human
+ * prompt: the boundary falls back to the end of the LEADING injected/system
+ * prefix, so an inject-woken turn keeps its foundation before the Thought
+ * (never a scan of mid-process system rows). Without steer metadata, the
+ * first user remains the initial-prompt fallback; consecutive users are
+ * queue/steer input, not a multi-row initial prompt. */
+function thoughtLeadBoundary(group: readonly TranscriptMessage[]): number {
   const firstInitialUserIndex = group.findIndex(
     member => member.kind === 'user' && member.steer !== true,
   )
-  return firstInitialUserIndex < 0 ? 0 : firstInitialUserIndex + 1
+  if (firstInitialUserIndex >= 0) return firstInitialUserIndex + 1
+  return leadingSystemPrefixEnd(group)
 }
 
 /** Whether one Assistant entry has semantic/finalized content. Pending

--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -383,7 +383,7 @@ export class FocusActivityComponent {
  * §12/§33): a turn with an initial prompt is grouped as
  * `user(s) → FocusActivity`; a turn with only same-turn steers starts with
  * `FocusActivity` and keeps those steers in process order. A turn woken by
- * injected/system context keeps that LEADING prefix as its foundation
+ * injected-context keeps that LEADING prefix as its foundation
  * before the Thought (expanded and collapsed). Expanded process/final and
  * compaction rows follow, so the raw TranscriptMessage union is never
  * polluted with a fake `focus-activity` kind and the session data stays
@@ -392,7 +392,7 @@ export class FocusActivityComponent {
  * Collapsed turns HIDE the process rows — thinking, tool, mid-turn
  * system/inject and intermediate-assistant — entirely: they cannot leak
  * through Ctrl+O/Alt+T because they are not in the rendered list at all
- * (plan §15.2). The LEADING injected/system prefix (the turn foundation)
+ * (plan §15.2). The LEADING injected-context prefix (the turn foundation)
  * and every human user row stay visible before the Thought. The final
  * assistant only appears after the authoritative `turn/end` (plan §13.1)
  * and never duplicates in the expanded view (it stays at its
@@ -464,13 +464,13 @@ export function projectFocus(
       // turn's `max tokens reached` system row must never land after the
       // final: the settled order is User → Thought → process → final).
       // The THOUGHT-LEAD boundary precedes the Thought: rows before the
-      // turn's FIRST non-steer user (injected/system context) stay in place
+      // turn's FIRST non-steer user (injected context) stay in place
       // and that initial user itself stays above the Thought; every later
       // user/steer returns to its chronological position in the process
       // (plan: expanded chronology — the projection reorders, never the
       // session events). With a non-steer user, the first such row is the
       // compatibility boundary; when every user is a steer, the boundary
-      // falls back to the end of the LEADING injected/system prefix, so an
+      // falls back to the end of the LEADING injected-context prefix, so an
       // inject-woken turn keeps its foundation before the Thought (never a
       // scan of mid-process system rows). Consecutive users after the
       // boundary stay in chronological order; they are not a multi-row
@@ -497,13 +497,14 @@ export function projectFocus(
       continue
     }
     // Collapsed Focus summarizes the turn's INPUTS before the Thought: the
-    // leading injected/system prefix (the turn foundation) and EVERY human
+    // leading injected-context prefix (the turn foundation) and EVERY human
     // user row (same-turn steers included) precede the Thought; the process
     // stays hidden inside it. This is a summary, not strict chronology — a
     // steer-only turn still shows its user input above the Thought. Only
-    // the LEADING system prefix is lifted; mid-turn injected context stays
-    // process content, hidden under the collapsed Thought.
-    for (const member of group.slice(0, leadingSystemPrefixEnd(group))) {
+    // the LEADING injected-context prefix is lifted; mid-turn injected
+    // context and orchestration rows (llm/retry, max-tokens) stay process
+    // content, hidden under the collapsed Thought.
+    for (const member of group.slice(0, leadingInjectedContextPrefixEnd(group))) {
       out.push({ kind: 'message', message: member })
     }
     for (const member of group) {
@@ -537,32 +538,40 @@ function assistantForStep(
   return undefined
 }
 
-/** The end of the turn's LEADING injected/system prefix: only consecutive
- * `kind === 'system'` rows at the very start of the group count as the
- * opening turn foundation. Mid-process system rows are never included, so a
- * later inject can never be lifted before the Thought. */
-function leadingSystemPrefixEnd(group: readonly TranscriptMessage[]): number {
+/** The end of the turn's LEADING injected-context prefix: only consecutive
+ * `kind === 'system'` rows carrying the source-derived `context` marker at
+ * the very start of the group count as the opening turn foundation. Other
+ * `kind: 'system'` rows (llm/retry, max-tokens) are orchestration, not
+ * foundation — they must stay process content, never lifted before the
+ * Thought. Mid-process system rows are never included either, so a later
+ * inject can never be lifted before the Thought. */
+function leadingInjectedContextPrefixEnd(group: readonly TranscriptMessage[]): number {
   let end = 0
-  while (group[end]?.kind === 'system') end += 1
+  while (true) {
+    const member = group[end]
+    if (member === undefined || member.kind !== 'system' || member.context !== true) break
+    end += 1
+  }
   return end
 }
 
 /** The Thought-lead boundary of one turn group: the index AFTER the
- * turn's FIRST unmarked user row. Rows before it (injected/system context)
+ * turn's FIRST unmarked user row. Rows before it (injected context)
  * and the initial user itself stay above the Thought; every later row
  * (same-turn steers included) returns to its chronological position. A turn
  * whose user rows are all marked same-turn steers has no opening human
- * prompt: the boundary falls back to the end of the LEADING injected/system
+ * prompt: the boundary falls back to the end of the LEADING injected-context
  * prefix, so an inject-woken turn keeps its foundation before the Thought
- * (never a scan of mid-process system rows). Without steer metadata, the
- * first user remains the initial-prompt fallback; consecutive users are
- * queue/steer input, not a multi-row initial prompt. */
+ * (never a scan of mid-process system rows, and never orchestration rows
+ * like llm/retry). Without steer metadata, the first user remains the
+ * initial-prompt fallback; consecutive users are queue/steer input, not a
+ * multi-row initial prompt. */
 function thoughtLeadBoundary(group: readonly TranscriptMessage[]): number {
   const firstInitialUserIndex = group.findIndex(
     member => member.kind === 'user' && member.steer !== true,
   )
   if (firstInitialUserIndex >= 0) return firstInitialUserIndex + 1
-  return leadingSystemPrefixEnd(group)
+  return leadingInjectedContextPrefixEnd(group)
 }
 
 /** Whether one Assistant entry has semantic/finalized content. Pending

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,13 +352,16 @@ function commandRejectsAttachments(
 }
 
 /**
- * The AUTHORITATIVE host-owned command catalog (P1-04): every command name
- * the TUI registers itself (registerTuiCommands in commands.ts) plus the
- * ownership sets (LOCAL_COMMANDS and SESSIONLESS_COMMANDS — /kill and
- * other core commands the TUI does not register but dispatches locally).
- * A plugin command contribution is validated against this catalog at
- * register time: an exact or near-synonym collision is rejected loudly,
- * so a plugin can never shadow a built-in command.
+ * The STATIC host-owned command catalog (P1-04): the ownership sets
+ * (LOCAL_COMMANDS and SESSIONLESS_COMMANDS — the TUI's own local/UI command
+ * names, including the ones `registerTuiCommands` registers, plus core
+ * commands such as /kill that the TUI does not register but dispatches
+ * locally) and `/plan`. A plugin command contribution is validated against
+ * this fixed catalog at register time: an exact or near-synonym collision is
+ * rejected loudly, so a plugin can never shadow a built-in command. Names
+ * that only the CURRENT host catalog owns (session-scoped or dynamically
+ * registered commands) are not in this set — those collisions surface at
+ * candidate synthesis time instead.
  */
 export const HOST_COMMAND_CATALOG: ReadonlySet<string> = new Set([
   ...LOCAL_COMMANDS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5223,6 +5223,16 @@ export function apply(ctx: Context, config: Config): void {
       // no session at all; the contextual `!` creates the session first
       // (the FIRST user message is the deferred trigger).
       if (text.startsWith('!')) {
+        // A local shell line is a UI control with NO attachment delivery path
+        // (`runLocalShell` neither admits nor consumes drafts): a staged
+        // attachment must never become shell arguments, and the success path
+        // must never consume it. Refuse and hand the draft (placeholder
+        // intact) back, exactly like a local command.
+        if (draftHasAttachments(text, draftImages, draftFiles)) {
+          app.setEditorText(mergeDraft(app.getDraft(), text))
+          app.notify('Attachments cannot be included in a local command.', 'error')
+          return
+        }
         if (text.startsWith('!!')) {
           // `!!` runs purely locally with NO session write (pi's
           // excluded-from-context escape hatch) — the row is sessionless

--- a/src/index.ts
+++ b/src/index.ts
@@ -4519,6 +4519,32 @@ export function apply(ctx: Context, config: Config): void {
           const restoreCommandAttachmentDraft = (): void => {
             if (draftHasAttachments(text, draftImages, draftFiles)) restoreSubmissionDraft(text)
           }
+          // DEFERRED AUTHORITY: the session may have committed a host command
+          // the standing view could not see when the composer classified this
+          // line (an unknown slash line becomes a session-scoped command).
+          // Re-apply the attachment policy against the FINAL catalog BEFORE
+          // the command plane runs: an undeclared command must never receive
+          // a placeholder line with no payload (and must never consume the
+          // attachment), while a declaring command keeps its payload and a
+          // skill invocation keeps its agent-facing delivery.
+          const lateRefusal = parsed === undefined ? undefined : attachmentRefusal(
+            parsed,
+            text,
+            commandIsLocalForAttachments(
+              parsed,
+              isSkillWrapperName,
+              n => extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false,
+              isHostCommandName,
+            ),
+            isSkillInvocation(parsed, text),
+          )
+          if (lateRefusal !== undefined) {
+            fallbackPin()
+            restoreCommandAttachmentDraft()
+            app.notify(lateRefusal, 'error')
+            settleLocalSubmitAck('attachments refused by the command declaration', { token: submitAckToken, terminal: true })
+            return
+          }
           // The session-transition write fence: the identity check above
           // can yield across a concurrent /new, /fork, rewind or
           // switch — once a transition is in flight, executing the command

--- a/src/index.ts
+++ b/src/index.ts
@@ -4388,13 +4388,15 @@ export function apply(ctx: Context, config: Config): void {
         // liveAgent: writing through a re-read closure variable could
         // target a session the identity check did not see (a switch
         // between the check and the write).
-        // An extension `submission` contribution is AGENT-FACING input, never
-        // a command-plane execution: its resolved mode delivers the LINE,
-        // exactly like an unclaimed slash prompt (web parity — an unclaimed
-        // line is a prompt). Running the plugin's command handler here would
-        // execute it immediately under a mode the user explicitly resolved to
-        // 'queue' — the ownership the contribution declared is the whole
-        // contract.
+        // An extension `submission` contribution is a SUBMISSION LINE, not a
+        // command execution (web parity — in the web composer only a CLAIM
+        // runs a command handler; a skill-style line is a plain prompt with
+        // the policy-resolved mode). The TUI therefore delivers the raw
+        // `/<name> args` line to the session and never runs the
+        // commands-service handler for it; `execution: 'local'` is the
+        // ownership that executes a handler. This is a deliberate BREAKING
+        // ownership change (see TuiCommandContribution.execution), not an
+        // accident of the busy policy.
         const submissionLine = parsedAtSubmit !== undefined
           && extensionService?.commands.find(parsedAtSubmit.name)?.execution === 'submission'
         const commands = ctx.get('commands')
@@ -4679,7 +4681,17 @@ export function apply(ctx: Context, config: Config): void {
      * sessionless command that failed to register falls back to the
      * session dispatch, which reports unknown commands as messages.
      */
-    const runLocalCommand = (parsed: { name: string; rawInput: string }, text: string, persistHistory: (sessionId: string | undefined) => void, delivery: SubmitDelivery): void => {
+    const runLocalCommand = (
+      parsed: { name: string; rawInput: string },
+      text: string,
+      persistHistory: (sessionId: string | undefined) => void,
+      delivery: SubmitDelivery,
+      // The history identity of THIS call site: a sessionless command writes
+      // an unscoped row (Current directory / All directories), while a local
+      // command submitted inside a live session scopes its row to that
+      // session like every other local command (/status).
+      historyKind: 'agent-facing' | 'sessionless',
+    ): void => {
       // M5: a plugin-declared local command with a bridge handler routes
       // to the bridge FIRST (its rawInput is passed verbatim — never
       // re-parsed or rewritten, the skill rawInput regression gate); the
@@ -4712,10 +4724,11 @@ export function apply(ctx: Context, config: Config): void {
         dispatchViaSession(text, persistHistory, delivery)
         return
       }
-      // A truly local command: no session is created — the row persists
-      // sessionless (Current directory / All directories, never Current
-      // session).
-      persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id))
+      // A truly local command: the handler runs in-process, so no session is
+      // needed for the EXECUTION. The row follows the call site's identity
+      // (sessionless commands write an unscoped row; a local command inside
+      // a live session carries that session id).
+      persistHistory(historySessionIdFor(historyKind, liveAgent?.session.id))
       // An owned workflow: the result decides the notify, the failure lands
       // in diagnostics — runOwned (AGENTS.md), never a bare void. The
       // handler may be a SYNC implementation, so the factory must run inside
@@ -5161,6 +5174,21 @@ export function apply(ctx: Context, config: Config): void {
             // local commands are local while registered).
             name => extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false,
           )
+      // A plugin-declared LOCAL command whose plugin implements it through
+      // the bridge handler executes locally — with or without a live
+      // session. The bridge handler IS the implementation (the
+      // commands-service definition is only the fallback when the
+      // contribution declares none): without this route the line would fall
+      // through to the command plane — or, for a contribution with no
+      // definition at all, to the MODEL, which must never receive a local UI
+      // command.
+      if (parsed !== undefined && extensionService?.commands.localHandlerFor(parsed.name) !== undefined) {
+        // The row identity follows the command's OWN sessionless
+        // classification: a sessionless local command never appears in
+        // Current session, even when it runs inside a live one.
+        runLocalCommand(parsed, text, persistHistory, delivery, isSessionless ? 'sessionless' : 'agent-facing')
+        return
+      }
       if (parsed !== undefined && isSessionless) {
         // A recognized sessionless command: its history row is sessionless
         // — it must NEVER appear in Current session, whether or not a
@@ -5171,7 +5199,7 @@ export function apply(ctx: Context, config: Config): void {
         // it dispatches through the session's command service, but the
         // persist closure still supplies undefined.
         if (liveAgent === undefined) {
-          runLocalCommand(parsed, text, persistHistory, delivery)
+          runLocalCommand(parsed, text, persistHistory, delivery, 'sessionless')
         } else {
           dispatchViaSession(text, () => persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id)), delivery)
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -398,6 +398,19 @@ export function isLocalCommandLine(
 }
 
 /**
+ * Whether one parsed line is the BARE slash token (DSH `matchEnter`'s `bare`:
+ * no input follows the name — trailing whitespace is not input). It is the
+ * whole difference between a command invocation and an ordinary submission
+ * for the NAME-keyed client routes: a client command contribution claims the
+ * bare token only, exactly like an execute-kind host command.
+ * @param parsed - the parsed slash command.
+ * @returns whether the line carries no input after the command name.
+ */
+export function isBareCommandLine(parsed: { name: string; rawInput?: string }): boolean {
+  return (parsed.rawInput?.trim() ?? '') === ''
+}
+
+/**
  * The attachment gate's local-command classification for ONE parsed line —
  * the SINGLE classification the dispatch and its regression tests share, and
  * the DSH client namespace order applied to a LINE:
@@ -410,7 +423,10 @@ export function isLocalCommandLine(
  *   line of an execute-kind command, `/compact extra`) the line is an
  *   ordinary submission — never a command and never a same-named client
  *   contribution's;
- * - everything else follows the live client contribution of that name.
+ * - everything else follows the live client contribution of that name — for
+ *   the BARE token only: a contribution claims `/name`, so an argued line
+ *   (`/deploy explain`) is an ordinary multimodal submission that keeps its
+ *   attachments.
  * @param parsed - the parsed slash command (undefined = plain prompt).
  * @param isSkillWrapper - the live skill-wrapper test (absent = none).
  * @param isDynamicLocal - the live client-contribution test (absent = none).
@@ -428,8 +444,14 @@ export function commandIsLocalForAttachments(
   // bare `/skill` picker is a TUI-local command.
   if (parsed.name === 'skill' && (parsed.rawInput?.trim() ?? '') !== '') return false
   // The host catalog's view of THIS LINE outranks a same-named client
-  // contribution, exactly like the dispatch's namespace order.
-  return isLocalCommandLine(parsed.name, isSkillWrapper, isDynamicLocal, hostClaim?.(parsed))
+  // contribution, exactly like the dispatch's namespace order; the
+  // contribution term itself is asked for a BARE line alone (DSH `matchEnter`).
+  return isLocalCommandLine(
+    parsed.name,
+    isSkillWrapper,
+    isBareCommandLine(parsed) ? isDynamicLocal : undefined,
+    hostClaim?.(parsed),
+  )
 }
 
 /**
@@ -4462,11 +4484,12 @@ export function apply(ctx: Context, config: Config): void {
       // routing decision (before any session creation): only a line whose
       // initial route was a LIVE client contribution keeps the client-local
       // attachment classification under the final authority. A contribution
-      // that appears LATER never turns a generic line into a UI control
-      // (upstream `matchEnter` checks the contribution once, before the session
-      // work), and this route never runs the new handler anyway — the line is
-      // an ordinary submission.
+      // claims the BARE token only (DSH `matchEnter`), and a contribution that
+      // appears LATER never turns a generic line into a UI control — this route
+      // never runs the new handler anyway, so the line is an ordinary
+      // submission.
       const clientLocalAtSubmit = parsedAtSubmit !== undefined
+        && isBareCommandLine(parsedAtSubmit)
         && extensionService?.commands.find(parsedAtSubmit.name) !== undefined
       // Whether the command plane OWNS the submitted line, asked against the
       // LIVE catalog at INVOCATION time (after ensureSession: a deferred start
@@ -5397,32 +5420,24 @@ export function apply(ctx: Context, config: Config): void {
       // plain prompts AND per-skill slash lines, including `/skill <name>
       // [image #N ...]` (`skill` is local only as the bare picker; with
       // arguments it is a loadSkill agent prompt — review finding).
-      // The line's attachment classification is RE-EVALUATED at every ask
-      // (a thunk, never a snapshot): the deferred resolution below must
-      // classify against the catalog the session committed, not the standing
-      // view the gesture saw.
-      const localForAttachments = (): boolean => commandIsLocalForAttachments(
-        parsed,
-        isSkillWrapperName,
-        n => extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false,
-        hostClaimOf,
-      )
-      // A session-backed client contribution on a DEFERRED START is the ONE
-      // classification the standing view cannot settle: the session commits
-      // the session-scoped host catalog (and the skill catalog) the view
-      // could not see, and either outranks the contribution. Refusing an
-      // attachment here would be irrevocable — the real host command would
-      // never get its chance — so the refusal DEFERS to the same authority
-      // resolution the namespace decision waits for (see the client-command
-      // block below, which reserves the drafts across the window). Every
-      // other local classification (TUI/core commands, a live contribution)
-      // is final and refuses NOW.
-      const deferredClientAttachments = parsed !== undefined
-        && liveAgent === undefined
-        && extensionService?.commands.find(parsed.name)?.sessionless === false
-        && localForAttachments()
-      if (!deferredClientAttachments && parsed !== undefined) {
-        const refusal = attachmentRefusal(parsed, text, localForAttachments(), isSkillInvocation(parsed, text))
+      // The line's attachment classification against the CURRENT catalog.
+      // Every local classification refuses NOW: a contribution claims the BARE
+      // token only (DSH `matchEnter`), and a bare line can never reference a
+      // draft, so there is no attachment to carry across a deferred window —
+      // an argued line of a contribution name is an ordinary submission, with
+      // its attachments.
+      if (parsed !== undefined) {
+        const refusal = attachmentRefusal(
+          parsed,
+          text,
+          commandIsLocalForAttachments(
+            parsed,
+            isSkillWrapperName,
+            n => extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false,
+            hostClaimOf,
+          ),
+          isSkillInvocation(parsed, text),
+        )
         if (refusal !== undefined) {
           app.setEditorText(mergeDraft(app.getDraft(), text))
           app.notify(refusal, 'error')
@@ -5468,11 +5483,12 @@ export function apply(ctx: Context, config: Config): void {
       }
       // 2. CLIENT-OWNED command contribution: its behavior lives entirely on
       // the client, so it executes locally and never steers — the namespace
-      // decision is NOT the generic sessionless branch's to make. A name the
-      // host catalog RESOLVES is host territory even when the catalog does
-      // not claim THIS line (an argued line of an execute-kind command): the
-      // line is an ordinary submission, so the contribution of that name
-      // never runs for it.
+      // decision is NOT the generic sessionless branch's to make. A
+      // contribution is a slash-MENU entry, so it claims the BARE `/name`
+      // token only (DSH `matchEnter`: `if (!bare) return undefined`): an argued
+      // line (`/deploy explain`) is an ordinary submission, and the handler
+      // never runs for it. A name the host catalog RESOLVES is host territory
+      // in both states, so a contribution never runs for such a line either.
       // `sessionless` decides whether it may run before a session exists:
       // true runs immediately (no session is created); false (default)
       // resolves/creates the session FIRST — the host command surface is
@@ -5481,12 +5497,12 @@ export function apply(ctx: Context, config: Config): void {
       // name (the contribution may have been registered before the skill
       // catalog loaded).
       const contribution = parsed === undefined
+        || !isBareCommandLine(parsed)
         || isSkillWrapperName?.(parsed.name) === true
         // A name the host catalog RESOLVES is host territory even when it does
-        // not claim THIS line: the line is an ordinary submission (upstream
-        // `matchEnter` `if (!bare) return undefined`), so a same-named
-        // contribution — reachable only in the failed-source collision state —
-        // never runs for it.
+        // not claim THIS line: the line is an ordinary submission, so a
+        // same-named contribution — reachable only in the failed-source
+        // collision state — never runs for it.
         || hostView !== undefined
         ? undefined
         : extensionService?.commands.find(parsed.name)
@@ -5504,38 +5520,25 @@ export function apply(ctx: Context, config: Config): void {
         // user did not submit (see the fence inside).
         const submitted = contribution
         runOwned('client command session', () => runReservedSubmit({
-          // The editor was already cleared by the gesture: the referenced
-          // drafts must survive the deferred window — an attach-time prune
-          // during session creation must not delete what this submission is
-          // about to admit (a late host claim / skill wrapper) or refuse.
-          // No await may precede this reservation.
+          // The submit-flow core's ordering contract. A contribution is only
+          // ever invoked by its BARE token, so the line references no drafts
+          // and this reservation pins nothing — it stays because the failure
+          // path (restore the draft when the session cannot be created) is the
+          // shared one. No await may precede it.
           reserve: (draft) => pinDraftAttachments(draft, draftImages, draftFiles),
           run: async () => {
             await ensureSession()
             if (liveAgent === undefined) return
-            // The COMPOSER attachment policy is resolved with the FINAL
-            // authority: a late host claim that does not declare
-            // `input.attachments` refuses the line (a declared one takes it
-            // WITH the images, see the delivery side); a late skill wrapper
-            // delivers to the model; a contribution that keeps the line
-            // refuses as a local command — the synchronous gate's outcome,
-            // only now final.
-            const refusal = attachmentRefusal(parsed, text, localForAttachments(), isSkillInvocation(parsed, text))
-            if (refusal !== undefined) {
-              restoreSubmissionDraft(text)
-              app.notify(refusal, 'error')
-              return
-            }
             // AUTHORITY RE-CHECK after the session exists: the deferred start
             // commits a session whose scoped catalog the standing view could
             // not see, and the skill catalog may load with it. A live HOST
             // claim FOR THIS LINE or a TUI skill wrapper outranks the
-            // contribution that was decided before the session existed — and a
-            // name the committed catalog resolves WITHOUT claiming this line
-            // is an ordinary submission the contribution must not run either.
-            // The delivery resolved before the session existed, so it is a
-            // queue-mode submission: `dispatchViaSession` delivers the line
-            // itself (its command-plane gate refuses the unclaimed line).
+            // contribution that was decided before the session existed. (A host
+            // name can only CLAIM this bare line: the argued lines a catalog
+            // resolves without claiming are ordinary submissions and never
+            // reach this branch.) The delivery resolved before the session
+            // existed, so it is a queue-mode submission: `dispatchViaSession`
+            // delivers the line itself.
             if (hostClaimOf?.(parsed) !== undefined || isSkillWrapperName?.(parsed.name) === true) {
               dispatchViaSession(text, persistHistory, delivery)
               return

--- a/src/index.ts
+++ b/src/index.ts
@@ -4673,13 +4673,17 @@ export function apply(ctx: Context, config: Config): void {
       })
     }
     /**
-     * Run a sessionless slash command locally — no session, no session
-     * log. The input-history row still persists, sessionless (Current
-     * directory / All directories, never Current session). The handler
-     * comes from the commands service's global layer (in-process lookup
-     * with no agent is safe: it reads the global layer only). A
-     * sessionless command that failed to register falls back to the
-     * session dispatch, which reports unknown commands as messages.
+     * Run a LOCAL slash command in-process, with or without a live session.
+     * The route is chosen by the caller: a sessionless command (no session
+     * is created, its history row stays sessionless — Current directory /
+     * All directories, never Current session) or a plugin-declared local
+     * command whose contribution owns a bridge handler (it runs locally even
+     * inside a live session, and its row follows the command's OWN
+     * sessionless classification via `historyKind`). The handler comes from
+     * the bridge FIRST (rawInput verbatim), then from the commands service's
+     * global layer (in-process lookup with no agent is safe: it reads the
+     * global layer only). A command with neither falls back to the session
+     * dispatch, which reports unknown commands as messages.
      */
     const runLocalCommand = (
       parsed: { name: string; rawInput: string },

--- a/src/index.ts
+++ b/src/index.ts
@@ -5183,12 +5183,30 @@ export function apply(ctx: Context, config: Config): void {
       // plain prompts AND per-skill slash lines, including `/skill <name>
       // [image #N ...]` (`skill` is local only as the bare picker; with
       // arguments it is a loadSkill agent prompt — review finding).
-      if (commandRejectsAttachments(parsed, text, draftImages, draftFiles, commandIsLocalForAttachments(
+      // The line's attachment classification is computed ONCE and reused by
+      // the deferred resolution below (the same predicate, live view).
+      const localForAttachments = commandIsLocalForAttachments(
         parsed,
         isSkillWrapperName,
         n => extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false,
         isHostCommandName,
-      ))) {
+      )
+      // A session-backed client contribution on a DEFERRED START is the ONE
+      // classification the standing view cannot settle: the session commits
+      // the session-scoped host catalog (and the skill catalog) the view
+      // could not see, and either outranks the contribution. Refusing an
+      // attachment here would be irrevocable — the real host command would
+      // never get its chance — so the refusal DEFERS to the same authority
+      // resolution the namespace decision waits for (see the client-command
+      // block below, which reserves the drafts across the window). Every
+      // other local classification (TUI/core commands, a live contribution)
+      // is final and refuses NOW.
+      const deferredClientAttachments = parsed !== undefined
+        && liveAgent === undefined
+        && extensionService?.commands.find(parsed.name)?.sessionless === false
+        && localForAttachments(parsed.name)
+      if (!deferredClientAttachments
+        && commandRejectsAttachments(parsed, text, draftImages, draftFiles, localForAttachments)) {
         app.setEditorText(mergeDraft(app.getDraft(), text))
         app.notify('Attachments cannot be included in a local command.', 'error')
         return
@@ -5249,25 +5267,59 @@ export function apply(ctx: Context, config: Config): void {
           runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
           return
         }
-        runOwned('client command session', async () => {
-          await ensureSession()
-          if (liveAgent === undefined) return
-          // AUTHORITY RE-CHECK after the session exists: the deferred start
-          // commits a session whose scoped catalog the standing view could
-          // not see, and the skill catalog may load with it. A live HOST
-          // claim or a TUI skill wrapper outranks the contribution that was
-          // decided before the session existed.
-          if (isHostCommandName?.(parsed.name) === true || isSkillWrapperName?.(parsed.name) === true) {
-            dispatchViaSession(text, persistHistory, delivery)
-            return
-          }
-          runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
-        }, {
+        // The captured contribution is a PROVISIONAL authority: it is bound
+        // here so the post-await resolution can never run a generation the
+        // user did not submit (see the fence inside).
+        const submitted = contribution
+        runOwned('client command session', () => runReservedSubmit({
+          // The editor was already cleared by the gesture: the referenced
+          // drafts must survive the deferred window — an attach-time prune
+          // during session creation must not delete what this submission is
+          // about to admit (a late host claim / skill wrapper) or refuse.
+          // No await may precede this reservation.
+          reserve: (draft) => pinDraftAttachments(draft, draftImages, draftFiles),
+          run: async () => {
+            await ensureSession()
+            if (liveAgent === undefined) return
+            // AUTHORITY RE-CHECK after the session exists: the deferred start
+            // commits a session whose scoped catalog the standing view could
+            // not see, and the skill catalog may load with it. A live HOST
+            // claim or a TUI skill wrapper outranks the contribution that was
+            // decided before the session existed.
+            if (isHostCommandName?.(parsed.name) === true || isSkillWrapperName?.(parsed.name) === true) {
+              dispatchViaSession(text, persistHistory, delivery)
+              return
+            }
+            // IDENTITY + GENERATION FENCE: the client handler runs only while
+            // the EXACT registration the user submitted is still live. A
+            // dispose + reload (HMR) is a NEW bridge record — possibly under
+            // the same owner/id — and a vanished name must never fall through
+            // `runLocalCommand`'s name-only lookup (which would either run
+            // the new generation's handler or deliver the line to the MODEL).
+            if (extensionService?.commands.find(parsed.name) !== submitted) {
+              app.notify(`/${parsed.name} is no longer available — the draft was restored, submit it again`, 'error')
+              restoreSubmissionDraft(text)
+              return
+            }
+            // The FINAL owner is the client command: its local route refuses
+            // attachments. The refusal is the synchronous gate's outcome,
+            // resolved late — now that no host claim or skill wrapper can
+            // take the line instead.
+            if (commandRejectsAttachments(parsed, text, draftImages, draftFiles, localForAttachments)) {
+              restoreSubmissionDraft(text)
+              app.notify('Attachments cannot be included in a local command.', 'error')
+              return
+            }
+            runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
+          },
+          restore: (draft) => restoreSubmissionDraft(draft),
+        }, text), {
           diag,
           sessionId: () => liveAgent?.session.id,
           onError: (error) => {
+            // The flow restored the editor BEFORE the reservation released;
+            // this sink only notifies (never a second restore).
             app.notify(safeErrorMessage(error), 'error')
-            restoreSubmissionDraft(text)
           },
         })
         return

--- a/src/index.ts
+++ b/src/index.ts
@@ -4126,8 +4126,9 @@ export function apply(ctx: Context, config: Config): void {
      * the staged attachments.
      * - a TUI/core local command and a client contribution are UI controls —
      *   refused;
-     * - a LIVE skill wrapper, a `/skill <name>` invocation and a plain prompt
-     *   are agent-facing — delivered to the model;
+     * - an explicit `/skill <name> ...` invocation and a LIVE skill wrapper
+     *   are agent-facing — loadSkill delivers them and their attachments to
+     *   the model (never classified as a command);
      * - a HOST command accepts attachments ONLY when its descriptor declares
      *   `input.attachments` (upstream refuses otherwise before dispatch);
      * - a declared command still refuses a FILE attachment: the host expects
@@ -4139,11 +4140,16 @@ export function apply(ctx: Context, config: Config): void {
       parsed: { name: string; rawInput?: string },
       draft: string,
       isLocalLine: (name: string) => boolean,
+      // The ONE skill-invocation predicate (`isSkillInvocation`: an explicit
+      // `/skill <name> ...` or a live skill wrapper) — TUI-owned agent-facing
+      // input that loadSkill owns. It is supplied rather than re-derived: the
+      // predicate applies the argued-`/skill` short-circuit, and WITHOUT it
+      // the line would fall into the HOST branch below (`/skill` is itself a
+      // registered TUI command) and be refused as a non-declaring command.
+      skillInvocation: boolean,
     ): string | undefined => {
       if (!draftHasAttachments(draft, draftImages, draftFiles)) return undefined
-      // A skill wrapper is TUI-owned agent-facing input even when a client
-      // contribution shares the name.
-      if (isSkillWrapperName?.(parsed.name) === true) return undefined
+      if (skillInvocation) return undefined
       if (!isLocalLine(parsed.name)) {
         if (isHostCommandName?.(parsed.name) === true) {
           if (isHostCommandAcceptingAttachments?.(parsed.name) !== true) {
@@ -4542,12 +4548,23 @@ export function apply(ctx: Context, config: Config): void {
             // same call stack, so a TUI-owned skill handler captures its
             // submission's mode before any await (see withDelivery).
             // The command plane receives the submitted attachments (DSH
-            // `CommandSubmitAttachment`): the gate already proved that the
-            // resolved command DECLARES `input.attachments` and that the line
-            // carries images only, so this is the web composer's
-            // `leadingClaim.submit(args, attachments)` path — the host admits
-            // them through its own store before the handler runs.
-            return withCommandDelivery(delivery, () => commands.execute(agent as Agent, toggled, commandSubmitAttachments(text), signal))
+            // `CommandSubmitAttachment`) ONLY for a HOST command that
+            // DECLARES `input.attachments` — the web composer's
+            // `leadingClaim.submit(args, attachments)` path; the host admits
+            // them through its own store before the handler runs. A
+            // TUI-owned command must never carry them on this wire: its
+            // descriptor does not declare attachments (`/skill <name>` is
+            // itself a registered TUI command, and a live skill wrapper is
+            // TUI-owned too), so the host executor would reject the
+            // invocation BEFORE the handler — their placeholder line is
+            // delivered as-is and the images are admitted by the delivery
+            // path (loadSkill → prepareUserMessage).
+            const submittedAttachments = parsedAtSubmit !== undefined
+              && isHostCommandName?.(parsedAtSubmit.name) === true
+              && isHostCommandAcceptingAttachments?.(parsedAtSubmit.name) === true
+              ? commandSubmitAttachments(text)
+              : []
+            return withCommandDelivery(delivery, () => commands.execute(agent as Agent, toggled, submittedAttachments, signal))
           }, {
             diag,
             sessionId: () => agent.session.id,
@@ -5265,7 +5282,7 @@ export function apply(ctx: Context, config: Config): void {
         && extensionService?.commands.find(parsed.name)?.sessionless === false
         && localForAttachments(parsed.name)
       if (!deferredClientAttachments && parsed !== undefined) {
-        const refusal = attachmentRefusal(parsed, text, localForAttachments)
+        const refusal = attachmentRefusal(parsed, text, localForAttachments, isSkillInvocation(parsed, text))
         if (refusal !== undefined) {
           app.setEditorText(mergeDraft(app.getDraft(), text))
           app.notify(refusal, 'error')
@@ -5349,7 +5366,7 @@ export function apply(ctx: Context, config: Config): void {
             // delivers to the model; a contribution that keeps the line
             // refuses as a local command — the synchronous gate's outcome,
             // only now final.
-            const refusal = attachmentRefusal(parsed, text, localForAttachments)
+            const refusal = attachmentRefusal(parsed, text, localForAttachments, isSkillInvocation(parsed, text))
             if (refusal !== undefined) {
               restoreSubmissionDraft(text)
               app.notify(refusal, 'error')

--- a/src/index.ts
+++ b/src/index.ts
@@ -5120,6 +5120,22 @@ export function apply(ctx: Context, config: Config): void {
         }
         return
       }
+      // Host-command claim (PR115-fix problem 1): a slash name the CURRENT
+      // effective command catalog resolves — and that is neither a TUI-local
+      // command nor a TUI-owned skill wrapper — is a Host command. It
+      // executes through the command plane; the busy queue/steer policy
+      // applies only to agent-facing prompts, never to a confirmed Host
+      // command (the command handler itself decides the busy outcome). A
+      // claimed command that the real session then lacks is consumed by the
+      // advertised-miss gate inside dispatchViaSession — never a plain
+      // model message.
+      if (parsed !== undefined
+        && !LOCAL_COMMANDS.has(parsed.name)
+        && !(extensionService?.commands.isLocal(parsed.name, LOCAL_COMMANDS) ?? false)
+        && isHostCommandName?.(parsed.name) === true) {
+        dispatchViaSession(text, persistHistory)
+        return
+      }
       // Busy-Enter preference (web busyEnter parity): while the agent is
       // RUNNING and the preference is 'steer', agent-facing input steers
       // into the running turn — plain prompts AND non-local commands. The
@@ -7294,6 +7310,11 @@ export function apply(ctx: Context, config: Config): void {
      * advertised by the CURRENT completion list? The dispatch captures it
      * BEFORE any session creation (see dispatchViaSession). */
     let wasAdvertisedClaim: ((name: string) => boolean) | undefined
+    /** The claim test installed by registerTuiCommands: is a slash name a
+     * HOST command in the current effective catalog (advertised, not a
+     * TUI-owned skill wrapper)? The dispatch consults it BEFORE the busy
+     * queue/steer policy (PR115-fix problem 1). */
+    let isHostCommandName: ((name: string) => boolean) | undefined
     /** The catalog refresh coordinator: the ONE post-mount refresh owner
      * (first session, switches, /preset, /reload). Built inside
      * registerCommands once the surface hooks exist. (Declared before
@@ -7636,6 +7657,7 @@ export function apply(ctx: Context, config: Config): void {
       try {
         const installed = registerTuiCommands(runner, initial)
         wasAdvertisedClaim = installed.wasAdvertised
+        isHostCommandName = installed.isHostCommand
         // The coordinator's surface hooks point INTO the command surface;
         // the runner's refreshCatalog routes every post-mount refresh here.
         catalogCoordinator = new CatalogRefreshCoordinator({

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ import {
 import type { TaskBrowserViewState, TaskPanelItem } from './task-panel.ts'
 import { TaskBrowserRuntime, type TaskBrowserDatasetScope } from './task-browser-runtime.ts'
 import type { TaskBrowserHandle, WorkflowAction } from './tui-app.ts'
-import { registerTuiCommands, type DefaultIntentRecord, type InitialCommandCatalog, type TuiCommandRunner } from './commands.ts'
+import { prefersSteer, registerTuiCommands, type DefaultIntentRecord, type InitialCommandCatalog, type SubmitDelivery, type TuiCommandRunner } from './commands.ts'
 import { normalizePersistedTheme, resolveThemeSelection } from './theme-source.ts'
 import { diagFromEnv, dshHome, type Diag } from './diag.ts'
 import { runDetached, runOwned, isCancellation, type OwnedTaskOptions } from './detached.ts'
@@ -394,11 +394,11 @@ export function shouldSteerOnEnter(
     // NOT the local picker: it steers like any other prompt. Only the bare
     // `/skill` picker counts as local (review finding — same classification
     // as the image-rejection gate).
-    if (parsed.name === 'skill' && (parsed.rawInput?.trim() ?? '') !== '') return running && busyEnter === 'steer'
+    if (parsed.name === 'skill' && (parsed.rawInput?.trim() ?? '') !== '') return prefersSteer(running, busyEnter)
     if (LOCAL_COMMANDS.has(parsed.name)) return false
     if (isDynamicLocal !== undefined && isDynamicLocal(parsed.name)) return false
   }
-  return running && busyEnter === 'steer'
+  return prefersSteer(running, busyEnter)
 }
 
 /**
@@ -4299,8 +4299,11 @@ export function apply(ctx: Context, config: Config): void {
     }
     /** The session-backed dispatch: create the session lazily (the first
      * user input is the deferred trigger), then execute a registered slash
-     * command or follow up. */
-    const dispatchViaSession = (text: string, persistHistory: (sessionId: string | undefined) => void): void => {
+     * command or follow up.
+     * @param delivery - the delivery mode the submit boundary resolved for
+     *   this submission; bound for the command execution so a TUI-owned
+     *   skill handler accepts it instead of re-deriving it. */
+    const dispatchViaSession = (text: string, persistHistory: (sessionId: string | undefined) => void, delivery: SubmitDelivery): void => {
       // Local submit acknowledgement (plan D): the row appears NOW —
       // before any session create / admission / command work — because
       // this gesture owns no user-visible feedback until the first
@@ -4431,7 +4434,11 @@ export function apply(ctx: Context, config: Config): void {
             commandHealthRef = liveCommandId === undefined
               ? undefined
               : extensionService?._recordRegistryHealthRef('command', liveCommandId)
-            return commands.execute(agent as Agent, toggled, [], signal)
+            // The resolution's delivery mode is bound for THIS synchronous
+            // window: `commands.execute` invokes a resolved handler in the
+            // same call stack, so a TUI-owned skill handler captures its
+            // submission's mode before any await (see withDelivery).
+            return withCommandDelivery(delivery, () => commands.execute(agent as Agent, toggled, [], signal))
           }, {
             diag,
             sessionId: () => agent.session.id,
@@ -4659,7 +4666,7 @@ export function apply(ctx: Context, config: Config): void {
      * sessionless command that failed to register falls back to the
      * session dispatch, which reports unknown commands as messages.
      */
-    const runLocalCommand = (parsed: { name: string; rawInput: string }, text: string, persistHistory: (sessionId: string | undefined) => void): void => {
+    const runLocalCommand = (parsed: { name: string; rawInput: string }, text: string, persistHistory: (sessionId: string | undefined) => void, delivery: SubmitDelivery): void => {
       // M5: a plugin-declared local command with a bridge handler routes
       // to the bridge FIRST (its rawInput is passed verbatim — never
       // re-parsed or rewritten, the skill rawInput regression gate); the
@@ -4678,7 +4685,7 @@ export function apply(ctx: Context, config: Config): void {
         // a session dispatch — the history row goes through the
         // deferred-start gate (persist AFTER the session exists, with the
         // final session id), never a sessionless write here.
-        dispatchViaSession(text, persistHistory)
+        dispatchViaSession(text, persistHistory, delivery)
         return
       }
       const invocation = {
@@ -4689,7 +4696,7 @@ export function apply(ctx: Context, config: Config): void {
       } as CommandInvocation
       const handler = bridgeHandler ?? definition?.handler
       if (handler === undefined) {
-        dispatchViaSession(text, persistHistory)
+        dispatchViaSession(text, persistHistory, delivery)
         return
       }
       // A truly local command: no session is created — the row persists
@@ -5104,6 +5111,23 @@ export function apply(ctx: Context, config: Config): void {
         SESSIONLESS_COMMANDS.has(parsed.name)
         || (extensionService?.commands.isSessionless(parsed.name, SESSIONLESS_COMMANDS) ?? false)
       )
+      // The submission's effective delivery mode — resolved ONCE, here at
+      // the boundary (web ComposerSubmissionPolicy parity): a non-running
+      // agent, busyEnter=queue, and the Ctrl+Enter force-queue chord all
+      // resolve to 'queue'. The resolved mode rides into the command plane
+      // (dispatchViaSession → withDelivery → the TUI skill delivery), which
+      // never re-derives it from the persisted preference — a one-shot chord
+      // does not survive in settings. Commands that own their own busy
+      // semantics (Host commands, local UI commands) ignore it.
+      const delivery: SubmitDelivery = shouldSteerOnEnter(
+        parsed,
+        liveAgent?.status === 'running',
+        tuiSettings?.get().busyEnter,
+        forceQueue,
+        // M5: the CommandBridge's effective-local check (dynamic plugin
+        // local commands are local while registered).
+        name => extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false,
+      ) ? 'steer' : 'queue'
       if (parsed !== undefined && isSessionless) {
         // A recognized sessionless command: its history row is sessionless
         // — it must NEVER appear in Current session, whether or not a
@@ -5114,17 +5138,18 @@ export function apply(ctx: Context, config: Config): void {
         // it dispatches through the session's command service, but the
         // persist closure still supplies undefined.
         if (liveAgent === undefined) {
-          runLocalCommand(parsed, text, persistHistory)
+          runLocalCommand(parsed, text, persistHistory, delivery)
         } else {
-          dispatchViaSession(text, () => persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id)))
+          dispatchViaSession(text, () => persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id)), delivery)
         }
         return
       }
       // Host-command claim (PR115-fix problem 1): a slash name the CURRENT
       // effective command catalog resolves — and that is neither a TUI-local
-      // command nor a TUI-owned skill wrapper — is a Host command. It
-      // executes through the command plane; the busy queue/steer policy
-      // applies only to agent-facing prompts, never to a confirmed Host
+      // command nor agent-facing input the TUI/extension layer owns (a
+      // TUI-owned skill wrapper, an extension contribution) — is a Host
+      // command. It executes through the command plane; the busy queue/steer
+      // policy applies only to agent-facing prompts, never to a confirmed Host
       // command (the command handler itself decides the busy outcome). A
       // claimed command that the real session then lacks is consumed by the
       // advertised-miss gate inside dispatchViaSession — never a plain
@@ -5133,7 +5158,7 @@ export function apply(ctx: Context, config: Config): void {
         && !LOCAL_COMMANDS.has(parsed.name)
         && !(extensionService?.commands.isLocal(parsed.name, LOCAL_COMMANDS) ?? false)
         && isHostCommandName?.(parsed.name) === true) {
-        dispatchViaSession(text, persistHistory)
+        dispatchViaSession(text, persistHistory, delivery)
         return
       }
       // Busy-Enter preference (web busyEnter parity): while the agent is
@@ -5146,10 +5171,7 @@ export function apply(ctx: Context, config: Config): void {
       // (/status, /settings, ...) always execute directly; plugin-declared
       // local commands (M5 CommandBridge) join the same set; `!` shells and
       // sessionless commands returned before this gate.
-      if (shouldSteerOnEnter(parsed, liveAgent?.status === 'running', tuiSettings?.get().busyEnter, forceQueue,
-        // M5: the CommandBridge's effective-local check (dynamic plugin
-        // local commands are local while registered).
-        name => extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false)) {
+      if (delivery === 'steer') {
         // An explicit `/skill <name>` invocation steers its NORMALIZED
         // `/<name> <args>` line — the harness gesture recognizes the
         // skill's own slash name and injects its body; the raw `/skill
@@ -5160,7 +5182,7 @@ export function apply(ctx: Context, config: Config): void {
         steerNow(normalizeSkillInvocation(text) ?? text, true, persistHistory)
         return
       }
-      dispatchViaSession(text, persistHistory)
+      dispatchViaSession(text, persistHistory, delivery)
     }
     // M3 runner wiring (F-1): when the extension host service is mounted,
     // the TUI surface attaches a SurfaceHost over its ledger — extensions
@@ -7315,6 +7337,12 @@ export function apply(ctx: Context, config: Config): void {
      * TUI-owned skill wrapper)? The dispatch consults it BEFORE the busy
      * queue/steer policy (PR115-fix problem 1). */
     let isHostCommandName: ((name: string) => boolean) | undefined
+    /** The delivery binding installed by registerTuiCommands: bind one
+     * submission's resolved queue/steer mode for the synchronous window that
+     * launches a command execution (the TUI skill handlers consume it).
+     * Before the command surface is wired nothing can consume a binding, so
+     * the unwired default simply runs the launch. */
+    let withCommandDelivery = <T>(_delivery: SubmitDelivery, run: () => T): T => run()
     /** The catalog refresh coordinator: the ONE post-mount refresh owner
      * (first session, switches, /preset, /reload). Built inside
      * registerCommands once the surface hooks exist. (Declared before
@@ -7658,6 +7686,7 @@ export function apply(ctx: Context, config: Config): void {
         const installed = registerTuiCommands(runner, initial)
         wasAdvertisedClaim = installed.wasAdvertised
         isHostCommandName = installed.isHostCommand
+        withCommandDelivery = installed.withDelivery
         // The coordinator's surface hooks point INTO the command surface;
         // the runner's refreshCatalog routes every post-mount refresh here.
         catalogCoordinator = new CatalogRefreshCoordinator({

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,8 +381,9 @@ export function isLocalCommandLine(
 ): boolean {
   // The NAMESPACE ORDER decides: a TUI-owned local command is local, while
   // the agent-facing routes (a live skill wrapper, a live HOST claim) outrank
-  // a client contribution — the host handler owns its own attachment policy,
-  // and a contribution must never suppress it.
+  // a client contribution — a host claim's own `input.attachments`
+  // declaration decides whether it may carry attachments (never classified
+  // local here), and a contribution must never suppress that claim.
   if (LOCAL_COMMANDS.has(name)) return true
   if (isSkillWrapper?.(name) === true) return false
   if (isHostCommand?.(name) === true) return false
@@ -400,7 +401,9 @@ export function isLocalCommandLine(
  * @param isSkillWrapper - the live skill-wrapper test (absent = none).
  * @param isDynamicLocal - the live client-contribution test (absent = none).
  * @param isHostCommand - the live HOST-claim test (absent = none): a host
- *   command owns its own attachment policy, so it is never classified local.
+ *   command is never classified local here — its own `input.attachments`
+ *   declaration decides whether the composer may attach anything
+ *   ({@link attachmentRefusal}).
  * @returns the predicate for `commandRejectsImages` /
  *   {@link attachmentRefusal} (the dispatch's composer attachment policy).
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,8 +143,8 @@ import {
 } from './tasks-browser.ts'
 import type { TaskBrowserViewState, TaskPanelItem } from './task-panel.ts'
 import { TaskBrowserRuntime, type TaskBrowserDatasetScope } from './task-browser-runtime.ts'
-import type { TaskBrowserHandle, WorkflowAction } from './tui-app.ts'
-import { prefersSteer, registerTuiCommands, type DefaultIntentRecord, type InitialCommandCatalog, type SubmitDelivery, type TuiCommandRunner } from './commands.ts'
+import type { ComposerSubmitGesture, ComposerSubmitRequest, TaskBrowserHandle, WorkflowAction } from './tui-app.ts'
+import { resolveComposerDelivery, registerTuiCommands, type DefaultIntentRecord, type InitialCommandCatalog, type SubmitDelivery, type TuiCommandRunner } from './commands.ts'
 import { normalizePersistedTheme, resolveThemeSelection } from './theme-source.ts'
 import { diagFromEnv, dshHome, type Diag } from './diag.ts'
 import { runDetached, runOwned, isCancellation, type OwnedTaskOptions } from './detached.ts'
@@ -370,35 +370,37 @@ export const HOST_COMMAND_CATALOG: ReadonlySet<string> = new Set([
 ])
 
 /**
- * Whether one submission steers under the busy-Enter preference: NOT a
- * force-queued chord, NOT a TUI-owned local command, and the agent is
- * running with the preference set to 'steer'. Pure so the dispatch gate
- * (inside the runner closure) is testable headless.
+ * The TUI dispatch boundary's delivery resolution: the WEB composer policy
+ * ({@link resolveComposerDelivery}) applied to agent-facing input, with the
+ * TUI's own ownership terms on top. Pure so the dispatch gate (inside the
+ * runner closure) is testable headless.
  * @param parsed - the parsed slash command, undefined for a plain prompt.
  * @param running - whether the live agent reports running.
+ * @param gesture - the composer gesture that raised the submission.
  * @param busyEnter - the persisted preference value (''/undefined = queue).
- * @param forceQueue - the Ctrl+Enter chord: always queue, never steer.
  * @param isDynamicLocal - M5: the CommandBridge's effective-local check for
  *   plugin-declared local commands (absent = static set only).
  */
-export function shouldSteerOnEnter(
+export function resolveSubmitDelivery(
   parsed: { name: string; rawInput?: string } | undefined,
   running: boolean,
+  gesture: ComposerSubmitGesture,
   busyEnter: string | undefined,
-  forceQueue: boolean,
   isDynamicLocal?: (name: string) => boolean,
-): boolean {
-  if (forceQueue) return false
+): SubmitDelivery {
   if (parsed !== undefined) {
     // `/skill <name> [args...]` is an AGENT-facing invocation (loadSkill),
-    // NOT the local picker: it steers like any other prompt. Only the bare
-    // `/skill` picker counts as local (review finding — same classification
-    // as the image-rejection gate).
-    if (parsed.name === 'skill' && (parsed.rawInput?.trim() ?? '') !== '') return prefersSteer(running, busyEnter)
-    if (LOCAL_COMMANDS.has(parsed.name)) return false
-    if (isDynamicLocal !== undefined && isDynamicLocal(parsed.name)) return false
+    // NOT the local picker: it follows the busy policy like any other
+    // prompt. Only the bare `/skill` picker counts as local (review finding
+    // — same classification as the image-rejection gate).
+    if (parsed.name === 'skill' && (parsed.rawInput?.trim() ?? '') !== '') return resolveComposerDelivery(running, gesture, busyEnter)
+    // A TUI-owned local command (and a plugin-declared local one) executes
+    // through its own surface and never steers; its delivery value is only
+    // ever a placeholder for the (never taken) skill-delivery binding.
+    if (LOCAL_COMMANDS.has(parsed.name)) return 'queue'
+    if (isDynamicLocal !== undefined && isDynamicLocal(parsed.name)) return 'queue'
   }
-  return prefersSteer(running, busyEnter)
+  return resolveComposerDelivery(running, gesture, busyEnter)
 }
 
 /**
@@ -4386,8 +4388,17 @@ export function apply(ctx: Context, config: Config): void {
         // liveAgent: writing through a re-read closure variable could
         // target a session the identity check did not see (a switch
         // between the check and the write).
+        // An extension `submission` contribution is AGENT-FACING input, never
+        // a command-plane execution: its resolved mode delivers the LINE,
+        // exactly like an unclaimed slash prompt (web parity — an unclaimed
+        // line is a prompt). Running the plugin's command handler here would
+        // execute it immediately under a mode the user explicitly resolved to
+        // 'queue' — the ownership the contribution declared is the whole
+        // contract.
+        const submissionLine = parsedAtSubmit !== undefined
+          && extensionService?.commands.find(parsedAtSubmit.name)?.execution === 'submission'
         const commands = ctx.get('commands')
-        if (commands !== undefined) {
+        if (commands !== undefined && !submissionLine) {
           // Bare `/plan` toggles: when plan mode is already active it exits
           // instead of re-entering (the official command needs `/plan off`).
           const parsed = parseCommand(text)
@@ -4599,8 +4610,10 @@ export function apply(ctx: Context, config: Config): void {
           })
           return
         }
-        // No commands service: direct follow-up on the CAPTURED agent (see
-        // the note above — never a re-read closure variable). Images ride
+        // No commands service — or a submission-owned line, already
+        // classified as plain agent input above: direct follow-up on the
+        // CAPTURED agent (see the note above — never a re-read closure
+        // variable). Images ride
         // the same prepared message as every other path (§13). The WHOLE
         // write runs inside the operation barrier (convergence plan
         // phase 3): a transition started during the admission waits for
@@ -4938,15 +4951,31 @@ export function apply(ctx: Context, config: Config): void {
       }
     }
     /**
+     * Whether one submission is a TUI-owned skill invocation: a LIVE skill
+     * wrapper, or the explicit `/skill <name>` form. Skill delivery belongs
+     * to loadSkill in BOTH modes — it builds the normalized `/name` line,
+     * steers or queues it with the resolved mode, and injects the body
+     * whenever the host's dsh-tool-skill pre-step does not (a composition
+     * without that loader). A bare steered line would silently skip the
+     * skill body, and a missing skill registry is reported there too.
+     * @param parsed - the parsed slash command, undefined for a plain prompt.
+     * @param text - the submitted line.
+     */
+    const isSkillInvocation = (parsed: { name: string } | undefined, text: string): boolean =>
+      parsed !== undefined && (parsed.name === 'skill'
+        ? normalizeSkillInvocation(text) !== undefined
+        : isSkillWrapperName?.(parsed.name) === true)
+    /**
      * Dispatch one user submission end to end: the viewer guard, the input-
      * history persistence, `!` local shells, sessionless commands, the
-     * busy-Enter preference, and the session dispatch. The Ctrl+Enter
-     * opposite chord forces the QUEUE mode (forceQueue), web busyEnter
-     * parity — the accelerated chord uses the other behavior.
+     * busy-Enter policy, and the session dispatch. The delivery mode is
+     * resolved ONCE below (web ComposerSubmissionPolicy parity — the
+     * accelerated chord is the OPPOSITE of the preference, and the explicit
+     * queue action is a fixed queue).
      * @param text - the submitted draft.
-     * @param forceQueue - the chord: never steer, queue instead.
+     * @param request - the request the submission was raised by.
      */
-    const dispatchUserInput = (text: string, forceQueue = false): void => {
+    const dispatchUserInput = (text: string, request: ComposerSubmitRequest = 'enter'): void => {
       // P0 (empty-submission semantics): an EMPTY serialized wire form is
       // a silent no-op — no history write, no session creation, no
       // followup/steer, no attachment admission, no queue mutation. Judged on
@@ -5112,22 +5141,26 @@ export function apply(ctx: Context, config: Config): void {
         || (extensionService?.commands.isSessionless(parsed.name, SESSIONLESS_COMMANDS) ?? false)
       )
       // The submission's effective delivery mode — resolved ONCE, here at
-      // the boundary (web ComposerSubmissionPolicy parity): a non-running
-      // agent, busyEnter=queue, and the Ctrl+Enter force-queue chord all
-      // resolve to 'queue'. The resolved mode rides into the command plane
-      // (dispatchViaSession → withDelivery → the TUI skill delivery), which
-      // never re-derives it from the persisted preference — a one-shot chord
-      // does not survive in settings. Commands that own their own busy
-      // semantics (Host commands, local UI commands) ignore it.
-      const delivery: SubmitDelivery = shouldSteerOnEnter(
-        parsed,
-        liveAgent?.status === 'running',
-        tuiSettings?.get().busyEnter,
-        forceQueue,
-        // M5: the CommandBridge's effective-local check (dynamic plugin
-        // local commands are local while registered).
-        name => extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false,
-      ) ? 'steer' : 'queue'
+      // the boundary (web ComposerSubmissionPolicy parity, DSH
+      // 0.1.3-alpha.2): an idle agent queues, plain Enter takes the
+      // preference, the accelerated chord takes its OPPOSITE, and the
+      // explicit queue action always queues. The resolved mode rides into
+      // the command plane (dispatchViaSession → withDelivery → the TUI skill
+      // delivery), which never re-derives it from the persisted preference —
+      // a one-shot gesture does not survive in settings. Commands that own
+      // their own busy semantics (Host commands, local UI commands) ignore
+      // it.
+      const delivery: SubmitDelivery = request === 'explicit-queue'
+        ? 'queue'
+        : resolveSubmitDelivery(
+            parsed,
+            liveAgent?.status === 'running',
+            request,
+            tuiSettings?.get().busyEnter,
+            // M5: the CommandBridge's effective-local check (dynamic plugin
+            // local commands are local while registered).
+            name => extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false,
+          )
       if (parsed !== undefined && isSessionless) {
         // A recognized sessionless command: its history row is sessionless
         // — it must NEVER appear in Current session, whether or not a
@@ -5161,25 +5194,29 @@ export function apply(ctx: Context, config: Config): void {
         dispatchViaSession(text, persistHistory, delivery)
         return
       }
-      // Busy-Enter preference (web busyEnter parity): while the agent is
-      // RUNNING and the preference is 'steer', agent-facing input steers
-      // into the running turn — plain prompts AND non-local commands. The
-      // per-skill slash commands steer as their raw `/name` line, which the
-      // host's pre-step listener resolves into the injected skill body
-      // (dsh-tool-skill) — exactly like the web's `session.prompt`, which
-      // has no command-execution wire for skills. TUI-owned LOCAL commands
+      // Busy-Enter policy (web parity): agent-facing input steers into the
+      // running turn under the resolved 'steer' mode — plain prompts AND
+      // non-local commands. The per-skill slash commands steer as the
+      // `/name` line the host's pre-step listener (dsh-tool-skill)
+      // recognizes — exactly like the web's `session.prompt`, which has no
+      // command-execution wire for skills. TUI-owned LOCAL commands
       // (/status, /settings, ...) always execute directly; plugin-declared
       // local commands (M5 CommandBridge) join the same set; `!` shells and
       // sessionless commands returned before this gate.
       if (delivery === 'steer') {
-        // An explicit `/skill <name>` invocation steers its NORMALIZED
-        // `/<name> <args>` line — the harness gesture recognizes the
-        // skill's own slash name and injects its body; the raw `/skill
-        // <name>` form would never match (review finding 2). Image
-        // placeholders ride the normalized line untouched. The history
-        // row is written inside steerNow AFTER the session exists (the
+        // Skill delivery belongs to loadSkill in BOTH modes: it builds the
+        // NORMALIZED `/<name> <args>` line (the harness gesture recognizes
+        // the skill's own slash name — the raw `/skill <name>` form would
+        // never match, review finding 2), steers it with this delivery, and
+        // injects the body when the host's pre-step listener does not.
+        // Image placeholders ride the line untouched; the history row is
+        // written by the dispatch AFTER the session exists (the
         // deferred-start gate), with the FINAL session id.
-        steerNow(normalizeSkillInvocation(text) ?? text, true, persistHistory)
+        if (isSkillInvocation(parsed, text)) {
+          dispatchViaSession(text, persistHistory, delivery)
+          return
+        }
+        steerNow(text, true, persistHistory)
         return
       }
       dispatchViaSession(text, persistHistory, delivery)
@@ -5252,7 +5289,10 @@ export function apply(ctx: Context, config: Config): void {
     if (lifecycleController.signal.aborted) return
     startupStatus.clear()
     app = startProcessTui({
-      onSubmit: (text) => dispatchUserInput(text),
+      // ONE submission entry: the request (the Enter gesture, the
+      // accelerated chord, or the explicit queue action) rides along — the
+      // boundary resolves its delivery mode.
+      onSubmit: (text, request) => dispatchUserInput(text, request),
       // The image-only submit gate (plan §11.1): an empty-text draft with
       // staged images is a real submission.
       isImageDraft: () => draftHasImages(app.getDraft(), draftImages),
@@ -5303,9 +5343,6 @@ export function apply(ctx: Context, config: Config): void {
           onError: (error) => app.notify(safeErrorMessage(error), 'error'),
         })
       },
-      // The Ctrl+Enter opposite chord (web busyEnter parity): force the
-      // QUEUE delivery mode regardless of the busyEnter preference.
-      onQueueSubmit: (input) => dispatchUserInput(input, true),
       // The owned-task entry for UI-layer one-shot flows (the external
       // editor): runOwned with the runner's diag pre-attached.
       runOwned: <T>(label: string, task: () => T | Promise<T>, options: Omit<OwnedTaskOptions<T>, 'diag' | 'sessionId'>) => {
@@ -5351,11 +5388,15 @@ export function apply(ctx: Context, config: Config): void {
           case 'submit-draft': {
             // Host-owned submit path: history + notify clear + draft
             // clear, exactly like a normal Enter (round-1 P2).
-            app.submitDraft(false)
+            app.submitDraft('enter')
             break
           }
           case 'queue-draft': {
-            app.submitDraft(true)
+            // The PUBLIC queue action: an explicit delivery command, never a
+            // gesture — it queues regardless of the busy-Enter preference
+            // (the accelerated CHORD is the preference's opposite, see
+            // ComposerSubmitRequest).
+            app.submitDraft('explicit-queue')
             break
           }
           case 'steer-draft': {
@@ -7337,6 +7378,11 @@ export function apply(ctx: Context, config: Config): void {
      * TUI-owned skill wrapper)? The dispatch consults it BEFORE the busy
      * queue/steer policy (PR115-fix problem 1). */
     let isHostCommandName: ((name: string) => boolean) | undefined
+    /** The skill-wrapper test installed by registerTuiCommands: is a slash
+     * name a LIVE TUI-owned skill wrapper? The steer path consults it to
+     * decide whether a composition without the host skill-body loader must
+     * deliver through loadSkill instead of steering a bare line. */
+    let isSkillWrapperName: ((name: string) => boolean) | undefined
     /** The delivery binding installed by registerTuiCommands: bind one
      * submission's resolved queue/steer mode for the synchronous window that
      * launches a command execution (the TUI skill handlers consume it).
@@ -7686,6 +7732,7 @@ export function apply(ctx: Context, config: Config): void {
         const installed = registerTuiCommands(runner, initial)
         wasAdvertisedClaim = installed.wasAdvertised
         isHostCommandName = installed.isHostCommand
+        isSkillWrapperName = installed.isSkillWrapper
         withCommandDelivery = installed.withDelivery
         // The coordinator's surface hooks point INTO the command surface;
         // the runner's refreshCatalog routes every post-mount refresh here.

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,6 +370,58 @@ export const HOST_COMMAND_CATALOG: ReadonlySet<string> = new Set([
 ])
 
 /**
+ * The TUI-local classification the attachment gate uses: a TUI/core local
+ * command or a live client command contribution is LOCAL (its line is a UI
+ * control — attachments are refused), while a LIVE skill wrapper is
+ * AGENT-FACING input (multimodal) even when a client contribution shares its
+ * name: the wrapper route outranks the contribution everywhere.
+ * @param name - the slash name.
+ * @param isSkillWrapper - the live skill-wrapper test (absent = none).
+ * @param isDynamicLocal - the live client-contribution test (absent = none).
+ */
+export function isLocalCommandLine(
+  name: string,
+  isSkillWrapper: ((name: string) => boolean) | undefined,
+  isDynamicLocal: ((name: string) => boolean) | undefined,
+  isHostCommand?: ((name: string) => boolean) | undefined,
+): boolean {
+  // The NAMESPACE ORDER decides: a TUI-owned local command is local, while
+  // the agent-facing routes (a live skill wrapper, a live HOST claim) outrank
+  // a client contribution — the host handler owns its own attachment policy,
+  // and a contribution must never suppress it.
+  if (LOCAL_COMMANDS.has(name)) return true
+  if (isSkillWrapper?.(name) === true) return false
+  if (isHostCommand?.(name) === true) return false
+  return isDynamicLocal?.(name) ?? false
+}
+
+/**
+ * The attachment gate's local-command predicate for one parsed line — the
+ * SINGLE classification the dispatch and its regression tests share:
+ * `/skill <name> ...` is agent-facing (loadSkill), a LIVE skill wrapper is
+ * agent-facing (multimodal) even when a client contribution shares its name,
+ * and everything else follows {@link isLocalCommandLine} (TUI/core local
+ * commands and live client command contributions are local).
+ * @param parsed - the parsed slash command (undefined = plain prompt).
+ * @param isSkillWrapper - the live skill-wrapper test (absent = none).
+ * @param isDynamicLocal - the live client-contribution test (absent = none).
+ * @param isHostCommand - the live HOST-claim test (absent = none): a host
+ *   command owns its own attachment policy, so it is never classified local.
+ * @returns the predicate for `commandRejectsAttachments` / `commandRejectsImages`.
+ */
+export function commandIsLocalForAttachments(
+  parsed: { name: string; rawInput?: string } | undefined,
+  isSkillWrapper: ((name: string) => boolean) | undefined,
+  isDynamicLocal: ((name: string) => boolean) | undefined,
+  isHostCommand?: ((name: string) => boolean) | undefined,
+): (name: string) => boolean {
+  return name => {
+    if (name === 'skill' && (parsed?.rawInput?.trim() ?? '') !== '') return false
+    return isLocalCommandLine(name, isSkillWrapper, isDynamicLocal, isHostCommand)
+  }
+}
+
+/**
  * The TUI dispatch boundary's delivery resolution: the WEB composer policy
  * ({@link resolveComposerDelivery}) applied to agent-facing input, with the
  * TUI's own ownership terms on top. Pure so the dispatch gate (inside the
@@ -378,15 +430,12 @@ export const HOST_COMMAND_CATALOG: ReadonlySet<string> = new Set([
  * @param running - whether the live agent reports running.
  * @param gesture - the composer gesture that raised the submission.
  * @param busyEnter - the persisted preference value (''/undefined = queue).
- * @param isDynamicLocal - M5: the CommandBridge's effective-local check for
- *   plugin-declared local commands (absent = static set only).
  */
 export function resolveSubmitDelivery(
   parsed: { name: string; rawInput?: string } | undefined,
   running: boolean,
   gesture: ComposerSubmitGesture,
   busyEnter: string | undefined,
-  isDynamicLocal?: (name: string) => boolean,
 ): SubmitDelivery {
   if (parsed !== undefined) {
     // `/skill <name> [args...]` is an AGENT-facing invocation (loadSkill),
@@ -394,11 +443,11 @@ export function resolveSubmitDelivery(
     // prompt. Only the bare `/skill` picker counts as local (review finding
     // — same classification as the image-rejection gate).
     if (parsed.name === 'skill' && (parsed.rawInput?.trim() ?? '') !== '') return resolveComposerDelivery(running, gesture, busyEnter)
-    // A TUI-owned local command (and a plugin-declared local one) executes
-    // through its own surface and never steers; its delivery value is only
-    // ever a placeholder for the (never taken) skill-delivery binding.
+    // A TUI-owned local command executes through its own surface and never
+    // steers; its delivery value is only ever a placeholder for the (never
+    // taken) skill-delivery binding. Client contributions never reach this
+    // resolver at all (the namespace dispatch routes them first).
     if (LOCAL_COMMANDS.has(parsed.name)) return 'queue'
-    if (isDynamicLocal !== undefined && isDynamicLocal(parsed.name)) return 'queue'
   }
   return resolveComposerDelivery(running, gesture, busyEnter)
 }
@@ -5131,19 +5180,17 @@ export function apply(ctx: Context, config: Config): void {
       // plain prompts AND per-skill slash lines, including `/skill <name>
       // [image #N ...]` (`skill` is local only as the bare picker; with
       // arguments it is a loadSkill agent prompt — review finding).
-      if (commandRejectsAttachments(parsed, text, draftImages, draftFiles, name => {
-        if (name === 'skill' && (parsed?.rawInput.trim() ?? '') !== '') return false
-        return LOCAL_COMMANDS.has(name)
-          || (extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false)
-      })) {
+      if (commandRejectsAttachments(parsed, text, draftImages, draftFiles, commandIsLocalForAttachments(
+        parsed,
+        isSkillWrapperName,
+        n => extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false,
+        isHostCommandName,
+      ))) {
         app.setEditorText(mergeDraft(app.getDraft(), text))
         app.notify('Attachments cannot be included in a local command.', 'error')
         return
       }
-      const isSessionless = parsed !== undefined && (
-        SESSIONLESS_COMMANDS.has(parsed.name)
-        || (extensionService?.commands.isSessionless(parsed.name, SESSIONLESS_COMMANDS) ?? false)
-      )
+      const isSessionless = parsed !== undefined && SESSIONLESS_COMMANDS.has(parsed.name)
       // The submission's effective delivery mode — resolved ONCE, here at
       // the boundary (web ComposerSubmissionPolicy parity, DSH
       // 0.1.3-alpha.2): an idle agent queues, plain Enter takes the
@@ -5152,83 +5199,87 @@ export function apply(ctx: Context, config: Config): void {
       // the command plane (dispatchViaSession → withDelivery → the TUI skill
       // delivery), which never re-derives it from the persisted preference —
       // a one-shot gesture does not survive in settings. Commands that own
-      // their own busy semantics (Host commands, local UI commands) ignore
-      // it.
+      // their own busy semantics (Host commands, client commands) ignore it.
       const delivery: SubmitDelivery = request === 'explicit-queue'
         ? 'queue'
-        : resolveSubmitDelivery(
-            parsed,
-            liveAgent?.status === 'running',
-            request,
-            tuiSettings?.get().busyEnter,
-            // M5: the CommandBridge's effective-local check (dynamic plugin
-            // local commands are local while registered).
-            name => extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false,
-          )
-      // Host-command claim (HOST AUTHORITY): a slash name the CURRENT
-      // effective host catalog resolves is a host command — a client command
-      // contribution can never shadow it (the DSH client contribution rule:
-      // candidate synthesis fails loud, never shadows; the host command keeps
-      // its claim and its handler decides the busy outcome). TUI-owned names
-      // are excluded here: LOCAL_COMMANDS execute through their own surface
-      // and a TUI skill wrapper is agent-facing input. A claimed command the
-      // real session then lacks is consumed by the advertised-miss gate
-      // inside dispatchViaSession — never a plain model message.
+        : resolveSubmitDelivery(parsed, liveAgent?.status === 'running', request, tuiSettings?.get().busyEnter)
+      // NAMESPACE ORDER (DSH client command contribution parity):
+      //   1. host command claim (the closed host catalog always wins);
+      //   2. client command contribution (client-owned behavior);
+      //   3. TUI-owned sessionless command;
+      //   4. agent-facing input (steer / prompt).
+      //
+      // 1. HOST AUTHORITY: a slash name the CURRENT effective host catalog
+      // resolves is a host command — a client contribution can never shadow
+      // it (upstream: candidate synthesis fails loud, never shadows; the host
+      // handler decides the busy outcome). TUI-owned LOCAL_COMMANDS execute
+      // through their own surface and are excluded here; a TUI skill wrapper
+      // is agent-facing input (also excluded from the claim). A claimed
+      // command the real session then lacks is consumed by the
+      // advertised-miss gate inside dispatchViaSession — never a plain model
+      // message.
       if (parsed !== undefined
         && !LOCAL_COMMANDS.has(parsed.name)
         && isHostCommandName?.(parsed.name) === true) {
         dispatchViaSession(text, persistHistory, delivery)
         return
       }
+      // 2. CLIENT-OWNED command contribution: its behavior lives entirely on
+      // the client, so it executes locally and never steers — the namespace
+      // decision is NOT the generic sessionless branch's to make.
+      // `sessionless` decides whether it may run before a session exists:
+      // true runs immediately (no session is created); false (default)
+      // resolves/creates the session FIRST — the host command surface is
+      // session-keyed — and then runs the handler. A LIVE skill wrapper is
+      // TUI-owned agent-facing input and outranks a contribution of the same
+      // name (the contribution may have been registered before the skill
+      // catalog loaded).
+      const contribution = parsed === undefined || isSkillWrapperName?.(parsed.name) === true
+        ? undefined
+        : extensionService?.commands.find(parsed.name)
+      if (parsed !== undefined && contribution !== undefined) {
+        if (contribution.sessionless) {
+          runLocalCommand(parsed, text, persistHistory, delivery, 'sessionless')
+          return
+        }
+        if (liveAgent !== undefined) {
+          runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
+          return
+        }
+        runOwned('client command session', async () => {
+          await ensureSession()
+          if (liveAgent === undefined) return
+          // AUTHORITY RE-CHECK after the session exists: the deferred start
+          // commits a session whose scoped catalog the standing view could
+          // not see, and the skill catalog may load with it. A live HOST
+          // claim or a TUI skill wrapper outranks the contribution that was
+          // decided before the session existed.
+          if (isHostCommandName?.(parsed.name) === true || isSkillWrapperName?.(parsed.name) === true) {
+            dispatchViaSession(text, persistHistory, delivery)
+            return
+          }
+          runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
+        }, {
+          diag,
+          sessionId: () => liveAgent?.session.id,
+          onError: (error) => {
+            app.notify(safeErrorMessage(error), 'error')
+            restoreSubmissionDraft(text)
+          },
+        })
+        return
+      }
+      // 3. A recognized TUI-owned sessionless command: its history row is
+      // sessionless — it must NEVER appear in Current session, whether or not
+      // a session exists. Without a live agent it runs locally (and creates
+      // none); with a live agent it dispatches through the session's command
+      // service, but the persist closure still supplies undefined.
       if (parsed !== undefined && isSessionless) {
-        // A recognized sessionless command: its history row is sessionless
-        // — it must NEVER appear in Current session, whether or not a
-        // session exists. Without a live agent it runs locally (and
-        // creates none; its fallback path goes through the deferred-start
-        // gate instead, so an unknown "sessionless" command that creates a
-        // session still carries the final session id). With a live agent
-        // it dispatches through the session's command service, but the
-        // persist closure still supplies undefined.
         if (liveAgent === undefined) {
           runLocalCommand(parsed, text, persistHistory, delivery, 'sessionless')
         } else {
           dispatchViaSession(text, () => persistHistory(historySessionIdFor('sessionless', liveAgent?.session.id)), delivery)
         }
-        return
-      }
-      // A CLIENT-OWNED command contribution (the DSH client contribution
-      // shape): its behavior lives entirely on the client, so it executes
-      // locally and never steers. `sessionless` decides whether it may run
-      // before a session exists: false (default) resolves/creates the
-      // session FIRST — the host command surface is session-keyed — and only
-      // then runs the handler; true runs immediately without creating one.
-      const contribution = parsed === undefined ? undefined : extensionService?.commands.find(parsed.name)
-      if (contribution !== undefined && parsed !== undefined) {
-        if (contribution.sessionless) {
-          runLocalCommand(parsed, text, persistHistory, delivery, 'sessionless')
-          return
-        }
-        // A session-backed client command: with a live session it runs NOW
-        // (its row carries that session id); on a deferred start the session
-        // is resolved/created FIRST — the host command surface is
-        // session-keyed — and only then does the handler run, through the
-        // owned flow (a failed creation restores the draft and reports).
-        if (liveAgent === undefined) {
-          runOwned('client command session', async () => {
-            await ensureSession()
-            if (liveAgent === undefined) return
-            runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
-          }, {
-            diag,
-            sessionId: () => liveAgent?.session.id,
-            onError: (error) => {
-              app.notify(safeErrorMessage(error), 'error')
-              restoreSubmissionDraft(text)
-            },
-          })
-          return
-        }
-        runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
         return
       }
       // Busy-Enter policy (web parity): agent-facing input steers into the

--- a/src/index.ts
+++ b/src/index.ts
@@ -4158,7 +4158,11 @@ export function apply(ctx: Context, config: Config): void {
      * `CommandSubmitAttachment`): the draft store holds the exact bytes, and
      * the host admits them through its own store at execute time. Only a
      * declared host command reaches this builder — an undeclared command and
-     * any file attachment are refused before dispatch. */
+     * any file attachment are refused before dispatch. A RECALLED image
+     * carries no local bytes (it is already durable): the wire has no
+     * ref-based variant, so the host's admission rejects the empty payload
+     * and the command settles as an error — the draft and its attachments
+     * are kept for correction (never silently dropped). */
     const commandSubmitAttachments = (draft: string) => expandImagePlaceholders(draft, draftImages)
       .flatMap(segment => segment.type === 'image' ? [segment.image] : [])
       .map(image => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4388,19 +4388,8 @@ export function apply(ctx: Context, config: Config): void {
         // liveAgent: writing through a re-read closure variable could
         // target a session the identity check did not see (a switch
         // between the check and the write).
-        // An extension `submission` contribution is a SUBMISSION LINE, not a
-        // command execution (web parity — in the web composer only a CLAIM
-        // runs a command handler; a skill-style line is a plain prompt with
-        // the policy-resolved mode). The TUI therefore delivers the raw
-        // `/<name> args` line to the session and never runs the
-        // commands-service handler for it; `execution: 'local'` is the
-        // ownership that executes a handler. This is a deliberate BREAKING
-        // ownership change (see TuiCommandContribution.execution), not an
-        // accident of the busy policy.
-        const submissionLine = parsedAtSubmit !== undefined
-          && extensionService?.commands.find(parsedAtSubmit.name)?.execution === 'submission'
         const commands = ctx.get('commands')
-        if (commands !== undefined && !submissionLine) {
+        if (commands !== undefined) {
           // Bare `/plan` toggles: when plan mode is already active it exits
           // instead of re-entering (the official command needs `/plan off`).
           const parsed = parseCommand(text)
@@ -4612,10 +4601,8 @@ export function apply(ctx: Context, config: Config): void {
           })
           return
         }
-        // No commands service — or a submission-owned line, already
-        // classified as plain agent input above: direct follow-up on the
-        // CAPTURED agent (see the note above — never a re-read closure
-        // variable). Images ride
+        // No commands service: direct follow-up on the CAPTURED agent (see
+        // the note above — never a re-read closure variable). Images ride
         // the same prepared message as every other path (§13). The WHOLE
         // write runs inside the operation barrier (convergence plan
         // phase 3): a transition started during the admission waits for
@@ -5178,19 +5165,19 @@ export function apply(ctx: Context, config: Config): void {
             // local commands are local while registered).
             name => extensionService?.commands.isLocal(name, LOCAL_COMMANDS) ?? false,
           )
-      // A plugin-declared LOCAL command whose plugin implements it through
-      // the bridge handler executes locally — with or without a live
-      // session. The bridge handler IS the implementation (the
-      // commands-service definition is only the fallback when the
-      // contribution declares none): without this route the line would fall
-      // through to the command plane — or, for a contribution with no
-      // definition at all, to the MODEL, which must never receive a local UI
-      // command.
-      if (parsed !== undefined && extensionService?.commands.localHandlerFor(parsed.name) !== undefined) {
-        // The row identity follows the command's OWN sessionless
-        // classification: a sessionless local command never appears in
-        // Current session, even when it runs inside a live one.
-        runLocalCommand(parsed, text, persistHistory, delivery, isSessionless ? 'sessionless' : 'agent-facing')
+      // Host-command claim (HOST AUTHORITY): a slash name the CURRENT
+      // effective host catalog resolves is a host command — a client command
+      // contribution can never shadow it (the DSH client contribution rule:
+      // candidate synthesis fails loud, never shadows; the host command keeps
+      // its claim and its handler decides the busy outcome). TUI-owned names
+      // are excluded here: LOCAL_COMMANDS execute through their own surface
+      // and a TUI skill wrapper is agent-facing input. A claimed command the
+      // real session then lacks is consumed by the advertised-miss gate
+      // inside dispatchViaSession — never a plain model message.
+      if (parsed !== undefined
+        && !LOCAL_COMMANDS.has(parsed.name)
+        && isHostCommandName?.(parsed.name) === true) {
+        dispatchViaSession(text, persistHistory, delivery)
         return
       }
       if (parsed !== undefined && isSessionless) {
@@ -5209,21 +5196,39 @@ export function apply(ctx: Context, config: Config): void {
         }
         return
       }
-      // Host-command claim (PR115-fix problem 1): a slash name the CURRENT
-      // effective command catalog resolves — and that is neither a TUI-local
-      // command nor agent-facing input the TUI/extension layer owns (a
-      // TUI-owned skill wrapper, an extension contribution) — is a Host
-      // command. It executes through the command plane; the busy queue/steer
-      // policy applies only to agent-facing prompts, never to a confirmed Host
-      // command (the command handler itself decides the busy outcome). A
-      // claimed command that the real session then lacks is consumed by the
-      // advertised-miss gate inside dispatchViaSession — never a plain
-      // model message.
-      if (parsed !== undefined
-        && !LOCAL_COMMANDS.has(parsed.name)
-        && !(extensionService?.commands.isLocal(parsed.name, LOCAL_COMMANDS) ?? false)
-        && isHostCommandName?.(parsed.name) === true) {
-        dispatchViaSession(text, persistHistory, delivery)
+      // A CLIENT-OWNED command contribution (the DSH client contribution
+      // shape): its behavior lives entirely on the client, so it executes
+      // locally and never steers. `sessionless` decides whether it may run
+      // before a session exists: false (default) resolves/creates the
+      // session FIRST — the host command surface is session-keyed — and only
+      // then runs the handler; true runs immediately without creating one.
+      const contribution = parsed === undefined ? undefined : extensionService?.commands.find(parsed.name)
+      if (contribution !== undefined && parsed !== undefined) {
+        if (contribution.sessionless) {
+          runLocalCommand(parsed, text, persistHistory, delivery, 'sessionless')
+          return
+        }
+        // A session-backed client command: with a live session it runs NOW
+        // (its row carries that session id); on a deferred start the session
+        // is resolved/created FIRST — the host command surface is
+        // session-keyed — and only then does the handler run, through the
+        // owned flow (a failed creation restores the draft and reports).
+        if (liveAgent === undefined) {
+          runOwned('client command session', async () => {
+            await ensureSession()
+            if (liveAgent === undefined) return
+            runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
+          }, {
+            diag,
+            sessionId: () => liveAgent?.session.id,
+            onError: (error) => {
+              app.notify(safeErrorMessage(error), 'error')
+              restoreSubmissionDraft(text)
+            },
+          })
+          return
+        }
+        runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
         return
       }
       // Busy-Enter policy (web parity): agent-facing input steers into the
@@ -6499,8 +6504,10 @@ export function apply(ctx: Context, config: Config): void {
           // M2: registry invalidations (including plugin keybinding
           // register/unload) flush through the batcher into this callback
           // — sync the plugin rules into the effective keymap (a no-op
-          // when unchanged), then repaint.
+          // when unchanged), re-synthesize the slash completions (a late
+          // client command contribution joins the menu), then repaint.
           syncPluginKeybindings()
+          refreshCommandCompletions?.()
           app.requestRender(force)
         },
       )
@@ -7415,6 +7422,10 @@ export function apply(ctx: Context, config: Config): void {
      * decide whether a composition without the host skill-body loader must
      * deliver through loadSkill instead of steering a bare line. */
     let isSkillWrapperName: ((name: string) => boolean) | undefined
+    /** The completion re-synthesis installed by registerTuiCommands: a late
+     * CLIENT command contribution must join the `/` menu without waiting for
+     * a session refresh (the extension-invalidate hook calls it). */
+    let refreshCommandCompletions: (() => void) | undefined
     /** The delivery binding installed by registerTuiCommands: bind one
      * submission's resolved queue/steer mode for the synchronous window that
      * launches a command execution (the TUI skill handlers consume it).
@@ -7765,6 +7776,7 @@ export function apply(ctx: Context, config: Config): void {
         wasAdvertisedClaim = installed.wasAdvertised
         isHostCommandName = installed.isHostCommand
         isSkillWrapperName = installed.isSkillWrapper
+        refreshCommandCompletions = installed.refreshCommandCompletions
         withCommandDelivery = installed.withDelivery
         // The coordinator's surface hooks point INTO the command surface;
         // the runner's refreshCatalog routes every post-mount refresh here.

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ import {
 import type { TaskBrowserViewState, TaskPanelItem } from './task-panel.ts'
 import { TaskBrowserRuntime, type TaskBrowserDatasetScope } from './task-browser-runtime.ts'
 import type { ComposerSubmitGesture, ComposerSubmitRequest, TaskBrowserHandle, WorkflowAction } from './tui-app.ts'
-import { resolveComposerDelivery, registerTuiCommands, type DefaultIntentRecord, type InitialCommandCatalog, type SubmitDelivery, type TuiCommandRunner } from './commands.ts'
+import { resolveComposerDelivery, registerTuiCommands, type DefaultIntentRecord, type HostCommandClaim, type InitialCommandCatalog, type SubmitDelivery, type TuiCommandRunner } from './commands.ts'
 import { normalizePersistedTheme, resolveThemeSelection } from './theme-source.ts'
 import { diagFromEnv, dshHome, type Diag } from './diag.ts'
 import { runDetached, runOwned, isCancellation, type OwnedTaskOptions } from './detached.ts'
@@ -330,16 +330,18 @@ export const LOCAL_COMMANDS = new Set([
  * @param parsed - the parsed slash command, undefined for a plain prompt.
  * @param text - the submission text.
  * @param store - the live draft store.
- * @param isLocal - whether the command name is a LOCAL (TUI-owned/UI)
- *   command; skill names answer false.
+ * @param isLocal - whether THIS LINE is a LOCAL (TUI-owned/UI) command; skill
+ *   names answer false. Never derived from the name alone: a host command's
+ *   input KIND decides which line it claims (see
+ *   {@link commandIsLocalForAttachments}).
  */
 export function commandRejectsImages(
-  parsed: { name: string } | undefined,
+  parsed: { name: string; rawInput?: string } | undefined,
   text: string,
   store: import('./image/types.ts').DraftImageStoreLike,
-  isLocal: (name: string) => boolean,
+  isLocal: boolean,
 ): boolean {
-  return parsed !== undefined && isLocal(parsed.name) && draftHasImages(text, store)
+  return parsed !== undefined && isLocal && draftHasImages(text, store)
 }
 
 /**
@@ -372,51 +374,62 @@ export const HOST_COMMAND_CATALOG: ReadonlySet<string> = new Set([
  * @param name - the slash name.
  * @param isSkillWrapper - the live skill-wrapper test (absent = none).
  * @param isDynamicLocal - the live client-contribution test (absent = none).
+ * @param hostView - the host catalog's view of THIS LINE (`undefined` = the
+ *   catalog does not resolve the name at all; see {@link HostCommandClaim}).
+ *   A name the catalog RESOLVES is never a client-local line: when the
+ *   catalog claims the line the host's own `input.attachments` declaration
+ *   decides, and when it does not (an argued line of an execute-kind
+ *   command) the line is an ordinary submission — never a same-named client
+ *   contribution's.
  */
 export function isLocalCommandLine(
   name: string,
   isSkillWrapper: ((name: string) => boolean) | undefined,
   isDynamicLocal: ((name: string) => boolean) | undefined,
-  isHostCommand?: ((name: string) => boolean) | undefined,
+  hostView?: HostCommandClaim | undefined,
 ): boolean {
-  // The NAMESPACE ORDER decides: a TUI-owned local command is local, while
-  // the agent-facing routes (a live skill wrapper, a live HOST claim) outrank
-  // a client contribution — a host claim's own `input.attachments`
-  // declaration decides whether it may carry attachments (never classified
-  // local here), and a contribution must never suppress that claim.
+  // A TUI-owned name is local no matter what the host catalog holds: the
+  // dispatch excludes LOCAL_COMMANDS from the host route, so the
+  // classification must not claim a host authority the route never grants.
   if (LOCAL_COMMANDS.has(name)) return true
   if (isSkillWrapper?.(name) === true) return false
-  if (isHostCommand?.(name) === true) return false
+  if (hostView !== undefined) return false
   return isDynamicLocal?.(name) ?? false
 }
 
 /**
- * The attachment gate's local-command predicate for one parsed line — the
- * SINGLE classification the dispatch and its regression tests share:
- * `/skill <name> ...` is agent-facing (loadSkill), a LIVE skill wrapper is
- * agent-facing (multimodal) even when a client contribution shares its name,
- * and everything else follows {@link isLocalCommandLine} (TUI/core local
- * commands and live client command contributions are local).
+ * The attachment gate's local-command classification for ONE parsed line —
+ * the SINGLE classification the dispatch and its regression tests share, and
+ * the DSH client namespace order applied to a LINE:
+ * - a TUI/core local command is local;
+ * - `/skill <name> ...` and a LIVE skill wrapper are agent-facing
+ *   (multimodal) even when a client contribution shares the name;
+ * - a name the HOST catalog RESOLVES is never local: when the catalog claims
+ *   the line, the claiming descriptor's `input.attachments` declaration
+ *   decides (`/goal <objective>` is claimed), and when it does not (an argued
+ *   line of an execute-kind command, `/compact extra`) the line is an
+ *   ordinary submission — never a command and never a same-named client
+ *   contribution's;
+ * - everything else follows the live client contribution of that name.
  * @param parsed - the parsed slash command (undefined = plain prompt).
  * @param isSkillWrapper - the live skill-wrapper test (absent = none).
  * @param isDynamicLocal - the live client-contribution test (absent = none).
- * @param isHostCommand - the live HOST-claim test (absent = none): a host
- *   command is never classified local here — its own `input.attachments`
- *   declaration decides whether the composer may attach anything
- *   ({@link attachmentRefusal}).
- * @returns the predicate for `commandRejectsImages` /
- *   {@link attachmentRefusal} (the dispatch's composer attachment policy).
+ * @param hostClaim - the live HOST-catalog view of THIS LINE (absent = none).
+ * @returns whether the line is a local command line.
  */
 export function commandIsLocalForAttachments(
   parsed: { name: string; rawInput?: string } | undefined,
   isSkillWrapper: ((name: string) => boolean) | undefined,
   isDynamicLocal: ((name: string) => boolean) | undefined,
-  isHostCommand?: ((name: string) => boolean) | undefined,
-): (name: string) => boolean {
-  return name => {
-    if (name === 'skill' && (parsed?.rawInput?.trim() ?? '') !== '') return false
-    return isLocalCommandLine(name, isSkillWrapper, isDynamicLocal, isHostCommand)
-  }
+  hostClaim?: ((parsed: { name: string; rawInput?: string }) => HostCommandClaim | undefined) | undefined,
+): boolean {
+  if (parsed === undefined) return false
+  // `/skill <name> ...` is agent-facing (loadSkill owns it) even though the
+  // bare `/skill` picker is a TUI-local command.
+  if (parsed.name === 'skill' && (parsed.rawInput?.trim() ?? '') !== '') return false
+  // The host catalog's view of THIS LINE outranks a same-named client
+  // contribution, exactly like the dispatch's namespace order.
+  return isLocalCommandLine(parsed.name, isSkillWrapper, isDynamicLocal, hostClaim?.(parsed))
 }
 
 /**
@@ -487,7 +500,10 @@ export function normalizeSkillInvocation(text: string): string | undefined {
  * unadvertised miss keeps the existing plain-input fallback (the user may
  * deliberately send slash text to the model).
  * @param execution - the settled `commands.execute` outcome.
- * @param wasAdvertised - the claim captured BEFORE session creation.
+ * @param wasAdvertised - whether the submission was an advertised command
+ *   INVOCATION: the submit-time name claim AND the command plane's final
+ *   ownership of the line (an argued line of an execute-kind command never
+ *   reached the plane, so it is an ordinary submission).
  * @returns whether the miss must be consumed as an advertised miss.
  */
 export function shouldConsumeAdvertisedMiss(
@@ -4129,8 +4145,11 @@ export function apply(ctx: Context, config: Config): void {
      * - an explicit `/skill <name> ...` invocation and a LIVE skill wrapper
      *   are agent-facing — loadSkill delivers them and their attachments to
      *   the model (never classified as a command);
-     * - a HOST command accepts attachments ONLY when its descriptor declares
-     *   `input.attachments` (upstream refuses otherwise before dispatch);
+     * - a line the HOST catalog CLAIMS accepts attachments ONLY when the
+     *   claiming descriptor declares `input.attachments` (upstream refuses
+     *   otherwise before dispatch). The claim is LINE-level: an argued line
+     *   of an execute-kind command is no invocation at all (it falls back to
+     *   the ordinary submission) and keeps its attachments;
      * - a declared command still refuses a FILE attachment: the host expects
      *   an upload receipt, which this client has no seam to produce (fail
      *   closed rather than silently drop the file).
@@ -4139,7 +4158,11 @@ export function apply(ctx: Context, config: Config): void {
     const attachmentRefusal = (
       parsed: { name: string; rawInput?: string },
       draft: string,
-      isLocalLine: (name: string) => boolean,
+      // Whether THIS LINE is a local command line — the dispatch's ONE
+      // classification (`commandIsLocalForAttachments`), computed by the
+      // caller because it must be re-readable against the FINAL catalog for a
+      // deferred start.
+      isLocal: boolean,
       // The ONE skill-invocation predicate (`isSkillInvocation`: an explicit
       // `/skill <name> ...` or a live skill wrapper) — TUI-owned agent-facing
       // input that loadSkill owns. It is supplied rather than re-derived: the
@@ -4150,9 +4173,10 @@ export function apply(ctx: Context, config: Config): void {
     ): string | undefined => {
       if (!draftHasAttachments(draft, draftImages, draftFiles)) return undefined
       if (skillInvocation) return undefined
-      if (!isLocalLine(parsed.name)) {
-        if (isHostCommandName?.(parsed.name) === true) {
-          if (isHostCommandAcceptingAttachments?.(parsed.name) !== true) {
+      if (!isLocal) {
+        const claim = hostClaimOf?.(parsed)
+        if (claim?.claimed === true) {
+          if (claim.attachments !== true) {
             return `/${parsed.name} does not accept attachments; remove them first`
           }
           if (draftHasFiles(draft, draftImages, draftFiles)) {
@@ -4419,13 +4443,55 @@ export function apply(ctx: Context, config: Config): void {
       // authoritative event lands. The TOKEN arms every terminal exit of
       // THIS workflow: a newer gesture supersedes them.
       const submitAckToken = acceptLocalSubmitAck()
-      // Capture the advertised claim BEFORE any session creation: the
-      // boolean must reflect the completion generation at submit time, never
-      // a re-query after ensureSession (a refresh may have already revoked
-      // the claim). A probed command the real session then lacks is consumed
-      // with an explicit error below — it must never fall through to the
-      // model as a plain user message.
       const parsedAtSubmit = parseCommand(text)
+      // The advertised NAME claim, captured BEFORE any session creation: a
+      // refresh may have revoked it since (the completion generation the user
+      // saw is the one that promised the command), and a probed command the
+      // real session then lacks must be consumed with an explicit error —
+      // never a plain model message. It is only consumed for a line the
+      // command plane actually OWNS at invocation time (`planeAdvertised`).
+      const wasAdvertisedAtSubmit = parsedAtSubmit !== undefined
+        && wasAdvertisedClaim?.(parsedAtSubmit.name) === true
+      // The host catalog's view of the line at SUBMIT time, captured before any
+      // session creation: a line it already knew to be a NON-invocation (an
+      // argued line of an execute-kind command) stays one — no later catalog
+      // change may turn it into an invocation except the final catalog
+      // actually CLAIMING it.
+      const submitView = parsedAtSubmit === undefined ? undefined : hostClaimOf?.(parsedAtSubmit)
+      // The CLIENT-LOCAL eligibility of the submitted line, captured with the
+      // routing decision (before any session creation): only a line whose
+      // initial route was a LIVE client contribution keeps the client-local
+      // attachment classification under the final authority. A contribution
+      // that appears LATER never turns a generic line into a UI control
+      // (upstream `matchEnter` checks the contribution once, before the session
+      // work), and this route never runs the new handler anyway — the line is
+      // an ordinary submission.
+      const clientLocalAtSubmit = parsedAtSubmit !== undefined
+        && extensionService?.commands.find(parsedAtSubmit.name) !== undefined
+      // Whether the command plane OWNS the submitted line, asked against the
+      // LIVE catalog at INVOCATION time (after ensureSession: a deferred start
+      // commits a session-scoped catalog the standing view could not see, and
+      // the descriptor of a resolved name may differ there — in either
+      // direction). The plane owns a TUI-owned route (a local command, or a
+      // live skill wrapper whose `/name args` line the plane's own handler
+      // turns into loadSkill) and every line the FINAL catalog CLAIMS. It does
+      // NOT own an argued line of an execute-kind host command: upstream
+      // `matchEnter` makes it an ordinary submission, and the host registry
+      // resolves by NAME, so asking it would run the command anyway.
+      const commandPlaneOwnsLine = (): boolean => {
+        if (parsedAtSubmit === undefined) return true
+        if (LOCAL_COMMANDS.has(parsedAtSubmit.name)) return true
+        if (isSkillWrapperName?.(parsedAtSubmit.name) === true) return true
+        const finalView = hostClaimOf?.(parsedAtSubmit)
+        // A resolved final catalog answers for itself (claimed = the plane
+        // runs the command; unclaimed = an ordinary submission).
+        if (finalView !== undefined) return finalView.claimed
+        // The final catalog does not resolve the name at all: the plane decides
+        // (a session-scoped command the standing view cannot see) — UNLESS the
+        // line was ALREADY a known non-invocation when it was submitted, which
+        // no disappearance can turn into an invocation.
+        return submitView?.claimed !== false
+      }
       const extensionCommandId = parsedAtSubmit === undefined
         ? undefined
         : extensionService?.commands.idFor(parsedAtSubmit.name)
@@ -4436,7 +4502,13 @@ export function apply(ctx: Context, config: Config): void {
       // reload in between means the REAL invocation runs the NEW owner's
       // command). It is re-captured inside the runOwned factory,
       // immediately before execute() — see below (the review's P2).
-      const wasAdvertised = parsedAtSubmit !== undefined && wasAdvertisedClaim?.(parsedAtSubmit.name) === true
+      // Whether the submission reached the plane AS AN ADVERTISED COMMAND
+      // INVOCATION: the submit-time advertised claim AND the plane's final
+      // ownership of the line (resolved in the factory below). The
+      // advertised-miss gate may consume only a line the plane actually
+      // owned — an argued line of an execute-kind command is an ordinary
+      // submission even when its name was advertised.
+      let planeAdvertised = false
       // An owned workflow: the chain's outcome drives the editor draft, the
       // notices and the queue — runOwned (AGENTS.md), never a bare void.
       // Reserve the referenced drafts SYNCHRONOUSLY, in the SAME call stack
@@ -4533,8 +4605,19 @@ export function apply(ctx: Context, config: Config): void {
             commandIsLocalForAttachments(
               parsed,
               isSkillWrapperName,
-              n => extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false,
-              isHostCommandName,
+              // The dynamic (client contribution) term is STICKY to the
+              // submit-time route: a contribution that appeared during the
+              // deferred window does not reclassify an ordinary line as a UI
+              // control under the final authority.
+              n => clientLocalAtSubmit && (extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false),
+              // STICKY SUBMIT-TIME AUTHORITY: once the host catalog RESOLVED
+              // this name when the line was submitted, the name is host
+              // territory for the lifetime of the submission — the line never
+              // falls back to a same-named client contribution (which only
+              // ever owns names the host catalog does not resolve at all),
+              // even when the name disappears from the final catalog. The
+              // final catalog still decides the CLAIM itself.
+              line => hostClaimOf?.(line) ?? submitView,
             ),
             isSkillInvocation(parsed, text),
           )
@@ -4577,7 +4660,9 @@ export function apply(ctx: Context, config: Config): void {
             // `CommandSubmitAttachment`) ONLY for a HOST command that
             // DECLARES `input.attachments` — the web composer's
             // `leadingClaim.submit(args, attachments)` path; the host admits
-            // them through its own store before the handler runs. A
+            // them through its own store before the handler runs. The claim
+            // is asked for THIS LINE: an argued line of an execute-kind
+            // command is not an invocation at all (see the routing gate). A
             // TUI-owned command must never carry them on this wire: its
             // descriptor does not declare attachments (`/skill <name>` is
             // itself a registered TUI command, and a live skill wrapper is
@@ -4585,12 +4670,22 @@ export function apply(ctx: Context, config: Config): void {
             // invocation BEFORE the handler — their placeholder line is
             // delivered as-is and the images are admitted by the delivery
             // path (loadSkill → prepareUserMessage).
-            const submittedAttachments = parsedAtSubmit !== undefined
-              && isHostCommandName?.(parsedAtSubmit.name) === true
-              && isHostCommandAcceptingAttachments?.(parsedAtSubmit.name) === true
+            const submittedClaim = parsedAtSubmit === undefined ? undefined : hostClaimOf?.(parsedAtSubmit)
+            const submittedAttachments = submittedClaim?.claimed === true && submittedClaim.attachments
               ? commandSubmitAttachments(text)
               : []
-            return withCommandDelivery(delivery, () => commands.execute(agent as Agent, toggled, submittedAttachments, signal))
+            // The plane is asked only for a line it owns, resolved against the
+            // FINAL catalog here (see commandPlaneOwnsLine): the host registry
+            // resolves by NAME, so handing it an argued line of an execute-kind
+            // command would run the command the DSH decision table never made
+            // an invocation. An unowned line resolves undefined and keeps the
+            // ordinary delivery below; the advertised-miss gate follows the
+            // SAME resolution.
+            const commandPlaneLine = commandPlaneOwnsLine()
+            planeAdvertised = commandPlaneLine && wasAdvertisedAtSubmit
+            return withCommandDelivery(delivery, () => commandPlaneLine
+              ? commands.execute(agent as Agent, toggled, submittedAttachments, signal)
+              : Promise.resolve(undefined))
           }, {
             diag,
             sessionId: () => agent.session.id,
@@ -4611,7 +4706,7 @@ export function apply(ctx: Context, config: Config): void {
               // message. Attachment-bearing drafts are restored below; plain slash lines
                // remain consumed (the refreshed completions already revoked the
                // claim, and a mechanical retry could ride the unadvertised fallback).
-               if (shouldConsumeAdvertisedMiss(execution, wasAdvertised)) {
+               if (shouldConsumeAdvertisedMiss(execution, planeAdvertised)) {
                 restoreCommandAttachmentDraft()
                 app.notify(`/${parsedAtSubmit?.name ?? '?'} is not available in the created session`, 'error')
                 settleLocalSubmitAck('submit consumed by an unadvertised command', { token: submitAckToken, terminal: true })
@@ -5287,6 +5382,13 @@ export function apply(ctx: Context, config: Config): void {
       // like /plan, and plain prompts — creates the session lazily. M5: a
       // plugin-declared sessionless command (CommandBridge) joins the set.
       const parsed = parseCommand(text)
+      // The CURRENT host catalog's view of THIS LINE, asked ONCE for the
+      // synchronous routing decisions below (the deferred resolution asks
+      // again, against the catalog the session committed). A name the
+      // catalog RESOLVES is host territory even when it does not claim this
+      // line: `/compact extra` is an ordinary submission, never a same-named
+      // client contribution's.
+      const hostView = parsed === undefined ? undefined : hostClaimOf?.(parsed)
       // Command semantics matrix (plan §19.3): slash commands are not LLM
       // prompts — an image-bearing command line is REJECTED explicitly
       // (never a silent drop, never a stray placeholder sent to the model).
@@ -5295,13 +5397,15 @@ export function apply(ctx: Context, config: Config): void {
       // plain prompts AND per-skill slash lines, including `/skill <name>
       // [image #N ...]` (`skill` is local only as the bare picker; with
       // arguments it is a loadSkill agent prompt — review finding).
-      // The line's attachment classification is computed ONCE and reused by
-      // the deferred resolution below (the same predicate, live view).
-      const localForAttachments = commandIsLocalForAttachments(
+      // The line's attachment classification is RE-EVALUATED at every ask
+      // (a thunk, never a snapshot): the deferred resolution below must
+      // classify against the catalog the session committed, not the standing
+      // view the gesture saw.
+      const localForAttachments = (): boolean => commandIsLocalForAttachments(
         parsed,
         isSkillWrapperName,
         n => extensionService?.commands.isLocal(n, LOCAL_COMMANDS) ?? false,
-        isHostCommandName,
+        hostClaimOf,
       )
       // A session-backed client contribution on a DEFERRED START is the ONE
       // classification the standing view cannot settle: the session commits
@@ -5316,9 +5420,9 @@ export function apply(ctx: Context, config: Config): void {
       const deferredClientAttachments = parsed !== undefined
         && liveAgent === undefined
         && extensionService?.commands.find(parsed.name)?.sessionless === false
-        && localForAttachments(parsed.name)
+        && localForAttachments()
       if (!deferredClientAttachments && parsed !== undefined) {
-        const refusal = attachmentRefusal(parsed, text, localForAttachments, isSkillInvocation(parsed, text))
+        const refusal = attachmentRefusal(parsed, text, localForAttachments(), isSkillInvocation(parsed, text))
         if (refusal !== undefined) {
           app.setEditorText(mergeDraft(app.getDraft(), text))
           app.notify(refusal, 'error')
@@ -5344,24 +5448,31 @@ export function apply(ctx: Context, config: Config): void {
       //   3. TUI-owned sessionless command;
       //   4. agent-facing input (steer / prompt).
       //
-      // 1. HOST AUTHORITY: a slash name the CURRENT effective host catalog
-      // resolves is a host command — a client contribution can never shadow
-      // it (upstream: candidate synthesis fails loud, never shadows; the host
-      // handler decides the busy outcome). TUI-owned LOCAL_COMMANDS execute
-      // through their own surface and are excluded here; a TUI skill wrapper
-      // is agent-facing input (also excluded from the claim). A claimed
-      // command the real session then lacks is consumed by the
-      // advertised-miss gate inside dispatchViaSession — never a plain model
-      // message.
+      // 1. HOST AUTHORITY: a line the CURRENT effective host catalog CLAIMS
+      // is a host command — a client contribution can never shadow it
+      // (upstream: candidate synthesis fails loud, never shadows; the host
+      // handler decides the busy outcome). The claim belongs to the LINE, not
+      // to the name: a `leadingInput` descriptor claims its argued line
+      // (`/goal ship`), an execute-kind one claims the bare token only, so
+      // `/compact extra` is an ordinary submission (upstream `matchEnter`
+      // parity). TUI-owned LOCAL_COMMANDS execute through their own surface
+      // and are excluded here; a TUI skill wrapper is agent-facing input
+      // (also excluded from the claim). A claimed command the real session
+      // then lacks is consumed by the advertised-miss gate inside
+      // dispatchViaSession — never a plain model message.
       if (parsed !== undefined
         && !LOCAL_COMMANDS.has(parsed.name)
-        && isHostCommandName?.(parsed.name) === true) {
+        && hostView?.claimed === true) {
         dispatchViaSession(text, persistHistory, delivery)
         return
       }
       // 2. CLIENT-OWNED command contribution: its behavior lives entirely on
       // the client, so it executes locally and never steers — the namespace
-      // decision is NOT the generic sessionless branch's to make.
+      // decision is NOT the generic sessionless branch's to make. A name the
+      // host catalog RESOLVES is host territory even when the catalog does
+      // not claim THIS line (an argued line of an execute-kind command): the
+      // line is an ordinary submission, so the contribution of that name
+      // never runs for it.
       // `sessionless` decides whether it may run before a session exists:
       // true runs immediately (no session is created); false (default)
       // resolves/creates the session FIRST — the host command surface is
@@ -5369,7 +5480,14 @@ export function apply(ctx: Context, config: Config): void {
       // TUI-owned agent-facing input and outranks a contribution of the same
       // name (the contribution may have been registered before the skill
       // catalog loaded).
-      const contribution = parsed === undefined || isSkillWrapperName?.(parsed.name) === true
+      const contribution = parsed === undefined
+        || isSkillWrapperName?.(parsed.name) === true
+        // A name the host catalog RESOLVES is host territory even when it does
+        // not claim THIS line: the line is an ordinary submission (upstream
+        // `matchEnter` `if (!bare) return undefined`), so a same-named
+        // contribution — reachable only in the failed-source collision state —
+        // never runs for it.
+        || hostView !== undefined
         ? undefined
         : extensionService?.commands.find(parsed.name)
       if (parsed !== undefined && contribution !== undefined) {
@@ -5402,7 +5520,7 @@ export function apply(ctx: Context, config: Config): void {
             // delivers to the model; a contribution that keeps the line
             // refuses as a local command — the synchronous gate's outcome,
             // only now final.
-            const refusal = attachmentRefusal(parsed, text, localForAttachments, isSkillInvocation(parsed, text))
+            const refusal = attachmentRefusal(parsed, text, localForAttachments(), isSkillInvocation(parsed, text))
             if (refusal !== undefined) {
               restoreSubmissionDraft(text)
               app.notify(refusal, 'error')
@@ -5411,9 +5529,14 @@ export function apply(ctx: Context, config: Config): void {
             // AUTHORITY RE-CHECK after the session exists: the deferred start
             // commits a session whose scoped catalog the standing view could
             // not see, and the skill catalog may load with it. A live HOST
-            // claim or a TUI skill wrapper outranks the contribution that was
-            // decided before the session existed.
-            if (isHostCommandName?.(parsed.name) === true || isSkillWrapperName?.(parsed.name) === true) {
+            // claim FOR THIS LINE or a TUI skill wrapper outranks the
+            // contribution that was decided before the session existed — and a
+            // name the committed catalog resolves WITHOUT claiming this line
+            // is an ordinary submission the contribution must not run either.
+            // The delivery resolved before the session existed, so it is a
+            // queue-mode submission: `dispatchViaSession` delivers the line
+            // itself (its command-plane gate refuses the unclaimed line).
+            if (hostClaimOf?.(parsed) !== undefined || isSkillWrapperName?.(parsed.name) === true) {
               dispatchViaSession(text, persistHistory, delivery)
               return
             }
@@ -7636,16 +7759,12 @@ export function apply(ctx: Context, config: Config): void {
      * advertised by the CURRENT completion list? The dispatch captures it
      * BEFORE any session creation (see dispatchViaSession). */
     let wasAdvertisedClaim: ((name: string) => boolean) | undefined
-    /** The claim test installed by registerTuiCommands: is a slash name a
-     * HOST command in the current effective catalog (advertised, not a
-     * TUI-owned skill wrapper)? The dispatch consults it BEFORE the busy
-     * queue/steer policy (PR115-fix problem 1). */
-    let isHostCommandName: ((name: string) => boolean) | undefined
-    /** The declaration test installed by registerTuiCommands: does the
-     * current host catalog's command for this name declare
-     * `input.attachments`? The composer refuses an attachment-bearing line
-     * for any other command (web `CommandUiRuntime.candidates` parity). */
-    let isHostCommandAcceptingAttachments: ((name: string) => boolean) | undefined
+    /** The claim test installed by registerTuiCommands: does the CURRENT
+     * effective host catalog claim THIS LINE (and does the claiming
+     * descriptor declare `input.attachments`)? The dispatch consults it
+     * BEFORE the busy queue/steer policy and for every attachment decision
+     * (PR115-fix problem 1). */
+    let hostClaimOf: ((parsed: { name: string; rawInput?: string }) => HostCommandClaim | undefined) | undefined
     /** The skill-wrapper test installed by registerTuiCommands: is a slash
      * name a LIVE TUI-owned skill wrapper? The steer path consults it to
      * decide whether a composition without the host skill-body loader must
@@ -8003,8 +8122,7 @@ export function apply(ctx: Context, config: Config): void {
       try {
         const installed = registerTuiCommands(runner, initial)
         wasAdvertisedClaim = installed.wasAdvertised
-        isHostCommandName = installed.isHostCommand
-        isHostCommandAcceptingAttachments = installed.isHostCommandAcceptingAttachments
+        hostClaimOf = installed.hostClaimOf
         isSkillWrapperName = installed.isSkillWrapper
         refreshCommandCompletions = installed.refreshCommandCompletions
         withCommandDelivery = installed.withDelivery

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,8 @@ import {
   pruneUnreferencedDraftAttachments,
   type PrepareInputDeps,
 } from './image/submit.ts'
+import { expandImagePlaceholders } from './image/placeholder.ts'
+import { draftHasFiles } from './attachment/placeholder.ts'
 import { runReservedSubmit } from './image/submit-flow.ts'
 import { dshVersion } from './dsh-version.ts'
 import { createExitController } from './exit.ts'
@@ -340,17 +342,6 @@ export function commandRejectsImages(
   return parsed !== undefined && isLocal(parsed.name) && draftHasImages(text, store)
 }
 
-/** Whether a local command line carries any live attachment placeholder. */
-function commandRejectsAttachments(
-  parsed: { name: string } | undefined,
-  text: string,
-  imageStore: import('./image/types.ts').DraftImageStoreLike,
-  fileStore: import('./attachment/file-draft.ts').DraftFileStoreLike | undefined,
-  isLocal: (name: string) => boolean,
-): boolean {
-  return parsed !== undefined && isLocal(parsed.name) && draftHasAttachments(text, imageStore, fileStore)
-}
-
 /**
  * The STATIC host-owned command catalog (P1-04): the ownership sets
  * (LOCAL_COMMANDS and SESSIONLESS_COMMANDS — the TUI's own local/UI command
@@ -410,7 +401,8 @@ export function isLocalCommandLine(
  * @param isDynamicLocal - the live client-contribution test (absent = none).
  * @param isHostCommand - the live HOST-claim test (absent = none): a host
  *   command owns its own attachment policy, so it is never classified local.
- * @returns the predicate for `commandRejectsAttachments` / `commandRejectsImages`.
+ * @returns the predicate for `commandRejectsImages` /
+ *   {@link attachmentRefusal} (the dispatch's composer attachment policy).
  */
 export function commandIsLocalForAttachments(
   parsed: { name: string; rawInput?: string } | undefined,
@@ -4125,6 +4117,56 @@ export function apply(ctx: Context, config: Config): void {
      * against concurrent attach-time prunes). Correctness side effect
      * first; never throws.
      */
+    /**
+     * The COMPOSER-side attachment policy for one parsed line (DSH web
+     * parity): returns the refusal text, or undefined when the line may carry
+     * the staged attachments.
+     * - a TUI/core local command and a client contribution are UI controls —
+     *   refused;
+     * - a LIVE skill wrapper, a `/skill <name>` invocation and a plain prompt
+     *   are agent-facing — delivered to the model;
+     * - a HOST command accepts attachments ONLY when its descriptor declares
+     *   `input.attachments` (upstream refuses otherwise before dispatch);
+     * - a declared command still refuses a FILE attachment: the host expects
+     *   an upload receipt, which this client has no seam to produce (fail
+     *   closed rather than silently drop the file).
+     * The host executor re-enforces the declaration at admission.
+     */
+    const attachmentRefusal = (
+      parsed: { name: string; rawInput?: string },
+      draft: string,
+      isLocalLine: (name: string) => boolean,
+    ): string | undefined => {
+      if (!draftHasAttachments(draft, draftImages, draftFiles)) return undefined
+      // A skill wrapper is TUI-owned agent-facing input even when a client
+      // contribution shares the name.
+      if (isSkillWrapperName?.(parsed.name) === true) return undefined
+      if (!isLocalLine(parsed.name)) {
+        if (isHostCommandName?.(parsed.name) === true) {
+          if (isHostCommandAcceptingAttachments?.(parsed.name) !== true) {
+            return `/${parsed.name} does not accept attachments; remove them first`
+          }
+          if (draftHasFiles(draft, draftImages, draftFiles)) {
+            return `/${parsed.name} cannot receive file attachments in this client; remove them first`
+          }
+        }
+        return undefined
+      }
+      return 'Attachments cannot be included in a local command.'
+    }
+    /** The encoded images ONE command invocation carries (DSH
+     * `CommandSubmitAttachment`): the draft store holds the exact bytes, and
+     * the host admits them through its own store at execute time. Only a
+     * declared host command reaches this builder — an undeclared command and
+     * any file attachment are refused before dispatch. */
+    const commandSubmitAttachments = (draft: string) => expandImagePlaceholders(draft, draftImages)
+      .flatMap(segment => segment.type === 'image' ? [segment.image] : [])
+      .map(image => ({
+        type: 'image' as const,
+        mediaType: image.mediaType,
+        data: Buffer.from(image.bytes).toString('base64'),
+        ...(image.name === undefined ? {} : { name: image.name }),
+      }))
     const restoreSubmissionDraft = (draft: string): void => {
       if (lifecycleController.signal.aborted) return
       app.setEditorText(mergeDraft(app.getDraft(), draft))
@@ -4492,7 +4534,13 @@ export function apply(ctx: Context, config: Config): void {
             // window: `commands.execute` invokes a resolved handler in the
             // same call stack, so a TUI-owned skill handler captures its
             // submission's mode before any await (see withDelivery).
-            return withCommandDelivery(delivery, () => commands.execute(agent as Agent, toggled, [], signal))
+            // The command plane receives the submitted attachments (DSH
+            // `CommandSubmitAttachment`): the gate already proved that the
+            // resolved command DECLARES `input.attachments` and that the line
+            // carries images only, so this is the web composer's
+            // `leadingClaim.submit(args, attachments)` path — the host admits
+            // them through its own store before the handler runs.
+            return withCommandDelivery(delivery, () => commands.execute(agent as Agent, toggled, commandSubmitAttachments(text), signal))
           }, {
             diag,
             sessionId: () => agent.session.id,
@@ -4607,10 +4655,14 @@ export function apply(ctx: Context, config: Config): void {
                     : 'the draft changed while sending — review it before submitting again (the earlier text was preserved below)', 'error')
                 }
               } else {
-                // A recognized command error committed no agent-facing
-                // message; restore any staged attachment draft before the
-                // handoff pin is released. A success consumed its refs.
+                // A command submission CONSUMES its attachments only after
+                // handler success (web parity: an error outcome keeps the
+                // draft and its attachments for correction, so a failed
+                // command never silently drops the user's attachment). An
+                // error result committed no agent-facing message: restore the
+                // staged draft before the handoff pin is released.
                 if (execution.result.kind === 'error') restoreCommandAttachmentDraft()
+                else consumeDraftAttachments(text, draftImages, draftFiles)
                 // The command COMMITTED (no image fallback): release the
                 // handoff pin.
                 fallbackPin()
@@ -5205,11 +5257,13 @@ export function apply(ctx: Context, config: Config): void {
         && liveAgent === undefined
         && extensionService?.commands.find(parsed.name)?.sessionless === false
         && localForAttachments(parsed.name)
-      if (!deferredClientAttachments
-        && commandRejectsAttachments(parsed, text, draftImages, draftFiles, localForAttachments)) {
-        app.setEditorText(mergeDraft(app.getDraft(), text))
-        app.notify('Attachments cannot be included in a local command.', 'error')
-        return
+      if (!deferredClientAttachments && parsed !== undefined) {
+        const refusal = attachmentRefusal(parsed, text, localForAttachments)
+        if (refusal !== undefined) {
+          app.setEditorText(mergeDraft(app.getDraft(), text))
+          app.notify(refusal, 'error')
+          return
+        }
       }
       const isSessionless = parsed !== undefined && SESSIONLESS_COMMANDS.has(parsed.name)
       // The submission's effective delivery mode — resolved ONCE, here at
@@ -5281,6 +5335,19 @@ export function apply(ctx: Context, config: Config): void {
           run: async () => {
             await ensureSession()
             if (liveAgent === undefined) return
+            // The COMPOSER attachment policy is resolved with the FINAL
+            // authority: a late host claim that does not declare
+            // `input.attachments` refuses the line (a declared one takes it
+            // WITH the images, see the delivery side); a late skill wrapper
+            // delivers to the model; a contribution that keeps the line
+            // refuses as a local command — the synchronous gate's outcome,
+            // only now final.
+            const refusal = attachmentRefusal(parsed, text, localForAttachments)
+            if (refusal !== undefined) {
+              restoreSubmissionDraft(text)
+              app.notify(refusal, 'error')
+              return
+            }
             // AUTHORITY RE-CHECK after the session exists: the deferred start
             // commits a session whose scoped catalog the standing view could
             // not see, and the skill catalog may load with it. A live HOST
@@ -5299,15 +5366,6 @@ export function apply(ctx: Context, config: Config): void {
             if (extensionService?.commands.find(parsed.name) !== submitted) {
               app.notify(`/${parsed.name} is no longer available — the draft was restored, submit it again`, 'error')
               restoreSubmissionDraft(text)
-              return
-            }
-            // The FINAL owner is the client command: its local route refuses
-            // attachments. The refusal is the synchronous gate's outcome,
-            // resolved late — now that no host claim or skill wrapper can
-            // take the line instead.
-            if (commandRejectsAttachments(parsed, text, draftImages, draftFiles, localForAttachments)) {
-              restoreSubmissionDraft(text)
-              app.notify('Attachments cannot be included in a local command.', 'error')
               return
             }
             runLocalCommand(parsed, text, persistHistory, delivery, 'agent-facing')
@@ -7523,6 +7581,11 @@ export function apply(ctx: Context, config: Config): void {
      * TUI-owned skill wrapper)? The dispatch consults it BEFORE the busy
      * queue/steer policy (PR115-fix problem 1). */
     let isHostCommandName: ((name: string) => boolean) | undefined
+    /** The declaration test installed by registerTuiCommands: does the
+     * current host catalog's command for this name declare
+     * `input.attachments`? The composer refuses an attachment-bearing line
+     * for any other command (web `CommandUiRuntime.candidates` parity). */
+    let isHostCommandAcceptingAttachments: ((name: string) => boolean) | undefined
     /** The skill-wrapper test installed by registerTuiCommands: is a slash
      * name a LIVE TUI-owned skill wrapper? The steer path consults it to
      * decide whether a composition without the host skill-body loader must
@@ -7881,6 +7944,7 @@ export function apply(ctx: Context, config: Config): void {
         const installed = registerTuiCommands(runner, initial)
         wasAdvertisedClaim = installed.wasAdvertised
         isHostCommandName = installed.isHostCommand
+        isHostCommandAcceptingAttachments = installed.isHostCommandAcceptingAttachments
         isSkillWrapperName = installed.isSkillWrapper
         refreshCommandCompletions = installed.refreshCommandCompletions
         withCommandDelivery = installed.withDelivery

--- a/src/keybinding-registry.ts
+++ b/src/keybinding-registry.ts
@@ -97,7 +97,7 @@ interface BindingRecord {
  * (default keyboard exit confirmation, Ctrl+S steer-all, Ctrl+F search,
  * Ctrl+O expand, Ctrl+T
  * todo, Ctrl+G external editor, Ctrl+R history search, Ctrl+V clipboard,
- * Ctrl+Enter queue, Enter submit, Esc cancel, Shift+Tab permission,
+ * Ctrl+Enter accelerated submit (the busy-Enter opposite), Enter submit, Esc cancel, Shift+Tab permission,
  * Alt+Up dequeue, Alt+T thinking, Alt+K dismiss, Ctrl+End jump latest).
  * When a NEW default
  * host lifecycle key lands, extend THIS list in the same commit so
@@ -122,7 +122,7 @@ export const RESERVED_HOST_KEYS: readonly NormalizedKey[] = [
   // parser — isTerminalAmbiguousKeyId) rejects a plugin registration on it
   // anyway: on a legacy terminal the byte IS Enter, so the binding could
   // never fire through the router's normalized lookup (round-13 finding).
-  { key: 'enter', ctrl: true, alt: false, shift: false, super: false }, // Ctrl+Enter queue
+  { key: 'enter', ctrl: true, alt: false, shift: false, super: false }, // Ctrl+Enter accelerated submit
   { key: 'enter', ctrl: false, alt: false, shift: false, super: false }, // Enter submit
   { key: 'escape', ctrl: false, alt: false, shift: false, super: false }, // Esc cancel
   { key: 'tab', ctrl: false, alt: false, shift: true, super: false },   // Shift+Tab permission cycle

--- a/src/keybinding-ui/model.ts
+++ b/src/keybinding-ui/model.ts
@@ -89,7 +89,7 @@ export interface KeybindingEditorModel {
 const LABELS: Readonly<Partial<Record<AppKeybindingId, string>>> = {
   'app.input.submit': 'Submit draft',
   'app.input.steer': 'Steer running turn',
-  'app.input.queue': 'Queue draft while busy',
+  'app.input.submitAccelerated': 'Submit (opposite busy behavior)',
   'app.input.dequeue': 'Pull queued draft back',
   'app.agent.interrupt': 'Interrupt active turn',
   'app.exit.request': 'Quit the TUI',

--- a/src/keybinding-ui/model.ts
+++ b/src/keybinding-ui/model.ts
@@ -90,6 +90,7 @@ const LABELS: Readonly<Partial<Record<AppKeybindingId, string>>> = {
   'app.input.submit': 'Submit draft',
   'app.input.steer': 'Steer running turn',
   'app.input.submitAccelerated': 'Submit (opposite busy behavior)',
+  'app.input.queue': 'Queue draft (deprecated)',
   'app.input.dequeue': 'Pull queued draft back',
   'app.agent.interrupt': 'Interrupt active turn',
   'app.exit.request': 'Quit the TUI',

--- a/src/keybindings/action-dispatcher.ts
+++ b/src/keybindings/action-dispatcher.ts
@@ -84,6 +84,10 @@ export class AppActionDispatcher {
         return this.host.submitDraft('enter')
       case 'app.input.submitAccelerated':
         return this.host.submitDraft('accelerated')
+      case 'app.input.queue':
+        // The DEPRECATED fixed-queue action (no default key): a stored remap
+        // keeps queueing — never the accelerated opposite.
+        return this.host.submitDraft('explicit-queue')
       case 'app.input.steer':
         return this.host.steerDraft()
       case 'app.input.dequeue':

--- a/src/keybindings/action-dispatcher.ts
+++ b/src/keybindings/action-dispatcher.ts
@@ -15,14 +15,17 @@
  */
 
 import type { KeyId } from '@xmoon76/pi-tui'
+import type { ComposerSubmitRequest } from '../tui-app.ts'
 import type { AppKeybindingId } from './types.ts'
 
 /** The Host business surface the dispatcher routes to. Every method
  * returns whether the key was consumed (false lets the input fall through
  * to the editor/plugin stages). */
 export interface AppActionHost {
-  /** Submit the draft (forceQueue = the Ctrl+Enter parity). */
-  submitDraft(forceQueue?: boolean): boolean
+  /** Submit the draft with the request the action carries: the two composer
+   * gestures resolve through the busy-Enter policy, `explicit-queue` is the
+   * public queue action. */
+  submitDraft(request?: ComposerSubmitRequest): boolean
   /** Steer the running agent with the draft. */
   steerDraft(): boolean
   /** Pull queued input back into the editor. */
@@ -78,9 +81,9 @@ export class AppActionDispatcher {
   dispatch(action: AppKeybindingId, key?: KeyId): boolean {
     switch (action) {
       case 'app.input.submit':
-        return this.host.submitDraft(false)
-      case 'app.input.queue':
-        return this.host.submitDraft(true)
+        return this.host.submitDraft('enter')
+      case 'app.input.submitAccelerated':
+        return this.host.submitDraft('accelerated')
       case 'app.input.steer':
         return this.host.steerDraft()
       case 'app.input.dequeue':

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -36,17 +36,6 @@ import type { AppKeybindingId, LeaderBinding, LeaderConfig, UserKeybindingValue,
 const LEADER_KEY = 'leader'
 const BINDINGS_KEY = 'bindings'
 
-/** Renamed action ids still accepted from a user keybinding document (the
- * id is a settings-level public name — a stored override keeps applying to
- * the action it was written for). A MAP, never an object literal: a
- * document key like `toString` must stay an unknown action, not inherit a
- * definition through the prototype. */
-const RENAMED_ACTION_IDS: ReadonlyMap<string, AppKeybindingId> = new Map([
-  // Named for the old fixed-queue chord; the gesture is now the web
-  // composer's accelerated submit (the opposite busy-Enter behavior).
-  ['app.input.queue', 'app.input.submitAccelerated'],
-])
-
 /** The leader sequence marker (`<leader>t`). */
 export const LEADER_PREFIX = '<leader>'
 
@@ -248,20 +237,11 @@ export function parseUserKeybindings(
   }
 
   for (const [actionId, value] of entries) {
-    // A renamed action id (a settings-level public name) keeps applying to
-    // the action it was written for: `app.input.queue` was named for the old
-    // fixed-queue chord, which is now the web composer's accelerated submit
-    // gesture (the OPPOSITE of the busy-Enter preference).
-    const renamed = RENAMED_ACTION_IDS.get(actionId)
-    if (renamed !== undefined) {
-      diagnostics.push(`keybindings: action "${actionId}" was renamed to "${renamed}" — the override still applies`)
-    }
-    const resolvedId = renamed ?? actionId
-    if (!Object.prototype.hasOwnProperty.call(APP_KEYBINDINGS, resolvedId)) {
+    if (!Object.prototype.hasOwnProperty.call(APP_KEYBINDINGS, actionId)) {
       diagnostics.push(`keybindings: unknown action "${actionId}" — ignored`)
       continue
     }
-    const action = resolvedId as AppKeybindingId
+    const action = actionId as AppKeybindingId
     if (NON_CONFIGURABLE_ACTIONS.has(action)) {
       diagnostics.push(`keybindings: action "${actionId}" is not user-configurable in this version — ignored`)
       continue

--- a/src/keybindings/config.ts
+++ b/src/keybindings/config.ts
@@ -36,6 +36,17 @@ import type { AppKeybindingId, LeaderBinding, LeaderConfig, UserKeybindingValue,
 const LEADER_KEY = 'leader'
 const BINDINGS_KEY = 'bindings'
 
+/** Renamed action ids still accepted from a user keybinding document (the
+ * id is a settings-level public name — a stored override keeps applying to
+ * the action it was written for). A MAP, never an object literal: a
+ * document key like `toString` must stay an unknown action, not inherit a
+ * definition through the prototype. */
+const RENAMED_ACTION_IDS: ReadonlyMap<string, AppKeybindingId> = new Map([
+  // Named for the old fixed-queue chord; the gesture is now the web
+  // composer's accelerated submit (the opposite busy-Enter behavior).
+  ['app.input.queue', 'app.input.submitAccelerated'],
+])
+
 /** The leader sequence marker (`<leader>t`). */
 export const LEADER_PREFIX = '<leader>'
 
@@ -237,11 +248,20 @@ export function parseUserKeybindings(
   }
 
   for (const [actionId, value] of entries) {
-    if (!Object.prototype.hasOwnProperty.call(APP_KEYBINDINGS, actionId)) {
+    // A renamed action id (a settings-level public name) keeps applying to
+    // the action it was written for: `app.input.queue` was named for the old
+    // fixed-queue chord, which is now the web composer's accelerated submit
+    // gesture (the OPPOSITE of the busy-Enter preference).
+    const renamed = RENAMED_ACTION_IDS.get(actionId)
+    if (renamed !== undefined) {
+      diagnostics.push(`keybindings: action "${actionId}" was renamed to "${renamed}" — the override still applies`)
+    }
+    const resolvedId = renamed ?? actionId
+    if (!Object.prototype.hasOwnProperty.call(APP_KEYBINDINGS, resolvedId)) {
       diagnostics.push(`keybindings: unknown action "${actionId}" — ignored`)
       continue
     }
-    const action = actionId as AppKeybindingId
+    const action = resolvedId as AppKeybindingId
     if (NON_CONFIGURABLE_ACTIONS.has(action)) {
       diagnostics.push(`keybindings: action "${actionId}" is not user-configurable in this version — ignored`)
       continue

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -44,11 +44,22 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
     id: 'app.input.submitAccelerated',
     defaultKeys: ['ctrl+enter'],
     // The web composer's accelerated submit gesture: it resolves to the
-    // OPPOSITE of the busy-Enter preference (never a fixed queue mode). The
-    // historical id `app.input.queue` was named for the old fixed-queue
-    // behavior and remains accepted as a settings alias (see
-    // parseUserKeybindings).
+    // OPPOSITE of the busy-Enter preference (never a fixed queue mode).
     description: 'Submit with the opposite busy-Enter behavior',
+    category: 'Input',
+    scope: 'editor',
+    configurable: true,
+  },
+  'app.input.queue': {
+    id: 'app.input.queue',
+    // NO default key: Ctrl+Enter belongs to the accelerated gesture. The
+    // action itself is DEPRECATED but keeps its ORIGINAL fixed-queue
+    // semantic for stored remaps (`app.input.queue: alt+q` still queues) —
+    // re-interpreting an old action id as the new gesture would silently
+    // migrate a user's explicit choice. `/keybindings` lists it (and can
+    // reset/disable it) like any other action.
+    defaultKeys: [],
+    description: 'Queue the draft (deprecated: use the accelerated submit action)',
     category: 'Input',
     scope: 'editor',
     configurable: true,
@@ -527,6 +538,7 @@ export const PROTECTED_HOST_ACTIONS: ReadonlySet<AppKeybindingId> = new Set([
 export const VIEWER_BLOCKED_PARENT_ACTIONS: ReadonlySet<AppKeybindingId> = new Set([
   'app.input.steer',
   'app.input.submitAccelerated',
+  'app.input.queue',
   'app.input.dequeue',
   'app.permission.cycle',
   'app.transcript.search',

--- a/src/keybindings/definitions.ts
+++ b/src/keybindings/definitions.ts
@@ -40,10 +40,15 @@ export const APP_KEYBINDINGS: Record<AppKeybindingId, AppKeybindingDefinition> =
     // disabled — not just the hints (PR review finding).
     hostResolved: false,
   },
-  'app.input.queue': {
-    id: 'app.input.queue',
+  'app.input.submitAccelerated': {
+    id: 'app.input.submitAccelerated',
     defaultKeys: ['ctrl+enter'],
-    description: 'Queue input (the busy-Enter opposite chord)',
+    // The web composer's accelerated submit gesture: it resolves to the
+    // OPPOSITE of the busy-Enter preference (never a fixed queue mode). The
+    // historical id `app.input.queue` was named for the old fixed-queue
+    // behavior and remains accepted as a settings alias (see
+    // parseUserKeybindings).
+    description: 'Submit with the opposite busy-Enter behavior',
     category: 'Input',
     scope: 'editor',
     configurable: true,
@@ -521,7 +526,7 @@ export const PROTECTED_HOST_ACTIONS: ReadonlySet<AppKeybindingId> = new Set([
  * remap automatically stays blocked. */
 export const VIEWER_BLOCKED_PARENT_ACTIONS: ReadonlySet<AppKeybindingId> = new Set([
   'app.input.steer',
-  'app.input.queue',
+  'app.input.submitAccelerated',
   'app.input.dequeue',
   'app.permission.cycle',
   'app.transcript.search',

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -43,7 +43,7 @@ import type { KeyId } from '@xmoon76/pi-tui'
 export type AppKeybindingId =
   // Input / Agent
   | 'app.input.submit'
-  | 'app.input.queue'
+  | 'app.input.submitAccelerated'
   | 'app.input.steer'
   | 'app.input.dequeue'
   | 'app.agent.interrupt'

--- a/src/keybindings/types.ts
+++ b/src/keybindings/types.ts
@@ -44,6 +44,10 @@ export type AppKeybindingId =
   // Input / Agent
   | 'app.input.submit'
   | 'app.input.submitAccelerated'
+  /** Deprecated (no default key): the historical fixed-queue action. Kept as
+   * a REAL action so a stored remap keeps meaning "queue the draft" — never
+   * silently re-interpreted as the accelerated gesture. */
+  | 'app.input.queue'
   | 'app.input.steer'
   | 'app.input.dequeue'
   | 'app.agent.interrupt'

--- a/src/steer.ts
+++ b/src/steer.ts
@@ -295,9 +295,9 @@ async function steerAllCore(deps: SteerDeps, text: string, options: SteerAllOpti
   }
   if (onlyDraft) {
     // Busy-Enter steer: the DRAFT only — the queue (explicitly queued via
-    // Ctrl+Enter or notices) is never swept along; steered input cannot be
-    // pulled back, so a queued message must not be dragged into the turn
-    // behind the user's back.
+    // `queue-draft` / a queue-mode submission, or notices) is never swept
+    // along; steered input cannot be pulled back, so a queued message must
+    // not be dragged into the turn behind the user's back.
     const message = deps.createDraft(text)
     if (now.status === 'running') deliverSteer(deps, message)
     else deliverFollowup(deps, message)

--- a/src/surface-catalog.ts
+++ b/src/surface-catalog.ts
@@ -27,7 +27,14 @@ import {
 export interface SurfaceCommandSummary {
   readonly name: string
   readonly description: string
-  readonly input?: { readonly hint: string }
+  readonly input?: {
+    readonly hint: string
+    /** The descriptor's attachment declaration (DSH
+     * `CommandInputDescriptor.attachments`): ONLY a command declaring it may
+     * be invoked with composer attachments (the composer-side half of the
+     * contract — the host executor enforces the other half at admission). */
+    readonly attachments?: boolean
+  }
 }
 
 /** One provider's detached failure text (never the thrown value itself). */
@@ -85,7 +92,12 @@ export function commandSummaryOf(descriptor: CommandDescriptor): SurfaceCommandS
     description: descriptor.description,
     ...descriptor.input === undefined
       ? {}
-      : { input: Object.freeze({ hint: descriptor.input.hint }) },
+      : {
+          input: Object.freeze({
+            hint: descriptor.input.hint,
+            ...descriptor.input.attachments === true ? { attachments: true } : {},
+          }),
+        },
   })
 }
 
@@ -96,6 +108,10 @@ function sameCommand(left: CommandDescriptor, right: CommandDescriptor): boolean
   return left.name === right.name
     && left.description === right.description
     && left.input?.hint === right.input?.hint
+    // The attachment DECLARATION is part of the effective behavior (it
+    // decides whether a composer may attach anything), so a scoped entry
+    // that differs only in it is NOT the identical visible result.
+    && (left.input?.attachments === true) === (right.input?.attachments === true)
 }
 
 /**

--- a/src/transcript-window.ts
+++ b/src/transcript-window.ts
@@ -150,7 +150,13 @@ export class TranscriptWindowController {
     return true
   }
 
-  /** Move one overlapping page toward older turns. */
+  /** Move one overlapping page toward older turns. The move is a no-op
+   * when the CURRENT projected window already reaches the oldest retained
+   * turn: the window's start index is derived from the current anchor, and
+   * at 0 there is no older page to show — the controller state stays
+   * untouched (hasOlder=false ⇒ moveOlder=false + no mutation), so a short
+   * session can never be paged into a bogus history state that hides its
+   * content. */
   moveOlder(): boolean {
     this.refreshTurnOrder()
     if (this.turns.length === 0) return false
@@ -159,6 +165,11 @@ export class TranscriptWindowController {
       ? latestIndex
       : this.turnIndex(this.current.endTurn ?? this.turns[latestIndex]!)
     if (currentIndex < 0) return false
+    // The current projected window already reaches the oldest retained
+    // turn: no older page exists — never switch latest → history and never
+    // move an existing history anchor.
+    const startIndex = Math.max(0, currentIndex - this.windowTurns + 1)
+    if (startIndex === 0) return false
     const nextIndex = Math.max(0, currentIndex - this.stepTurns)
     if (nextIndex === currentIndex) return false
     const endTurn = this.turns[nextIndex]

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -94,9 +94,12 @@ export type TranscriptMessage =
    * Labeled entries carry the Web-provenance producer name (e.g. AGENTS.md,
    * @deepseek-ai/dsh-system-prompt, skill-catalog), a source-kind icon
    * SEMANTIC (never a concrete glyph — the renderer resolves the palette),
-   * and, for notice forms, the producer's one-line summary.
+   * and, for notice forms, the producer's one-line summary. `context` is the
+   * source-derived semantic marker distinguishing injected context from
+   * other `kind: 'system'` presentation rows (llm/retry, max-tokens), which
+   * are orchestration and must never be treated as turn foundation.
    */
-  | { kind: 'system'; turn: number; text: string; label?: string; summary?: string; icon?: IconSemantic }
+  | { kind: 'system'; turn: number; text: string; label?: string; summary?: string; icon?: IconSemantic; context?: true }
   | TranscriptToolMessage
   | TranscriptWorkflowMessage
   /** Older-than-window turns collapsed into one line (windowing). */
@@ -3502,6 +3505,10 @@ export class TranscriptFolder {
             ...provenance.label === null ? {} : { label: provenance.label },
             ...summary === null ? {} : { summary },
             icon: contextIconSemantic(event.data.source),
+            // The source-derived semantic marker: this row IS injected
+            // context (never orchestration like llm/retry or max-tokens),
+            // so Focus may treat it as turn foundation.
+            context: true as const,
           })
           // Focus aggregation: injected context (skill-invocation,
           // skill-catalog, system reminders) is orchestration, NOT one of

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -1598,6 +1598,22 @@ export interface SubagentViewerTarget {
   readonly access?: ViewerAccess
 }
 
+/**
+ * The WEB composer submit gestures (DSH `ComposerSubmitGesture`): plain
+ * Enter, or the Cmd/Ctrl-accelerated chord. The busy-Enter policy resolves
+ * each to a delivery mode — plain Enter to the preferred mode, the
+ * accelerated chord to its OPPOSITE — so the chord is never a fixed mode.
+ */
+export type ComposerSubmitGesture = 'enter' | 'accelerated'
+
+/**
+ * One submission request raised at the editor seat. The two gestures are
+ * resolved by the busy-Enter policy; `explicit-queue` is the public
+ * `queue-draft` action — an explicit delivery command, NOT a gesture: it
+ * queues regardless of the preference (and of the agent's liveness).
+ */
+export type ComposerSubmitRequest = ComposerSubmitGesture | 'explicit-queue'
+
 /** A semantic follow-up submit from the interactive subagent viewer: the
  * runner's write path is the official `ctx.subagents.prompt(…)` human
  * prompt (a distinct FIFO turn in the child's inbox), NEVER
@@ -1656,8 +1672,10 @@ export interface SubagentViewerFooter {
 /** Base callbacks every TuiApp host must provide; the external-editor
  * pair is bound on top of this (see {@link TuiAppEvents}). */
 export interface TuiAppEventsBase {
-  /** The user submitted a line in the editor. */
-  onSubmit: (text: string) => void
+  /** The user submitted a line in the editor, with the request it was
+   * raised by (the delivery mode is the RUNNER's to resolve — see
+   * {@link ComposerSubmitRequest}). */
+  onSubmit: (text: string, request: ComposerSubmitRequest) => void
   /**
    * Clipboard paste with image intake (the paste-media action, plan M3):
    * the host consumed the key and asks the runner to probe the clipboard — an image lands as a draft
@@ -1707,14 +1725,6 @@ export interface TuiAppEventsBase {
    * alone otherwise. Optional.
    */
   onSteer?: (text: string) => void
-  /**
-   * The busy-Enter opposite chord (the queue action, default: Ctrl+Enter):
-   * submit the draft in the
-   * QUEUE delivery mode regardless of the busyEnter preference (web
-   * busyEnter parity — the accelerated chord uses the other behavior).
-   * Optional.
-   */
-  onQueueSubmit?: (text: string) => void
   /**
    * A follow-up submit from the INTERACTIVE subagent viewer (Enter while
    * viewing a `continuable` child): the runner delivers the text through
@@ -3428,7 +3438,7 @@ export class TuiApp {
       // does the same later. Resetting after the dispatch would clobber a
       // synchronous restore.
       this.resetEditorMode()
-      this.events.onSubmit(serialized)
+      this.events.onSubmit(serialized, 'enter')
     }
     this.editor.onChange = () => {
       // Ordinary editor input is an intervening action, so it disarms a
@@ -3508,12 +3518,12 @@ export class TuiApp {
             // non-empty wire form, and must reach the existing protocol
             // like the literal prefix did before the mode feature.
             if (!serializedDraftHasPayload(this.expandedSeatWireDraft())) return false
-            this.submitDraft(false)
+            this.submitDraft('enter')
             return true
           }
           case 'queue-submit': {
             if (!serializedDraftHasPayload(this.expandedSeatWireDraft())) return false
-            this.submitDraft(true)
+            this.submitDraft('explicit-queue')
             return true
           }
           case 'steer': {
@@ -4032,7 +4042,7 @@ export class TuiApp {
       return { consume: true }
     }
     if (this.isSubmitKey(data)) {
-      this.submitDraft(false)
+      this.submitDraft('enter')
       return { consume: true }
     }
     // ExtensionEditor's false result follows the public contract: let the
@@ -4777,23 +4787,22 @@ export class TuiApp {
    * must fall through (e.g. pasteMedia without a clipboard handler). */
   private buildActionHost(): AppActionHost {
     return {
-      submitDraft: (forceQueue = false) => {
-        if (forceQueue) {
-          // The busy-Enter opposite chord (web busyEnter parity): without
-          // a wired onQueueSubmit, or with an EMPTY draft, the chord is a
-          // HOST-GUARDED NO-OP — the host OWNS Ctrl+Enter and consumes it
-          // (an empty chord would otherwise dispatch a session-creating
-          // empty followup). Guard no-ops stay host-owned; only GENUINE
-          // feature absence (pasteMedia with no handler) declines to the
-          // remainder (convergence §4.9).
-          if (this.events.onQueueSubmit === undefined) return true
+      submitDraft: (request: ComposerSubmitRequest = 'enter') => {
+        if (request !== 'enter') {
+          // The accelerated chord and the explicit queue action are
+          // HOST-OWNED: with an EMPTY draft they are a HOST-GUARDED NO-OP —
+          // the host owns the key and consumes it (an empty one would
+          // otherwise dispatch a session-creating empty followup). Guard
+          // no-ops stay host-owned; only GENUINE feature absence
+          // (pasteMedia with no handler) declines to the remainder
+          // (convergence §4.9).
           // Emptiness is judged on the SERIALIZED wire form: a bare
           // `!` / `!!` shell mode has an empty BODY but a non-empty wire
-          // form, and must reach the queue protocol like the literal
-          // prefix did before the mode feature.
+          // form, and must reach the protocol like the literal prefix did
+          // before the mode feature.
           if (!serializedDraftHasPayload(this.expandedSeatWireDraft())) return true
         }
-        this.submitDraft(forceQueue)
+        this.submitDraft(request)
         return true
       },
       steerDraft: () => {
@@ -12273,12 +12282,12 @@ export class TuiApp {
    * M6 host-owned draft submission (the semantic actions submit-draft /
    * queue-draft route through this, NOT a raw dispatch): mirrors the
    * editor's Enter-submit path exactly — history, notify clear and draft
-   * clear — then fires the submit/queue event through the runner. The
-   * plugin never touches the editor directly.
-   * @param forceQueue - Ctrl+Enter parity: queue delivery regardless of
-   *   the busyEnter preference.
+   * clear — then fires the submit event with the request through the
+   * runner. The plugin never touches the editor directly.
+   * @param request - the request this submission was raised by (see
+   *   {@link ComposerSubmitRequest}); the RUNNER resolves its delivery mode.
    */
-  submitDraft(forceQueue = false): void {
+  submitDraft(request: ComposerSubmitRequest = 'enter'): void {
     // Submission is an explicit intervening action even when the draft is
     // empty or a viewer guard rejects it.
     this.clearExitConfirmation()
@@ -12335,11 +12344,7 @@ export class TuiApp {
     // Reset BEFORE the dispatch: a synchronous rejection restores the
     // serialized text (and with it the mode) through setEditorText.
     this.resetEditorMode()
-    if (forceQueue) {
-      this.events.onQueueSubmit?.(serialized)
-    } else {
-      this.events.onSubmit(serialized)
-    }
+    this.events.onSubmit(serialized, request)
     this.requestRender()
   }
 

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -7028,6 +7028,11 @@ export class TuiApp {
     return [...this.installedCommandCompletions]
   }
 
+  /** Headless-test hook: the CURRENT transient notice text ('' = none). */
+  notifyTextForTest(): string {
+    return this.notifyText
+  }
+
   fullscreenScrollForTest(): { scrollTop: number; isFollowingEnd: boolean; viewportHeight: number; contentHeight: number; maxScrollTop: number } | undefined {
     if (this.fullscreenScroll === undefined) return undefined
     const contentHeight = this.messagesView.render(this.terminal.columns).length

--- a/src/tui-app.ts
+++ b/src/tui-app.ts
@@ -2878,6 +2878,9 @@ export class TuiApp {
   private notifyText = ''
   /** Lightweight, persistent transcript-window hint; empty in latest mode. */
   private transcriptWindowHint = ''
+  /** The last installed slash-command rows (host catalog + client command
+   * contributions) — the headless-test read of the `/` menu source. */
+  private installedCommandCompletions: readonly SlashCommand[] = []
   /** The latest window metadata, retained so remapped key hints stay live. */
   private transcriptWindow: (TranscriptWindowState & { firstTurn?: number; lastTurn?: number; hasNewer?: boolean }) | undefined
   /** Styling of the current notify line: info (default) is dim with a ℹ,
@@ -7019,6 +7022,12 @@ export class TuiApp {
    * view (the same line count the frame paints); `maxScrollTop` is the
    * clamp — tests can then assert an anchored view is NOT at the max.
    * Undefined while not fullscreen. */
+  /** Headless-test hook: the installed slash-command rows (the host catalog
+   * merged with the live client command contributions). */
+  commandCompletionsForTest(): readonly SlashCommand[] {
+    return [...this.installedCommandCompletions]
+  }
+
   fullscreenScrollForTest(): { scrollTop: number; isFollowingEnd: boolean; viewportHeight: number; contentHeight: number; maxScrollTop: number } | undefined {
     if (this.fullscreenScroll === undefined) return undefined
     const contentHeight = this.messagesView.render(this.terminal.columns).length
@@ -12729,6 +12738,7 @@ export class TuiApp {
       localCwd,
       skillReferences,
     )
+    this.installedCommandCompletions = [...commands]
     if (extensionSuggest === undefined) {
       this.editor.setAutocompleteProvider(base)
       return

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -476,16 +476,14 @@ test('isHostCommand claims advertised non-skill commands and never skill wrapper
   t.app.stop()
 })
 
-test('isHostCommand never claims an extension contribution: advertised ≠ Host-owned (PR115-fix problem 2)', () => {
-  // An extension command is advertised in the effective catalog too (the
-  // plugin registers it through the commands service), but its
-  // `execution` metadata owns the classification: 'submission' flows
-  // through the busy queue/steer policy like a skill invocation, 'local'
-  // never steers. Claiming either as a Host command would bypass the busy
-  // policy (and the accelerated chord) before it is even consulted.
-  const contributions = new Map<string, { name: string; execution: 'local' | 'submission' }>([
-    ['deploy', { name: 'deploy', execution: 'submission' }],
-    ['panel', { name: 'panel', execution: 'local' }],
+test('isHostCommand keeps HOST AUTHORITY: a client contribution never removes a host claim', () => {
+  // A client command contribution only ADDS a client-owned name. When the
+  // host catalog resolves the same name, the host command keeps its claim —
+  // upstream's candidate synthesis fails loud on the collision instead of
+  // shadowing, so the dispatch can never downgrade it to a prompt.
+  const contributions = new Map<string, { name: string }>([
+    ['deploy', { name: 'deploy' }],
+    ['panel', { name: 'panel' }],
   ])
   const t = setup({
     extensions: {
@@ -493,17 +491,14 @@ test('isHostCommand never claims an extension contribution: advertised ≠ Host-
     },
   })
   t.commands.service.register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
-  t.commands.service.register({ name: 'panel', handler: () => ({ kind: 'success' }) })
   t.commands.service.register({ name: 'compact', handler: () => ({ kind: 'success' }) })
   t.installed.installSnapshot({ commands: [], scopedCommands: [], skills: [], issues: [] })
-  assert.equal(t.installed.isHostCommand('deploy'), false,
-    'an extension submission command must keep the session submission policy')
-  assert.equal(t.installed.isHostCommand('panel'), false,
-    'an extension local command is never Host-owned either')
-  // The genuine Host command is unaffected: the predicate stays
-  // catalog-driven for names no TUI/extension owner claims.
+  assert.equal(t.installed.isHostCommand('deploy'), true,
+    'a host command keeps its claim even when a client contribution shares the name')
   assert.equal(t.installed.isHostCommand('compact'), true,
-    'a real Host command must still be claimed')
+    'a real Host command stays claimed')
+  assert.equal(t.installed.isHostCommand('panel'), false,
+    'a client-only name is not a host claim (it never entered the host list)')
   t.app.stop()
 })
 

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -120,7 +120,9 @@ function fakeCommands() {
         defs.push(def)
         return () => {}
       },
-      list: () => [{ name: 'builtin', description: 'a builtin', input: { hint: '' } }],
+      // The completion list mirrors the registry (like the real service's
+      // effective view), so the advertised-claim surface sees registrations.
+      list: () => defs.map(def => ({ name: def.name, description: 'a command', input: { hint: '' } })),
       find: () => undefined,
       execute: async () => undefined,
     },
@@ -213,7 +215,7 @@ function setup(options: { busyEnter?: string; localShellSandbox?: string } = {})
     extensions: undefined,
     exit: () => {},
   }
-  registerTuiCommands(runner)
+  const installed = registerTuiCommands(runner)
   const def = commands.defs.find(entry => entry.name === 'settings')
   assert.ok(def?.handler !== undefined, 'settings handler missing')
   const run = async (rawInput: string): Promise<unknown> =>
@@ -239,7 +241,7 @@ function setup(options: { busyEnter?: string; localShellSandbox?: string } = {})
     await vt.waitForRender()
     return vt.getViewport().join('\n')
   }
-  return { vt, app, run, runCommand, view, settings, registered: commands.defs.map(def => def.name) }
+  return { vt, app, run, runCommand, view, settings, installed, commands, registered: commands.defs.map(def => def.name) }
 }
 
 test('every command registerTuiCommands registers is in LOCAL_COMMANDS', () => {
@@ -433,5 +435,30 @@ test('/settings frame left padding does not activate SettingsList rows (v0.85.1 
   t.vt.sendInput(`\x1b[<0;${leftBorder + 2};${rowY + 1}m`)
   await t.view()
   assert.equal(t.settings.writes.length, 0, 'a left-padding click must not toggle a row')
+  t.app.stop()
+})
+
+test('isHostCommand claims advertised non-skill commands and never skill wrappers (PR115-fix problem 1)', () => {
+  const t = setup()
+  // A Host command (e.g. /compact) registered by the Host joins the
+  // effective catalog; a snapshot commit refreshes the advertised claims.
+  t.commands.service.register({ name: 'compact', handler: () => ({ kind: 'success' }) })
+  t.installed.installSnapshot({ commands: [], scopedCommands: [], skills: [], issues: [] })
+  assert.equal(t.installed.isHostCommand('compact'), true,
+    'an advertised Host command must be claimed as a Host command')
+  // A TUI-owned skill wrapper is advertised too, but it is an agent-facing
+  // invocation — never a Host-command claim.
+  t.installed.installSnapshot({
+    commands: [],
+    scopedCommands: [],
+    skills: [{ name: 'grilling', description: 'a skill' }],
+    issues: [],
+  })
+  assert.equal(t.installed.isHostCommand('grilling'), false,
+    'a TUI-owned skill wrapper must never be claimed as a Host command')
+  // The claim is catalog-driven: a name absent from the effective catalog
+  // is not claimed (it keeps the ordinary prompt semantics).
+  assert.equal(t.installed.isHostCommand('not-a-command'), false,
+    'an unadvertised name must not be claimed')
   t.app.stop()
 })

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -130,7 +130,7 @@ function fakeCommands() {
 }
 
 /** Register the TUI commands with a stubbed runner and return /settings. */
-function setup(options: { busyEnter?: string; localShellSandbox?: string } = {}) {
+function setup(options: { busyEnter?: string; localShellSandbox?: string; extensions?: unknown } = {}) {
   const ctx = new Context()
   const vt = new VirtualTerminal(100, 24)
   const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
@@ -212,7 +212,7 @@ function setup(options: { busyEnter?: string; localShellSandbox?: string } = {})
     withSessionWriter: async <T>(_sessionId: string, task: () => T | Promise<T>) => task(),
     enterView: async () => {},
     requestExit: () => {},
-    extensions: undefined,
+    extensions: options.extensions as never,
     exit: () => {},
   }
   const installed = registerTuiCommands(runner)
@@ -460,5 +460,36 @@ test('isHostCommand claims advertised non-skill commands and never skill wrapper
   // is not claimed (it keeps the ordinary prompt semantics).
   assert.equal(t.installed.isHostCommand('not-a-command'), false,
     'an unadvertised name must not be claimed')
+  t.app.stop()
+})
+
+test('isHostCommand never claims an extension contribution: advertised ≠ Host-owned (PR115-fix problem 2)', () => {
+  // An extension command is advertised in the effective catalog too (the
+  // plugin registers it through the commands service), but its
+  // `execution` metadata owns the classification: 'submission' flows
+  // through the busy queue/steer policy like a skill invocation, 'local'
+  // never steers. Claiming either as a Host command would bypass the busy
+  // policy (and the force-queue chord) before it is even consulted.
+  const contributions = new Map<string, { name: string; execution: 'local' | 'submission' }>([
+    ['deploy', { name: 'deploy', execution: 'submission' }],
+    ['panel', { name: 'panel', execution: 'local' }],
+  ])
+  const t = setup({
+    extensions: {
+      commands: { find: (name: string) => contributions.get(name) },
+    },
+  })
+  t.commands.service.register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  t.commands.service.register({ name: 'panel', handler: () => ({ kind: 'success' }) })
+  t.commands.service.register({ name: 'compact', handler: () => ({ kind: 'success' }) })
+  t.installed.installSnapshot({ commands: [], scopedCommands: [], skills: [], issues: [] })
+  assert.equal(t.installed.isHostCommand('deploy'), false,
+    'an extension submission command must keep the session submission policy')
+  assert.equal(t.installed.isHostCommand('panel'), false,
+    'an extension local command is never Host-owned either')
+  // The genuine Host command is unaffected: the predicate stays
+  // catalog-driven for names no TUI/extension owner claims.
+  assert.equal(t.installed.isHostCommand('compact'), true,
+    'a real Host command must still be claimed')
   t.app.stop()
 })

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -125,17 +125,25 @@ function fakeTuiSettings(busyEnter: string, localShellSandbox = 'bypass'): { val
 
 /** A fake commands service recording the registered definitions. */
 function fakeCommands() {
-  const defs: { name: string; handler?: unknown }[] = []
+  const defs: { name: string; handler?: unknown; input?: { hint: string; attachments?: boolean } }[] = []
   return {
     defs,
     service: {
-      register: (def: { name: string; handler?: unknown }): (() => void) => {
+      register: (def: { name: string; handler?: unknown; input?: { hint: string; attachments?: boolean } }): (() => void) => {
         defs.push(def)
         return () => {}
       },
       // The completion list mirrors the registry (like the real service's
-      // effective view), so the advertised-claim surface sees registrations.
-      list: () => defs.map(def => ({ name: def.name, description: 'a command', input: { hint: '' } })),
+      // effective view), so the advertised-claim surface sees registrations —
+      // INCLUDING the descriptor's input kind: fabricating an `input` for an
+      // execute-kind command would erase the DSH distinction between a
+      // `leadingInput` command (`/goal <objective>`) and a bare one
+      // (`/compact`) and make the claim tests pass for the wrong reason.
+      list: () => defs.map(def => ({
+        name: def.name,
+        description: 'a command',
+        ...(def.input === undefined ? {} : { input: def.input }),
+      })),
       find: () => undefined,
       execute: async () => undefined,
     },
@@ -451,14 +459,22 @@ test('/settings frame left padding does not activate SettingsList rows (v0.85.1 
   t.app.stop()
 })
 
-test('isHostCommand claims advertised non-skill commands and never skill wrappers (PR115-fix problem 1)', () => {
+test('hostClaimOf claims the LINE an advertised host command owns, never a skill wrapper (PR115-fix problem 1)', () => {
   const t = setup()
-  // A Host command (e.g. /compact) registered by the Host joins the
-  // effective catalog; a snapshot commit refreshes the advertised claims.
+  // A Host command (e.g. /compact) registered by the Host WITHOUT an input
+  // descriptor is execute-kind: it claims the BARE token only, exactly like
+  // the DSH client's `matchEnter` decision table.
   t.commands.service.register({ name: 'compact', handler: () => ({ kind: 'success' }) })
   t.installed.installSnapshot({ commands: [], scopedCommands: [], skills: [], issues: [] })
-  assert.equal(t.installed.isHostCommand('compact'), true,
-    'an advertised Host command must be claimed as a Host command')
+  assert.deepEqual(t.installed.hostClaimOf({ name: 'compact', rawInput: '' }), { claimed: true, attachments: false },
+    'the bare token of an advertised Host command must be claimed')
+  assert.deepEqual(t.installed.hostClaimOf({ name: 'compact', rawInput: ' extra' }), { claimed: false },
+    'an argued line of an execute-kind command is NOT a command invocation')
+  // A leadingInput descriptor claims its argued line too.
+  t.commands.service.register({ name: 'goal', handler: () => ({ kind: 'success' }), input: { hint: '<objective>' } })
+  t.installed.installSnapshot({ commands: [], scopedCommands: [], skills: [], issues: [] })
+  assert.deepEqual(t.installed.hostClaimOf({ name: 'goal', rawInput: ' ship it' }), { claimed: true, attachments: false },
+    'a leadingInput command claims its argued line (without an attachment declaration)')
   // A TUI-owned skill wrapper is advertised too, but it is an agent-facing
   // invocation — never a Host-command claim.
   t.installed.installSnapshot({
@@ -467,16 +483,16 @@ test('isHostCommand claims advertised non-skill commands and never skill wrapper
     skills: [{ name: 'grilling', description: 'a skill' }],
     issues: [],
   })
-  assert.equal(t.installed.isHostCommand('grilling'), false,
+  assert.equal(t.installed.hostClaimOf({ name: 'grilling', rawInput: ' args' }), undefined,
     'a TUI-owned skill wrapper must never be claimed as a Host command')
   // The claim is catalog-driven: a name absent from the effective catalog
   // is not claimed (it keeps the ordinary prompt semantics).
-  assert.equal(t.installed.isHostCommand('not-a-command'), false,
+  assert.equal(t.installed.hostClaimOf({ name: 'not-a-command', rawInput: '' }), undefined,
     'an unadvertised name must not be claimed')
   t.app.stop()
 })
 
-test('isHostCommand keeps HOST AUTHORITY: a client contribution never removes a host claim', () => {
+test('hostClaimOf keeps HOST AUTHORITY: a client contribution never removes a host claim', () => {
   // A client command contribution only ADDS a client-owned name. When the
   // host catalog resolves the same name, the host command keeps its claim —
   // upstream's candidate synthesis fails loud on the collision instead of
@@ -490,14 +506,14 @@ test('isHostCommand keeps HOST AUTHORITY: a client contribution never removes a 
       commands: { find: (name: string) => contributions.get(name) },
     },
   })
-  t.commands.service.register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  t.commands.service.register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '<target>' } })
   t.commands.service.register({ name: 'compact', handler: () => ({ kind: 'success' }) })
   t.installed.installSnapshot({ commands: [], scopedCommands: [], skills: [], issues: [] })
-  assert.equal(t.installed.isHostCommand('deploy'), true,
+  assert.deepEqual(t.installed.hostClaimOf({ name: 'deploy', rawInput: ' prod' }), { claimed: true, attachments: false },
     'a host command keeps its claim even when a client contribution shares the name')
-  assert.equal(t.installed.isHostCommand('compact'), true,
+  assert.deepEqual(t.installed.hostClaimOf({ name: 'compact', rawInput: '' }), { claimed: true, attachments: false },
     'a real Host command stays claimed')
-  assert.equal(t.installed.isHostCommand('panel'), false,
+  assert.equal(t.installed.hostClaimOf({ name: 'panel', rawInput: '' }), undefined,
     'a client-only name is not a host claim (it never entered the host list)')
   t.app.stop()
 })

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -507,16 +507,19 @@ test('isHostCommand never claims an extension contribution: advertised ≠ Host-
   t.app.stop()
 })
 
-test('a stored app.input.queue override still applies after the id rename (settings aliases)', () => {
-  // The id is a settings-level public name: a user document written before
-  // the rename (the chord became the web accelerated-submit gesture) must
-  // keep applying to the action it was written for — never be dropped as
-  // "unknown action".
+test('the deprecated app.input.queue action keeps its own (fixed-queue) identity', () => {
+  // The chord became the web accelerated gesture, but the OLD action id is a
+  // settings-level public name: a stored remap must keep meaning "queue the
+  // draft" — never be silently re-interpreted as the opposite behavior, and
+  // never be dropped as an unknown action.
   const parsed = parseUserKeybindings({ 'app.input.queue': 'ctrl+y' })
-  assert.equal(parsed.bindings['app.input.submitAccelerated'], 'ctrl+y',
-    'the legacy id must apply to the renamed action')
-  assert.ok(parsed.diagnostics.some(entry => entry.includes('app.input.queue') && entry.includes('renamed')),
-    `the rename must be diagnosed, got: ${JSON.stringify(parsed.diagnostics)}`)
-  // The new id is the documented one.
-  assert.equal(parseUserKeybindings({ 'app.input.submitAccelerated': 'ctrl+y' }).bindings['app.input.submitAccelerated'], 'ctrl+y')
+  assert.equal(parsed.bindings['app.input.queue'], 'ctrl+y', 'the deprecated action keeps its own declaration')
+  assert.equal(parsed.bindings['app.input.submitAccelerated'], undefined,
+    'the accelerated action must not inherit the legacy declaration')
+  assert.deepEqual(parsed.diagnostics, [], 'the deprecated id is a KNOWN action — no diagnostic')
+  // The two actions are independent: declaring both binds both.
+  const both = parseUserKeybindings({ 'app.input.queue': 'ctrl+y', 'app.input.submitAccelerated': 'ctrl+k' })
+  assert.equal(both.bindings['app.input.queue'], 'ctrl+y')
+  assert.equal(both.bindings['app.input.submitAccelerated'], 'ctrl+k')
+  assert.deepEqual(both.diagnostics, [], 'two distinct actions never collide')
 })

--- a/test/busy-enter.test.ts
+++ b/test/busy-enter.test.ts
@@ -1,12 +1,11 @@
 /**
  * Headless tests for the busy-Enter preference surface (web busyEnter
  * parity): the /settings row reflects the persisted value and its Enter
- * toggle persists the other behavior, and the pure dispatch gate
- * (shouldSteerOnEnter) separates LOCAL commands (always execute) from
- * everything else (plain prompts AND per-skill slash commands steer while
- * the agent is running). The steer-side semantics (steerAll onlyDraft)
- * live in steer.test.ts; the Ctrl+Enter chord lives in
- * input-experience.test.ts.
+ * toggle persists the other behavior, and the pure dispatch boundary
+ * (resolveSubmitDelivery) applies the web ComposerSubmissionPolicy to
+ * agent-facing input while LOCAL commands always execute. The steer-side
+ * semantics (steerAll onlyDraft) live in steer.test.ts; the accelerated
+ * chord lives in input-experience.test.ts.
  * @module @xmoon76/dsh-pi-tui/busy-enter.test
  */
 
@@ -15,7 +14,7 @@ import { afterEach, test } from 'node:test'
 import { Context } from '@deepseek-ai/cordis'
 import { CommandId } from '@deepseek-ai/dsh-commands'
 import { registerTuiCommands, type TuiCommandRunner, type TuiSettingsLike } from '../src/commands.ts'
-import { LOCAL_COMMANDS, shouldSteerOnEnter } from '../src/index.ts'
+import { LOCAL_COMMANDS, resolveSubmitDelivery } from '../src/index.ts'
 import { parseUserKeybindings } from '../src/keybindings/config.ts'
 import { createDiag } from '../src/diag.ts'
 import { TuiApp } from '../src/tui-app.ts'
@@ -61,28 +60,42 @@ test('LOCAL_COMMANDS covers every TUI-owned command and nothing else', () => {
   }
 })
 
-test('shouldSteerOnEnter: plain prompts and skill commands steer; local commands never do', () => {
+test('resolveSubmitDelivery: plain prompts and skill commands follow the policy; local commands never do', () => {
   const cmd = (name: string) => ({ name })
-  // Plain prompt (no slash command): steers while running with the
-  // preference set — the web parity baseline.
-  assert.equal(shouldSteerOnEnter(undefined, true, 'steer', false), true, 'plain prompt + running + steer')
-  assert.equal(shouldSteerOnEnter(undefined, true, 'queue', false), false, 'queue preference queues')
-  assert.equal(shouldSteerOnEnter(undefined, false, 'steer', false), false, 'idle never steers')
-  assert.equal(shouldSteerOnEnter(undefined, true, undefined, false), false, 'absent preference queues')
+  // Plain prompt (no slash command): the web ComposerSubmissionPolicy
+  // baseline — an idle agent queues, plain Enter takes the preference.
+  assert.equal(resolveSubmitDelivery(undefined, true, 'enter', 'steer'), 'steer', 'plain prompt + running + steer')
+  assert.equal(resolveSubmitDelivery(undefined, true, 'enter', 'queue'), 'queue', 'queue preference queues')
+  assert.equal(resolveSubmitDelivery(undefined, false, 'enter', 'steer'), 'queue', 'idle never steers')
+  assert.equal(resolveSubmitDelivery(undefined, true, 'enter', undefined), 'queue', 'absent preference queues')
+  // The ACCELERATED chord is the OPPOSITE of the preference (never a fixed
+  // queue): with the DEFAULT preference it steers, with 'steer' it queues.
+  assert.equal(resolveSubmitDelivery(undefined, true, 'accelerated', 'queue'), 'steer',
+    'the accelerated chord steers under the default queue preference')
+  assert.equal(resolveSubmitDelivery(undefined, true, 'accelerated', 'steer'), 'queue',
+    'the accelerated chord queues under the steer preference')
+  assert.equal(resolveSubmitDelivery(undefined, true, 'accelerated', undefined), 'steer',
+    'an absent preference reads as queue, so the chord steers')
+  assert.equal(resolveSubmitDelivery(undefined, false, 'accelerated', 'queue'), 'queue',
+    'an idle agent queues every gesture')
   // Local commands ALWAYS execute, even with the preference set.
-  assert.equal(shouldSteerOnEnter(cmd('status'), true, 'steer', false), false, '/status must execute')
-  assert.equal(shouldSteerOnEnter(cmd('settings'), true, 'steer', false), false, '/settings must execute')
-  assert.equal(shouldSteerOnEnter(cmd('subagents'), true, 'steer', false), false, '/subagents alias must execute (alias of /tasks)')
-  assert.equal(shouldSteerOnEnter(cmd('skill'), true, 'steer', false), false, '/skill picker must execute')
-  // Non-local commands (per-skill slash commands) steer like plain prompts:
-  // the raw `/name` line lands in the running turn and the host's pre-step
-  // listener (dsh-tool-skill) resolves the skill body — web parity.
-  assert.equal(shouldSteerOnEnter(cmd('grilling'), true, 'steer', false), true, 'skill command steers while running')
-  assert.equal(shouldSteerOnEnter(cmd('grilling'), true, 'queue', false), false, 'queue preference queues the skill')
-  assert.equal(shouldSteerOnEnter(cmd('grilling'), false, 'steer', false), false, 'idle skill executes normally')
-  // The Ctrl+Enter chord forces queue mode for EVERYTHING.
-  assert.equal(shouldSteerOnEnter(undefined, true, 'steer', true), false, 'the chord never steers')
-  assert.equal(shouldSteerOnEnter(cmd('grilling'), true, 'steer', true), false, 'the chord queues skill commands')
+  assert.equal(resolveSubmitDelivery(cmd('status'), true, 'enter', 'steer'), 'queue', '/status must execute')
+  assert.equal(resolveSubmitDelivery(cmd('settings'), true, 'enter', 'steer'), 'queue', '/settings must execute')
+  assert.equal(resolveSubmitDelivery(cmd('subagents'), true, 'enter', 'steer'), 'queue', '/subagents alias must execute (alias of /tasks)')
+  assert.equal(resolveSubmitDelivery(cmd('skill'), true, 'enter', 'steer'), 'queue', '/skill picker must execute')
+  // A local command's delivery value is never consumed, so the accelerated
+  // chord must not turn one into a steer either.
+  assert.equal(resolveSubmitDelivery(cmd('status'), true, 'accelerated', 'queue'), 'queue',
+    'a local command never steers, whatever the gesture')
+  // Non-local commands (per-skill slash commands) follow the policy like
+  // plain prompts: under steer the raw `/name` line lands in the running
+  // turn and the host's pre-step listener (dsh-tool-skill) resolves the
+  // skill body — web parity.
+  assert.equal(resolveSubmitDelivery(cmd('grilling'), true, 'enter', 'steer'), 'steer', 'skill command steers while running')
+  assert.equal(resolveSubmitDelivery(cmd('grilling'), true, 'enter', 'queue'), 'queue', 'queue preference queues the skill')
+  assert.equal(resolveSubmitDelivery(cmd('grilling'), false, 'enter', 'steer'), 'queue', 'idle skill executes normally')
+  assert.equal(resolveSubmitDelivery(cmd('grilling'), true, 'accelerated', 'steer'), 'queue', 'the chord queues skill commands')
+  assert.equal(resolveSubmitDelivery(cmd('grilling'), true, 'accelerated', 'queue'), 'steer', 'the chord steers skill commands under the default preference')
 })
 
 // themeOptOut() skips terminal queries under NO_COLOR / FORCE_COLOR=0 /
@@ -338,13 +351,13 @@ test('the local-shell-sandbox row Enter toggle persists the other behavior', asy
   t.app.stop()
 })
 
-test('shouldSteerOnEnter: /skill <name> with args steers; the bare picker does not (review finding)', () => {
-  const withArgs = shouldSteerOnEnter({ name: 'skill', rawInput: 'grilling [image #1 (800×600)]' }, true, 'steer', false)
-  assert.equal(withArgs, true, '/skill <name> [image ...] is agent input while running')
-  const bare = shouldSteerOnEnter({ name: 'skill', rawInput: '' }, true, 'steer', false)
-  assert.equal(bare, false, 'the bare /skill picker stays local')
-  const idle = shouldSteerOnEnter({ name: 'skill', rawInput: 'grilling x' }, false, 'steer', false)
-  assert.equal(idle, false, 'idle never steers')
+test('resolveSubmitDelivery: /skill <name> with args follows the policy; the bare picker does not (review finding)', () => {
+  const withArgs = resolveSubmitDelivery({ name: 'skill', rawInput: 'grilling [image #1 (800×600)]' }, true, 'enter', 'steer')
+  assert.equal(withArgs, 'steer', '/skill <name> [image ...] is agent input while running')
+  const bare = resolveSubmitDelivery({ name: 'skill', rawInput: '' }, true, 'enter', 'steer')
+  assert.equal(bare, 'queue', 'the bare /skill picker stays local')
+  const idle = resolveSubmitDelivery({ name: 'skill', rawInput: 'grilling x' }, false, 'enter', 'steer')
+  assert.equal(idle, 'queue', 'idle never steers')
 })
 
 test('/help copy is key-neutral after a remap — no stale bare Esc/Enter claims (review round 37)', async () => {
@@ -469,7 +482,7 @@ test('isHostCommand never claims an extension contribution: advertised ≠ Host-
   // `execution` metadata owns the classification: 'submission' flows
   // through the busy queue/steer policy like a skill invocation, 'local'
   // never steers. Claiming either as a Host command would bypass the busy
-  // policy (and the force-queue chord) before it is even consulted.
+  // policy (and the accelerated chord) before it is even consulted.
   const contributions = new Map<string, { name: string; execution: 'local' | 'submission' }>([
     ['deploy', { name: 'deploy', execution: 'submission' }],
     ['panel', { name: 'panel', execution: 'local' }],
@@ -492,4 +505,18 @@ test('isHostCommand never claims an extension contribution: advertised ≠ Host-
   assert.equal(t.installed.isHostCommand('compact'), true,
     'a real Host command must still be claimed')
   t.app.stop()
+})
+
+test('a stored app.input.queue override still applies after the id rename (settings aliases)', () => {
+  // The id is a settings-level public name: a user document written before
+  // the rename (the chord became the web accelerated-submit gesture) must
+  // keep applying to the action it was written for — never be dropped as
+  // "unknown action".
+  const parsed = parseUserKeybindings({ 'app.input.queue': 'ctrl+y' })
+  assert.equal(parsed.bindings['app.input.submitAccelerated'], 'ctrl+y',
+    'the legacy id must apply to the renamed action')
+  assert.ok(parsed.diagnostics.some(entry => entry.includes('app.input.queue') && entry.includes('renamed')),
+    `the rename must be diagnosed, got: ${JSON.stringify(parsed.diagnostics)}`)
+  // The new id is the documented one.
+  assert.equal(parseUserKeybindings({ 'app.input.submitAccelerated': 'ctrl+y' }).bindings['app.input.submitAccelerated'], 'ctrl+y')
 })

--- a/test/command-catalog.test.ts
+++ b/test/command-catalog.test.ts
@@ -70,7 +70,7 @@ function stubRunner(
   app: TuiApp,
   state: { agent: Agent | undefined },
   diag: ReturnType<typeof createDiag> = createDiag({ filePath: undefined, stderrLevel: 'off' }),
-  options: { transitionPending?: boolean } = {},
+  options: { transitionPending?: boolean; busyEnter?: string } = {},
 ): TuiCommandRunner {
   return {
     ctx,
@@ -84,7 +84,12 @@ function stubRunner(
     setDefaultIntent: () => {},
     defaultIntentRecord: undefined,
     settleIntent: () => {},
-    tuiSettings: undefined,
+    tuiSettings: options.busyEnter === undefined
+      ? undefined
+      : {
+          get: () => ({ busyEnter: options.busyEnter }),
+          replace: async () => undefined,
+        } as never,
     applyFooterSettings: () => {},
     agents: {} as never,
     sessionReader: {
@@ -918,5 +923,59 @@ test('the transition fence does NOT refuse skill invocations when no transition 
   const result = await (wrapper!.handler as (invocation: { rawInput: string }) => Promise<{ kind: string }>)({ rawInput: '' })
   assert.equal(result.kind, 'success')
   assert.equal(delivered.length, 2, 'the skill delivers the line and the body as usual')
+  app.stop()
+})
+
+// ── review P2: the picker resolves the delivery mode at SELECTION time ─────
+
+test('the /skill picker resolves the delivery mode at SELECTION time, not at open time', async () => {
+  const ctx = new Context()
+  const vt = new VirtualTerminal(100, 24)
+  const app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {} })
+  app.start()
+  startedApps.add(app)
+  const services = fakeServices()
+  ctx.provide('commands', services.commands as never)
+  const delivered: { kind: 'steer' | 'followup' | 'inject'; text: string }[] = []
+  const agent = fakeAgent('session-a', delivered, 'running')
+  const summary = {
+    name: 'glab',
+    description: 'GitLab CLI',
+    content: 'body',
+    invocation: { modelInvocable: true, userInvocable: true },
+    source: 'bundled',
+    provider: 't',
+  }
+  ctx.provide('skills', {
+    list: async () => [summary],
+    get: async () => summary,
+  } as never)
+  // The host's dsh-tool-skill pre-step listener IS visible: the queue mode
+  // then really queues (without it loadSkill keeps its order-preserving
+  // steer, which would make this assertion mode-blind).
+  ctx.provide('tools', {
+    get: (name: string) => name === 'skill' ? { name: 'skill', execute: async () => ({}) } : undefined,
+  } as never)
+  const { defs } = services
+  registerTuiCommands(stubRunner(ctx, app, { agent }, undefined, { busyEnter: 'steer' }))
+  const skillDef = defs.find(def => def.name === 'skill')
+  assert.ok(skillDef?.handler !== undefined)
+  // The picker opens while the agent is RUNNING with busyEnter=steer: a mode
+  // frozen at open time would be 'steer'.
+  const opened = await (skillDef!.handler as (invocation: { rawInput: string }) => Promise<{ kind: string }>)({ rawInput: '' })
+  assert.equal(opened.kind, 'success')
+  await vt.waitForRender()
+  assert.ok(vt.getViewport().join('\n').includes('glab'), 'the picker must offer the skill')
+  // The agent finishes its turn while the modal is open: the selection is
+  // the delivery boundary — an idle plain-Enter selection queues.
+  ;(agent as unknown as { status: string }).status = 'idle'
+  vt.sendInput('\r') // toggle the selected row's value (fires onChange)
+  await vt.waitForRender()
+  for (let round = 0; round < 20 && delivered.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(delivered.map(entry => entry.kind), ['followup'],
+    'an idle selection must queue — a mode frozen at picker-open time would steer')
+  assert.equal(delivered[0]?.text, '/glab', 'the queued line is the /name form')
   app.stop()
 })

--- a/test/editor-registry.test.ts
+++ b/test/editor-registry.test.ts
@@ -536,7 +536,7 @@ test('TuiApp: the EditorHost subscription is DRIVEN by host mutations (P1-11)', 
   // (With the plugin winner, host writes go through seat writes — the
   // listener sees the CURRENT seat occupant's text either way.)
   const before = snapshots.length
-  app.submitDraft(false)
+  app.submitDraft('enter')
   assert.ok(snapshots.length > before, 'a submit (draft clear) must notify subscribers')
   // Unsubscribe stops delivery (the ORIGINAL listener's disposer).
   unsubscribe!()
@@ -874,9 +874,9 @@ test('TuiApp: repeated declined Up events continue host history navigation', asy
   startedApps.add(app)
   await vt.waitForRender()
   app.setDraft('first')
-  app.submitDraft(false)
+  app.submitDraft('enter')
   app.setDraft('second')
-  app.submitDraft(false)
+  app.submitDraft('enter')
   let text = ''
   let cursor = 0
   registry.register({
@@ -1307,14 +1307,14 @@ test('TuiApp: a plugin editor survives a fullscreen toggle with focus intact (ro
   // input works — a submit after the toggle reads the plugin draft).
   app.setFullscreen(true)
   await vt.waitForRender()
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submitted, ['fs plugin draft'], 'submit works in fullscreen with a plugin occupant')
   // Fullscreen out: focus returns to the seat occupant.
   app.setFullscreen(false)
   await vt.waitForRender()
   app.setDraft('after fs')
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submitted, ['fs plugin draft', 'after fs'], 'submit works after returning to regular')
   app.stop()

--- a/test/extension-api-v1.test.ts
+++ b/test/extension-api-v1.test.ts
@@ -78,7 +78,7 @@ test('M11: extensionHealthRows reports the live registry counts', async () => {
   const { RendererRegistry } = await import('../src/renderer-registry.ts')
   const { EditorRegistry } = await import('../src/editor-registry.ts')
   const commands = new CommandBridge()
-  commands.register({ id: 'c1', name: 'vimmode', description: '', execution: 'local' }, 'owner')
+  commands.register({ id: 'c1', name: 'vimmode', description: '', handler: () => ({ kind: 'success' }) }, 'owner')
   const themes = new ThemeRegistry()
   const settings = new SettingsRegistry()
   const autocomplete = new AutocompleteRegistry()
@@ -436,7 +436,7 @@ test('the invocation-time command health capture resolves a command registered A
     await startup
     await ctx.plugin(applyExtensionHost)
     const service = ctx.get('piTuiExtensions') as unknown as {
-      registerCommand(contribution: { id: string; name: string; description: string; execution: 'local' }): unknown
+      registerCommand(contribution: { id: string; name: string; description: string; handler: () => { kind: 'success' } }): unknown
       commands: { idFor(name: string): string | undefined }
       _recordRegistryHealthRef(slot: string, id: string): { slot: string; id: string; owner: string } | undefined
     }
@@ -447,8 +447,8 @@ test('the invocation-time command health capture resolves a command registered A
     assert.equal(service._recordRegistryHealthRef('command', 'deploy'), undefined)
     // The plugin loads during the async phase (HMR / first registration).
     const fiber = ctx.plugin({ name: 'late-command', apply(c) {
-      const svc = c.get('piTuiExtensions') as unknown as { registerCommand(contribution: { id: string; name: string; description: string; execution: 'local' }): unknown }
-      svc.registerCommand({ id: 'deploy-cmd', name: 'deploy', description: 'deploy', execution: 'local' })
+      const svc = c.get('piTuiExtensions') as unknown as { registerCommand(contribution: { id: string; name: string; description: string; handler: () => { kind: 'success' } }): unknown }
+      svc.registerCommand({ id: 'deploy-cmd', name: 'deploy', description: 'deploy', handler: () => ({ kind: 'success' }) })
     } })
     await fiber
     // INVOCATION time: the re-capture resolves — the dispatched command
@@ -458,49 +458,6 @@ test('the invocation-time command health capture resolves a command registered A
     const ref = service._recordRegistryHealthRef('command', id)
     assert.ok(ref !== undefined, 'the invocation-time capture must resolve the late-registered command')
     assert.ok(ref.owner.endsWith(':late-command'), `the ref must name the late-registering owner: ${ref.owner}`)
-  } finally {
-    for (const runtime of [...ctx.registry.values()]) {
-      for (const fiber of runtime.fibers) await Promise.resolve(fiber.dispose())
-    }
-  }
-})
-
-test('a submission contribution cannot be sessionless — rejected loudly at registration', async () => {
-  // The TUI would otherwise run the line through its LOCAL path when no
-  // session exists yet, executing a handler the submission ownership
-  // explicitly does not run (and never delivering the agent-facing line).
-  const { Context } = await import('@deepseek-ai/cordis')
-  const Loader = (await import('@deepseek-ai/cordis-plugin-loader')).default
-  const { apply: applyExtensionHost } = await import('../src/extensions.ts')
-  const { TUI_STARTUP_SERVICE } = await import('../src/startup.ts')
-  const ctx = new Context()
-  try {
-    await ctx.plugin(Loader)
-    await ctx.plugin((c) => { c.provide(TUI_STARTUP_SERVICE, {}) })
-    await ctx.plugin(applyExtensionHost)
-    const service = ctx.get('piTuiExtensions') as unknown as {
-      registerCommand(contribution: {
-        id: string; name: string; description: string
-        execution: 'local' | 'submission'
-        sessionless?: boolean
-      }): unknown
-      commands: { find(name: string): { execution: string } | undefined }
-    }
-    await assert.rejects(async () => {
-      await ctx.plugin({ name: 'bad-command', apply(c) {
-        const svc = c.get('piTuiExtensions') as unknown as {
-          registerCommand(contribution: {
-            id: string; name: string; description: string
-            execution: 'local' | 'submission'
-            sessionless?: boolean
-          }): unknown
-        }
-        svc.registerCommand({
-          id: 'deploy-cmd', name: 'deploy', description: 'deploy', execution: 'submission', sessionless: true,
-        })
-      } })
-    }, /sessionless/)
-    assert.equal(service.commands.find('deploy'), undefined, 'the invalid contribution is never installed')
   } finally {
     for (const runtime of [...ctx.registry.values()]) {
       for (const fiber of runtime.fibers) await Promise.resolve(fiber.dispose())

--- a/test/extension-api-v1.test.ts
+++ b/test/extension-api-v1.test.ts
@@ -464,3 +464,46 @@ test('the invocation-time command health capture resolves a command registered A
     }
   }
 })
+
+test('a submission contribution cannot be sessionless — rejected loudly at registration', async () => {
+  // The TUI would otherwise run the line through its LOCAL path when no
+  // session exists yet, executing a handler the submission ownership
+  // explicitly does not run (and never delivering the agent-facing line).
+  const { Context } = await import('@deepseek-ai/cordis')
+  const Loader = (await import('@deepseek-ai/cordis-plugin-loader')).default
+  const { apply: applyExtensionHost } = await import('../src/extensions.ts')
+  const { TUI_STARTUP_SERVICE } = await import('../src/startup.ts')
+  const ctx = new Context()
+  try {
+    await ctx.plugin(Loader)
+    await ctx.plugin((c) => { c.provide(TUI_STARTUP_SERVICE, {}) })
+    await ctx.plugin(applyExtensionHost)
+    const service = ctx.get('piTuiExtensions') as unknown as {
+      registerCommand(contribution: {
+        id: string; name: string; description: string
+        execution: 'local' | 'submission'
+        sessionless?: boolean
+      }): unknown
+      commands: { find(name: string): { execution: string } | undefined }
+    }
+    await assert.rejects(async () => {
+      await ctx.plugin({ name: 'bad-command', apply(c) {
+        const svc = c.get('piTuiExtensions') as unknown as {
+          registerCommand(contribution: {
+            id: string; name: string; description: string
+            execution: 'local' | 'submission'
+            sessionless?: boolean
+          }): unknown
+        }
+        svc.registerCommand({
+          id: 'deploy-cmd', name: 'deploy', description: 'deploy', execution: 'submission', sessionless: true,
+        })
+      } })
+    }, /sessionless/)
+    assert.equal(service.commands.find('deploy'), undefined, 'the invalid contribution is never installed')
+  } finally {
+    for (const runtime of [...ctx.registry.values()]) {
+      for (const fiber of runtime.fibers) await Promise.resolve(fiber.dispose())
+    }
+  }
+})

--- a/test/extension-cordis-lifecycle.test.ts
+++ b/test/extension-cordis-lifecycle.test.ts
@@ -653,7 +653,7 @@ test('M5: command/theme/setting registrations are fiber-bound (owner unload clea
         id: string
         name: string
         description: string
-        execution: 'local' | 'submission'
+        handler: () => { kind: 'success' }
       }): { id: string; dispose(): void }
       registerTheme(contribution: { id: string; name: string; palette: object }): { id: string; dispose(): void }
       registerSetting(contribution: { id: string; label: string; currentValue: string }): { id: string; dispose(): void }
@@ -673,7 +673,7 @@ test('M5: command/theme/setting registrations are fiber-bound (owner unload clea
     // Plugin A registers one contribution in every M5 registry.
     const disposer = await mount(ctx, (pluginCtx) => {
       const svc = pluginCtx.get(PI_TUI_EXTENSIONS_SERVICE) as typeof service
-      svc.registerCommand({ id: 'cmd-a', name: 'acmd', description: 'a', execution: 'local' })
+      svc.registerCommand({ id: 'cmd-a', name: 'acmd', description: 'a', handler: () => ({ kind: 'success' }) })
       svc.registerTheme({ id: 'theme-a', name: 'A Theme', palette: { text: '#fff' } })
       svc.registerSetting({ id: 'set-a', label: 'A Setting', currentValue: 'v' })
       svc.registerAutocomplete({ id: 'auto-a', provider: { getSuggestions: async () => null } })

--- a/test/extension-cordis-lifecycle.test.ts
+++ b/test/extension-cordis-lifecycle.test.ts
@@ -642,6 +642,53 @@ test('a duplicate subscribeState listener is rejected loudly (round-4 finding)',
 // ── M5: fiber-bound registries (commands/themes/settings/autocomplete/ ─────
 // ── keybindings) ───────────────────────────────────────────────────────────
 
+test('M5: a STALE command handle never untracks a later registration (same owner + id)', async () => {
+  // The ledger health record is keyed (slot, owner, id) — it cannot tell two
+  // registrations of one id apart. A repeated/late cleanup of a disposed
+  // handle must therefore leave a NEWER generation (same owner, same id) both
+  // registered AND tracked.
+  const ctx = new Context()
+  try {
+    await ctx.plugin(Loader)
+    await mount(ctx, startupPlugin)
+    await mount(ctx, applyExtensionHost)
+    const service = ctx.get(PI_TUI_EXTENSIONS_SERVICE) as unknown as {
+      registerCommand(contribution: {
+        id: string
+        name: string
+        description: string
+        handler: () => { kind: 'success' }
+      }): { id: string; dispose(): void }
+      commands: { isLocal(name: string, statics: ReadonlySet<string>): boolean }
+      _ledger(): { healthSnapshot(): readonly { id: string; state: string }[] }
+    }
+    const spec = {
+      id: 'stale-cmd',
+      name: 'stalecmd',
+      description: 'stale handle',
+      handler: () => ({ kind: 'success' as const }),
+    }
+    const first = service.registerCommand(spec)
+    first.dispose()
+    assert.equal(service.commands.isLocal('stalecmd', new Set()), false, 'the first disposal removed it')
+    const second = service.registerCommand(spec)
+    // The late/repeated cleanup of the OLD handle.
+    first.dispose()
+    first.dispose()
+    assert.equal(service.commands.isLocal('stalecmd', new Set()), true, 'the newer registration stays live')
+    assert.equal(service._ledger().healthSnapshot().some(entry => entry.id === 'stale-cmd'), true,
+      'the newer registration health record survives the stale cleanup')
+    second.dispose()
+    assert.equal(service.commands.isLocal('stalecmd', new Set()), false, 'the current handle disposes its own')
+    assert.equal(service._ledger().healthSnapshot().some(entry => entry.id === 'stale-cmd'), false,
+      'and untracks its own record')
+  } finally {
+    for (const runtime of [...ctx.registry.values()]) {
+      for (const fiber of runtime.fibers) await Promise.resolve(fiber.dispose())
+    }
+  }
+})
+
 test('M5: command/theme/setting registrations are fiber-bound (owner unload cleans up)', async () => {
   const ctx = new Context()
   try {

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -94,6 +94,24 @@ test('CommandBridge: near-synonym names are reported (AGENTS hard rule)', () => 
   assert.equal(ok.kind, 'registered')
 })
 
+test('CommandBridge: a submission command cannot be sessionless (needs a session)', () => {
+  const bridge = new CommandBridge()
+  // A submission contribution is an agent-facing LINE: it is delivered to a
+  // session, so `sessionless` (which lets a LOCAL command run before any
+  // session exists) would route it into the local path and execute a handler
+  // the submission ownership does not run. Rejected at registration.
+  const outcome = bridge.register({
+    id: 'deploy', name: 'deploy', description: '', execution: 'submission', sessionless: true,
+  }, 'owner-a')
+  assert.equal(outcome.kind, 'invalid')
+  assert.match(outcome.kind === 'invalid' ? outcome.reason : '', /sessionless/)
+  assert.equal(bridge.find('deploy'), undefined, 'an invalid contribution is never stored')
+  // The same command as a LOCAL contribution may be sessionless.
+  assert.equal(bridge.register({
+    id: 'deploy', name: 'deploy', description: '', execution: 'local', sessionless: true,
+  }, 'owner-a').kind, 'registered')
+})
+
 test('CommandBridge: a duplicate id is an error', () => {
   const bridge = new CommandBridge()
   bridge.register({ id: 'x', name: 'a', description: '', execution: 'local' }, 'o1')

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -41,6 +41,31 @@ test('CommandBridge: dynamic local commands join the effective-local set', () =>
   assert.equal(bridge.isLocal('grilling', LOCAL_COMMANDS), false, 'unregistered is not local')
 })
 
+test('CommandBridge: a disposed handle never removes a LATER registration of the same id', () => {
+  // Caller-owned lifecycle: the handle names ONE registration. A repeated or
+  // late cleanup of a disposed handle (a fiber disposer running after an HMR
+  // reload re-registered the same id) must never remove the NEW generation.
+  const bridge = new CommandBridge()
+  const spec = { id: 'plugin-cmd', name: 'mycommand', description: 'a plugin command', handler: () => ({ kind: 'success' as const }) }
+  const first = bridge.register(spec, 'owner-a')
+  assert.equal(first.kind, 'registered')
+  if (first.kind !== 'registered') return
+  first.handle.dispose()
+  assert.equal(bridge.snapshot().entries.length, 0, 'the first registration is gone')
+  const second = bridge.register(spec, 'owner-a')
+  assert.equal(second.kind, 'registered')
+  if (second.kind !== 'registered') return
+  // The LATE / REPEATED dispose of the old handle: idempotent for itself and
+  // a no-op for the new generation.
+  first.handle.dispose()
+  first.handle.dispose()
+  assert.equal(bridge.snapshot().entries.length, 1, 'the new generation stays registered')
+  assert.equal(bridge.isLocal('mycommand', LOCAL_COMMANDS), true, 'the new generation stays live')
+  assert.equal(bridge.snapshot().entries[0]?.generation, 2, 'the live entry is the SECOND generation')
+  second.handle.dispose()
+  assert.equal(bridge.snapshot().entries.length, 0, 'the new handle still disposes its own registration')
+})
+
 test('CommandBridge: a plugin command can NEVER shadow a host-owned command (P1-04)', () => {
   // The authoritative host catalog (TUI commands + ownership sets).
   const catalog = new Set(['status', 'sessions', 'help', 'exit', 'kill', 'settings'])

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -18,7 +18,7 @@ import { ThemeRegistry } from '../src/theme-registry.ts'
 import { SettingsRegistry } from '../src/settings-registry.ts'
 import { AutocompleteRegistry } from '../src/autocomplete-registry.ts'
 import { KeybindingRegistry } from '../src/keybinding-registry.ts'
-import { HOST_COMMAND_CATALOG, LOCAL_COMMANDS, SESSIONLESS_COMMANDS, shouldSteerOnEnter } from '../src/index.ts'
+import { HOST_COMMAND_CATALOG, LOCAL_COMMANDS, SESSIONLESS_COMMANDS, resolveSubmitDelivery } from '../src/index.ts'
 
 /** A minimal valid structural autocomplete provider for tests. */
 function provider(getSuggestions: () => Promise<import('../src/extension/public-types.ts').TuiAutocompleteSuggestions | null>): import('../src/extension/public-types.ts').TuiAutocompleteProvider {
@@ -118,14 +118,14 @@ test('CommandBridge: dynamic unload makes the command submission again (busy-ent
   assert.equal(handle.kind, 'registered')
   // While registered: never steers.
   assert.equal(
-    shouldSteerOnEnter({ name: 'dyncmd' }, true, 'steer', false, name => bridge.isLocal(name, LOCAL_COMMANDS)),
-    false,
+    resolveSubmitDelivery({ name: 'dyncmd' }, true, 'enter', 'steer', name => bridge.isLocal(name, LOCAL_COMMANDS)),
+    'queue',
   )
   // After unload: submission policy applies.
   if (handle.kind === 'registered') handle.handle.dispose()
   assert.equal(
-    shouldSteerOnEnter({ name: 'dyncmd' }, true, 'steer', false, name => bridge.isLocal(name, LOCAL_COMMANDS)),
-    true,
+    resolveSubmitDelivery({ name: 'dyncmd' }, true, 'enter', 'steer', name => bridge.isLocal(name, LOCAL_COMMANDS)),
+    'steer',
   )
 })
 

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -102,7 +102,7 @@ test('CommandBridge: a sessionless client command records its flag', () => {
   }, 'owner-a')
   assert.equal(outcome.kind, 'registered')
   assert.equal(bridge.find('vimmode')?.sessionless, true)
-  assert.equal(bridge.isSessionless('vimmode', new Set()), true, 'the sessionless classification is contribution-driven')
+  assert.equal(bridge.find('vimmode')?.sessionless, true, 'the sessionless classification lives on the contribution record')
 })
 
 test('CommandBridge: a duplicate id is an error', () => {
@@ -127,17 +127,17 @@ test('CommandBridge: dynamic unload drops the client ownership (busy-enter regre
     id: 'dyn', name: 'dyncmd', description: '', handler: () => ({ kind: 'success' }),
   }, 'owner-a')
   assert.equal(handle.kind, 'registered')
-  // While registered: never steers.
+  // While registered it is a CLIENT command: the namespace dispatch routes it
+  // before the busy policy (the resolver is never consulted for it).
+  assert.equal(bridge.isLocal('dyncmd', LOCAL_COMMANDS), true)
   assert.equal(
-    resolveSubmitDelivery({ name: 'dyncmd' }, true, 'enter', 'steer', name => bridge.isLocal(name, LOCAL_COMMANDS)),
-    'queue',
-  )
-  // After unload: submission policy applies.
-  if (handle.kind === 'registered') handle.handle.dispose()
-  assert.equal(
-    resolveSubmitDelivery({ name: 'dyncmd' }, true, 'enter', 'steer', name => bridge.isLocal(name, LOCAL_COMMANDS)),
+    resolveSubmitDelivery({ name: 'dyncmd' }, true, 'enter', 'steer'),
     'steer',
+    'a client name is not TUI-local for the resolver: it would follow the busy policy',
   )
+  // After unload the name returns to the ordinary routes.
+  if (handle.kind === 'registered') handle.handle.dispose()
+  assert.equal(bridge.isLocal('dyncmd', LOCAL_COMMANDS), false)
 })
 
 test('CommandBridge: rawInput is preserved verbatim (skill rawInput regression)', () => {
@@ -159,12 +159,12 @@ test('CommandBridge: rawInput is preserved verbatim (skill rawInput regression)'
   assert.equal(received, raw, 'the bridge must never re-parse or rewrite rawInput')
 })
 
-test('CommandBridge: sessionless contributions join the sessionless set', () => {
+test('CommandBridge: the sessionless flag stays on the contribution record (the static set is the TUI core)', () => {
   const bridge = new CommandBridge()
   bridge.register({ id: 's', name: 'nosession', description: '', sessionless: true, handler: () => ({ kind: 'success' }) }, 'o')
-  assert.equal(bridge.isSessionless('nosession', SESSIONLESS_COMMANDS), true)
-  assert.equal(bridge.isSessionless('exit', SESSIONLESS_COMMANDS), true, 'static core stays')
-  assert.equal(bridge.isSessionless('nosession2', SESSIONLESS_COMMANDS), false)
+  assert.equal(bridge.find('nosession')?.sessionless, true, 'the contribution declares it')
+  assert.equal(bridge.find('nosession2'), undefined, 'an unknown name has no record')
+  assert.equal(SESSIONLESS_COMMANDS.has('exit'), true, 'the static TUI core stays the dispatch baseline')
 })
 
 // ── ThemeRegistry ──────────────────────────────────────────────────────────
@@ -712,4 +712,15 @@ test('KeybindingRegistry: duplicate keys conflict; unload removes bindings', () 
   assert.equal(registry.actionFor({ key: 'y', ctrl: true, alt: true, shift: false, super: false }), 'open-search')
   handle.dispose()
   assert.equal(registry.actionFor({ key: 'y', ctrl: false, alt: true, shift: false, super: false }), undefined)
+})
+
+test('CommandBridge: a contribution without a handler fails loud at the boundary', () => {
+  // TypeScript requires `handler`, but a plain-JS / stale compiled caller can
+  // bypass it: installing a menu row with no behavior would be silent.
+  const bridge = new CommandBridge()
+  assert.throws(
+    () => bridge.register({ id: 'x', name: 'broken', description: '' } as never, 'o1'),
+    /must declare its handler/,
+  )
+  assert.equal(bridge.find('broken'), undefined, 'nothing malformed is stored')
 })

--- a/test/extension-registry-m5.test.ts
+++ b/test/extension-registry-m5.test.ts
@@ -33,7 +33,7 @@ test('CommandBridge: dynamic local commands join the effective-local set', () =>
     id: 'plugin-cmd',
     name: 'mycommand',
     description: 'a plugin command',
-    execution: 'local',
+    handler: () => ({ kind: 'success' }),
   }, 'owner-a')
   assert.equal(outcome.kind, 'registered')
   assert.equal(bridge.isLocal('mycommand', LOCAL_COMMANDS), true)
@@ -46,20 +46,20 @@ test('CommandBridge: a plugin command can NEVER shadow a host-owned command (P1-
   const catalog = new Set(['status', 'sessions', 'help', 'exit', 'kill', 'settings'])
   const bridge = new CommandBridge(() => {}, catalog)
   // EXACT collision with a TUI-registered command: rejected loudly.
-  const status = bridge.register({ id: 's1', name: 'status', description: '', execution: 'local' }, 'plugin')
+  const status = bridge.register({ id: 's1', name: 'status', description: '', handler: () => ({ kind: 'success' }) }, 'plugin')
   assert.equal(status.kind, 'conflict')
   assert.equal(status.existingOwner, 'host', 'the conflict is owned by the HOST, not another plugin')
   // EXACT collision with a core command the TUI dispatches locally (/kill).
-  const kill = bridge.register({ id: 's2', name: 'kill', description: '', execution: 'local' }, 'plugin')
+  const kill = bridge.register({ id: 's2', name: 'kill', description: '', handler: () => ({ kind: 'success' }) }, 'plugin')
   assert.equal(kill.kind, 'conflict')
   assert.equal(kill.existingOwner, 'host')
   // NEAR-SYNONYM of a host command (/session vs /sessions): rejected too.
-  const near = bridge.register({ id: 's3', name: 'session', description: '', execution: 'local' }, 'plugin')
+  const near = bridge.register({ id: 's3', name: 'session', description: '', handler: () => ({ kind: 'success' }) }, 'plugin')
   assert.equal(near.kind, 'conflict')
   assert.equal(near.existingOwner, 'host')
   assert.ok(near.nearSynonym !== undefined, 'the near-synonym pair is reported')
   // A genuinely NEW name still registers (the catalog never blocks growth).
-  const fresh = bridge.register({ id: 's4', name: 'vimish', description: '', execution: 'local' }, 'plugin')
+  const fresh = bridge.register({ id: 's4', name: 'vimish', description: '', handler: () => ({ kind: 'success' }) }, 'plugin')
   assert.equal(fresh.kind, 'registered')
   assert.equal(bridge.snapshot().entries.length, 1)
   // The built-in is still local and still routes to the HOST handler.
@@ -68,13 +68,13 @@ test('CommandBridge: a plugin command can NEVER shadow a host-owned command (P1-
 
   assert.equal(HOST_COMMAND_CATALOG.has('plan'), true, 'special-cased /plan is host-owned')
   const plan = new CommandBridge(() => {}, HOST_COMMAND_CATALOG)
-  assert.equal(plan.register({ id: 'plan-plugin', name: 'plan', description: '', execution: 'local' }, 'plugin').kind, 'conflict')
+  assert.equal(plan.register({ id: 'plan-plugin', name: 'plan', description: '', handler: () => ({ kind: 'success' }) }, 'plugin').kind, 'conflict')
 })
 
 test('CommandBridge: a name conflict is reported, never silently overridden', () => {
   const bridge = new CommandBridge()
-  bridge.register({ id: 'a', name: 'dup', description: '', execution: 'local' }, 'owner-a')
-  const outcome = bridge.register({ id: 'b', name: 'dup', description: '', execution: 'local' }, 'owner-b')
+  bridge.register({ id: 'a', name: 'dup', description: '', handler: () => ({ kind: 'success' }) }, 'owner-a')
+  const outcome = bridge.register({ id: 'b', name: 'dup', description: '', handler: () => ({ kind: 'success' }) }, 'owner-b')
   assert.equal(outcome.kind, 'conflict')
   assert.equal(outcome.existingOwner, 'owner-a')
   assert.equal(bridge.snapshot().entries.length, 1, 'the second registration is not stored')
@@ -82,56 +82,49 @@ test('CommandBridge: a name conflict is reported, never silently overridden', ()
 
 test('CommandBridge: near-synonym names are reported (AGENTS hard rule)', () => {
   const bridge = new CommandBridge()
-  bridge.register({ id: 'a', name: 'session', description: '', execution: 'local' }, 'owner-a')
+  bridge.register({ id: 'a', name: 'session', description: '', handler: () => ({ kind: 'success' }) }, 'owner-a')
   // Exact prefix of an existing name: a confusion risk, rejected.
-  const outcome = bridge.register({ id: 'b', name: 'sessions', description: '', execution: 'local' }, 'owner-b')
+  const outcome = bridge.register({ id: 'b', name: 'sessions', description: '', handler: () => ({ kind: 'success' }) }, 'owner-b')
   assert.equal(outcome.kind, 'conflict')
   assert.equal(outcome.nearSynonym, 'session ↔ sessions')
   // The bridge stores only the first.
   assert.equal(bridge.snapshot().entries.length, 1)
   // Unrelated names are fine.
-  const ok = bridge.register({ id: 'c', name: 'grilling', description: '', execution: 'submission' }, 'owner-c')
+  const ok = bridge.register({ id: 'c', name: 'grilling', description: '', handler: () => ({ kind: 'success' }) }, 'owner-c')
   assert.equal(ok.kind, 'registered')
 })
 
-test('CommandBridge: a submission command cannot be sessionless (needs a session)', () => {
+test('CommandBridge: a sessionless client command records its flag', () => {
   const bridge = new CommandBridge()
-  // A submission contribution is an agent-facing LINE: it is delivered to a
-  // session, so `sessionless` (which lets a LOCAL command run before any
-  // session exists) would route it into the local path and execute a handler
-  // the submission ownership does not run. Rejected at registration.
   const outcome = bridge.register({
-    id: 'deploy', name: 'deploy', description: '', execution: 'submission', sessionless: true,
+    id: 'vimmode', name: 'vimmode', description: '', sessionless: true,
+    handler: () => ({ kind: 'success' }),
   }, 'owner-a')
-  assert.equal(outcome.kind, 'invalid')
-  assert.match(outcome.kind === 'invalid' ? outcome.reason : '', /sessionless/)
-  assert.equal(bridge.find('deploy'), undefined, 'an invalid contribution is never stored')
-  // The same command as a LOCAL contribution may be sessionless.
-  assert.equal(bridge.register({
-    id: 'deploy', name: 'deploy', description: '', execution: 'local', sessionless: true,
-  }, 'owner-a').kind, 'registered')
+  assert.equal(outcome.kind, 'registered')
+  assert.equal(bridge.find('vimmode')?.sessionless, true)
+  assert.equal(bridge.isSessionless('vimmode', new Set()), true, 'the sessionless classification is contribution-driven')
 })
 
 test('CommandBridge: a duplicate id is an error', () => {
   const bridge = new CommandBridge()
-  bridge.register({ id: 'x', name: 'a', description: '', execution: 'local' }, 'o1')
-  assert.throws(() => bridge.register({ id: 'x', name: 'b', description: '', execution: 'local' }, 'o2'), /duplicate/)
+  bridge.register({ id: 'x', name: 'a', description: '', handler: () => ({ kind: 'success' }) }, 'o1')
+  assert.throws(() => bridge.register({ id: 'x', name: 'b', description: '', handler: () => ({ kind: 'success' }) }, 'o2'), /duplicate/)
 })
 
 test('CommandBridge: owner unload removes exactly the owner contributions', () => {
   const bridge = new CommandBridge()
-  bridge.register({ id: 'p1', name: 'one', description: '', execution: 'local' }, 'owner-a')
-  bridge.register({ id: 'p2', name: 'two', description: '', execution: 'submission' }, 'owner-b')
+  bridge.register({ id: 'p1', name: 'one', description: '', handler: () => ({ kind: 'success' }) }, 'owner-a')
+  bridge.register({ id: 'p2', name: 'two', description: '', handler: () => ({ kind: 'success' }) }, 'owner-b')
   bridge.disposeOwner('owner-a')
   assert.equal(bridge.isLocal('one', LOCAL_COMMANDS), false)
-  assert.equal(bridge.find('two')?.execution, 'submission')
+  assert.equal(bridge.find('two')?.name, 'two')
   assert.equal(bridge.snapshot().entries.length, 1)
 })
 
-test('CommandBridge: dynamic unload makes the command submission again (busy-enter regression)', () => {
+test('CommandBridge: dynamic unload drops the client ownership (busy-enter regression)', () => {
   const bridge = new CommandBridge()
   const handle = bridge.register({
-    id: 'dyn', name: 'dyncmd', description: '', execution: 'local',
+    id: 'dyn', name: 'dyncmd', description: '', handler: () => ({ kind: 'success' }),
   }, 'owner-a')
   assert.equal(handle.kind, 'registered')
   // While registered: never steers.
@@ -154,7 +147,6 @@ test('CommandBridge: rawInput is preserved verbatim (skill rawInput regression)'
     id: 'arg-cmd',
     name: 'argcmd',
     description: '',
-    execution: 'local',
     handler: (invocation) => {
       received = invocation.rawInput
       return { kind: 'success' as const }
@@ -169,7 +161,7 @@ test('CommandBridge: rawInput is preserved verbatim (skill rawInput regression)'
 
 test('CommandBridge: sessionless contributions join the sessionless set', () => {
   const bridge = new CommandBridge()
-  bridge.register({ id: 's', name: 'nosession', description: '', execution: 'local', sessionless: true }, 'o')
+  bridge.register({ id: 's', name: 'nosession', description: '', sessionless: true, handler: () => ({ kind: 'success' }) }, 'o')
   assert.equal(bridge.isSessionless('nosession', SESSIONLESS_COMMANDS), true)
   assert.equal(bridge.isSessionless('exit', SESSIONLESS_COMMANDS), true, 'static core stays')
   assert.equal(bridge.isSessionless('nosession2', SESSIONLESS_COMMANDS), false)

--- a/test/extension-stable-api.test.ts
+++ b/test/extension-stable-api.test.ts
@@ -1,8 +1,9 @@
 /**
- * M11 tests (plan §16): API v1 hardening — the deprecation policy
- * surface, the /status extension-health rows, and the stability contract
- * (capability feature-detect).
- * @module @xmoon76/dsh-pi-tui/extension-api-v1.test
+ * M11 tests (plan §16): the STABLE API contract — currently API v2 (the
+ * client-command contribution contract; v1 was the M0–M3 foundation). The
+ * deprecation policy surface, the /status extension-health rows, and the
+ * stability contract (capability feature-detect).
+ * @module @xmoon76/dsh-pi-tui/extension-stable-api.test
  */
 
 import assert from 'node:assert/strict'
@@ -23,7 +24,7 @@ afterEach(() => {
   }
 })
 
-test('API v1: the deprecation map is part of the api() contract and empty at v1', async () => {
+test('the deprecation map is part of the api() contract and empty at the current API version', async () => {
   // Mount the REAL service (startup + extension host) and read api()
   // from it — the contract is asserted against the implementation, not a
   // locally fabricated object.
@@ -31,14 +32,19 @@ test('API v1: the deprecation map is part of the api() contract and empty at v1'
   const { service, dispose } = await mountRealService()
   try {
     const info = service.api()
-    assert.equal(info.apiVersion, 1)
-    assert.equal(info.deprecations.size, 0, 'nothing is deprecated at API v1')
+    // The reported version is the exported contract constant, not a literal:
+    // a breaking extension-surface change bumps BOTH together (the
+    // client-command contribution contract is v2).
+    const { API_VERSION } = await import('../src/extension/public-types.ts')
+    assert.equal(info.apiVersion, 2)
+    assert.equal(info.apiVersion, API_VERSION)
+    assert.equal(info.deprecations.size, 0, 'nothing is deprecated at the current API version')
   } finally {
     dispose()
   }
 })
 
-test('API v1: capabilities are feature-detected, never version-parsed', async () => {
+test('stable API: capabilities are feature-detected, never version-parsed', async () => {
   // The REAL service advertises the full slot set from provide-time (no
   // surface attached yet) — the feature-detect contract plugins rely on.
   const { mountRealService } = await import('./extension-lifecycle-helpers.ts')
@@ -126,7 +132,7 @@ test('M11: the capability row reflects the real capability set across states (ro
     keybindings: new KeybindingRegistry(),
     renderers: new RendererRegistry(),
     editors: new EditorRegistry(),
-    api: () => ({ apiVersion: 1 as const, hostVersion: '0.2.0', capabilities: new Set(['slot.input.widget', 'surface.snapshot']), deprecations: new Map() }),
+    api: () => ({ apiVersion: 2 as const, hostVersion: '0.2.0', capabilities: new Set(['slot.input.widget', 'surface.snapshot']), deprecations: new Map() }),
   }
   const rows = extensionHealthRows({ extensions: base } as never)
   const capabilities = rows.find(row => row.id === 'ext-capabilities')

--- a/test/fixtures/vim-plugin/src/index.ts
+++ b/test/fixtures/vim-plugin/src/index.ts
@@ -256,9 +256,9 @@ export function apply(ctx: Context): void {
     })
   }
 
-  // 4. COMMAND: a TUI-owned local command (execution ownership metadata —
-  //    the bridge carries it, the RUNNER executes this contribution's own
-  //    handler locally, live session or not). The command
+  // 4. COMMAND: a client-owned command (the bridge carries the handler, the
+  //    RUNNER executes this contribution's own handler locally, live session
+  //    or not; `sessionless: true` makes it work before a session exists). The command
   //    ALSO exposes the managed-overlay trigger (round-1 finding 4: the
   //    overlay must be actually reachable, not dead code). The overlay is
   //    a TOGGLE (round-2 finding 3: no timer at all — nothing can leak

--- a/test/fixtures/vim-plugin/src/index.ts
+++ b/test/fixtures/vim-plugin/src/index.ts
@@ -269,7 +269,6 @@ export function apply(ctx: Context): void {
     id: 'vim-mode-cmd',
     name: 'vimmode',
     description: 'Vim fixture: show the mode and toggle the fixture overlay.',
-    execution: 'local',
     sessionless: true,
     handler: (invocation) => {
       void invocation

--- a/test/fixtures/vim-plugin/src/index.ts
+++ b/test/fixtures/vim-plugin/src/index.ts
@@ -257,7 +257,8 @@ export function apply(ctx: Context): void {
   }
 
   // 4. COMMAND: a TUI-owned local command (execution ownership metadata —
-  //    the bridge never executes; the commands service does). The command
+  //    the bridge carries it, the RUNNER executes this contribution's own
+  //    handler locally, live session or not). The command
   //    ALSO exposes the managed-overlay trigger (round-1 finding 4: the
   //    overlay must be actually reachable, not dead code). The overlay is
   //    a TOGGLE (round-2 finding 3: no timer at all — nothing can leak

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2689,7 +2689,7 @@ test('metadata-free logs keep the first user as the initial-prompt fallback', ()
   assert.deepEqual(blockKinds(collapsed), ['user', 'activity', 'assistant'])
 })
 
-test('collapsed: a claimed steer in a non-user turn follows the Thought', () => {
+test('collapsed: a claimed steer in a non-user turn precedes the Thought', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, [
     eventAt('turn/start', { turn: 0 }, 1000, 0),
@@ -2710,11 +2710,18 @@ test('collapsed: a claimed steer in a non-user turn follows the Thought', () => 
     eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1009, 9),
   ])
   const blocks = projectTools(folder.messages(), folder.turnActivities(), new Set())
-  assert.deepEqual(blockKinds(blocks), ['activity', 'user', 'compaction', 'assistant'],
-    'a non-user turn must put Thought, steer, compaction, and final in order when collapsed')
+  // Collapsed Focus summarizes inputs: every human user row (a same-turn
+  // steer included) precedes the Thought; compaction and the final keep
+  // their existing lifecycle.
+  assert.deepEqual(blockKinds(blocks), ['user', 'activity', 'compaction', 'assistant'],
+    'a non-user turn must put steer, Thought, compaction, and final in order when collapsed')
+  const steer = blocks.find(block => block.kind === 'message' && block.message.kind === 'user')
+  assert.ok(steer !== undefined && steer.kind === 'message' && steer.message.kind === 'user')
+  assert.equal(steer.message.steer, true,
+    'the projection change must not touch the durable steer fact')
 })
 
-test('Focus keeps injected context and a claimed steer under the Thought root', () => {
+test('Focus surfaces an opening injected trigger before Thought while keeping the steer chronological when expanded', () => {
   const events: SessionEvent[] = [
     eventAt('turn/start', { turn: 0 }, 1000, 0),
     eventAt('user/message', {
@@ -2734,9 +2741,44 @@ test('Focus keeps injected context and a claimed steer under the Thought root', 
   const folder = new TranscriptFolder()
   applyMixed(folder, events)
   const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
-  assert.deepEqual(blockKinds(expanded), ['activity', 'system', 'thinking', 'user', 'assistant'])
+  // The opening injected trigger is the turn foundation: it stays BEFORE
+  // the Thought; the claimed steer returns to its chronological process
+  // position (expanded chronology preserved).
+  assert.deepEqual(blockKinds(expanded), ['system', 'activity', 'thinking', 'user', 'assistant'],
+    `the opening inject must precede the Thought while the steer stays chronological: ${blockKinds(expanded).join(',')}`)
   const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
-  assert.deepEqual(blockKinds(collapsed), ['activity', 'user', 'assistant'])
+  // Collapsed Focus summarizes inputs: opening injected context + every
+  // human user row (the steer included) precede the Thought.
+  assert.deepEqual(blockKinds(collapsed), ['system', 'user', 'activity', 'assistant'],
+    `collapsed Focus must surface the opening inject and the steer before the Thought: ${blockKinds(collapsed).join(',')}`)
+  // The system row is still the ORIGINAL injected context (same text and
+  // label — the projection never rewrites or duplicates the fact).
+  const expandedSystem = expanded.find(block => block.kind === 'message' && block.message.kind === 'system')
+  assert.ok(expandedSystem !== undefined && expandedSystem.kind === 'message' && expandedSystem.message.kind === 'system')
+  assert.equal(expandedSystem.message.text, 'system reminder')
+  assert.equal(expandedSystem.message.label, 'agent-instructions')
+  // The steer keeps its durable `steer: true` fact — only the projection
+  // moved, never the provenance.
+  const expandedUsers = expanded.flatMap(block => block.kind === 'message' && block.message.kind === 'user' ? [block.message] : [])
+  assert.equal(expandedUsers.length, 1)
+  assert.equal(expandedUsers[0]?.steer, true)
+  // Click-owner contract: the opening system row is foundation, NOT
+  // process — it must never collapse the owner Thought; the expanded
+  // thinking row is process content and keeps the owner mark; user and
+  // final stay unmarked.
+  assert.equal(expandedSystem.collapseFocusOwnerOnClick, undefined,
+    'an opening injected row must not carry the Thought collapse mark')
+  const expandedThinking = expanded.find(block => block.kind === 'message' && block.message.kind === 'thinking')
+  assert.ok(expandedThinking !== undefined && expandedThinking.kind === 'message')
+  assert.equal(expandedThinking.collapseFocusOwnerOnClick, 0,
+    'expanded process rows keep the owner-turn collapse mark')
+  for (const block of expanded) {
+    if (block.kind !== 'message') continue
+    if (block.message.kind === 'user' || block.message.kind === 'assistant') {
+      assert.equal(block.collapseFocusOwnerOnClick, undefined,
+        `user/final rows never carry the owner mark: ${block.message.kind}`)
+    }
+  }
 })
 
 test('a steer claimed before reasoning is still identified durably', () => {
@@ -2754,6 +2796,88 @@ test('a steer claimed before reasoning is still identified durably', () => {
   const blocks = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
   assert.deepEqual(blockKinds(blocks), ['activity', 'user', 'thinking', 'assistant'],
     'durable next-step identity must not depend on a prior visible process row')
+})
+
+test('expanded: a mid-turn injected/system row stays in its process position (never lifted to the lead)', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('user/message', {
+      id: MessageId('u0'), role: 'user',
+      content: [{ type: 'text', text: 'initial prompt 0' }],
+      source: { kind: 'user' },
+    }, 1001, 1),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1002, 2),
+    // A NON-opening injected context: it lands mid-process, after thinking.
+    eventAt('user/message', {
+      id: MessageId('mid-inject'), role: 'user',
+      content: [{ type: 'text', text: 'mid-turn reminder' }],
+      source: { kind: 'plugin', plugin: 'agent-instructions' },
+    }, 1003, 3),
+    ...claimedSteer('mid-steer', 'steer after inject', 1004, 4),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('mid-a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1007, 7),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1008, 8),
+  ])
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  // Only the LEADING system prefix is the turn foundation; a mid-turn
+  // inject stays at its real chronological position inside the process.
+  assert.deepEqual(blockKinds(expanded), ['user', 'activity', 'thinking', 'system', 'user', 'assistant'],
+    `a mid-turn inject must stay in its process position when expanded: ${blockKinds(expanded).join(',')}`)
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  // Collapsed Focus summarizes inputs only: the mid-turn inject is process
+  // content and stays hidden under the Thought — never lifted to the lead.
+  assert.deepEqual(blockKinds(collapsed), ['user', 'user', 'activity', 'assistant'],
+    `a mid-turn inject must not surface before the collapsed Thought: ${blockKinds(collapsed).join(',')}`)
+  const expandedSystem = expanded.find(block => block.kind === 'message' && block.message.kind === 'system')
+  assert.ok(expandedSystem !== undefined && expandedSystem.kind === 'message' && expandedSystem.message.kind === 'system')
+  assert.equal(expandedSystem.message.text, 'mid-turn reminder')
+  assert.equal(expandedSystem.collapseFocusOwnerOnClick, 0,
+    'a mid-turn inject is process content: it keeps the owner-turn collapse mark')
+  assert.ok(!collapsed.some(block => block.kind === 'message' && block.message.kind === 'system'),
+    'collapsed Focus must not surface a mid-turn inject')
+})
+
+test('expanded and collapsed: multiple opening injected rows keep their order and never duplicate', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('user/message', {
+      id: MessageId('i1'), role: 'user',
+      content: [{ type: 'text', text: 'first reminder' }],
+      source: { kind: 'plugin', plugin: 'agent-instructions' },
+    }, 1001, 1),
+    eventAt('user/message', {
+      id: MessageId('i2'), role: 'user',
+      content: [{ type: 'text', text: 'second reminder' }],
+      source: { kind: 'plugin', plugin: 'skill-catalog' },
+    }, 1002, 2),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1003, 3),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('multi-a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1004, 4),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1005, 5),
+  ])
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  assert.deepEqual(blockKinds(expanded), ['system', 'system', 'activity', 'thinking', 'assistant'],
+    `every opening inject precedes the Thought when expanded: ${blockKinds(expanded).join(',')}`)
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['system', 'system', 'activity', 'assistant'],
+    `every opening inject precedes the Thought when collapsed: ${blockKinds(collapsed).join(',')}`)
+  const systemTexts = (blocks: readonly FocusProjectedBlock[]): string[] =>
+    blocks.flatMap(block => block.kind === 'message' && block.message.kind === 'system' ? [block.message.text] : [])
+  assert.deepEqual(systemTexts(expanded), ['first reminder', 'second reminder'],
+    'opening injects keep their original order when expanded')
+  assert.deepEqual(systemTexts(collapsed), ['first reminder', 'second reminder'],
+    'opening injects keep their original order when collapsed')
+  for (const block of [...expanded, ...collapsed]) {
+    if (block.kind !== 'message' || block.message.kind !== 'system') continue
+    assert.equal(block.collapseFocusOwnerOnClick, undefined,
+      'an opening injected row never carries the Thought collapse mark')
+  }
 })
 
 test('fold → expand → fold projection is reversible (same collapsed output)', () => {

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2880,6 +2880,81 @@ test('expanded and collapsed: multiple opening injected rows keep their order an
   }
 })
 
+test('expanded and collapsed: an llm/retry after the opening inject stays process content (never lifted to the lead)', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    // The opening injected trigger wakes the turn.
+    eventAt('user/message', {
+      id: MessageId('retry-inject'), role: 'user',
+      content: [{ type: 'text', text: 'system reminder' }],
+      source: { kind: 'plugin', plugin: 'agent-instructions' },
+    }, 1001, 1),
+    // The first model request fails BEFORE any visible output: the retry
+    // is orchestration, NOT turn foundation — it must never be lifted
+    // before the Thought.
+    eventAt('llm/retry', { turn: 0, step: 0, retry: 0, delayMs: 1000, failure: { code: 'E', message: 'boom' } }, 1002, 2),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1003, 3),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('retry-a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1004, 4),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1005, 5),
+  ])
+  const expanded = projectFocus(folder.messages(), folder.turnActivities(), new Set([0]), true)
+  // Only the injected context is the foundation; the retry stays in its
+  // chronological process position.
+  assert.deepEqual(blockKinds(expanded), ['system', 'activity', 'system', 'thinking', 'assistant'],
+    `the retry must stay inside the expanded process: ${blockKinds(expanded).join(',')}`)
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  // Collapsed Focus summarizes inputs only: the retry is process content
+  // and stays hidden under the Thought.
+  assert.deepEqual(blockKinds(collapsed), ['system', 'activity', 'assistant'],
+    `the retry must not surface before the collapsed Thought: ${blockKinds(collapsed).join(',')}`)
+  // The expanded retry row keeps the Thought owner click mark; the opening
+  // inject stays unmarked foundation.
+  const expandedRetry = expanded.find(block => block.kind === 'message' && block.message.kind === 'system' && block.message.text.includes('llm retry'))
+  assert.ok(expandedRetry !== undefined && expandedRetry.kind === 'message')
+  assert.equal(expandedRetry.collapseFocusOwnerOnClick, 0, 'the retry is process content: owner-marked')
+  const expandedInject = expanded.find(block => block.kind === 'message' && block.message.kind === 'system' && block.message.text === 'system reminder')
+  assert.ok(expandedInject !== undefined && expandedInject.kind === 'message')
+  assert.equal(expandedInject.collapseFocusOwnerOnClick, undefined, 'the opening inject is foundation: unmarked')
+})
+
+test('a system row with an icon but no context marker is never turn foundation (independent contracts)', () => {
+  const folder = new TranscriptFolder()
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('user/message', {
+      id: MessageId('ctx'), role: 'user',
+      content: [{ type: 'text', text: 'system reminder' }],
+      source: { kind: 'plugin', plugin: 'agent-instructions' },
+    }, 1001, 1),
+    eventAt('assistant/chunk', { turn: 0, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, 1002, 2),
+    eventAt('assistant/message', {
+      turn: 0, step: 1,
+      message: { id: MessageId('icon-a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, 1003, 3),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1004, 4),
+  ])
+  // A hand-built presentation row that carries an icon but NOT the context
+  // marker: the two contracts are independent — icon presence alone must
+  // never make a row part of the turn foundation.
+  const iconOnly: TranscriptMessage = { kind: 'system', turn: 0, text: 'icon without context', icon: 'context-generic' }
+  const messages = [folder.messages()[0]!, iconOnly, ...folder.messages().slice(1)]
+  const expanded = projectFocus(messages, folder.turnActivities(), new Set([0]), true)
+  // The real injected context is the foundation; the icon-only row stays
+  // in the process, after the Thought.
+  assert.deepEqual(blockKinds(expanded), ['system', 'activity', 'system', 'thinking', 'assistant'],
+    `the icon-only row must not extend the foundation prefix: ${blockKinds(expanded).join(',')}`)
+  const collapsed = projectTools(messages, folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['system', 'activity', 'assistant'],
+    'the icon-only row is hidden under the collapsed Thought')
+  const iconRow = expanded.find(block => block.kind === 'message' && block.message.kind === 'system' && block.message.text === 'icon without context')
+  assert.ok(iconRow !== undefined && iconRow.kind === 'message')
+  assert.equal(iconRow.collapseFocusOwnerOnClick, 0, 'the icon-only row is process content: owner-marked')
+})
+
 test('fold → expand → fold projection is reversible (same collapsed output)', () => {
   const folder = new TranscriptFolder()
   applyMixed(folder, steeredTurn(0, 0, 1000))

--- a/test/focus-ui.test.ts
+++ b/test/focus-ui.test.ts
@@ -389,6 +389,54 @@ test('a collapsed running turn stays collapsed after turn/end (◐ → ▸) and 
   app.stop()
 })
 
+test('collapsed Focus renders the opening inject, the steer, and the Thought in input-summary order', async () => {
+  const { vt, app } = startApp()
+  const folder = new TranscriptFolder()
+  const steerMessage = {
+    id: MessageId('ui-steer'),
+    role: 'user',
+    content: [{ type: 'text', text: 'steer after inject' }],
+    source: { kind: 'user' },
+  }
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 1 }, T0, 0),
+    // The opening injected trigger wakes the turn (no opening human prompt).
+    eventAt('user/message', {
+      id: MessageId('ui-inject'), role: 'user',
+      content: [{ type: 'text', text: 'system reminder' }],
+      source: { kind: 'plugin', plugin: 'agent-instructions' },
+    }, T0 + 1, 1),
+    eventAt('assistant/chunk', { turn: 1, step: 0, chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' } }, T0 + 2, 2),
+    eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [steerMessage] }, T0 + 3, 3),
+    eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, T0 + 3.1, 4),
+    eventAt('user/message', steerMessage, T0 + 4, 5),
+    eventAt('assistant/message', {
+      turn: 1, step: 1,
+      message: { id: MessageId('ui-a'), role: 'assistant', content: [{ type: 'text', text: 'answer' }], source: { kind: 'model', provider: 'p', model: 'm' } },
+    }, T0 + 6, 6),
+    eventAt('turn/end', { turn: 1, reason: { kind: 'completed' } }, T0 + 7000, 7),
+  ])
+  app.setFocusMode(true)
+  show(app, folder)
+  app.setFullscreen(true)
+  await vt.waitForRender()
+  const view = vt.getViewport()
+  const joined = view.join('\n')
+  // The collapsed system row shows its producer label (the body is folded
+  // behind the `(ctrl+o to expand)` hint), so the inject is located by the
+  // Context-injection card title.
+  const injectRow = findRow(view, 'Context injection agent-instructions')
+  const steerRow = findRow(view, 'steer after inject')
+  const thoughtRow = findRow(view, '🐋 Thought')
+  assert.ok(injectRow >= 0, `opening inject row missing:\n${joined}`)
+  assert.ok(steerRow >= 0, `steer row missing:\n${joined}`)
+  assert.ok(thoughtRow >= 0, `Thought row missing:\n${joined}`)
+  assert.ok(injectRow < steerRow && steerRow < thoughtRow,
+    `collapsed Focus must render opening inject → steer → Thought (rows ${injectRow}, ${steerRow}, ${thoughtRow}):\n${joined}`)
+  app.setFullscreen(false)
+  app.stop()
+})
+
 test('clicking the expanded header collapses the turn again while it runs', async () => {
   const { vt, app } = startApp()
   const folder = new TranscriptFolder()

--- a/test/home-end-keys.test.ts
+++ b/test/home-end-keys.test.ts
@@ -346,6 +346,82 @@ test('folder window summaries do not discard the older-page top anchor', async (
   }
 })
 
+test('older boundary: a short transcript at the top never pages into a bogus history state', async () => {
+  const vt = new VirtualTerminal(100, 24)
+  const folder = new TranscriptFolder()
+  const events: SessionEvent[] = []
+  for (let turn = 0; turn <= 1; turn += 1) {
+    events.push({
+      type: 'assistant/message',
+      seq: turn,
+      time: 1_700_000_000_000 + turn,
+      data: {
+        turn,
+        step: 0,
+        message: {
+          id: MessageId(`short-${turn}`),
+          role: 'assistant',
+          content: [{ type: 'text', text: [`turn-${turn}`, ...Array.from({ length: 30 }, (_, index) => `detail-${turn}-${index}`)].join('\n') }],
+        },
+      },
+    } as SessionEvent)
+  }
+  folder.apply(events)
+  const controller = new TranscriptWindowController({
+    windowTurns: 20,
+    stepTurns: 10,
+    turns: folder.groupedTurns(),
+  })
+  let app!: TuiApp
+  let moveOlderCalls = 0
+  const renderProjection = (): void => {
+    const endTurn = controller.endTurn()
+    const projection = folder.window({
+      maxTurns: controller.windowTurns,
+      ...(endTurn === undefined ? {} : { endTurn }),
+    })
+    app.setTranscript(projection.messages, undefined, {
+      ...controller.state(),
+      firstTurn: projection.firstTurn,
+      lastTurn: projection.lastTurn,
+      hasNewer: projection.hasNewer,
+    })
+  }
+  const moveOlder = (): boolean => {
+    moveOlderCalls += 1
+    const anchor = app.captureTranscriptViewportAnchor()
+    if (!controller.moveOlder()) return false
+    renderProjection()
+    return anchor !== undefined && app.restoreTranscriptViewportAnchor(anchor, 'top')
+  }
+  app = new TuiApp(vt, { onSubmit: () => {}, onExit: () => {}, onTranscriptMoveOlder: moveOlder })
+  app.start()
+  startedApps.add(app)
+  try {
+    renderProjection()
+    app.setFullscreen(true)
+    await vt.waitForRender()
+    app.scrollToTop({ disableFollow: true })
+    await vt.waitForRender()
+    const before = vt.getViewport().join('\n')
+    assert.ok(viewportHasLine(vt, 'turn-0'), 'the short transcript must show its oldest turn at the top')
+    // PageUp at the top invokes the registered older-boundary callback.
+    vt.sendInput('\x1b[57421u')
+    await vt.waitForRender()
+    assert.equal(moveOlderCalls, 1, 'the older-boundary callback must fire')
+    const after = vt.getViewport().join('\n')
+    assert.equal(after, before, 'a no-op older move must leave the transcript unchanged')
+    assert.equal(controller.isLatest(), true, 'the window mode must stay latest')
+    assert.equal(controller.endTurn(), undefined, 'no bogus history anchor may appear')
+    assert.ok(viewportHasLine(vt, 'turn-0'), 'the oldest turn must stay visible — the short session must not look empty')
+    const projection = folder.window({ maxTurns: controller.windowTurns })
+    assert.deepEqual(projection.messages.filter(message => message.kind === 'assistant').map(message => message.turn), [0, 1],
+      'the projection must still contain BOTH turns — nothing was paged away')
+  } finally {
+    app.dispose()
+  }
+})
+
 test('viewport mode: Home scrolls to the top, End to the bottom', async () => {
   resetKeybindings()
   applyHomeEndKeyMode('viewport')

--- a/test/image-command-semantics.test.ts
+++ b/test/image-command-semantics.test.ts
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { DraftImageStore } from '../src/image/draft-store.ts'
 import { commandIsLocalForAttachments, commandRejectsImages, isLocalCommandLine, LOCAL_COMMANDS, normalizeSkillInvocation, SESSIONLESS_COMMANDS } from '../src/index.ts'
+import type { HostCommandClaim } from '../src/commands.ts'
 
 function storeWithImage(): DraftImageStore {
   const store = new DraftImageStore()
@@ -19,52 +20,58 @@ function storeWithImage(): DraftImageStore {
 test('a plain prompt with an image is NOT a command rejection', () => {
   const store = storeWithImage()
   const image = store.values()[0]!
-  assert.equal(commandRejectsImages(undefined, `analyze ${image.placeholder}`, store, name => name === 'help'), false)
+  assert.equal(commandRejectsImages(undefined, `analyze ${image.placeholder}`, store, false), false)
 })
 
 test('a local command with an image placeholder is rejected', () => {
   const store = storeWithImage()
   const image = store.values()[0]!
-  assert.equal(commandRejectsImages({ name: 'help' }, `/help ${image.placeholder}`, store, name => name === 'help'), true)
-  assert.equal(commandRejectsImages({ name: 'status' }, `/status ${image.placeholder}`, store, name => name === 'status'), true)
+  assert.equal(commandRejectsImages({ name: 'help' }, `/help ${image.placeholder}`, store, LOCAL_COMMANDS.has('help')), true)
+  assert.equal(commandRejectsImages({ name: 'status' }, `/status ${image.placeholder}`, store, LOCAL_COMMANDS.has('status')), true)
 })
 
 test('a command without images is never rejected', () => {
   const store = storeWithImage()
-  assert.equal(commandRejectsImages({ name: 'help' }, '/help', store, name => name === 'help'), false)
-  assert.equal(commandRejectsImages({ name: 'model' }, '/model', store, name => name === 'model'), false)
+  assert.equal(commandRejectsImages({ name: 'help' }, '/help', store, LOCAL_COMMANDS.has('help')), false)
+  assert.equal(commandRejectsImages({ name: 'model' }, '/model', store, LOCAL_COMMANDS.has('model')), false)
 })
 
 test('a skill-style slash prompt with an image is AGENT input and NOT rejected (review finding 4)', () => {
   const store = storeWithImage()
   const image = store.values()[0]!
-  assert.equal(commandRejectsImages({ name: 'grilling' }, `/grilling ${image.placeholder}`, store, name => name === 'help'), false)
+  assert.equal(commandRejectsImages({ name: 'grilling' }, `/grilling ${image.placeholder}`, store, LOCAL_COMMANDS.has('grilling')), false)
 })
 
 test('a stale placeholder text is not a rejection (no staged image)', () => {
   const store = new DraftImageStore()
-  assert.equal(commandRejectsImages({ name: 'help' }, '/help [image #1 (800×600)]', store, name => name === 'help'), false)
+  assert.equal(commandRejectsImages({ name: 'help' }, '/help [image #1 (800×600)]', store, LOCAL_COMMANDS.has('help')), false)
 })
 
 test('every LOCAL_COMMANDS entry is covered by the rejection matrix', () => {
   const store = storeWithImage()
   const image = store.values()[0]!
   for (const name of LOCAL_COMMANDS) {
-    assert.equal(commandRejectsImages({ name }, `/${name} ${image.placeholder}`, store, () => true), true, `/${name} rejects images`)
+    assert.equal(commandRejectsImages({ name }, `/${name} ${image.placeholder}`, store, LOCAL_COMMANDS.has(name)), true, `/${name} rejects images`)
   }
 })
 
 test('a /skill <name> invocation with an image is agent input (bare /skill stays local)', () => {
   const store = storeWithImage()
   const image = store.values()[0]!
-  // The dispatch callback treats `skill` as non-local when it carries args.
-  const withArgs = commandRejectsImages({ name: 'skill', rawInput: 'grilling [image #1 (800×600)]' } as never,
-    `/skill grilling ${image.placeholder}`, store, name => name === 'skill' && false)
-  assert.equal(withArgs, false, '/skill <name> + image is not rejected')
-  // The bare picker stays local: rejected when the callback says local.
-  const bare = commandRejectsImages({ name: 'skill', rawInput: '' } as never,
-    '/skill', store, name => name === 'skill')
-  assert.equal(bare, false, 'no image attached → nothing to reject')
+  // The PRODUCTION classifier: `/skill <name> ...` is agent-facing, the bare
+  // picker is a TUI-local command.
+  assert.equal(commandRejectsImages(
+    { name: 'skill', rawInput: ' grilling' },
+    `/skill grilling ${image.placeholder}`,
+    store,
+    commandIsLocalForAttachments({ name: 'skill', rawInput: ' grilling' }, undefined, undefined),
+  ), false, '/skill <name> + image is not rejected')
+  assert.equal(commandRejectsImages(
+    { name: 'skill', rawInput: '' },
+    '/skill',
+    store,
+    commandIsLocalForAttachments({ name: 'skill', rawInput: '' }, undefined, undefined),
+  ), false, 'no image attached → nothing to reject')
 })
 
 test('attachment commands are local and sessionless', () => {
@@ -121,24 +128,59 @@ test('a client command with a staged attachment is REJECTED as a local command (
     'an explicit /skill <name> invocation is agent-facing')
 })
 
+/** A host catalog stub with the real claim semantics (DSH `matchEnter`): a
+ * descriptor with `input` claims its argued line, an execute-kind one claims
+ * the bare token only, and a name the catalog does not hold is unresolved.
+ * The catalogue is keyed by name. */
+function hostCatalog(rows: Record<string, { leadingInput?: boolean; attachments?: boolean }>) {
+  return (parsed: { name: string; rawInput?: string }): HostCommandClaim | undefined => {
+    const row = rows[parsed.name]
+    if (row === undefined) return undefined
+    if (row.leadingInput !== true && (parsed.rawInput?.trim() ?? '') !== '') return { claimed: false }
+    return { claimed: true, attachments: row.attachments === true }
+  }
+}
+
 test('a HOST claim outranks a same-named client contribution in the attachment gate', () => {
   // Host authority: a contribution must never turn an attachment-bearing
   // /deploy line into a rejected "local command" while the host catalog owns
-  // that name — the host handler decides its own attachment policy.
+  // that line — the host handler decides its own attachment policy.
   const store = storeWithImage()
   const image = store.values()[0]!
   const colliding = commandIsLocalForAttachments(
     { name: 'deploy', rawInput: ' prod' },
     undefined,
     name => name === 'deploy',
-    name => name === 'deploy',
+    hostCatalog({ deploy: { leadingInput: true } }),
   )
   assert.equal(commandRejectsImages({ name: 'deploy' }, `/deploy prod ${image.placeholder}`, store, colliding), false,
-    'a host-claimed name is never a local command (the host route owns it)')
-  const clientOnly = commandIsLocalForAttachments({ name: 'deploy', rawInput: ' prod' }, undefined, name => name === 'deploy', () => false)
+    'a host-claimed line is never a local command (the host route owns it)')
+  const clientOnly = commandIsLocalForAttachments({ name: 'deploy', rawInput: ' prod' }, undefined, name => name === 'deploy', hostCatalog({}))
   assert.equal(commandRejectsImages({ name: 'deploy' }, `/deploy prod ${image.placeholder}`, store, clientOnly), true,
     'without a host claim the same name is the local client command')
-  const core = commandIsLocalForAttachments({ name: 'help', rawInput: '' }, undefined, undefined, name => name === 'help')
+  const core = commandIsLocalForAttachments({ name: 'help', rawInput: '' }, undefined, undefined, hostCatalog({ help: { leadingInput: true } }))
   assert.equal(commandRejectsImages({ name: 'help' }, `/help ${image.placeholder}`, store, core), true,
     'a TUI-owned local command stays local even if a registry claim exists for it')
+})
+
+test('the host claim is LINE-level: an execute-kind command does not claim its argued line', () => {
+  // DSH `CommandDescriptor.input` decides which LINE a host command claims.
+  // `/compact extra` is not a command invocation at all (upstream
+  // `matchEnter`: `if (!bare) return undefined`), so it is an ordinary
+  // multimodal submission — never the execute-kind command's attachment
+  // refusal, and never a rejected "local command".
+  const store = storeWithImage()
+  const image = store.values()[0]!
+  const host = hostCatalog({ compact: {}, goal: { leadingInput: true } })
+  const bareCompact = commandIsLocalForAttachments({ name: 'compact', rawInput: '' }, undefined, undefined, host)
+  assert.equal(bareCompact, false, 'the bare token IS the execute-kind invocation')
+  const arguedCompact = commandIsLocalForAttachments({ name: 'compact', rawInput: ' extra' }, undefined, undefined, host)
+  assert.equal(arguedCompact, false, 'an argued line of an execute-kind command is an ordinary submission')
+  const arguedGoal = commandIsLocalForAttachments({ name: 'goal', rawInput: ' ship it' }, undefined, undefined, host)
+  assert.equal(arguedGoal, false, 'a leadingInput command claims its argued line')
+  // Without a client contribution of the same name both lines are ordinary
+  // submissions in the attachment gate — the refusal decision belongs to the
+  // dispatch, which distinguishes the claimed bare line from the rest.
+  assert.equal(commandRejectsImages({ name: 'compact', rawInput: ' extra' }, `/compact extra ${image.placeholder}`, store, arguedCompact), false,
+    'the argued execute-kind line keeps its image')
 })

--- a/test/image-command-semantics.test.ts
+++ b/test/image-command-semantics.test.ts
@@ -155,12 +155,27 @@ test('a HOST claim outranks a same-named client contribution in the attachment g
   )
   assert.equal(commandRejectsImages({ name: 'deploy' }, `/deploy prod ${image.placeholder}`, store, colliding), false,
     'a host-claimed line is never a local command (the host route owns it)')
-  const clientOnly = commandIsLocalForAttachments({ name: 'deploy', rawInput: ' prod' }, undefined, name => name === 'deploy', hostCatalog({}))
-  assert.equal(commandRejectsImages({ name: 'deploy' }, `/deploy prod ${image.placeholder}`, store, clientOnly), true,
-    'without a host claim the same name is the local client command')
   const core = commandIsLocalForAttachments({ name: 'help', rawInput: '' }, undefined, undefined, hostCatalog({ help: { leadingInput: true } }))
   assert.equal(commandRejectsImages({ name: 'help' }, `/help ${image.placeholder}`, store, core), true,
     'a TUI-owned local command stays local even if a registry claim exists for it')
+})
+
+test('a client contribution claims the BARE token only: an argued line keeps its attachments', () => {
+  // DSH `matchEnter`: a contribution is a slash-menu entry, so `if (!bare)
+  // return undefined` — `/deploy explain` is an ordinary multimodal
+  // submission, never a local client command (which would refuse the image).
+  const store = storeWithImage()
+  const image = store.values()[0]!
+  const isClientCommand = (name: string): boolean => name === 'deploy'
+  const host = hostCatalog({})
+  const bare = commandIsLocalForAttachments({ name: 'deploy', rawInput: '' }, undefined, isClientCommand, host)
+  assert.equal(bare, true, 'the bare token IS the contribution invocation (a local client command)')
+  assert.equal(commandRejectsImages({ name: 'deploy' }, `/deploy ${image.placeholder}`, store, bare), true,
+    '…whose attachment-bearing form is impossible, but the classification is local')
+  const argued = commandIsLocalForAttachments({ name: 'deploy', rawInput: ' explain' }, undefined, isClientCommand, host)
+  assert.equal(argued, false, 'an argued line of a contribution name is an ordinary submission')
+  assert.equal(commandRejectsImages({ name: 'deploy', rawInput: ' explain' }, `/deploy explain ${image.placeholder}`, store, argued), false,
+    'the argued line keeps its image (no local-command refusal)')
 })
 
 test('the host claim is LINE-level: an execute-kind command does not claim its argued line', () => {

--- a/test/image-command-semantics.test.ts
+++ b/test/image-command-semantics.test.ts
@@ -8,7 +8,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { DraftImageStore } from '../src/image/draft-store.ts'
-import { commandRejectsImages, LOCAL_COMMANDS, normalizeSkillInvocation, SESSIONLESS_COMMANDS } from '../src/index.ts'
+import { commandIsLocalForAttachments, commandRejectsImages, isLocalCommandLine, LOCAL_COMMANDS, normalizeSkillInvocation, SESSIONLESS_COMMANDS } from '../src/index.ts'
 
 function storeWithImage(): DraftImageStore {
   const store = new DraftImageStore()
@@ -87,4 +87,58 @@ test('normalizeSkillInvocation preserves the argument text VERBATIM (trailing wh
   // original text — only the command-name separator is normalized.
   assert.equal(normalizeSkillInvocation('/skill grilling foo bar   '), '/grilling foo bar   ')
   assert.equal(normalizeSkillInvocation('/skill grilling   spaced  args '), '/grilling spaced  args ')
+})
+
+test('a LIVE skill wrapper is agent-facing even when a client contribution shares its name', () => {
+  // The attachment gate must not treat a skill wrapper as a local UI command
+  // just because a client contribution of the same name exists: the wrapper
+  // route (its own slash line + injected body) supports images.
+  const contribution = (name: string): boolean => name === 'grilling'
+  const wrapper = (name: string): boolean => name === 'grilling'
+  assert.equal(isLocalCommandLine('grilling', wrapper, contribution), false,
+    'a live skill wrapper is agent-facing (multimodal), never a local command')
+  assert.equal(isLocalCommandLine('grilling', undefined, contribution), true,
+    'without a live wrapper the contribution IS the local client command')
+  assert.equal(isLocalCommandLine('help', wrapper, contribution), true, 'core local commands stay local')
+  assert.equal(isLocalCommandLine('plain', wrapper, contribution), false, 'an unknown name is not local')
+})
+
+test('a client command with a staged attachment is REJECTED as a local command (never run with a live attachment)', () => {
+  // The contribution classification rides the SAME predicate as the dispatch:
+  // a client-owned command is local, so an image/file-bearing line must be
+  // refused (the client handler has no attachment channel) — while a live
+  // skill wrapper of the same name stays agent-facing and is allowed.
+  const store = storeWithImage()
+  const image = store.values()[0]!
+  const clientCommand = commandIsLocalForAttachments({ name: 'panel', rawInput: '' }, undefined, name => name === 'panel')
+  assert.equal(commandRejectsImages({ name: 'panel' }, `/panel ${image.placeholder}`, store, clientCommand), true,
+    'a client command rejects attachments')
+  const skillWrapper = commandIsLocalForAttachments({ name: 'grilling', rawInput: ' args' }, name => name === 'grilling', name => name === 'grilling')
+  assert.equal(commandRejectsImages({ name: 'grilling' }, `/grilling args ${image.placeholder}`, store, skillWrapper), false,
+    'a live skill wrapper is agent-facing even when a client contribution shares the name')
+  const explicitSkill = commandIsLocalForAttachments({ name: 'skill', rawInput: ' grilling' }, undefined, undefined)
+  assert.equal(commandRejectsImages({ name: 'skill' }, `/skill grilling ${image.placeholder}`, store, explicitSkill), false,
+    'an explicit /skill <name> invocation is agent-facing')
+})
+
+test('a HOST claim outranks a same-named client contribution in the attachment gate', () => {
+  // Host authority: a contribution must never turn an attachment-bearing
+  // /deploy line into a rejected "local command" while the host catalog owns
+  // that name — the host handler decides its own attachment policy.
+  const store = storeWithImage()
+  const image = store.values()[0]!
+  const colliding = commandIsLocalForAttachments(
+    { name: 'deploy', rawInput: ' prod' },
+    undefined,
+    name => name === 'deploy',
+    name => name === 'deploy',
+  )
+  assert.equal(commandRejectsImages({ name: 'deploy' }, `/deploy prod ${image.placeholder}`, store, colliding), false,
+    'a host-claimed name is never a local command (the host route owns it)')
+  const clientOnly = commandIsLocalForAttachments({ name: 'deploy', rawInput: ' prod' }, undefined, name => name === 'deploy', () => false)
+  assert.equal(commandRejectsImages({ name: 'deploy' }, `/deploy prod ${image.placeholder}`, store, clientOnly), true,
+    'without a host claim the same name is the local client command')
+  const core = commandIsLocalForAttachments({ name: 'help', rawInput: '' }, undefined, undefined, name => name === 'help')
+  assert.equal(commandRejectsImages({ name: 'help' }, `/help ${image.placeholder}`, store, core), true,
+    'a TUI-owned local command stays local even if a registry claim exists for it')
 })

--- a/test/input-experience.test.ts
+++ b/test/input-experience.test.ts
@@ -136,14 +136,12 @@ test('ctrl+s with an empty draft still fires onSteer (the runner decides)', asyn
   assert.equal(app.getDraft(), '', 'editor must stay empty after ctrl+s')
 })
 
-test('ctrl+enter fires the queue-submit chord and clears the editor', async () => {
+test('ctrl+enter raises the ACCELERATED submit request and clears the editor', async () => {
   const vt = new VirtualTerminal(80, 24)
-  const queued: string[] = []
-  const submitted: string[] = []
+  const requests: { text: string; request: string }[] = []
   const app = new TuiApp(vt, {
-    onSubmit: (text) => submitted.push(text),
+    onSubmit: (text, request) => requests.push({ text, request }),
     onExit: () => {},
-    onQueueSubmit: (text) => queued.push(text),
   })
   app.start()
 
@@ -151,38 +149,53 @@ test('ctrl+enter fires the queue-submit chord and clears the editor', async () =
   vt.sendInput('queue me')
   vt.sendInput('\x1b[13;5u') // kitty ctrl+enter
   await viewport(vt)
-  assert.deepEqual(queued, ['queue me'], 'the chord must submit the draft in queue mode')
-  assert.deepEqual(submitted, [], 'the chord must not fire the plain submit')
+  // The chord is a GESTURE, not a fixed queue: it reaches the runner as the
+  // accelerated request, which resolves to the OPPOSITE of the busy-Enter
+  // preference (web ComposerSubmissionPolicy parity).
+  assert.deepEqual(requests, [{ text: 'queue me', request: 'accelerated' }],
+    'the chord must raise the accelerated submit request')
   // The editor was cleared: a follow-up Enter carries only the new text.
   vt.sendInput('x')
   vt.sendInput('\r')
   await viewport(vt)
-  assert.deepEqual(submitted, ['x'], 'the chord must clear the editor')
+  assert.deepEqual(requests[1], { text: 'x', request: 'enter' }, 'the chord must clear the editor')
 })
 
-test('ctrl+enter without a wired chord falls through (no draft loss)', async () => {
-  const { vt, app } = startApp()
-  vt.sendInput('keep me')
-  vt.sendInput('\x1b[13;5u') // kitty ctrl+enter with no onQueueSubmit wired
-  const view = await viewport(vt)
-  assert.ok(view.includes('keep me'), `draft must survive without a wired chord:\n${view}`)
-  void app
+test('the explicit queue action raises the explicit-queue request (never the chord request)', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const requests: { text: string; request: string }[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: (text, request) => requests.push({ text, request }),
+    onExit: () => {},
+  })
+  app.start()
+
+  startedApps.add(app)
+  vt.sendInput('queue me')
+  // The public `queue-draft` action (and the replacement editor's
+  // `queue-submit`) is an explicit delivery command: the app raises the
+  // `explicit-queue` request, which the runner delivers as a queue even when
+  // the accelerated CHORD would steer. The two semantics are deliberately
+  // distinct (the runner maps the extension action onto this request).
+  app.submitDraft('explicit-queue')
+  await viewport(vt)
+  assert.deepEqual(requests, [{ text: 'queue me', request: 'explicit-queue' }],
+    'the explicit queue action must not be confused with the accelerated gesture')
 })
 
 test('ctrl+enter on an empty draft does not fire the chord (no session-creating submit)', async () => {
   const vt = new VirtualTerminal(80, 24)
-  const queued: string[] = []
+  const requests: { text: string; request: string }[] = []
   const app = new TuiApp(vt, {
-    onSubmit: () => {},
+    onSubmit: (text, request) => requests.push({ text, request }),
     onExit: () => {},
-    onQueueSubmit: (text) => queued.push(text),
   })
   app.start()
 
   startedApps.add(app)
   vt.sendInput('\x1b[13;5u') // kitty ctrl+enter with an empty editor
   await viewport(vt)
-  assert.deepEqual(queued, [], 'an empty chord must not submit an empty followup')
+  assert.deepEqual(requests, [], 'an empty chord must not submit an empty followup')
 })
 
 // ── P0: empty-submission semantics (plan §4.1 / §6.2) ────────────────────────────────────

--- a/test/input-experience.test.ts
+++ b/test/input-experience.test.ts
@@ -183,6 +183,28 @@ test('the explicit queue action raises the explicit-queue request (never the cho
     'the explicit queue action must not be confused with the accelerated gesture')
 })
 
+test('the deprecated app.input.queue action still raises the explicit-queue request', async () => {
+  const vt = new VirtualTerminal(80, 24)
+  const requests: { text: string; request: string }[] = []
+  const app = new TuiApp(vt, {
+    onSubmit: (text, request) => requests.push({ text, request }),
+    onExit: () => {},
+  })
+  app.start()
+  startedApps.add(app)
+  vt.sendInput('queue me')
+  // The deprecated action keeps its ORIGINAL meaning (a stored remap must not
+  // turn into the accelerated opposite), and it is dispatched like any other
+  // semantic action.
+  const dispatched = (app as unknown as {
+    actionDispatcher: { dispatch: (action: string) => boolean }
+  }).actionDispatcher.dispatch('app.input.queue')
+  await viewport(vt)
+  assert.equal(dispatched, true, 'the deprecated queue action must be dispatchable')
+  assert.deepEqual(requests, [{ text: 'queue me', request: 'explicit-queue' }],
+    'the deprecated action must queue — never the accelerated gesture')
+})
+
 test('ctrl+enter on an empty draft does not fire the chord (no session-creating submit)', async () => {
   const vt = new VirtualTerminal(80, 24)
   const requests: { text: string; request: string }[] = []

--- a/test/input-router.test.ts
+++ b/test/input-router.test.ts
@@ -401,11 +401,10 @@ test('TuiApp: active host lifecycle keys never fire a plugin binding (action-dri
   const actions: string[] = []
   const queued: string[] = []
   const app = new TuiApp(vt, {
-    onSubmit: () => {},
+    // A real submit handler: with it wired, Ctrl+Enter is a live host action
+    // that CONSUMES (never declines) — the plugin must not see it.
+    onSubmit: (text, request) => { if (request === 'accelerated') queued.push(text) },
     onExit: () => {},
-    // A real queue handler: with it wired, Ctrl+Enter is a live host
-    // action that CONSUMES (never declines) — the plugin must not see it.
-    onQueueSubmit: (text) => { queued.push(text) },
     onExtensionAction: (action) => { actions.push(action) },
   }, {
     // A resolver that would claim EVERY key — the router must stop the
@@ -420,8 +419,9 @@ test('TuiApp: active host lifecycle keys never fire a plugin binding (action-dri
   vt.sendInput('\r')
   await vt.waitForRender()
   assert.deepEqual(actions, [], 'Enter must never fire a plugin binding')
-  // Ctrl+Enter (app.input.queue) with a LIVE handler AND a non-empty
-  // draft: the host action CONSUMES (queues) — never a plugin binding.
+  // Ctrl+Enter (app.input.submitAccelerated) with a LIVE handler AND a
+  // non-empty draft: the host action CONSUMES (submits) — never a plugin
+  // binding.
   app.setDraft('queued text')
   await vt.waitForRender()
   vt.sendInput('\x1b[13;5u') // kitty ctrl+enter
@@ -549,12 +549,12 @@ test('TuiApp: submitDraft clears the draft like a normal submit (round-1 P2)', a
   // Type a draft, then submit via the host-owned path.
   app.setDraft('hello from a plugin action')
   await vt.waitForRender()
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submitted, ['hello from a plugin action'])
   assert.equal(app.getDraft(), '', 'the draft must be cleared like a normal submit')
   // An empty draft submits nothing.
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submitted, ['hello from a plugin action'])
   app.stop()

--- a/test/input-router.test.ts
+++ b/test/input-router.test.ts
@@ -399,11 +399,11 @@ test('TuiApp: active host lifecycle keys never fire a plugin binding (action-dri
   const { TuiApp } = await import('../src/tui-app.ts')
   const vt = new VirtualTerminal(80, 24)
   const actions: string[] = []
-  const queued: string[] = []
+  const accelerated: string[] = []
   const app = new TuiApp(vt, {
     // A real submit handler: with it wired, Ctrl+Enter is a live host action
     // that CONSUMES (never declines) — the plugin must not see it.
-    onSubmit: (text, request) => { if (request === 'accelerated') queued.push(text) },
+    onSubmit: (text, request) => { if (request === 'accelerated') accelerated.push(text) },
     onExit: () => {},
     onExtensionAction: (action) => { actions.push(action) },
   }, {
@@ -422,11 +422,12 @@ test('TuiApp: active host lifecycle keys never fire a plugin binding (action-dri
   // Ctrl+Enter (app.input.submitAccelerated) with a LIVE handler AND a
   // non-empty draft: the host action CONSUMES (submits) — never a plugin
   // binding.
-  app.setDraft('queued text')
+  app.setDraft('accelerated text')
   await vt.waitForRender()
   vt.sendInput('\x1b[13;5u') // kitty ctrl+enter
   await vt.waitForRender()
-  assert.deepEqual(queued, ['queued text'], 'Ctrl+Enter must queue (host-owned)')
+  assert.deepEqual(accelerated, ['accelerated text'],
+    'the accelerated chord must be consumed by the host (never a plugin binding)')
   // Ctrl+O (app.transcript.toggleExpand): ACTIVE host action — never a
   // plugin binding. Kitty ctrl+o = modifier 5.
   vt.sendInput('\x1b[111;5u')

--- a/test/keybinding-definitions.test.ts
+++ b/test/keybinding-definitions.test.ts
@@ -41,6 +41,10 @@ test('the M0 gate: default keys match the pre-migration behavior', () => {
   const defaults = (id: AppKeybindingId): readonly string[] => APP_KEYBINDINGS[id].defaultKeys
   assert.deepEqual(defaults('app.input.submit'), ['enter'])
   assert.deepEqual(defaults('app.input.submitAccelerated'), ['ctrl+enter'])
+  // The deprecated fixed-queue action keeps NO default key: Ctrl+Enter
+  // belongs to the accelerated gesture, and the old action exists only so a
+  // stored remap keeps working.
+  assert.deepEqual(defaults('app.input.queue'), [])
   assert.deepEqual(defaults('app.input.steer'), ['ctrl+s'])
   assert.deepEqual(defaults('app.input.dequeue'), ['alt+up'])
   assert.deepEqual(defaults('app.agent.interrupt'), ['escape'])
@@ -101,6 +105,8 @@ test('viewer-blocked parent actions are all defined and configurable', () => {
   // implementation (M1 gate: the physical-key blacklist is fully replaced).
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.steer'))
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.submitAccelerated'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.queue'),
+    'the deprecated queue action can still queue the parent draft — it must stay blocked too')
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.dequeue'))
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.permission.cycle'))
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.transcript.search'))

--- a/test/keybinding-definitions.test.ts
+++ b/test/keybinding-definitions.test.ts
@@ -40,7 +40,7 @@ test('every definition carries description, category and scope', () => {
 test('the M0 gate: default keys match the pre-migration behavior', () => {
   const defaults = (id: AppKeybindingId): readonly string[] => APP_KEYBINDINGS[id].defaultKeys
   assert.deepEqual(defaults('app.input.submit'), ['enter'])
-  assert.deepEqual(defaults('app.input.queue'), ['ctrl+enter'])
+  assert.deepEqual(defaults('app.input.submitAccelerated'), ['ctrl+enter'])
   assert.deepEqual(defaults('app.input.steer'), ['ctrl+s'])
   assert.deepEqual(defaults('app.input.dequeue'), ['alt+up'])
   assert.deepEqual(defaults('app.agent.interrupt'), ['escape'])
@@ -100,7 +100,7 @@ test('viewer-blocked parent actions are all defined and configurable', () => {
   // The viewer guard must cover every parent-owned chord of the current
   // implementation (M1 gate: the physical-key blacklist is fully replaced).
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.steer'))
-  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.queue'))
+  assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.submitAccelerated'))
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.input.dequeue'))
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.permission.cycle'))
   assert.ok(VIEWER_BLOCKED_PARENT_ACTIONS.has('app.transcript.search'))

--- a/test/keybinding-ui-controller.test.ts
+++ b/test/keybinding-ui-controller.test.ts
@@ -510,3 +510,32 @@ test('a failed settings replace leaves the last-known runtime map untouched', as
     manager.dispose()
   }
 })
+
+test('the deprecated app.input.queue declaration is editable and resettable as its own action', async () => {
+  // A stored declaration of the DEPRECATED fixed-queue action must stay a
+  // first-class action in the editor: it keeps meaning "queue the draft"
+  // (never the accelerated opposite), and Reset must remove THAT
+  // declaration — a read-time alias onto `app.input.submitAccelerated`
+  // would leave the legacy key in the document, so the next parse would
+  // resurrect the binding after the UI reported success.
+  const fixture = settingsFixture({ 'app.input.queue': 'ctrl+y' })
+  const { controller, manager } = controllerFor(fixture)
+  try {
+    assert.deepEqual(manager.keysFor('app.input.queue'), ['ctrl+y'],
+      'the stored declaration applies to the deprecated action itself')
+    assert.deepEqual(manager.keysFor('app.input.submitAccelerated'), ['ctrl+enter'],
+      'the accelerated action keeps its own default — no inherited override')
+    const result = await controller.mutate({ kind: 'reset-action', action: 'app.input.queue' })
+    assert.equal(result.kind, 'applied')
+    // The deprecated action has NO builtin default, so resetting it drops the
+    // declaration entirely (an empty-array marker would be a redundant "no
+    // override"): the legacy key must be GONE from the persisted document.
+    assert.deepEqual((fixture.latest() as TuiSettingsDoc).keybindings, {})
+    assert.deepEqual(manager.keysFor('app.input.queue'), [], 'the reset removes the legacy binding')
+    // Re-parsing the persisted document must NOT resurrect it (the exact
+    // failure mode of an alias-only migration).
+    assert.equal(parseUserKeybindings((fixture.latest() as TuiSettingsDoc).keybindings).bindings['app.input.queue'], undefined)
+  } finally {
+    manager.dispose()
+  }
+})

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -67,7 +67,7 @@ function startApp(
   cwd: string,
   options: {
     onSubmit?: (text: string) => void
-    onQueueSubmit?: (text: string) => void
+    onAcceleratedSubmit?: (text: string) => void
     onSubagentSubmit?: (request: { parentSessionId: string; childSessionId: string; text: string }) => void
     commands?: { name: string; description: string }[]
     /** The Host-file seam (migration M1.10): `@`-mention completion is
@@ -81,8 +81,13 @@ function startApp(
   const queued: string[] = []
   let cancels = 0
   const app = new TuiApp(vt, {
-    onSubmit: (text) => { submitted.push(text); options.onSubmit?.(text) },
-    onQueueSubmit: (text) => { queued.push(text); options.onQueueSubmit?.(text) },
+    // The accelerated chord is a SUBMISSION request (the runner resolves its
+    // delivery mode): the harness splits it out for the chord assertions.
+    onSubmit: (text, request) => {
+      if (request === 'accelerated') { queued.push(text); options.onAcceleratedSubmit?.(text); return }
+      submitted.push(text)
+      options.onSubmit?.(text)
+    },
     onSubagentSubmit: options.onSubagentSubmit,
     onExit: () => {},
     onCancel: () => { cancels += 1 },
@@ -623,7 +628,7 @@ test('a bare ! reaches the submit protocol via submitDraft', async (t) => {
   await vt.waitForRender()
   vt.sendInput('!')
   await vt.waitForRender()
-  app.submitDraft(false)
+  app.submitDraft('enter')
   assert.deepEqual(submitted, ['!'], 'a bare ! shell mode must submit its wire form')
   assert.equal(app.inputModeForTest(), 'prompt')
 })

--- a/test/shell-editor-mode.test.ts
+++ b/test/shell-editor-mode.test.ts
@@ -75,16 +75,16 @@ function startApp(
      * (fallback mode), the rest keep the unavailable default. */
     fileReferences?: import('../src/runtime/host-file-port.ts').HostFilePort
   } = {},
-): { vt: VirtualTerminal; app: TuiApp; submitted: string[]; queued: string[]; cancels: number } {
+): { vt: VirtualTerminal; app: TuiApp; submitted: string[]; accelerated: string[]; cancels: number } {
   const vt = new VirtualTerminal(100, 24)
   const submitted: string[] = []
-  const queued: string[] = []
+  const accelerated: string[] = []
   let cancels = 0
   const app = new TuiApp(vt, {
     // The accelerated chord is a SUBMISSION request (the runner resolves its
     // delivery mode): the harness splits it out for the chord assertions.
     onSubmit: (text, request) => {
-      if (request === 'accelerated') { queued.push(text); options.onAcceleratedSubmit?.(text); return }
+      if (request === 'accelerated') { accelerated.push(text); options.onAcceleratedSubmit?.(text); return }
       submitted.push(text)
       options.onSubmit?.(text)
     },
@@ -95,7 +95,7 @@ function startApp(
   app.setCommandCompletions(options.commands ?? [], cwd, options.fileReferences ?? null)
   app.start()
   startedApps.add(app)
-  return { vt, app, submitted, queued, get cancels() { return cancels } }
+  return { vt, app, submitted, accelerated, get cancels() { return cancels } }
 }
 
 /** A continuable subagent viewer target (the editor stays live). */
@@ -609,16 +609,16 @@ test('a busy Esc keeps its Host-owned cancel priority over the shell-mode exit',
   app.setBusy(false)
 })
 
-test('a bare ! reaches the queue protocol via Ctrl+Enter', async (t) => {
+test('a bare ! reaches the accelerated submit with its wire form', async (t) => {
   const life = testLifecycle(t)
-  const { vt, app, queued } = startApp(fixtureWorkspace(life))
+  const { vt, app, accelerated } = startApp(fixtureWorkspace(life))
   life.defer(() => app.stop())
   await vt.waitForRender()
   vt.sendInput('!')
   await vt.waitForRender()
-  vt.sendInput('\x1b[13;5u') // kitty ctrl+enter: queue submit
-  assert.deepEqual(queued, ['!'], 'a bare ! shell mode must queue its wire form')
-  assert.equal(app.inputModeForTest(), 'prompt', 'mode resets after the queue submit')
+  vt.sendInput('\x1b[13;5u') // kitty ctrl+enter: the accelerated submit
+  assert.deepEqual(accelerated, ['!'], 'a bare ! shell mode must submit its wire form')
+  assert.equal(app.inputModeForTest(), 'prompt', 'mode resets after the accelerated submit')
 })
 
 test('a bare ! reaches the submit protocol via submitDraft', async (t) => {

--- a/test/steer.test.ts
+++ b/test/steer.test.ts
@@ -170,9 +170,9 @@ test('an empty queue falls back to the classic single-draft steer', async () => 
 
 test('onlyDraft steers the draft alone: explicitly queued messages stay queued', async () => {
   // Busy-Enter steer (web busyEnter parity): Enter steers the DRAFT only —
-  // a message the user queued explicitly (Ctrl+Enter or a notice) must not
-  // be swept into the turn, because already-steered input cannot be pulled
-  // back.
+  // a message the user queued explicitly (a queue-mode submission,
+  // `queue-draft`, or a notice) must not be swept into the turn, because
+  // already-steered input cannot be pulled back.
   const agent = fakeAgent(['queued'])
   agent.status = 'running'
   const outcome = await steerAll(makeDeps({ agent: () => agent }), 'draft text', { onlyDraft: true })

--- a/test/subagent-viewer-interactive.test.ts
+++ b/test/subagent-viewer-interactive.test.ts
@@ -145,11 +145,11 @@ test('Enter in a continuable viewer submits to onSubagentSubmit — never the pa
 
 test('the main session chords are inert inside the interactive viewer', async () => {
   const steered: string[] = []
-  const queued: string[] = []
+  const accelerated: string[] = []
   const singleEscapes: number[] = []
   const { vt, app } = await startApp({
     onSteer: (text) => steered.push(text),
-    onAcceleratedSubmit: (text) => queued.push(text),
+    onAcceleratedSubmit: (text) => accelerated.push(text),
     onSingleEscape: () => { singleEscapes.push(1); return true },
   })
   app.setViewerMode(continuable())
@@ -170,7 +170,7 @@ test('the main session chords are inert inside the interactive viewer', async ()
   vt.sendInput('\x03') // ctrl+c
   await vt.waitForRender()
   assert.deepEqual(steered, [], 'Ctrl+S must never steer the parent from the viewer')
-  assert.deepEqual(queued, [], 'Ctrl+Enter must never submit to the parent from the viewer')
+  assert.deepEqual(accelerated, [], 'Ctrl+Enter must never submit to the parent from the viewer')
   assert.equal(singleEscapes.length, 0, 'Ctrl+C must not exit (and no accidental Esc)')
   // The child draft is untouched by the blocked chords.
   assert.equal(app.getDraft(), 'draft text')

--- a/test/subagent-viewer-interactive.test.ts
+++ b/test/subagent-viewer-interactive.test.ts
@@ -54,17 +54,21 @@ async function startApp(
     onExit?: () => void
     onSingleEscape?: () => boolean | void
     onSteer?: (text: string) => void
-    onQueueSubmit?: (text: string) => void
+    onAcceleratedSubmit?: (text: string) => void
     onSubagentSubmit?: (request: { parentSessionId: string; childSessionId: string; text: string }) => void
   } = {},
 ): Promise<{ vt: VirtualTerminal; app: TuiApp }> {
   const vt = new VirtualTerminal(80, 24)
   const app = new TuiApp(vt, {
-    onSubmit: events.onSubmit ?? (() => {}),
+    // The accelerated chord is a submission REQUEST (the runner resolves its
+    // delivery mode): the harness splits it out for the chord assertions.
+    onSubmit: (text, request) => {
+      if (request === 'accelerated') { events.onAcceleratedSubmit?.(text); return }
+      events.onSubmit?.(text)
+    },
     onExit: events.onExit ?? (() => {}),
     onSingleEscape: events.onSingleEscape,
     onSteer: events.onSteer,
-    onQueueSubmit: events.onQueueSubmit,
     onSubagentSubmit: events.onSubagentSubmit,
   })
   app.start()
@@ -145,14 +149,15 @@ test('the main session chords are inert inside the interactive viewer', async ()
   const singleEscapes: number[] = []
   const { vt, app } = await startApp({
     onSteer: (text) => steered.push(text),
-    onQueueSubmit: (text) => queued.push(text),
+    onAcceleratedSubmit: (text) => queued.push(text),
     onSingleEscape: () => { singleEscapes.push(1); return true },
   })
   app.setViewerMode(continuable())
   await vt.waitForRender()
   vt.sendInput('draft text')
   await vt.waitForRender()
-  // Ctrl+S (steer) and Ctrl+Enter (queue) must be consumed, never parent.
+  // Ctrl+S (steer) and Ctrl+Enter (the accelerated submit) must be
+  // consumed, never parent.
   vt.sendInput('\x13') // ctrl+s
   await vt.waitForRender()
   vt.sendInput('\x1b[13;5u') // kitty ctrl+enter
@@ -165,7 +170,7 @@ test('the main session chords are inert inside the interactive viewer', async ()
   vt.sendInput('\x03') // ctrl+c
   await vt.waitForRender()
   assert.deepEqual(steered, [], 'Ctrl+S must never steer the parent from the viewer')
-  assert.deepEqual(queued, [], 'Ctrl+Enter must never queue the parent from the viewer')
+  assert.deepEqual(queued, [], 'Ctrl+Enter must never submit to the parent from the viewer')
   assert.equal(singleEscapes.length, 0, 'Ctrl+C must not exit (and no accidental Esc)')
   // The child draft is untouched by the blocked chords.
   assert.equal(app.getDraft(), 'draft text')
@@ -190,7 +195,7 @@ test('a one-shot viewer cannot submit through the host path either (hard reject)
   vt.sendInput('x')
   vt.sendInput('\r')
   await vt.waitForRender()
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(parentSubmits, [])
   assert.deepEqual(childSubmits, [])
@@ -223,7 +228,7 @@ test('a NESTED continuable child is read-only from the root (plan §6.10)', asyn
   vt.sendInput('x')
   vt.sendInput('\r')
   await vt.waitForRender()
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(parentSubmits, [], 'nested viewer must never submit to the parent')
   assert.deepEqual(childSubmits, [], 'nested viewer must never submit to the grandchild from the root')
@@ -360,7 +365,7 @@ test('a replacement (plugin) editor receives the child draft and the follow-up t
   await vt.waitForRender()
   assert.equal(app.getDraft(), 'child draft via runner', 'the child draft must not leak to the main draft')
   // The host-owned submit routes to the subagent even with a plugin editor.
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submits, [{
     parentSessionId: 'session-main',
@@ -407,7 +412,7 @@ test('a replacement editor submit clears the child slot EXPLICITLY (no resurrect
   // Submit through the host path (the plugin editor never fires the host
   // onChange): the slot must clear even though the plugin's setText is
   // what cleared the visible buffer.
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submits, [{
     parentSessionId: 'session-main',
@@ -470,7 +475,7 @@ test('a replacement editor that edits through its OWN handleInput submits the LA
   vt.sendInput('x')
   await vt.waitForRender()
   assert.equal(app.getDraft(), 'oldx', 'getDraft must read the VISIBLE editor in a continuable viewer')
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submits, [{ text: 'oldx' }], 'the submission must carry the LATEST visible text, never the stale slot')
   app.setViewerMode(undefined)

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -1237,8 +1237,6 @@ test('a dynamic Host command never enters the ordinary inbox while running (PR11
 })
 
 // ── extension command ownership (PR115-fix problem 2) ──────────────────────
-// An extension contribution declares its own `execution`: 'submission' flows
-// through the session submission policy (steer/queue) like a skill
 // The DSH client command contribution model: a contribution is a CLIENT-OWNED
 // command (menu row + client handler). A name that is also a host command is a
 // COLLISION: the host claim wins and the candidate synthesis fails loud —
@@ -1575,18 +1573,19 @@ test('a sessionless client command runs its handler even with a LIVE session', a
 })
 
 test('a dynamic host collision fails the command source (upstream source-failed parity)', async (t) => {
-  let failDeploy = false
   const { harness, mounted, registerContribution } = await bootCommandHarness(t, {
     busyEnter: 'queue',
     status: 'idle',
+    hostCommands: ['compact'],
     extensionCommands: [
       { id: 'deploy-cmd', name: 'deploy', description: 'client deploy', bridgeHandler: () => ({ kind: 'success' }) },
       { id: 'keep-cmd', name: 'keep', description: 'client keep', bridgeHandler: () => ({ kind: 'success' }) },
     ],
   })
-  // T0: both client rows are in the menu.
+  // T0: the host row and both client rows are in the menu — one source.
   const t0 = mounted.app.commandCompletionsForTest().map(row => row.name)
   assert.ok(t0.includes('deploy') && t0.includes('keep'), `both client rows installed: ${t0.join(',')}`)
+  assert.ok(t0.includes('compact'), `the host row shares the source: ${t0.join(',')}`)
   // T1: the host catalog gains /deploy; a later registration flushes the
   // extension invalidation into a completion refresh.
   const disposeHost = (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
@@ -1612,7 +1611,49 @@ test('a dynamic host collision fails the command source (upstream source-failed 
   const recovered = mounted.app.commandCompletionsForTest().map(row => row.name)
   assert.ok(recovered.includes('deploy') && recovered.includes('keep') && recovered.includes('omega'),
     `the menu recovers after a successful synthesis: ${recovered.join(',')}`)
-  void failDeploy
+})
+
+test('a SECOND colliding contribution is surfaced too (aggregated fresh-collision notice)', async (t) => {
+  // A collides first and is notified; B starts colliding while A keeps
+  // colliding. B must be surfaced as well — the failed pass notifies every
+  // FRESH collision (one per identity and failure generation), aggregated
+  // into the single transient notice slot.
+  const healthOf = (id: string): { state: string } | undefined =>
+    extensionServiceOf().find(entry => entry.id === id)
+  const { harness, mounted, registerContribution, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [
+      { id: 'alpha-cmd', name: 'alpha', description: 'alpha', bridgeHandler: () => ({ kind: 'success' }) },
+      { id: 'beta-cmd', name: 'beta', description: 'beta', bridgeHandler: () => ({ kind: 'success' }) },
+    ],
+  })
+  const extensionServiceOf = (): readonly { id: string; state: string }[] =>
+    extensionService._ledger().healthSnapshot()
+  const registerHost = (name: string): (() => void) =>
+    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }) })
+  // T0: /alpha becomes a host command → the first collision, notified.
+  const disposeAlpha = registerHost('alpha')
+  await registerContribution({ id: 'gamma-cmd', name: 'gamma', description: 'gamma', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.match(mounted.app.notifyTextForTest(), /\/alpha/, 'the first collision is surfaced')
+  assert.equal(healthOf('alpha-cmd')?.state, 'failed')
+  // T1: /beta becomes a host command while /alpha still collides.
+  const disposeBeta = registerHost('beta')
+  await registerContribution({ id: 'delta-cmd', name: 'delta', description: 'delta', bridgeHandler: () => ({ kind: 'success' }) })
+  const notice = mounted.app.notifyTextForTest()
+  assert.match(notice, /\/beta/, 'the NEWLY colliding contribution is surfaced')
+  assert.match(notice, /\/alpha/, 'the still-colliding contribution is included in the aggregated notice')
+  assert.equal(healthOf('beta-cmd')?.state, 'failed')
+  // Recovery: both host descriptors go away; a successful synthesis clears
+  // both notice keys and both health records.
+  disposeAlpha()
+  disposeBeta()
+  await registerContribution({ id: 'epsilon-cmd', name: 'epsilon', description: 'epsilon', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf('alpha-cmd')?.state, 'active', 'the recovered collision clears')
+  assert.equal(healthOf('beta-cmd')?.state, 'active', 'the recovered collision clears')
+  const names = mounted.app.commandCompletionsForTest().map(row => row.name)
+  assert.ok(names.includes('alpha') && names.includes('beta'), `client rows return: ${names.join(',')}`)
 })
 
 test('a collision health record clears on recovery, while a HANDLER failure record survives an unrelated refresh', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -1682,6 +1682,126 @@ for (const form of [
   })
 }
 
+test('an unknown slash line that becomes an UNDECLARED host command refuses its attachment (deferred authority)', async (t) => {
+  // Deferred start with NO client contribution for the name: the standing
+  // view cannot classify the line, so the composer lets the attachment
+  // through. The session then commits a session-scoped host command that does
+  // NOT declare `input.attachments` — the dispatch must re-apply the composer
+  // policy against the FINAL catalog before the command plane runs. The host
+  // executor only validates the SUBMITTED payload, so passing `[]` would let
+  // the handler run with the placeholder as a raw argument and then consume
+  // the draft: the attachment would be silently dropped.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-late-host-attachment-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(6, 6))
+  const { harness, mounted, imageSaves } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    attachments: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  harness.onCreateSession(() => {
+    ;(harness.commands as {
+      register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+    }).register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  })
+  const staged = await stageAttachmentDraft(mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
+  assert.deepEqual(harness.createdSessionIds, [], 'the sessionless intake creates no session')
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 60 && !/does not accept attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.match(mounted.app.notifyTextForTest(), /\/deploy does not accept attachments; remove them first/)
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
+    `the undeclared late claim never reaches the command plane: ${JSON.stringify(harness.executed)}`)
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
+  assert.deepEqual(imageSaves, [], 'nothing is admitted either')
+  assert.match(mounted.app.getDraft(), /^\/deploy /, 'the draft comes back')
+  assert.match(mounted.app.getDraft(), /\[image #1/, 'with its attachment placeholder intact')
+  assert.equal(harness.createdSessionIds.length, 1, 'the authority resolution ran (the session is session-keyed)')
+})
+
+test('an unknown slash line that becomes a DECLARED host command delivers and consumes its attachment', async (t) => {
+  // The same deferred authority, with the command DECLARING
+  // `input.attachments`: the encoded image must ride the command invocation
+  // (the dispatch-side re-check must not over-refuse), and success consumes
+  // the draft.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-late-host-attachment-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(7, 7))
+  const { harness, mounted, imageSaves } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    attachments: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  harness.onCreateSession(() => {
+    ;(harness.commands as {
+      register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+    }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '', attachments: true } })
+  })
+  const staged = await stageAttachmentDraft(mounted, path)
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 60 && !harness.executed.some(entry => entry.line.startsWith('/deploy')); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  const call = harness.executed.find(entry => entry.line.startsWith('/deploy'))
+  assert.equal(call?.outcome, 'executed', `the declared late claim is admitted: ${JSON.stringify(harness.executed)}`)
+  assert.equal(call?.attachments.length, 1, 'the declared command receives the submitted image')
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
+  assert.deepEqual(imageSaves, [], 'the host admits the image, not the client')
+  // CONSUME-ON-SUCCESS: the same placeholder as a plain prompt is plain text.
+  mounted.app.setDraft(staged.trim())
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'consumed late-host placeholder')
+  assert.deepEqual(imageSaves, [], 'the consumed attachment is not re-admitted')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual([...delivered.content], [{ type: 'text', text: staged.trim() }], 'the line stays plain text')
+})
+
+test('an unknown slash line that becomes a DECLARED host command still refuses a FILE (no receipt seam)', async (t) => {
+  // The late-authority policy covers FILES too: a declared command receives
+  // images, never a file (the host expects an upload receipt this client
+  // cannot produce). Without the dispatch-side re-check the placeholder line
+  // would run with an empty payload and the success path would CONSUME the
+  // file draft — a silent drop of a user attachment.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-late-host-attachment-')
+  const path = join(root, 'report.pdf')
+  await writeFile(path, Buffer.from('%PDF-1.7\nbody'))
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    attachments: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  harness.onCreateSession(() => {
+    ;(harness.commands as {
+      register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+    }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '', attachments: true } })
+  })
+  const staged = await stageAttachmentDraft(mounted, path)
+  assert.match(staged, /\[file #1/, `the file is staged: ${JSON.stringify(staged)}`)
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 60 && !/cannot receive file attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.match(mounted.app.notifyTextForTest(), /\/deploy cannot receive file attachments in this client; remove them first/)
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
+    `the file-bearing invocation never reaches the command plane: ${JSON.stringify(harness.executed)}`)
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
+  assert.match(mounted.app.getDraft(), /\[file #1/, 'the file draft comes back unconsumed')
+})
+
 test('a HOST command that does not declare input.attachments refuses an attachment (web composer parity)', async (t) => {
   // Upstream `CommandUiRuntime` refuses an attachment-bearing invocation of a
   // command whose descriptor does not declare `input.attachments`. The TUI

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -1051,14 +1051,23 @@ test('running + steer: an ordinary prompt still steers (PR115-fix problem 1)', a
 })
 
 test('running + steer: /skill <name> stays an agent-facing invocation (PR115-fix problem 1)', async (t) => {
-  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'steer', status: 'running' })
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    skills: true,
+    hostLoadsSkillBody: true,
+  })
   mounted.app.setDraft('/skill grilling args')
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
   await waitForDelivery(harness.host, 'skill steer')
+  // Agent-facing input, never a Host command: it STEERS (a Host command
+  // would execute and never steer), through loadSkill's normalized
+  // `/<name> <args>` line, and the host's pre-step listener owns the body.
   assert.equal(harness.host.steered.length, 1, 'a skill invocation must keep the agent-facing steer')
   const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
   assert.equal(steered.content[0]?.text, '/grilling args', 'the skill line must steer in its normalized /name args form')
-  assert.equal(harness.executed.length, 0, 'a skill invocation must never be claimed as a Host command')
+  assert.equal(harness.host.followedUp.length, 0, 'the steer mode never queues')
+  assert.equal(harness.host.injected.length, 0, 'the host loader owns the body injection')
 })
 
 test('running + queue: /skill <name> queues like a plain prompt when the host injects the body (web parity)', async (t) => {
@@ -1103,7 +1112,7 @@ test('running + queue: /skill <name> keeps the steer path when the TUI must inje
   assert.equal(harness.host.followedUp.length, 0, 'no followup — the body order contract forbids it')
 })
 
-test('running + steer: the Ctrl+Enter chord force-queues /skill <name> (delivery mode resolved once)', async (t) => {
+test('running + steer: the accelerated chord queues /skill <name> (delivery mode resolved once)', async (t) => {
   const { harness, mounted } = await bootCommandHarness(t, {
     busyEnter: 'steer',
     status: 'running',
@@ -1111,13 +1120,13 @@ test('running + steer: the Ctrl+Enter chord force-queues /skill <name> (delivery
     hostLoadsSkillBody: true,
   })
   mounted.app.setDraft('/skill grilling args')
-  // The Ctrl+Enter opposite chord: force the QUEUE delivery regardless of
-  // the busyEnter preference. The chord is a property of THIS submission —
-  // the skill delivery accepts the mode the submit boundary resolved and
-  // must never re-derive it from the persisted preference (busyEnter=steer
-  // here), because a one-shot chord does not survive in settings.
-  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
-  await waitForDelivery(harness.host, 'force-queued skill')
+  // The accelerated chord is the OPPOSITE of the busyEnter preference: with
+  // busyEnter=steer it QUEUES. It is a property of THIS submission — the
+  // skill delivery accepts the mode the submit boundary resolved and must
+  // never re-derive it from the persisted preference, because a one-shot
+  // gesture does not survive in settings.
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  await waitForDelivery(harness.host, 'accelerated skill')
   assert.equal(harness.host.followedUp.length, 1, 'the chord must force the queue delivery')
   const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
   assert.equal(followed.content[0]?.text, '/grilling args', 'the queued line is the normalized /name args form')
@@ -1125,7 +1134,7 @@ test('running + steer: the Ctrl+Enter chord force-queues /skill <name> (delivery
   assert.equal(harness.host.injected.length, 0, 'the host owns the body injection — no TUI fallback body')
 })
 
-test('running + steer: the Ctrl+Enter chord force-queues a per-skill wrapper (/grilling args)', async (t) => {
+test('running + steer: the accelerated chord queues a per-skill wrapper (/grilling args)', async (t) => {
   const { harness, mounted } = await bootCommandHarness(t, {
     busyEnter: 'steer',
     status: 'running',
@@ -1134,8 +1143,8 @@ test('running + steer: the Ctrl+Enter chord force-queues a per-skill wrapper (/g
   })
   await waitForSkillWrapper(harness, 'grilling')
   mounted.app.setDraft('/grilling args')
-  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
-  await waitForDelivery(harness.host, 'force-queued skill wrapper')
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  await waitForDelivery(harness.host, 'accelerated skill wrapper')
   assert.equal(harness.executed.length, 1, 'the wrapper is a TUI command: it executes through the command plane')
   assert.equal(harness.executed[0]?.line, '/grilling args', 'the wrapper receives its own slash line')
   assert.equal(harness.host.followedUp.length, 1, 'the chord must force the queue delivery')
@@ -1165,7 +1174,7 @@ test('a dynamic Host command never enters the ordinary inbox while running (PR11
 // through the session submission policy (steer/queue) like a skill
 // invocation, 'local' never steers. Being advertised in the effective
 // catalog does NOT make either a Host command: the busy policy (and the
-// force-queue chord) must be consulted before any command plane execution.
+// accelerated chord) must be consulted before any command plane execution.
 
 test('running + steer: an extension submission command keeps the busy steer, never the Host claim', async (t) => {
   const { harness, mounted } = await bootCommandHarness(t, {
@@ -1182,21 +1191,93 @@ test('running + steer: an extension submission command keeps the busy steer, nev
   assert.equal(harness.executed.length, 0, 'an advertised extension command must never be claimed as a Host command')
 })
 
-test('running + steer: the Ctrl+Enter chord force-queues an extension submission command', async (t) => {
+test('running + steer: the accelerated chord queues an extension submission command as a PROMPT', async (t) => {
   const { harness, mounted } = await bootCommandHarness(t, {
     busyEnter: 'steer',
     status: 'running',
     extensionCommands: [{ id: 'deploy', name: 'deploy', description: 'deploy the app', execution: 'submission' }],
   })
   mounted.app.setDraft('/deploy now')
-  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
-  await waitForCommand(harness)
-  // The chord resolves 'queue' at the submit boundary; the submission route
-  // hands the line to the command plane (the plugin's own handler owns the
-  // session write), and the TUI never steers it into the running turn.
-  assert.equal(harness.executed.length, 1, 'the queue-side submission route reaches the command plane')
-  assert.equal(harness.executed[0]?.line, '/deploy now')
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  await waitForDelivery(harness.host, 'queued extension submission')
+  // `execution: 'submission'` means the command flows through the session
+  // submission policy like a skill invocation: the resolved 'queue' mode
+  // delivers its LINE (exactly like an unclaimed slash prompt), and the
+  // plugin's command handler is NOT run ahead of the queue it asked to join.
+  assert.equal(harness.host.followedUp.length, 1, 'the queue mode delivers the line as a queued prompt')
+  const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
+  assert.equal(followed.content[0]?.text, '/deploy now', 'the raw line is the queued prompt')
+  assert.equal(harness.executed.length, 0, 'the queue mode must not execute the plugin command handler')
   assert.equal(harness.host.steered.length, 0, 'the chord must never steer')
+})
+
+test('running + queue: the DEFAULT preference makes the accelerated chord STEER (web parity)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'queue', status: 'running' })
+  mounted.app.setDraft('hello world')
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  await waitForDelivery(harness.host, 'accelerated prompt')
+  // The web ComposerSubmissionPolicy (0.1.3-alpha.2) resolves the
+  // accelerated gesture to the OPPOSITE of the preference: with the DEFAULT
+  // busyEnter=queue it steers. A fixed "always queue" chord would get the
+  // default configuration exactly backwards.
+  assert.equal(harness.host.steered.length, 1, 'the accelerated chord steers under busyEnter=queue')
+  const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
+  assert.equal(steered.content[0]?.text, 'hello world', 'the draft rides the steer')
+  assert.equal(harness.host.followedUp.length, 0, 'the chord must not queue under busyEnter=queue')
+})
+
+test('running + steer: an accelerated skill invocation queues (the opposite of the preference)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    skills: true,
+    hostLoadsSkillBody: true,
+  })
+  mounted.app.setDraft('/skill grilling args')
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  await waitForDelivery(harness.host, 'accelerated skill')
+  assert.equal(harness.host.followedUp.length, 1, 'the chord queues the skill invocation under busyEnter=steer')
+  const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
+  assert.equal(followed.content[0]?.text, '/grilling args', 'the queued line is the normalized /name args form')
+  assert.equal(harness.host.steered.length, 0, 'the chord must never steer')
+})
+
+test('running + steer: a skill invocation WITHOUT the host loader still injects its body', async (t) => {
+  // The stripped composition: the skills registry exists, the host's
+  // dsh-tool-skill pre-step listener does not — so the TUI owns the body
+  // injection (loadSkill's fallback). The steer path must therefore reach
+  // loadSkill: a bare steered line would leave the model with no skill body
+  // at all (the skill would silently not load).
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    skills: true,
+  })
+  mounted.app.setDraft('/skill grilling args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'no-loader skill steer')
+  assert.equal(harness.host.steered.length, 1, 'the invocation steers into the running turn')
+  const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
+  assert.equal(steered.content[0]?.text, '/grilling args', 'the steered line is the normalized /name args form')
+  assert.equal(harness.host.injected.length, 1, 'the TUI fallback injects the skill body exactly once')
+  const injected = harness.host.injected[0] as { content: { type: string; text: string }[] }
+  assert.match(injected.content[0]?.text ?? '', /<skill_content name="grilling">/, 'the injected body is the official rendering')
+})
+
+test('running + steer: a no-loader per-skill wrapper also injects its body', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    skills: true,
+  })
+  await waitForSkillWrapper(harness, 'grilling')
+  mounted.app.setDraft('/grilling args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'no-loader wrapper steer')
+  assert.equal(harness.executed.length, 1, 'the wrapper executes through the command plane')
+  assert.equal(harness.executed[0]?.line, '/grilling args', 'the wrapper receives its own slash line')
+  assert.equal(harness.host.steered.length, 1, 'the invocation steers into the running turn')
+  assert.equal(harness.host.injected.length, 1, 'the TUI fallback injects the skill body exactly once')
 })
 
 test('running + steer: an extension local command still executes directly under both chords', async (t) => {
@@ -1211,7 +1292,7 @@ test('running + steer: an extension local command still executes directly under 
   assert.equal(harness.executed.length, 1, 'an extension local command always executes locally')
   // The Ctrl+Enter chord cannot change a local command's ownership either.
   mounted.app.setDraft('/panel')
-  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
   for (let round = 0; round < 20 && harness.executed.length < 2; round += 1) {
     await new Promise<void>(resolve => setImmediate(resolve))
   }
@@ -1226,7 +1307,7 @@ test('running + steer: the Ctrl+Enter chord never turns a Host command into a qu
     hostCommands: ['compact'],
   })
   mounted.app.setDraft('/compact')
-  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
   await waitForCommand(harness)
   assert.equal(harness.executed.length, 1, 'a Host command owns its execution regardless of the chord')
   assert.equal(harness.host.followedUp.length, 0, 'the chord must not queue a Host command as a prompt')

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -11,6 +11,7 @@
  */
 
 import assert from 'node:assert/strict'
+import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import test, { type TestContext } from 'node:test'
 import { Context } from '@deepseek-ai/cordis'
@@ -281,7 +282,11 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
       }
     },
     list: () => [...definitions.values()].map(({ name, description }) => ({ name, description: description ?? '', input: { hint: '' } })),
-    find: () => undefined,
+    // The real commands service resolves a definition by name for the
+    // global layer too (`find(undefined, name)`); the harness mirrors it so
+    // a TUI-owned sessionless command runs LOCALLY in a deferred start
+    // instead of falling through to the session dispatch.
+    find: (_agent: unknown, name: string) => definitions.get(name),
     // A REGISTERED command executes through the command plane (the Host
     // command semantics): the handler runs with a CommandRuntime-shaped
     // invocation, so a real handler (e.g. /skill → loadSkill) delivers
@@ -949,7 +954,11 @@ async function bootCommandHarness(
     bridgeHandler: () => { kind: 'success' | 'error'; text?: string }
   }): Promise<void>
   /** The mounted extension service (health assertions). */
-  extensionService: { _ledger(): { healthSnapshot(): readonly { id: string; owner: string; state: string; lastError?: string }[] } }
+  extensionService: {
+    _ledger(): {
+      healthSnapshot(): readonly { id: string; owner: string; extensionPoint: string; state: string; lastError?: string }[]
+    }
+  }
 }> {
   const life = testLifecycle(t)
   const home = life.tempDir('dsh-pi-tui-command-arb-')
@@ -1060,7 +1069,9 @@ async function bootCommandHarness(
     options.deferredStart === true ? {} : { sessionId: 'command-session' })
   harness.host.status = options.status
   return { harness, mounted, registerContribution, extensionService: extensionService as {
-    _ledger(): { healthSnapshot(): readonly { id: string; owner: string; state: string; lastError?: string }[] }
+    _ledger(): {
+      healthSnapshot(): readonly { id: string; owner: string; extensionPoint: string; state: string; lastError?: string }[]
+    }
   } }
 }
 
@@ -1476,6 +1487,139 @@ test('a host command that appears only AFTER the deferred session outranks the c
   assert.equal(harness.host.steered.length, 0, 'never steered')
 })
 
+/** Stage ONE real generic-file attachment through the REAL `/attach`
+ * sessionless command: the intake inserts its placeholder into the editor,
+ * which is exactly the draft text the user submits next. */
+async function stageAttachmentDraft(mounted: { app: TuiApp }, path: string): Promise<string> {
+  mounted.app.setDraft(`/attach ${path}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && !/\[file #1/.test(mounted.app.getDraft()); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  return mounted.app.getDraft()
+}
+
+test('an attachment-bearing client command defers its local refusal: a LATE host claim takes the line', async (t) => {
+  // Deferred start + a session-backed client contribution + a REAL staged
+  // attachment. The standing view classifies the line LOCAL (the client
+  // contribution), but the session may commit a session-scoped host claim
+  // that outranks it and accepts the attachment — so the irrevocable local
+  // refusal must wait for the same authority resolution instead of firing
+  // before `ensureSession()` (which would leave the real host command no
+  // chance to take the line).
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-deferred-attachment-')
+  const path = join(root, 'report.pdf')
+  await writeFile(path, Buffer.from('%PDF-1.7\nbody'))
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  harness.onCreateSession(() => {
+    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void })
+      .register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  })
+  const staged = await stageAttachmentDraft(mounted, path)
+  assert.match(staged, /\[file #1/, `the attachment is staged through the real intake: ${JSON.stringify(staged)}`)
+  assert.deepEqual(harness.createdSessionIds, [], 'the sessionless intake creates no session')
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the LATE host claim owns the line')
+  assert.match(harness.executed[0]?.line ?? '', /^\/deploy /, 'the host command receives the raw line')
+  assert.deepEqual(calls, [], 'the client handler never runs once the session claims the name')
+  assert.equal(harness.host.followedUp.length, 0, 'never downgraded to a model prompt')
+  assert.ok(!mounted.app.notifyTextForTest().includes('Attachments cannot be included'),
+    `the local-attachment refusal must not fire before the authority resolves: ${mounted.app.notifyTextForTest()}`)
+})
+
+test('a deferred client command never runs a REPLACED contribution generation (and never becomes a prompt)', async (t) => {
+  // The submission captured one contribution generation, then the session
+  // create awaits. A plugin reload (dispose + re-register under the SAME
+  // owner and id) must not let the post-await resolution run the NEW
+  // generation's handler — the user submitted the old one — and a vanished
+  // name must never fall through `runLocalCommand`'s name-only lookup into
+  // the command plane or the MODEL.
+  const flush = async (): Promise<void> => {
+    for (let round = 0; round < 20; round += 1) await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  const calls: string[] = []
+  const { harness, mounted, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  const service = extensionService as unknown as {
+    registerCommand(contribution: {
+      id: string; name: string; description: string; handler: () => { kind: 'success' }
+    }): { dispose(): void }
+  }
+  const spec = { id: 'deploy-cmd', name: 'deploy', description: 'client deploy' }
+  const submitted = service.registerCommand({ ...spec, handler: () => { calls.push('submitted'); return { kind: 'success' } } })
+  await flush()
+  harness.armCreateGate()
+  mounted.app.setDraft('/deploy prod')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && harness.createdSessionIds.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.equal(harness.createdSessionIds.length, 1, 'the session create is in flight')
+  // The plugin reloads while the create awaits: SAME id, SAME owner (the
+  // registration context), a NEW generation.
+  submitted.dispose()
+  const replacement = service.registerCommand({ ...spec, handler: () => { calls.push('replacement'); return { kind: 'success' } } })
+  harness.releaseCreateGate()
+  await flush()
+  assert.deepEqual(calls, [], 'no generation runs: the submitted registration no longer exists')
+  assert.equal(harness.executed.length, 0, 'the command plane is never a fallback for a vanished contribution')
+  assert.equal(harness.host.followedUp.length, 0, 'never downgraded to a model prompt')
+  assert.match(mounted.app.notifyTextForTest(), /\/deploy is no longer available/)
+  assert.match(mounted.app.getDraft(), /^\/deploy prod/, 'the draft comes back for a retry')
+  replacement.dispose()
+})
+
+test('an attachment-bearing client command is refused AFTER the session resolves when the contribution keeps the line', async (t) => {
+  // The same deferral, with no late authority: the FINAL owner is the client
+  // contribution, whose local route refuses attachments. The refusal is the
+  // SAME user-visible outcome as the synchronous gate — just resolved late
+  // (the authority had to be settled) — and the draft, attachments included,
+  // comes back for a re-attach decision.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-deferred-attachment-')
+  const path = join(root, 'report.pdf')
+  await writeFile(path, Buffer.from('%PDF-1.7\nbody'))
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  const staged = await stageAttachmentDraft(mounted, path)
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 60 && !/Attachments cannot be included/.test(mounted.app.notifyTextForTest()); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.match(mounted.app.notifyTextForTest(), /Attachments cannot be included in a local command\./)
+  assert.deepEqual(calls, [], 'the local handler never runs for an attachment-bearing line')
+  assert.equal(harness.executed.length, 0, 'never the command plane')
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
+  assert.equal(harness.createdSessionIds.length, 1, 'the deferred authority resolution ran (the session is session-keyed)')
+  assert.match(mounted.app.getDraft(), /^\/deploy /, 'the draft comes back for a re-attach decision')
+  assert.match(mounted.app.getDraft(), /\[file #1/, 'with its attachment placeholder intact')
+})
+
 test('a sessionless client command runs without creating a session', async (t) => {
   const calls: string[] = []
   const { harness, mounted } = await bootCommandHarness(t, {
@@ -1881,4 +2025,98 @@ test('running + steer: the Ctrl+Enter chord never turns a Host command into a qu
   assert.equal(harness.executed.length, 1, 'a Host command owns its execution regardless of the chord')
   assert.equal(harness.host.followedUp.length, 0, 'the chord must not queue a Host command as a prompt')
   assert.equal(harness.host.steered.length, 0, 'the chord must not steer a Host command')
+})
+
+
+test('a DISPOSED colliding contribution never suppresses its next generation notice', async (t) => {
+  // The notice key is the contribution identity (id + owner) AND failure
+  // generation. A disposed contribution leaves the snapshot entirely — its
+  // bookkeeping must be purged with it, or a re-registration under the same
+  // id/owner (a plugin reload/HMR) inherits the suppression while the health
+  // record fails again: the second generation would be silent.
+  const { harness, mounted, registerContribution, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  const flush = async (): Promise<void> => {
+    for (let round = 0; round < 20; round += 1) await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  const registerHost = (name: string): (() => void) =>
+    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }) })
+  const disposeDeploy = registerHost('deploy')
+  const disposeCompact = registerHost('compact')
+  const healthOf = (id: string): { state: string; lastError?: string } | undefined =>
+    extensionService._ledger().healthSnapshot().find(entry => entry.id === id)
+  // A root-context registration keeps ONE owner across the generations (the
+  // identity the regression needs); a plugin-fiber helper would mint a new
+  // owner per call.
+  const service = extensionService as unknown as {
+    registerCommand(contribution: {
+      id: string; name: string; description: string; handler: () => { kind: 'success' }
+    }): { dispose(): void }
+  }
+  // Generation 1: /deploy collides → surfaced.
+  const first = service.registerCommand({
+    id: 'deploy-cmd', name: 'deploy', description: 'client deploy', handler: () => ({ kind: 'success' }),
+  })
+  await flush()
+  assert.match(mounted.app.notifyTextForTest(), /\/deploy/, 'the first collision is surfaced')
+  assert.equal(healthOf('deploy-cmd')?.state, 'failed')
+  // Dispose it: the snapshot is empty and the health record was untracked.
+  first.dispose()
+  await flush()
+  // Generation 2 under the SAME id/owner, but a different colliding name, so
+  // a suppressed notice is observable (a stale message instead of a new one).
+  const second = service.registerCommand({
+    id: 'deploy-cmd', name: 'compact', description: 'client compact', handler: () => ({ kind: 'success' }),
+  })
+  await flush()
+  assert.equal(healthOf('deploy-cmd')?.state, 'failed', 'the second generation fails again')
+  assert.match(mounted.app.notifyTextForTest(), /\/compact/,
+    'the second generation is surfaced, not suppressed by the disposed predecessor')
+  second.dispose()
+  disposeDeploy()
+  disposeCompact()
+})
+
+test('collision recovery clears only the COMMAND health record, never a same-id record in another slot', async (t) => {
+  // ExtensionHealth is keyed by (slot, owner, id); ONE plugin may legally
+  // reuse an id across slots (a theme and a command). The recovery lookup
+  // must therefore match the extension point as well, or it can read the
+  // OTHER slot's record and skip the clear this synthesis owns.
+  const { harness, mounted, registerContribution, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  const healthOf = (slot: string): { state: string; lastError?: string } | undefined =>
+    extensionService._ledger().healthSnapshot().find(entry => entry.extensionPoint === slot && entry.id === 'shared-id')
+  const registerHost = (name: string): (() => void) =>
+    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }) })
+  // The THEME registers FIRST so its (theme, owner, shared-id) record
+  // precedes the command record in the health snapshot.
+  const service = extensionService as unknown as {
+    registerTheme(theme: { id: string; name: string; palette: Record<string, string> }): { dispose(): void }
+    registerCommand(contribution: {
+      id: string; name: string; description: string; handler: () => { kind: 'success' }
+    }): { dispose(): void }
+  }
+  const theme = service.registerTheme({ id: 'shared-id', name: 'Shared', palette: { text: '#ffffff' } })
+  const disposeDeploy = registerHost('deploy')
+  const command = service.registerCommand({
+    id: 'shared-id', name: 'deploy', description: 'client deploy', handler: () => ({ kind: 'success' }),
+  })
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf('command')?.state, 'failed', 'the collision marks the command record failed')
+  // Recovery: the host descriptor goes away, the contribution merges again.
+  disposeDeploy()
+  await registerContribution({ id: 'omega-cmd', name: 'omega', description: 'omega', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf('theme')?.state, 'active', 'the theme record is untouched')
+  assert.equal(healthOf('command')?.state, 'active', 'the command record is cleared by the collision recovery')
+  command.dispose()
+  theme.dispose()
+  void mounted
 })

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -2081,6 +2081,49 @@ test('a DISPOSED colliding contribution never suppresses its next generation not
   disposeCompact()
 })
 
+test('a dispose + re-register inside ONE invalidate flush is still a new collision generation', async (t) => {
+  // HMR coalescing: the invalidate batcher flushes on a microtask, so a
+  // dispose and a re-registration in the SAME tick reach the synthesis as
+  // one pass over the NEW snapshot — the empty state is never observed, and
+  // a purge keyed on "identity absent from the snapshot" cannot see the gap.
+  // The notice identity must therefore follow the REGISTRATION GENERATION.
+  const flush = async (): Promise<void> => {
+    for (let round = 0; round < 20; round += 1) await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  const { harness, mounted, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  const healthOf = (id: string): { state: string; lastError?: string } | undefined =>
+    extensionService._ledger().healthSnapshot().find(entry => entry.id === id)
+  const registerHost = (name: string): (() => void) =>
+    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }) })
+  const disposeDeploy = registerHost('deploy')
+  const disposeCompact = registerHost('compact')
+  const service = extensionService as unknown as {
+    registerCommand(contribution: {
+      id: string; name: string; description: string; handler: () => { kind: 'success' }
+    }): { dispose(): void }
+  }
+  const spec = { id: 'deploy-cmd', description: 'client command', handler: () => ({ kind: 'success' }) as const }
+  const first = service.registerCommand({ ...spec, name: 'deploy' })
+  await flush()
+  assert.match(mounted.app.notifyTextForTest(), /\/deploy/, 'the first generation is surfaced')
+  assert.equal(healthOf('deploy-cmd')?.state, 'failed')
+  // SAME tick: dispose + re-register (same id, same owner, new generation).
+  first.dispose()
+  const second = service.registerCommand({ ...spec, name: 'compact' })
+  await flush()
+  assert.equal(healthOf('deploy-cmd')?.state, 'failed', 'the new generation fails again')
+  assert.match(mounted.app.notifyTextForTest(), /\/compact/,
+    'the coalesced generation is surfaced, not suppressed by its predecessor')
+  second.dispose()
+  disposeDeploy()
+  disposeCompact()
+})
+
 test('collision recovery clears only the COMMAND health record, never a same-id record in another slot', async (t) => {
   // ExtensionHealth is keyed by (slot, owner, id); ONE plugin may legally
   // reuse an id across slots (a theme and a command). The recovery lookup

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -914,6 +914,11 @@ async function bootCommandHarness(
       name: string
       description: string
       execution: 'local' | 'submission'
+      /** The contribution's LOCAL implementation (the bridge handler). */
+      bridgeHandler?: () => { kind: 'success' | 'error'; text?: string }
+      /** Whether the plugin ALSO registers a commands-service definition
+       * (default true; a bridge-only contribution is a real pattern). */
+      registerDefinition?: boolean
     }[]
   },
 ): Promise<{ harness: ReturnType<typeof makeHarness>; mounted: { dispose: () => Promise<void>; app: TuiApp } }> {
@@ -980,9 +985,13 @@ async function bootCommandHarness(
           execution: 'local' | 'submission'
         }): unknown
       }
-      for (const contribution of contributions) service.registerCommand(contribution)
+      for (const contribution of contributions) {
+        const { bridgeHandler, registerDefinition: _registerDefinition, ...spec } = contribution
+        service.registerCommand({ ...spec, ...bridgeHandler === undefined ? {} : { handler: bridgeHandler } })
+      }
     })
     for (const contribution of contributions) {
+      if (contribution.registerDefinition === false) continue
       // The plugin's own commands-service registration: the effective
       // completion surface (and with it the advertised claim) sees the
       // name, exactly like a real plugin's `ctx.commands.register`.
@@ -1191,7 +1200,7 @@ test('running + steer: an extension submission command keeps the busy steer, nev
   assert.equal(harness.executed.length, 0, 'an advertised extension command must never be claimed as a Host command')
 })
 
-test('running + steer: the accelerated chord queues an extension submission command as a PROMPT', async (t) => {
+test('running + steer: an extension submission command delivers its LINE, never the handler (declared ownership)', async (t) => {
   const { harness, mounted } = await bootCommandHarness(t, {
     busyEnter: 'steer',
     status: 'running',
@@ -1278,6 +1287,56 @@ test('running + steer: a no-loader per-skill wrapper also injects its body', asy
   assert.equal(harness.executed[0]?.line, '/grilling args', 'the wrapper receives its own slash line')
   assert.equal(harness.host.steered.length, 1, 'the invocation steers into the running turn')
   assert.equal(harness.host.injected.length, 1, 'the TUI fallback injects the skill body exactly once')
+})
+
+test('a live LOCAL command runs its bridge handler — never the model', async (t) => {
+  // A bridge-only local contribution (no commands-service definition) is a
+  // real plugin pattern (e.g. the vim fixture): with a LIVE session the line
+  // used to fall through to the command plane, miss, and be delivered to the
+  // MODEL as a prompt — the plugin's handler never ran. A local command is
+  // in-process by contract.
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    extensionCommands: [{
+      id: 'vimmode', name: 'vimmode', description: 'toggle vim mode', execution: 'local',
+      registerDefinition: false,
+      bridgeHandler: () => { calls.push('vimmode'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/vimmode')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && calls.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['vimmode'], 'the live local command must run its bridge handler')
+  assert.equal(harness.host.followedUp.length, 0, 'a local command must never reach the model')
+  assert.equal(harness.host.steered.length, 0, 'a local command never steers')
+  assert.equal(harness.executed.length, 0, 'a bridge-only contribution has no command-plane definition')
+})
+
+test('a live LOCAL command prefers its bridge handler over the commands definition', async (t) => {
+  // When BOTH exist the bridge handler is the implementation (public-types:
+  // "absent = the commands service handler runs") — the commands plane is
+  // the fallback, not the first choice.
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    extensionCommands: [{
+      id: 'panel', name: 'panel', description: 'toggle the panel', execution: 'local',
+      bridgeHandler: () => { calls.push('panel'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/panel')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && calls.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['panel'], 'the bridge handler must run')
+  assert.equal(harness.executed.length, 0, 'the commands definition is only the fallback')
+  assert.equal(harness.host.followedUp.length, 0, 'a local command must never reach the model')
 })
 
 test('running + steer: an extension local command still executes directly under both chords', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path'
 import test, { type TestContext } from 'node:test'
 import { Context } from '@deepseek-ai/cordis'
 import { ProcessTerminal } from '@xmoon76/pi-tui'
+import { CommandId } from '@deepseek-ai/dsh-commands'
 import { MessageId } from '@deepseek-ai/dsh-llm'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
@@ -115,6 +116,8 @@ interface FakeAgentHost {
   failFollowupAbort: boolean
   followedUp: unknown[]
   steered: unknown[]
+  /** The skill-body fallback injections (agent.inject), in call order. */
+  injected: unknown[]
 }
 
 function fakeAgent(session: LiveSession, host: FakeAgentHost | undefined): Agent {
@@ -142,6 +145,7 @@ function fakeAgent(session: LiveSession, host: FakeAgentHost | undefined): Agent
       host?.followedUp.push(message)
     },
     steer: (message: unknown) => { host?.steered.push(message) },
+    inject: (message: unknown) => { host?.injected.push(message) },
     cancel: (_reason: unknown, _options: { keepInbox: boolean }) => { /* the interrupt transport */ },
   } as unknown as Agent
 }
@@ -196,7 +200,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   armCreateGate(): void
   releaseCreateGate(): void
 } {
-  const host: FakeAgentHost = { status: 'idle', failFollowup: false, failFollowupAbort: false, followedUp: [], steered: [] }
+  const host: FakeAgentHost = { status: 'idle', failFollowup: false, failFollowupAbort: false, followedUp: [], steered: [], injected: [] }
   const persisted = new Map<string, LiveSession>()
   const live = new Map<string, Agent>()
   let liveSession: LiveSession | undefined
@@ -268,14 +272,24 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     list: () => [...definitions.values()].map(({ name, description }) => ({ name, description: description ?? '', input: { hint: '' } })),
     find: () => undefined,
     // A REGISTERED command executes through the command plane (the Host
-    // command semantics); a plain prompt is NOT a command: undefined falls
+    // command semantics): the handler runs with a CommandRuntime-shaped
+    // invocation, so a real handler (e.g. /skill → loadSkill) delivers
+    // like production. A plain prompt is NOT a command: undefined falls
     // back to the follow-up delivery (the runner's real semantics). Only
     // ACTUAL executions are recorded — an attempted miss is not a command.
-    execute: async (_agent: unknown, line: string) => {
+    execute: async (agent: unknown, line: string) => {
       const name = line.trim().replace(/^\//, '').split(/\s+/)[0] ?? ''
-      if (!definitions.has(name)) return undefined
+      const def = definitions.get(name)
+      if (def === undefined) return undefined
       executed.push({ line })
-      return { result: { kind: 'success' } }
+      const rawInput = line.slice(line.indexOf(name) + name.length)
+      const result = await (def.handler as (inv: unknown) => unknown)({
+        commandId: CommandId('cmd-test'),
+        agent,
+        rawInput,
+        signal: new AbortController().signal,
+      })
+      return { result }
     },
     handler: (name: string) => definitions.get(name)?.handler,
   }
@@ -865,7 +879,15 @@ async function waitForCommand(harness: ReturnType<typeof makeHarness>): Promise<
  * commands, and a busyEnter preference. */
 async function bootCommandHarness(
   t: TestContext,
-  options: { busyEnter: 'queue' | 'steer'; status: 'idle' | 'running'; hostCommands?: readonly string[] },
+  options: {
+    busyEnter: 'queue' | 'steer'
+    status: 'idle' | 'running'
+    hostCommands?: readonly string[]
+    /** Provide a skills registry (resolveSkill succeeds) and/or a tools
+     * service shaped like the dsh-tool-skill loader (hostLoadsSkillBody). */
+    skills?: boolean
+    hostLoadsSkillBody?: boolean
+  },
 ): Promise<{ harness: ReturnType<typeof makeHarness>; mounted: { dispose: () => Promise<void>; app: TuiApp } }> {
   const life = testLifecycle(t)
   const home = life.tempDir('dsh-pi-tui-command-arb-')
@@ -883,6 +905,21 @@ async function bootCommandHarness(
       name,
       handler: () => ({ kind: 'success' }),
     })
+  }
+  if (options.skills === true) {
+    context.provide('skills', {
+      get: async () => ({
+        name: 'grilling',
+        description: 'a skill',
+        content: 'skill body',
+        invocation: { userInvocable: true, modelInvocable: true },
+      }),
+    } as never)
+  }
+  if (options.hostLoadsSkillBody === true) {
+    context.provide('tools', {
+      get: (name: string) => name === 'skill' ? { execute: async () => {} } : undefined,
+    } as never)
   }
   const doc: Record<string, unknown> = { busyEnter: options.busyEnter }
   context.provide('settings', {
@@ -958,6 +995,48 @@ test('running + steer: /skill <name> stays an agent-facing invocation (PR115-fix
   const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
   assert.equal(steered.content[0]?.text, '/grilling args', 'the skill line must steer in its normalized /name args form')
   assert.equal(harness.executed.length, 0, 'a skill invocation must never be claimed as a Host command')
+})
+
+test('running + queue: /skill <name> queues like a plain prompt when the host injects the body (web parity)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    skills: true,
+    hostLoadsSkillBody: true,
+  })
+  mounted.app.setDraft('/skill grilling args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'queued skill')
+  // Web parity: a skill invocation is a plain agent-facing prompt — with
+  // busyEnter=queue it QUEUES (followup), never steers into the running
+  // turn. The host's dsh-tool-skill pre-step injects the body at the next
+  // model request, so the queue delivery keeps the web message order.
+  assert.equal(harness.host.followedUp.length, 1, 'the skill line must queue like a plain prompt')
+  const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
+  assert.equal(followed.content[0]?.text, '/grilling args', 'the queued line is the normalized /name args form')
+  assert.equal(harness.host.steered.length, 0, 'queue preference must not steer the skill')
+  assert.equal(harness.host.injected.length, 0, 'the host owns the body injection — no TUI fallback body')
+})
+
+test('running + queue: /skill <name> keeps the steer path when the TUI must inject the body itself (order-preserving fallback)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    skills: true,
+  })
+  mounted.app.setDraft('/skill grilling args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'fallback skill steer')
+  // Without the host loader the TUI injects the body into next-step: a
+  // followup would let the body arrive BEFORE the user's words (the driver
+  // claims next-step first), so the invocation keeps the steer path to
+  // preserve the original-line-before-body order — the documented
+  // exception to the queue preference.
+  assert.equal(harness.host.steered.length, 1, 'the fallback keeps the order-preserving steer')
+  const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
+  assert.equal(steered.content[0]?.text, '/grilling args', 'the steered line is the normalized /name args form')
+  assert.equal(harness.host.injected.length, 1, 'the TUI fallback injects the skill body')
+  assert.equal(harness.host.followedUp.length, 0, 'no followup — the body order contract forbids it')
 })
 
 test('a dynamic Host command never enters the ordinary inbox while running (PR115-fix problem 1)', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -11,6 +11,7 @@
  */
 
 import assert from 'node:assert/strict'
+import { existsSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import test, { type TestContext } from 'node:test'
@@ -438,6 +439,22 @@ async function mountRunner(
   return {
     dispose: () => Promise.resolve(),
     app: app as TuiApp,
+  }
+}
+
+/** Drain microtasks + nextTick + the poll phase until `ready` or a bounded
+ * deadline. Load-tolerant on purpose: the FULL product suite mounts many
+ * surfaces in parallel, so a pure iteration budget is not enough for work
+ * that depends on real fs/timer scheduling (the attachment intake), and a
+ * fixed sleep is not allowed. Returns the final readiness. */
+async function drainUntil(ready: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (ready()) return true
+    if (Date.now() >= deadline) return false
+    for (let index = 0; index < 50; index += 1) await Promise.resolve()
+    await new Promise<void>(resolve => process.nextTick(resolve))
+    await new Promise<void>(resolve => setImmediate(resolve))
   }
 }
 
@@ -1567,17 +1584,23 @@ function pngHeader(width: number, height: number): Uint8Array {
  * sessionless command: the intake inserts its placeholder into the editor,
  * which is exactly the draft text the user submits next. */
 async function stageAttachmentDraft(mounted: { app: TuiApp }, path: string): Promise<string> {
+  // The runner registers its TUI commands during mount, and the mount's
+  // readiness can lag under a loaded suite (the full product run mounts many
+  // surfaces in parallel): submitting before `/attach` is advertised makes
+  // the line fall back to the session dispatch, where the intake lands much
+  // later. Wait for the catalog row first (bounded, drain-based).
+  await drainUntil(
+    () => mounted.app.commandCompletionsForTest().some(row => row.name === 'attach'),
+    10_000,
+  )
   mounted.app.setDraft(`/attach ${path}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  // The intake reads the file through real fs I/O in a detached workflow, so
-  // the wait drains microtasks + nextTick + the poll phase per round (the
-  // repository's race-test pattern — never a wall-clock sleep).
-  for (let round = 0; round < 40 && !/\[(file|image) #1/.test(mounted.app.getDraft()); round += 1) {
-    for (let index = 0; index < 50; index += 1) await Promise.resolve()
-    await new Promise<void>(resolve => process.nextTick(resolve))
-    await new Promise<void>(resolve => setImmediate(resolve))
-  }
-  return mounted.app.getDraft()
+  // The intake then reads the file through real fs I/O in a detached workflow.
+  const staged = await drainUntil(() => /\[(file|image) #1/.test(mounted.app.getDraft()), 10_000)
+  const draft = mounted.app.getDraft()
+  assert.ok(staged,
+    `the attachment intake staged nothing (draft=${JSON.stringify(draft)}, notice=${JSON.stringify(mounted.app.notifyTextForTest())})`)
+  return draft
 }
 
 test('an attachment-bearing client command defers to a LATE declared host claim (delivered, then consumed)', async (t) => {
@@ -1712,9 +1735,7 @@ test('an unknown slash line that becomes an UNDECLARED host command refuses its 
   assert.deepEqual(harness.createdSessionIds, [], 'the sessionless intake creates no session')
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  for (let round = 0; round < 60 && !/does not accept attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
-    await new Promise<void>(resolve => setImmediate(resolve))
-  }
+  await drainUntil(() => /does not accept attachments/.test(mounted.app.notifyTextForTest()), 5000)
   assert.match(mounted.app.notifyTextForTest(), /\/deploy does not accept attachments; remove them first/)
   assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
     `the undeclared late claim never reaches the command plane: ${JSON.stringify(harness.executed)}`)
@@ -1749,9 +1770,7 @@ test('an unknown slash line that becomes a DECLARED host command delivers and co
   const staged = await stageAttachmentDraft(mounted, path)
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  for (let round = 0; round < 60 && !harness.executed.some(entry => entry.line.startsWith('/deploy')); round += 1) {
-    await new Promise<void>(resolve => setImmediate(resolve))
-  }
+  await drainUntil(() => harness.executed.some(entry => entry.line.startsWith('/deploy')), 5000)
   const call = harness.executed.find(entry => entry.line.startsWith('/deploy'))
   assert.equal(call?.outcome, 'executed', `the declared late claim is admitted: ${JSON.stringify(harness.executed)}`)
   assert.equal(call?.attachments.length, 1, 'the declared command receives the submitted image')
@@ -1792,15 +1811,49 @@ test('an unknown slash line that becomes a DECLARED host command still refuses a
   assert.match(staged, /\[file #1/, `the file is staged: ${JSON.stringify(staged)}`)
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  for (let round = 0; round < 60 && !/cannot receive file attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
-    await new Promise<void>(resolve => setImmediate(resolve))
-  }
+  await drainUntil(() => /cannot receive file attachments/.test(mounted.app.notifyTextForTest()), 5000)
   assert.match(mounted.app.notifyTextForTest(), /\/deploy cannot receive file attachments in this client; remove them first/)
   assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
     `the file-bearing invocation never reaches the command plane: ${JSON.stringify(harness.executed)}`)
   assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
   assert.match(mounted.app.getDraft(), /\[file #1/, 'the file draft comes back unconsumed')
 })
+
+// A `!`/`!!` shell line is a local UI control: the shell neither admits nor
+// consumes drafts, so a staged attachment must be refused BEFORE the
+// placeholder can become shell arguments (and before the success path could
+// consume it).
+for (const form of [
+  { label: 'context `!`', line: (staged: string) => `!echo ${staged.trim()}` },
+  { label: 'local `!!`', line: (staged: string) => `!!echo ${staged.trim()}` },
+] as const) {
+  test(`a shell line never carries an attachment placeholder into the shell (${form.label})`, async (t) => {
+    const life = testLifecycle(t)
+    const root = life.tempDir('dsh-pi-tui-shell-attachment-')
+    const marker = join(root, 'shell-ran.marker')
+    const image = join(root, 'shot.png')
+    await writeFile(image, pngHeader(8, 8))
+    const { harness, mounted } = await bootCommandHarness(t, {
+      busyEnter: 'queue',
+      status: 'idle',
+      attachments: true,
+    })
+    const staged = await stageAttachmentDraft(mounted, image)
+    assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
+    // The shell command would create the marker if it ever ran.
+    mounted.app.setDraft(form.line(staged).replace('echo ', `touch ${marker} # `))
+    ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+    for (let round = 0; round < 40 && !/Attachments cannot be included/.test(mounted.app.notifyTextForTest()); round += 1) {
+      await new Promise<void>(resolve => setImmediate(resolve))
+    }
+    // The strongest signal first: a shell that ran would have created the
+    // marker (the placeholder text is passed as shell arguments).
+    assert.equal(existsSync(marker), false, 'the shell never ran with the placeholder')
+    assert.match(mounted.app.notifyTextForTest(), /Attachments cannot be included in a local command\./)
+    assert.equal(harness.host.followedUp.length, 0, 'nothing is posted to the session')
+    assert.match(mounted.app.getDraft(), /\[image #1/, 'the draft comes back with its placeholder intact')
+  })
+}
 
 test('a HOST command that does not declare input.attachments refuses an attachment (web composer parity)', async (t) => {
   // Upstream `CommandUiRuntime` refuses an attachment-bearing invocation of a

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -1023,6 +1023,8 @@ async function bootCommandHarness(
   }): Promise<void>
   /** The recorded image-admission batches (only with `attachments: true`). */
   imageSaves: readonly (readonly { mediaType: string; byteLength: number }[])[]
+  /** The recorded FILE admissions (only with `attachments: true`). */
+  fileSaves: readonly { name: string | undefined; byteLength: number }[]
   /** Dispose one pre-registered `hostCommands` definition (a catalog name that
    * disappears — e.g. while a deferred session is being created). */
   disposeHostCommand(name: string): void
@@ -1044,6 +1046,7 @@ async function bootCommandHarness(
   const context = new Context()
   life.defer(() => disposeContext(context))
   const imageSaves: { mediaType: string; byteLength: number }[][] = []
+  const fileSaves: { name: string | undefined; byteLength: number }[] = []
   if (options.attachments === true) {
     context.provide('attachments', {
       imageLimits: {
@@ -1063,6 +1066,15 @@ async function bootCommandHarness(
           width: 1,
           height: 1,
         }))
+      },
+      // The streamed file-admission seam (a plain prompt or an argued
+      // command-name line carries its FILE drafts through the model path): the
+      // fake drains the stream and records the bytes it actually received.
+      saveFileStream: async (input: { data: AsyncIterable<Uint8Array>; name?: string }) => {
+        let bytes = 0
+        for await (const chunk of input.data) bytes += chunk.byteLength
+        fileSaves.push({ name: input.name, byteLength: bytes })
+        return { attachmentId: `file-${fileSaves.length}`, name: input.name ?? 'file', bytes }
       },
     } as never)
   }
@@ -1179,6 +1191,7 @@ async function bootCommandHarness(
     mounted,
     registerContribution,
     imageSaves,
+    fileSaves,
     disposeHostCommand: (name: string) => { hostCommandDisposers.get(name)?.() },
     extensionService: extensionService as {
       _ledger(): {
@@ -2407,39 +2420,74 @@ test('a FAILED declared command keeps its attachment (consume only after handler
   assert.deepEqual(delivered.content.map(block => block.type), ['image'], 'the image reaches the model')
 })
 
-test('an attachment-bearing client command is refused AFTER the session resolves when the contribution keeps the line', async (t) => {
-  // The same deferral, with no late authority: the FINAL owner is the client
-  // contribution, whose local route refuses attachments. The refusal is the
-  // SAME user-visible outcome as the synchronous gate — just resolved late
-  // (the authority had to be settled) — and the draft, attachments included,
-  // comes back for a re-attach decision.
+test('an argued line of a client command name is an ordinary submission (the handler never runs)', async (t) => {
+  // DSH `matchEnter`: a contribution is a slash-MENU entry — it claims the BARE
+  // `/name` token only (`if (!bare) return undefined`). `/deploy <args>` is an
+  // ordinary submission even for a session-backed contribution on a deferred
+  // start, so the client handler never runs for it, the line reaches the MODEL
+  // (with its attachment), and no local-command refusal is surfaced.
   const life = testLifecycle(t)
-  const root = life.tempDir('dsh-pi-tui-deferred-attachment-')
-  const path = join(root, 'report.pdf')
-  await writeFile(path, Buffer.from('%PDF-1.7\nbody'))
+  const root = life.tempDir('dsh-pi-tui-argued-contribution-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(2, 2))
   const calls: string[] = []
-  const { harness, mounted } = await bootCommandHarness(t, {
+  const { harness, mounted, imageSaves } = await bootCommandHarness(t, {
     busyEnter: 'queue',
     status: 'idle',
     deferredStart: true,
+    attachments: true,
     extensionCommands: [{
       id: 'deploy', name: 'deploy', description: 'deploy',
       bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
     }],
   })
   const staged = await stageAttachmentDraft(harness, mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  for (let round = 0; round < 60 && !/Attachments cannot be included/.test(mounted.app.notifyTextForTest()); round += 1) {
-    await new Promise<void>(resolve => setImmediate(resolve))
-  }
-  assert.match(mounted.app.notifyTextForTest(), /Attachments cannot be included in a local command\./)
-  assert.deepEqual(calls, [], 'the local handler never runs for an attachment-bearing line')
+  await waitForDelivery(harness.host, 'argued contribution line')
+  assert.equal(mounted.app.notifyTextForTest(), '', 'no local-command refusal is surfaced')
+  assert.deepEqual(calls, [], 'the client handler never runs for an argued line')
   assert.equal(harness.executed.length, 0, 'never the command plane')
-  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
-  assert.equal(harness.createdSessionIds.length, 1, 'the deferred authority resolution ran (the session is session-keyed)')
-  assert.match(mounted.app.getDraft(), /^\/deploy /, 'the draft comes back for a re-attach decision')
-  assert.match(mounted.app.getDraft(), /\[file #1/, 'with its attachment placeholder intact')
+  assert.equal(imageSaves.length, 1, 'the image is admitted through the ordinary model path')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.type), ['text', 'image'],
+    'the model receives the multimodal prompt')
+  assert.match(delivered.content[0]?.text ?? '', /^\/deploy /, 'with the raw line (placeholder included)')
+})
+
+test('an argued line of a client command name carries a FILE as an ordinary submission', async (t) => {
+  // The same row with a generic FILE draft: the argued line is not a
+  // contribution invocation, so the file is admitted through the ordinary
+  // model path (never a local-command refusal, and the handler stays silent).
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-argued-contribution-file-')
+  const path = join(root, 'report.pdf')
+  await writeFile(path, Buffer.from('%PDF-1.7\nbody'))
+  const calls: string[] = []
+  const { harness, mounted, fileSaves } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    attachments: true,
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  const staged = await stageAttachmentDraft(harness, mounted, path)
+  assert.match(staged, /\[file #1/, `the file is staged: ${JSON.stringify(staged)}`)
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'argued contribution line with a file')
+  assert.equal(mounted.app.notifyTextForTest(), '', 'no local-command refusal is surfaced')
+  assert.deepEqual(calls, [], 'the client handler never runs for an argued line')
+  assert.equal(harness.executed.length, 0, 'never the command plane')
+  assert.deepEqual(fileSaves.map(save => ({ name: save.name, byteLength: save.byteLength })),
+    [{ name: 'report.pdf', byteLength: 13 }], 'the exact file bytes are admitted through the model path')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.type), ['text', 'file'],
+    'the model receives the file-bearing prompt')
 })
 
 test('a sessionless client command runs without creating a session', async (t) => {
@@ -2835,6 +2883,100 @@ test('a client command executes locally under both chords (never the plane, neve
   assert.equal(harness.host.steered.length, 0, 'a client command never steers')
   assert.equal(harness.host.followedUp.length, 0, 'a client command never reaches the model')
   assert.equal(harness.executed.length, 0, 'a client command never enters the command plane')
+})
+
+test('running + queue: an argued client-command line is an ordinary queued followup', async (t) => {
+  // DSH `matchEnter`: a contribution claims the BARE token only, so its argued
+  // line follows the ordinary busy policy — the handler never runs.
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy the app',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/deploy explain the risk')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'argued client-command line')
+  assert.deepEqual(calls, [], 'the client handler never runs for an argued line')
+  assert.equal(harness.executed.length, 0, 'never the command plane')
+  assert.equal(harness.host.followedUp.length, 1, 'the line takes the ordinary queue delivery')
+  assert.equal(harness.host.steered.length, 0, 'the queue preference never steers')
+})
+
+test('running + steer: an argued client-command line steers as an ordinary prompt', async (t) => {
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy the app',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/deploy explain the risk')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'argued client-command line')
+  assert.deepEqual(calls, [], 'the client handler never runs for an argued line')
+  assert.equal(harness.executed.length, 0, 'never the command plane')
+  assert.equal(harness.host.steered.length, 1, 'it takes the ordinary steer delivery')
+  assert.equal(harness.host.followedUp.length, 0, 'the steer preference never queues')
+})
+
+test('running + accelerated chord: an argued client-command line takes the OPPOSITE policy', async (t) => {
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy the app',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/deploy explain the risk')
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  await waitForDelivery(harness.host, 'accelerated argued client-command line')
+  assert.deepEqual(calls, [], 'the chord cannot turn the line into a client command either')
+  assert.equal(harness.executed.length, 0, 'never the command plane')
+  assert.equal(harness.host.steered.length, 1, 'the accelerated chord takes the opposite of the queue preference')
+  assert.equal(harness.host.followedUp.length, 0, 'the chord must not queue')
+})
+
+test('bare /panel runs the client handler while /panel args is an ordinary submission', async (t) => {
+  // The two rows of the DSH contribution decision table, side by side.
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{
+      id: 'panel', name: 'panel', description: 'toggle the panel',
+      bridgeHandler: () => { calls.push('panel'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/panel')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && calls.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['panel'], 'the BARE token runs the client handler')
+  assert.equal(harness.host.followedUp.length, 0, 'a client command never reaches the model')
+  // Trailing whitespace is NOT input (DSH `bare`), so the handler still runs —
+  // and it receives the preserved whitespace verbatim.
+  mounted.app.setDraft('/panel   ')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && calls.length < 2; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['panel', 'panel'], 'trailing whitespace keeps the line bare')
+  assert.equal(harness.host.followedUp.length, 0, 'still never the model')
+  mounted.app.setDraft('/panel with args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'argued /panel line')
+  assert.deepEqual(calls, ['panel', 'panel'], 'the argued line does not run the handler')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.equal(delivered.content[0]?.text, '/panel with args', 'the MODEL receives the raw line')
 })
 
 test('running + steer: the Ctrl+Enter chord never turns a Host command into a queued prompt', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -196,8 +196,9 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   defaultModel: unknown
   commands: unknown
   host: FakeAgentHost
-  /** Every `commands.execute` line, in call order (the command plane). */
-  executed: { line: string }[]
+  /** Every `commands.execute` call, in order (the command plane), with the
+   * submitted attachments the client handed over. */
+  executed: { line: string; attachments: readonly unknown[] }[]
   readonly session: LiveSession | undefined
   /** The session ids `agents.create` produced (the deferred-start gate). */
   createdSessionIds: string[]
@@ -272,16 +273,30 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     currentSelection: () => ({ provider: 'p', model: 'm' }),
     saveSelection: async () => {},
   }
-  const definitions = new Map<string, { name: string; description?: string; handler: (...args: never[]) => unknown }>()
-  const executed: { line: string }[] = []
+  const definitions = new Map<string, {
+    name: string
+    description?: string
+    input?: { hint: string; attachments?: boolean }
+    handler: (...args: never[]) => unknown
+  }>()
+  const executed: { line: string; attachments: readonly unknown[] }[] = []
   const commands = {
-    register: (definition: { name: string; handler: (...args: never[]) => unknown; description?: string; input?: { hint: string } }): (() => void) => {
+    register: (definition: {
+      name: string
+      handler: (...args: never[]) => unknown
+      description?: string
+      input?: { hint: string; attachments?: boolean }
+    }): (() => void) => {
       definitions.set(definition.name, definition)
       return () => {
         if (definitions.get(definition.name) === definition) definitions.delete(definition.name)
       }
     },
-    list: () => [...definitions.values()].map(({ name, description }) => ({ name, description: description ?? '', input: { hint: '' } })),
+    list: () => [...definitions.values()].map(({ name, description, input }) => ({
+      name,
+      description: description ?? '',
+      input: input ?? { hint: '' },
+    })),
     // The real commands service resolves a definition by name for the
     // global layer too (`find(undefined, name)`); the harness mirrors it so
     // a TUI-owned sessionless command runs LOCALLY in a deferred start
@@ -293,11 +308,11 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     // like production. A plain prompt is NOT a command: undefined falls
     // back to the follow-up delivery (the runner's real semantics). Only
     // ACTUAL executions are recorded — an attempted miss is not a command.
-    execute: async (agent: unknown, line: string) => {
+    execute: async (agent: unknown, line: string, attachments: readonly unknown[] = []) => {
       const name = line.trim().replace(/^\//, '').split(/\s+/)[0] ?? ''
       const def = definitions.get(name)
       if (def === undefined) return undefined
-      executed.push({ line })
+      executed.push({ line, attachments: [...attachments] })
       const rawInput = line.slice(line.indexOf(name) + name.length)
       const result = await (def.handler as (inv: unknown) => unknown)({
         commandId: CommandId('cmd-test'),
@@ -926,6 +941,9 @@ async function bootCommandHarness(
     hostLoadsSkillBody?: boolean
     /** Mount WITHOUT a resumed session (the deferred-start gate). */
     deferredStart?: boolean
+    /** Provide a recording fake `ctx.attachments` (image admission
+     * observability: `imageSaves` records each `saveImages` batch). */
+    attachments?: boolean
     /** Extension command contributions to mount (owner metadata + the
      * plugin's own commands-service registration, like a real plugin). */
     extensionCommands?: readonly {
@@ -953,6 +971,8 @@ async function bootCommandHarness(
     sessionless?: boolean
     bridgeHandler: () => { kind: 'success' | 'error'; text?: string }
   }): Promise<void>
+  /** The recorded image-admission batches (only with `attachments: true`). */
+  imageSaves: readonly (readonly { mediaType: string; byteLength: number }[])[]
   /** The mounted extension service (health assertions). */
   extensionService: {
     _ledger(): {
@@ -970,6 +990,29 @@ async function bootCommandHarness(
   })
   const context = new Context()
   life.defer(() => disposeContext(context))
+  const imageSaves: { mediaType: string; byteLength: number }[][] = []
+  if (options.attachments === true) {
+    context.provide('attachments', {
+      imageLimits: {
+        maxImageBytes: 20 * 1024 * 1024,
+        maxImagesPerMessage: 4,
+        maxMessageImageBytes: 200 * 1024 * 1024,
+        maxImagePixels: 64_000_000,
+        maxImageDimension: 8192,
+        mediaTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/gif'],
+      },
+      saveImages: async (inputs: readonly { mediaType: string; data: Uint8Array }[]) => {
+        imageSaves.push(inputs.map(input => ({ mediaType: input.mediaType, byteLength: input.data.byteLength })))
+        return inputs.map((input, index) => ({
+          attachmentId: `att-${imageSaves.length}-${index}`,
+          mediaType: input.mediaType,
+          bytes: input.data.byteLength,
+          width: 1,
+          height: 1,
+        }))
+      },
+    } as never)
+  }
   const harness = makeHarness(home, { id: 'command-session', events: sessionEvents('resumed answer') })
   for (const name of options.hostCommands ?? []) {
     ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void }).register({
@@ -1068,7 +1111,7 @@ async function bootCommandHarness(
   const mounted = await mountRunner(context, home, harness,
     options.deferredStart === true ? {} : { sessionId: 'command-session' })
   harness.host.status = options.status
-  return { harness, mounted, registerContribution, extensionService: extensionService as {
+  return { harness, mounted, registerContribution, imageSaves, extensionService: extensionService as {
     _ledger(): {
       healthSnapshot(): readonly { id: string; owner: string; extensionPoint: string; state: string; lastError?: string }[]
     }
@@ -1487,102 +1530,209 @@ test('a host command that appears only AFTER the deferred session outranks the c
   assert.equal(harness.host.steered.length, 0, 'never steered')
 })
 
+/** A minimal PNG header (magic + IHDR): the intake parses headers only, so a
+ * header is a complete fixture for the image attachment paths. */
+function pngHeader(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(33)
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0)
+  bytes.set([0, 0, 0, 13], 8)
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12)
+  const set32 = (offset: number, value: number): void => {
+    bytes[offset] = (value >>> 24) & 0xff
+    bytes[offset + 1] = (value >>> 16) & 0xff
+    bytes[offset + 2] = (value >>> 8) & 0xff
+    bytes[offset + 3] = value & 0xff
+  }
+  set32(16, width)
+  set32(20, height)
+  return bytes
+}
+
 /** Stage ONE real generic-file attachment through the REAL `/attach`
  * sessionless command: the intake inserts its placeholder into the editor,
  * which is exactly the draft text the user submits next. */
 async function stageAttachmentDraft(mounted: { app: TuiApp }, path: string): Promise<string> {
   mounted.app.setDraft(`/attach ${path}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  for (let round = 0; round < 40 && !/\[file #1/.test(mounted.app.getDraft()); round += 1) {
+  // The intake reads the file through real fs I/O in a detached workflow, so
+  // the wait drains microtasks + nextTick + the poll phase per round (the
+  // repository's race-test pattern — never a wall-clock sleep).
+  for (let round = 0; round < 40 && !/\[(file|image) #1/.test(mounted.app.getDraft()); round += 1) {
+    for (let index = 0; index < 50; index += 1) await Promise.resolve()
+    await new Promise<void>(resolve => process.nextTick(resolve))
     await new Promise<void>(resolve => setImmediate(resolve))
   }
   return mounted.app.getDraft()
 }
 
-test('an attachment-bearing client command defers its local refusal: a LATE host claim takes the line', async (t) => {
+test('an attachment-bearing client command defers to a LATE declared host claim (delivered, then consumed)', async (t) => {
   // Deferred start + a session-backed client contribution + a REAL staged
-  // attachment. The standing view classifies the line LOCAL (the client
-  // contribution), but the session may commit a session-scoped host claim
-  // that outranks it and accepts the attachment — so the irrevocable local
-  // refusal must wait for the same authority resolution instead of firing
-  // before `ensureSession()` (which would leave the real host command no
-  // chance to take the line).
+  // IMAGE. The standing view classifies the line LOCAL (the contribution),
+  // but the session commits a host command that DECLARES
+  // `input.attachments` — it takes the line and receives the encoded image
+  // (web composer parity: the leading claim's submit passes the attachments
+  // through). Success then CONSUMES the draft.
   const life = testLifecycle(t)
   const root = life.tempDir('dsh-pi-tui-deferred-attachment-')
-  const path = join(root, 'report.pdf')
-  await writeFile(path, Buffer.from('%PDF-1.7\nbody'))
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(2, 2))
   const calls: string[] = []
-  const { harness, mounted } = await bootCommandHarness(t, {
+  const { harness, mounted, imageSaves } = await bootCommandHarness(t, {
     busyEnter: 'queue',
     status: 'idle',
     deferredStart: true,
+    attachments: true,
     extensionCommands: [{
       id: 'deploy', name: 'deploy', description: 'deploy',
       bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
     }],
   })
   harness.onCreateSession(() => {
-    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void })
-      .register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+    ;(harness.commands as {
+      register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+    }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '', attachments: true } })
   })
   const staged = await stageAttachmentDraft(mounted, path)
-  assert.match(staged, /\[file #1/, `the attachment is staged through the real intake: ${JSON.stringify(staged)}`)
+  assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
   assert.deepEqual(harness.createdSessionIds, [], 'the sessionless intake creates no session')
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
   await waitForCommand(harness)
-  assert.equal(harness.executed.length, 1, 'the LATE host claim owns the line')
+  assert.equal(harness.executed.length, 1, 'the LATE declared host claim owns the line')
   assert.match(harness.executed[0]?.line ?? '', /^\/deploy /, 'the host command receives the raw line')
+  const submitted = harness.executed[0]?.attachments[0] as { type: string; mediaType: string; data: string; name?: string }
+  assert.equal(harness.executed[0]?.attachments.length, 1, 'the declared command receives the submitted image')
+  assert.equal(submitted.type, 'image')
+  assert.equal(submitted.mediaType, 'image/png')
+  assert.equal(submitted.name, 'shot.png')
+  assert.deepEqual([...Buffer.from(submitted.data, 'base64')], [...pngHeader(2, 2)],
+    'the EXACT encoded bytes ride the command invocation (no re-encode, no drop)')
   assert.deepEqual(calls, [], 'the client handler never runs once the session claims the name')
   assert.equal(harness.host.followedUp.length, 0, 'never downgraded to a model prompt')
-  assert.ok(!mounted.app.notifyTextForTest().includes('Attachments cannot be included'),
-    `the local-attachment refusal must not fire before the authority resolves: ${mounted.app.notifyTextForTest()}`)
+  assert.deepEqual(imageSaves, [], 'a command submission is admitted by the HOST, not saved locally')
+  // CONSUME-ON-SUCCESS: the same placeholder re-submitted as a PLAIN prompt
+  // is ordinary text now — a surviving draft would be admitted (saveImages).
+  mounted.app.setDraft(staged.trim())
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'consumed placeholder')
+  assert.deepEqual(imageSaves, [], 'the consumed attachment is not re-admitted by a later submit')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual([...delivered.content], [{ type: 'text', text: staged.trim() }], 'the line stays plain text')
 })
 
-test('a deferred client command never runs a REPLACED contribution generation (and never becomes a prompt)', async (t) => {
-  // The submission captured one contribution generation, then the session
-  // create awaits. A plugin reload (dispose + re-register under the SAME
-  // owner and id) must not let the post-await resolution run the NEW
-  // generation's handler — the user submitted the old one — and a vanished
-  // name must never fall through `runLocalCommand`'s name-only lookup into
-  // the command plane or the MODEL.
-  const flush = async (): Promise<void> => {
-    for (let round = 0; round < 20; round += 1) await new Promise<void>(resolve => setImmediate(resolve))
-  }
-  const calls: string[] = []
-  const { harness, mounted, extensionService } = await bootCommandHarness(t, {
+test('a HOST command that does not declare input.attachments refuses an attachment (web composer parity)', async (t) => {
+  // Upstream `CommandUiRuntime` refuses an attachment-bearing invocation of a
+  // command whose descriptor does not declare `input.attachments`. The TUI
+  // must not let the line through and then hand the host a placeholder with
+  // no bytes (the attachment would be silently dropped).
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-command-attachment-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(4, 4))
+  const { harness, mounted, registerContribution, imageSaves } = await bootCommandHarness(t, {
     busyEnter: 'queue',
     status: 'idle',
-    deferredStart: true,
+    attachments: true,
     extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
   })
-  const service = extensionService as unknown as {
-    registerCommand(contribution: {
-      id: string; name: string; description: string; handler: () => { kind: 'success' }
-    }): { dispose(): void }
-  }
-  const spec = { id: 'deploy-cmd', name: 'deploy', description: 'client deploy' }
-  const submitted = service.registerCommand({ ...spec, handler: () => { calls.push('submitted'); return { kind: 'success' } } })
-  await flush()
-  harness.armCreateGate()
-  mounted.app.setDraft('/deploy prod')
+  // /compact is a HOST command without an attachment declaration; a registry
+  // change (any extension invalidation) refreshes the effective catalog.
+  ;(harness.commands as {
+    register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+  }).register({ name: 'compact', handler: () => ({ kind: 'success' }) })
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  const staged = await stageAttachmentDraft(mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
+  const executedBefore = harness.executed.length
+  mounted.app.setDraft(`/compact ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  for (let round = 0; round < 40 && harness.createdSessionIds.length === 0; round += 1) {
+  for (let round = 0; round < 40 && !/does not accept attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
     await new Promise<void>(resolve => setImmediate(resolve))
   }
-  assert.equal(harness.createdSessionIds.length, 1, 'the session create is in flight')
-  // The plugin reloads while the create awaits: SAME id, SAME owner (the
-  // registration context), a NEW generation.
-  submitted.dispose()
-  const replacement = service.registerCommand({ ...spec, handler: () => { calls.push('replacement'); return { kind: 'success' } } })
-  harness.releaseCreateGate()
-  await flush()
-  assert.deepEqual(calls, [], 'no generation runs: the submitted registration no longer exists')
-  assert.equal(harness.executed.length, 0, 'the command plane is never a fallback for a vanished contribution')
-  assert.equal(harness.host.followedUp.length, 0, 'never downgraded to a model prompt')
-  assert.match(mounted.app.notifyTextForTest(), /\/deploy is no longer available/)
-  assert.match(mounted.app.getDraft(), /^\/deploy prod/, 'the draft comes back for a retry')
-  replacement.dispose()
+  assert.match(mounted.app.notifyTextForTest(), /\/compact does not accept attachments; remove them first/)
+  assert.equal(harness.executed.length, executedBefore, 'the undeclared command never executes')
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
+  assert.deepEqual(imageSaves, [], 'nothing is admitted either')
+  assert.match(mounted.app.getDraft(), /^\/compact /, 'the draft comes back')
+  assert.match(mounted.app.getDraft(), /\[image #1/, 'with its attachment placeholder intact')
+})
+
+test('a declared HOST command still refuses a FILE attachment (no host receipt seam)', async (t) => {
+  // The host contract carries files as upload RECEIPTS; this client has no
+  // seam to produce one, so a declared command refuses a file rather than
+  // handing over a placeholder with no payload (fail closed).
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-command-attachment-')
+  const path = join(root, 'report.pdf')
+  await writeFile(path, Buffer.from('%PDF-1.7\nbody'))
+  const { harness, mounted, registerContribution } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    attachments: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  ;(harness.commands as {
+    register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+  }).register({ name: 'goal', handler: () => ({ kind: 'success' }), input: { hint: '<objective>', attachments: true } })
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  const staged = await stageAttachmentDraft(mounted, path)
+  assert.match(staged, /\[file #1/)
+  const executedBefore = harness.executed.length
+  mounted.app.setDraft(`/goal ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && !/cannot receive file attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.match(mounted.app.notifyTextForTest(), /\/goal cannot receive file attachments in this client; remove them first/)
+  assert.equal(harness.executed.length, executedBefore, 'the command never executes with an undeliverable file')
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
+  assert.match(mounted.app.getDraft(), /\[file #1/, 'the file draft comes back')
+})
+
+test('a FAILED declared command keeps its attachment (consume only after handler success)', async (t) => {
+  // Web parity: "a submission consumes its attachments only after handler
+  // success; an error outcome keeps the draft and attachments" — a failed
+  // command must never swallow the user's image.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-command-attachment-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(3, 3))
+  const { harness, mounted, registerContribution, imageSaves } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    attachments: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  ;(harness.commands as {
+    register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+  }).register({
+    name: 'goal',
+    handler: () => ({ kind: 'error', text: 'goal rejected' }),
+    input: { hint: '<objective>', attachments: true },
+  })
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  const staged = await stageAttachmentDraft(mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
+  mounted.app.setDraft(`/goal ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && !harness.executed.some(entry => entry.line.startsWith('/goal ')); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  const goalCall = harness.executed.find(entry => entry.line.startsWith('/goal '))
+  assert.equal(goalCall?.attachments.length, 1, 'the declared command receives the image')
+  for (let round = 0; round < 40 && !/^\/goal /.test(mounted.app.getDraft()); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.match(mounted.app.getDraft(), /^\/goal /, 'the failed command restores the draft')
+  assert.deepEqual(imageSaves, [], 'the failed command admits nothing locally')
+  // The attachment SURVIVED: the same placeholder as a plain prompt is
+  // still an image submission (admitted through the model path).
+  mounted.app.setDraft(staged.trim())
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'kept attachment after a failed command')
+  assert.equal(imageSaves.length, 1, 'the kept attachment is admitted on the next plain-prompt submit')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.type), ['image'], 'the image reaches the model')
 })
 
 test('an attachment-bearing client command is refused AFTER the session resolves when the contribution keeps the line', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -279,7 +279,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     input?: { hint: string; attachments?: boolean }
     handler: (...args: never[]) => unknown
   }>()
-  const executed: { line: string; attachments: readonly unknown[] }[] = []
+  const executed: { line: string; attachments: readonly unknown[]; outcome: 'executed' | 'rejected' }[] = []
   const commands = {
     register: (definition: {
       name: string
@@ -311,16 +311,23 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     execute: async (agent: unknown, line: string, attachments: readonly unknown[] = []) => {
       const name = line.trim().replace(/^\//, '').split(/\s+/)[0] ?? ''
       const def = definitions.get(name)
+      // A name that does not resolve is NOT a command-plane call (the submit
+      // falls back to the ordinary delivery). A RESOLVED invocation is
+      // recorded WITH its settled outcome: the real host executor appends its
+      // lifecycle pair even when admission refuses it — the handler just
+      // never runs — so a refusal must stay visible as a refusal, never
+      // counted as an execution. The REAL executor enforces the descriptor
+      // declaration at admission: attachments sent to a command that does not
+      // declare `input.attachments` settle as an error result BEFORE the
+      // handler runs (dsh-commands `execute`). The fake mirrors it, so an
+      // integration test cannot pass by handing the host a payload it would
+      // refuse.
       if (def === undefined) return undefined
-      executed.push({ line, attachments: [...attachments] })
-      // The REAL host executor enforces the descriptor declaration at
-      // admission: attachments sent to a command that does not declare
-      // `input.attachments` settle as an error result BEFORE the handler runs
-      // (dsh-commands `execute`). The fake mirrors it, so an integration test
-      // cannot pass by handing the host a payload it would refuse.
       if (attachments.length > 0 && def.input?.attachments !== true) {
+        executed.push({ line, attachments: [...attachments], outcome: 'rejected' })
         return { result: { kind: 'error', text: `/${name} does not accept attachments` } }
       }
+      executed.push({ line, attachments: [...attachments], outcome: 'executed' })
       const rawInput = line.slice(line.indexOf(name) + name.length)
       const result = await (def.handler as (inv: unknown) => unknown)({
         commandId: CommandId('cmd-test'),
@@ -1608,6 +1615,7 @@ test('an attachment-bearing client command defers to a LATE declared host claim 
   await waitForCommand(harness)
   assert.equal(harness.executed.length, 1, 'the LATE declared host claim owns the line')
   assert.match(harness.executed[0]?.line ?? '', /^\/deploy /, 'the host command receives the raw line')
+  assert.equal(harness.executed[0]?.outcome, 'executed', 'the declared command is admitted by the executor')
   const submitted = harness.executed[0]?.attachments[0] as { type: string; mediaType: string; data: string; name?: string }
   assert.equal(harness.executed[0]?.attachments.length, 1, 'the declared command receives the submitted image')
   assert.equal(submitted.type, 'image')
@@ -1665,8 +1673,10 @@ for (const form of [
     assert.ok([...delivered.content].some(block => block.type === 'image'),
       `the image rides the skill prompt: ${JSON.stringify(delivered.content)}`)
     // The command plane either never saw the line (wrapper) or carried it with
-    // NO attachments (`/skill`): the host executor would have rejected them.
+    // NO attachments (`/skill`): the host executor would have rejected them,
+    // and the fake mirrors that rejection as a recorded outcome.
     for (const call of harness.executed) {
+      assert.equal(call.outcome, 'executed', `${call.line} must not be refused by the executor`)
       assert.equal(call.attachments.length, 0, `no command-plane payload for ${call.line}`)
     }
   })
@@ -1771,6 +1781,7 @@ test('a FAILED declared command keeps its attachment (consume only after handler
     await new Promise<void>(resolve => setImmediate(resolve))
   }
   const goalCall = harness.executed.find(entry => entry.line.startsWith('/goal '))
+  assert.equal(goalCall?.outcome, 'executed', 'the declared command is admitted by the executor')
   assert.equal(goalCall?.attachments.length, 1, 'the declared command receives the image')
   for (let round = 0; round < 40 && !/^\/goal /.test(mounted.app.getDraft()); round += 1) {
     await new Promise<void>(resolve => setImmediate(resolve))

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -928,7 +928,7 @@ async function bootCommandHarness(
       name: string
       description: string
       /** The contribution's client behavior (the bridge handler). */
-      bridgeHandler: () => { kind: 'success' | 'error'; text?: string }
+      bridgeHandler: () => { kind: 'success' | 'error'; text?: string } | Promise<{ kind: 'success'; text?: string } | { kind: 'error'; text: string }>
       sessionless?: boolean
       /** Whether the plugin ALSO registers a commands-service definition for
        * the same name (a HOST-command collision: the host claim wins and the
@@ -1001,14 +1001,14 @@ async function bootCommandHarness(
     name: string
     description: string
     sessionless?: boolean
-    bridgeHandler: () => { kind: 'success' | 'error'; text?: string }
+    bridgeHandler: () => { kind: 'success' | 'error'; text?: string } | Promise<{ kind: 'success'; text?: string } | { kind: 'error'; text: string }>
   }): Promise<void> => {
     const { bridgeHandler, ...spec } = contribution
     await context.plugin((pluginCtx) => {
       const service = pluginCtx.get(PI_TUI_EXTENSIONS_SERVICE) as {
         registerCommand(contribution: {
           id: string; name: string; description: string; sessionless?: boolean
-          handler: () => { kind: 'success' | 'error'; text?: string }
+          handler: () => { kind: 'success' | 'error'; text?: string } | Promise<{ kind: 'success'; text?: string } | { kind: 'error'; text: string }>
         }): unknown
       }
       service.registerCommand({ ...spec, handler: bridgeHandler })
@@ -1035,7 +1035,7 @@ async function bootCommandHarness(
           name: string
           description: string
           sessionless?: boolean
-          handler: () => { kind: 'success' | 'error'; text?: string }
+          handler: () => { kind: 'success' | 'error'; text?: string } | Promise<{ kind: 'success'; text?: string } | { kind: 'error'; text: string }>
         }): unknown
       }
       for (const contribution of contributions) {
@@ -1687,6 +1687,158 @@ test('a collision health record clears on recovery, while a HANDLER failure reco
   await registerContribution({ id: 'omega-cmd', name: 'omega', description: 'omega', bridgeHandler: () => ({ kind: 'success' }) })
   assert.equal(healthOf(extensionService, 'deploy-cmd')?.state, 'active', 'the recovered collision clears')
   assert.equal(healthOf(extensionService, 'boom-cmd')?.state, 'failed', 'the handler failure is untouched by the recovery')
+})
+
+// ── the KNOWN diagnostic limits of the shared command health record ────────
+// ONE contribution identity has THREE writers of its single extension-health
+// record: the candidate synthesis (a host claim on the name), the client
+// handler settlement, and the session command path reporting the HOST command
+// that runs under a colliding name — while the ledger keeps one failure
+// generation per record and DEDUPLICATES a repeat (the first message wins).
+// The tests below CHARACTERIZE the resulting limitations; they are accepted
+// and documented in `docs/surface-decisions.md`, NOT a specification of
+// desired behavior: health is a lossy diagnostic, not an authoritative
+// summary of every unrecovered failure. Routing, claims and the immediate
+// notices are unaffected and are asserted alongside.
+
+test('known limitation: a handler failure under a colliding name is masked, then cleared, by the collision record', async (t) => {
+  const healthOf = (id: string): { state: string; lastError?: string } | undefined =>
+    extensionServiceOf().find(entry => entry.id === id)
+  let releaseHandler: ((error: Error) => void) | undefined
+  let started = false
+  const { harness, mounted, registerContribution, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{
+      id: 'deploy-cmd', name: 'deploy', description: 'client deploy',
+      bridgeHandler: () => {
+        started = true
+        return new Promise((_resolve, reject) => { releaseHandler = reject })
+      },
+    }],
+  })
+  const extensionServiceOf = (): readonly { id: string; state: string; lastError?: string }[] =>
+    extensionService._ledger().healthSnapshot()
+  const registerHost = (name: string): (() => void) =>
+    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }) })
+  // 1. The async client handler is IN FLIGHT (no claim yet: the local route).
+  mounted.app.setDraft('/deploy')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && !started; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.equal(started, true, 'the async client handler started')
+  // 2. A same-named Host claim appears while the handler runs: the candidate
+  // synthesis fails and records the collision on the SAME health record.
+  const disposeHost = registerHost('deploy')
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf('deploy-cmd')?.state, 'failed', 'the collision is recorded while the handler is in flight')
+  assert.match(healthOf('deploy-cmd')?.lastError ?? '', /collides with a host command/)
+  // 3. The in-flight handler REJECTS: the user is told immediately, but the
+  // ledger's first-message-wins dedupe keeps the collision text. (The routing
+  // assertions live in the resolve/limit tests below — a host-plane
+  // submission would settle this record first and change the very state
+  // characterized here.)
+  releaseHandler?.(new Error('handler boom'))
+  for (let round = 0; round < 40 && !/handler boom/.test(mounted.app.notifyTextForTest()); round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.match(mounted.app.notifyTextForTest(), /handler boom/, 'the handler failure reaches the user immediately')
+  assert.match(healthOf('deploy-cmd')?.lastError ?? '', /collides with a host command/, 'the health record still shows the collision')
+  // 4. The claim goes away: the collision recovery clears the record, and the
+  // UNRECOVERED handler failure is not in health any more.
+  disposeHost()
+  await registerContribution({ id: 'omega-cmd', name: 'omega', description: 'omega', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf('deploy-cmd')?.state, 'active', 'the collision recovery clears the record although the handler never recovered')
+})
+
+test('known limitation: a handler success clears the still-active collision record', async (t) => {
+  const healthOf = (id: string): { state: string; lastError?: string } | undefined =>
+    extensionServiceOf().find(entry => entry.id === id)
+  let releaseHandler: (() => void) | undefined
+  let started = false
+  const { harness, mounted, registerContribution, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{
+      id: 'deploy-cmd', name: 'deploy', description: 'client deploy',
+      bridgeHandler: () => {
+        started = true
+        return new Promise(resolve => { releaseHandler = () => resolve({ kind: 'success' }) })
+      },
+    }],
+  })
+  const extensionServiceOf = (): readonly { id: string; state: string; lastError?: string }[] =>
+    extensionService._ledger().healthSnapshot()
+  const registerHost = (name: string): (() => void) =>
+    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }) })
+  // 1. The async client handler is IN FLIGHT.
+  mounted.app.setDraft('/deploy')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && !started; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  // 2. The same-named Host claim appears: the collision is recorded.
+  const disposeHost = registerHost('deploy')
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf('deploy-cmd')?.state, 'failed', 'the collision is recorded while the handler is in flight')
+  // 3. The handler SETTLES SUCCESSFULLY while the collision stays active: the
+  // settlement clears the collision record (a handler success is not a
+  // collision recovery).
+  releaseHandler?.()
+  for (let round = 0; round < 40 && healthOf('deploy-cmd')?.state !== 'active'; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.equal(healthOf('deploy-cmd')?.state, 'active', 'the handler success cleared the collision record')
+  // 4. The collision itself is untouched: the claim still owns the name and
+  // the failed source still offers no rows.
+  mounted.app.setDraft('/deploy from-host')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the host command still owns the name')
+  const names = mounted.app.commandCompletionsForTest().map(row => row.name)
+  assert.deepEqual(names, [], `the failed source still offers no rows: ${names.join(',')}`)
+  // 5. A successful synthesis restores the client row.
+  disposeHost()
+  await registerContribution({ id: 'omega-cmd', name: 'omega', description: 'omega', bridgeHandler: () => ({ kind: 'success' }) })
+  const recovered = mounted.app.commandCompletionsForTest().map(row => row.name)
+  assert.ok(recovered.includes('deploy'), `the client row returns: ${recovered.join(',')}`)
+})
+
+test('known limitation: a HOST command run under a colliding name settles the contribution health record', async (t) => {
+  // No async handler involved: the claim owns the name, a submission executes
+  // the HOST command through the session path, and that settlement is written
+  // to the CONTRIBUTION's health record (its ref resolves by contribution id).
+  const healthOf = (id: string): { state: string; lastError?: string } | undefined =>
+    extensionServiceOf().find(entry => entry.id === id)
+  const { harness, mounted, registerContribution, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [
+      { id: 'deploy-cmd', name: 'deploy', description: 'client deploy', bridgeHandler: () => ({ kind: 'success' }) },
+    ],
+  })
+  const extensionServiceOf = (): readonly { id: string; state: string; lastError?: string }[] =>
+    extensionService._ledger().healthSnapshot()
+  const registerHost = (name: string): (() => void) =>
+    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }) })
+  const disposeHost = registerHost('deploy')
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf('deploy-cmd')?.state, 'failed', 'the collision is recorded')
+  mounted.app.setDraft('/deploy from-host')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the host command runs')
+  for (let round = 0; round < 40 && healthOf('deploy-cmd')?.state !== 'active'; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.equal(healthOf('deploy-cmd')?.state, 'active', "the HOST command's success settled the contribution health record")
+  assert.equal(mounted.app.commandCompletionsForTest().length, 0, 'the claim still withdraws the whole source')
+  disposeHost()
+  await registerContribution({ id: 'omega-cmd', name: 'omega', description: 'omega', bridgeHandler: () => ({ kind: 'success' }) })
 })
 
 test('a client command executes locally under both chords (never the plane, never the model)', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -12,7 +12,7 @@
 
 import assert from 'node:assert/strict'
 import { join } from 'node:path'
-import test from 'node:test'
+import test, { type TestContext } from 'node:test'
 import { Context } from '@deepseek-ai/cordis'
 import { ProcessTerminal } from '@xmoon76/pi-tui'
 import { MessageId } from '@deepseek-ai/dsh-llm'
@@ -190,6 +190,8 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   defaultModel: unknown
   commands: unknown
   host: FakeAgentHost
+  /** Every `commands.execute` line, in call order (the command plane). */
+  executed: { line: string }[]
   readonly session: LiveSession | undefined
   armCreateGate(): void
   releaseCreateGate(): void
@@ -255,6 +257,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     saveSelection: async () => {},
   }
   const definitions = new Map<string, { name: string; description?: string; handler: (...args: never[]) => unknown }>()
+  const executed: { line: string }[] = []
   const commands = {
     register: (definition: { name: string; handler: (...args: never[]) => unknown; description?: string; input?: { hint: string } }): (() => void) => {
       definitions.set(definition.name, definition)
@@ -264,9 +267,16 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     },
     list: () => [...definitions.values()].map(({ name, description }) => ({ name, description: description ?? '', input: { hint: '' } })),
     find: () => undefined,
-    // A plain prompt is NOT a command: undefined falls back to the
-    // follow-up delivery (the runner's real semantics).
-    execute: async () => undefined,
+    // A REGISTERED command executes through the command plane (the Host
+    // command semantics); a plain prompt is NOT a command: undefined falls
+    // back to the follow-up delivery (the runner's real semantics). Only
+    // ACTUAL executions are recorded — an attempted miss is not a command.
+    execute: async (_agent: unknown, line: string) => {
+      const name = line.trim().replace(/^\//, '').split(/\s+/)[0] ?? ''
+      if (!definitions.has(name)) return undefined
+      executed.push({ line })
+      return { result: { kind: 'success' } }
+    },
     handler: (name: string) => definitions.get(name)?.handler,
   }
   return {
@@ -276,6 +286,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     defaultModel,
     commands,
     host,
+    executed,
     get session() { return liveSession as LiveSession | undefined as LiveSession },
     armCreateGate,
     releaseCreateGate: () => { releaseCreateGate?.() },
@@ -832,4 +843,134 @@ test('a CANCELLED submit ends the ack through the onCancel sink (never stuck, no
   assert.ok(!settled.includes('submission failed'),
     'a CANCELLATION must not surface as a failure notice (runOwned routes it to onCancel only)')
   assert.equal(harness.host.followedUp.length, 0, 'nothing was written')
+})
+// ── Host-command arbitration (PR115-fix problem 1) ─────────────────────────
+// A registered Host command (e.g. /compact) must execute through the command
+// plane even while the agent is running: the busy queue/steer policy applies
+// only to agent-facing prompts, never to a confirmed Host command (the
+// command handler itself decides the busy outcome).
+
+/** Poll until the submission reaches the command plane. */
+async function waitForCommand(harness: ReturnType<typeof makeHarness>): Promise<void> {
+  for (let round = 0; round < 40; round += 1) {
+    if (harness.executed.length > 0) return
+    for (let index = 0; index < 50; index += 1) await Promise.resolve()
+    await new Promise<void>(resolve => process.nextTick(resolve))
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.ok(harness.executed.length > 0, 'the submission must reach the command plane')
+}
+
+/** Boot a runner with a resumed session, optional pre-registered Host
+ * commands, and a busyEnter preference. */
+async function bootCommandHarness(
+  t: TestContext,
+  options: { busyEnter: 'queue' | 'steer'; status: 'idle' | 'running'; hostCommands?: readonly string[] },
+): Promise<{ harness: ReturnType<typeof makeHarness>; mounted: { dispose: () => Promise<void>; app: TuiApp } }> {
+  const life = testLifecycle(t)
+  const home = life.tempDir('dsh-pi-tui-command-arb-')
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  life.defer(() => {
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+  })
+  const context = new Context()
+  life.defer(() => disposeContext(context))
+  const harness = makeHarness(home, { id: 'command-session', events: sessionEvents('resumed answer') })
+  for (const name of options.hostCommands ?? []) {
+    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void }).register({
+      name,
+      handler: () => ({ kind: 'success' }),
+    })
+  }
+  const doc: Record<string, unknown> = { busyEnter: options.busyEnter }
+  context.provide('settings', {
+    register: () => ({
+      get: () => ({ ...doc }),
+      replace: async (next: Record<string, unknown>) => { Object.assign(doc, next) },
+    }),
+  } as never)
+  const mounted = await mountRunner(context, home, harness, { sessionId: 'command-session' })
+  harness.host.status = options.status
+  return { harness, mounted }
+}
+
+test('idle /compact executes as a Host command: no followup, no queue, no prompt (PR115-fix problem 1)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'queue', status: 'idle', hostCommands: ['compact'] })
+  mounted.app.setDraft('/compact')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the Host command must be executed')
+  assert.equal(harness.executed[0]?.line, '/compact', 'the exact command line must reach the command plane')
+  assert.equal(harness.host.followedUp.length, 0, 'no ordinary followup')
+  assert.equal(harness.host.steered.length, 0, 'no steer')
+})
+
+test('running + queue: /compact executes, never enters the ordinary queue (PR115-fix problem 1)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'queue', status: 'running', hostCommands: ['compact'] })
+  mounted.app.setDraft('/compact')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the command path must be taken while running')
+  assert.equal(harness.host.followedUp.length, 0, 'no /compact may land in the ordinary inbox queue')
+  assert.equal(harness.host.steered.length, 0, 'no steer')
+  // The command handler owns the busy outcome (the TUI only routes to the
+  // command plane — the Host decides busy/unavailable presentation).
+})
+
+test('running + steer: /compact executes, never steers into the turn (PR115-fix problem 1)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'steer', status: 'running', hostCommands: ['compact'] })
+  mounted.app.setDraft('/compact')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the command path must be taken before the steer policy')
+  assert.equal(harness.host.steered.length, 0, '/compact must never be steered as a prompt')
+  assert.equal(harness.host.followedUp.length, 0, 'no followup')
+})
+
+test('running + queue: an ordinary prompt still queues (PR115-fix problem 1)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'queue', status: 'running' })
+  mounted.app.setDraft('hello world')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'queued prompt')
+  assert.equal(harness.host.followedUp.length, 1, 'a plain prompt must keep the queue delivery')
+  assert.equal(harness.host.steered.length, 0, 'queue preference never steers')
+  assert.equal(harness.executed.length, 0, 'a plain prompt is not a command')
+})
+
+test('running + steer: an ordinary prompt still steers (PR115-fix problem 1)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'steer', status: 'running' })
+  mounted.app.setDraft('hello world')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'steered prompt')
+  assert.equal(harness.host.steered.length, 1, 'a plain prompt must keep the steer delivery')
+  assert.equal(harness.host.followedUp.length, 0, 'steer preference never queues')
+  assert.equal(harness.executed.length, 0, 'a plain prompt is not a command')
+})
+
+test('running + steer: /skill <name> stays an agent-facing invocation (PR115-fix problem 1)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'steer', status: 'running' })
+  mounted.app.setDraft('/skill grilling args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'skill steer')
+  assert.equal(harness.host.steered.length, 1, 'a skill invocation must keep the agent-facing steer')
+  const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
+  assert.equal(steered.content[0]?.text, '/grilling args', 'the skill line must steer in its normalized /name args form')
+  assert.equal(harness.executed.length, 0, 'a skill invocation must never be claimed as a Host command')
+})
+
+test('a dynamic Host command never enters the ordinary inbox while running (PR115-fix problem 1)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    hostCommands: ['test-host-command'],
+  })
+  mounted.app.setDraft('/test-host-command')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the dynamic Host command must execute')
+  assert.equal(harness.executed[0]?.line, '/test-host-command')
+  assert.equal(harness.host.steered.length, 0, 'no steer — the fix is architectural, not a /compact special case')
+  assert.equal(harness.host.followedUp.length, 0, 'no ordinary inbox entry')
 })

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -200,6 +200,8 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   readonly session: LiveSession | undefined
   /** The session ids `agents.create` produced (the deferred-start gate). */
   createdSessionIds: string[]
+  /** Register a hook that runs as each session is created. */
+  onCreateSession(hook: (sessionId: string) => void): void
   armCreateGate(): void
   releaseCreateGate(): void
 } {
@@ -242,9 +244,13 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
     createGate = new Promise<void>(resolve => { releaseCreateGate = resolve })
   }
   const createdSessionIds: string[] = []
+  /** Test hook: invoked with each CREATED session id, before the handle is
+   * returned — the place a session-scoped host catalog can appear. */
+  let onCreateSession: ((sessionId: string) => void) | undefined
   const agents = {
     create: async ({ sessionId }: { sessionId: string }) => {
       createdSessionIds.push(String(sessionId))
+      onCreateSession?.(String(sessionId))
       if (createGate !== undefined) await createGate
       const session = makeLiveSession(String(sessionId), { id: String(sessionId), cwd: home, createdAt: Date.now(), version: 0 }, [])
       persisted.set(session.id, session)
@@ -301,6 +307,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   return {
     counting,
     createdSessionIds,
+    onCreateSession: (hook: (sessionId: string) => void) => { onCreateSession = hook },
     agents,
     sessions,
     defaultModel,
@@ -930,7 +937,20 @@ async function bootCommandHarness(
       registerDefinition?: boolean
     }[]
   },
-): Promise<{ harness: ReturnType<typeof makeHarness>; mounted: { dispose: () => Promise<void>; app: TuiApp } }> {
+): Promise<{
+  harness: ReturnType<typeof makeHarness>
+  mounted: { dispose: () => Promise<void>; app: TuiApp }
+  /** Register a contribution AFTER the mount (a late/HMR plugin). */
+  registerContribution(contribution: {
+    id: string
+    name: string
+    description: string
+    sessionless?: boolean
+    bridgeHandler: () => { kind: 'success' | 'error'; text?: string }
+  }): Promise<void>
+  /** The mounted extension service (health assertions). */
+  extensionService: { _ledger(): { healthSnapshot(): readonly { id: string; owner: string; state: string; lastError?: string }[] } }
+}> {
   const life = testLifecycle(t)
   const home = life.tempDir('dsh-pi-tui-command-arb-')
   const previousHome = process.env.DSH_HOME
@@ -975,6 +995,28 @@ async function bootCommandHarness(
       replace: async (next: Record<string, unknown>) => { Object.assign(doc, next) },
     }),
   } as never)
+  let extensionService: unknown
+  const registerContribution = async (contribution: {
+    id: string
+    name: string
+    description: string
+    sessionless?: boolean
+    bridgeHandler: () => { kind: 'success' | 'error'; text?: string }
+  }): Promise<void> => {
+    const { bridgeHandler, ...spec } = contribution
+    await context.plugin((pluginCtx) => {
+      const service = pluginCtx.get(PI_TUI_EXTENSIONS_SERVICE) as {
+        registerCommand(contribution: {
+          id: string; name: string; description: string; sessionless?: boolean
+          handler: () => { kind: 'success' | 'error'; text?: string }
+        }): unknown
+      }
+      service.registerCommand({ ...spec, handler: bridgeHandler })
+    })
+    // The service batcher flushes the invalidation into the surface's
+    // completion refresh on a later tick.
+    for (let round = 0; round < 20; round += 1) await new Promise<void>(resolve => setImmediate(resolve))
+  }
   if (options.extensionCommands !== undefined) {
     // The extension host must be mounted BEFORE the runner reads its
     // service (the runner attaches a SurfaceHost over its ledger), and its
@@ -985,6 +1027,7 @@ async function bootCommandHarness(
     const contributions = options.extensionCommands
     context.provide(TUI_STARTUP_SERVICE, { ...options.deferredStart === true ? {} : { sessionId: 'command-session' }, shippedPresetRoot: home })
     await context.plugin(applyExtensionHost)
+    extensionService = context.get(PI_TUI_EXTENSIONS_SERVICE)
     await context.plugin((pluginCtx) => {
       const service = pluginCtx.get(PI_TUI_EXTENSIONS_SERVICE) as {
         registerCommand(contribution: {
@@ -1016,7 +1059,9 @@ async function bootCommandHarness(
   const mounted = await mountRunner(context, home, harness,
     options.deferredStart === true ? {} : { sessionId: 'command-session' })
   harness.host.status = options.status
-  return { harness, mounted }
+  return { harness, mounted, registerContribution, extensionService: extensionService as {
+    _ledger(): { healthSnapshot(): readonly { id: string; owner: string; state: string; lastError?: string }[] }
+  } }
 }
 
 test('idle /compact executes as a Host command: no followup, no queue, no prompt (PR115-fix problem 1)', async (t) => {
@@ -1232,12 +1277,19 @@ test('a host/client name collision fails the candidate synthesis loud (never a p
       registerDefinition: true,
     }],
   })
-  // The synthesis pass throws, so the contribution never reaches the menu and
-  // the previous list stays installed (no partial success).
+  // The synthesis pass throws; the containment seam marks the command SOURCE
+  // failed (upstream `source-failed` parity: the source's whole group is
+  // removed) — no command row is offered until a synthesis succeeds again.
   const rows = mounted.app.commandCompletionsForTest()
-  assert.equal(rows.some(row => row.name === 'deploy'), false,
-    'a colliding contribution must never appear in the menu')
-  assert.ok(harness.host !== undefined, 'harness wired')
+  assert.equal(rows.some(entry => entry.name === 'deploy'), false,
+    'the failed source offers no command rows (client or host)')
+  // The HOST CLAIM was refreshed before the merge, so the input authority is
+  // untouched even while the menu is empty.
+  mounted.app.setDraft('/deploy prod')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the host command keeps its claim and executes')
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
 })
 
 test('running + queue: the DEFAULT preference makes the accelerated chord STEER (web parity)', async (t) => {
@@ -1394,6 +1446,38 @@ test('a client command is session-backed by default: the session resolves BEFORE
     'a session-backed client command resolves the session first (the host command surface is session-keyed)')
 })
 
+test('a host command that appears only AFTER the deferred session outranks the client contribution', async (t) => {
+  // Deferred start: the standing catalog does not resolve /deploy, so the
+  // submission is classified as a client command. The session-scoped host
+  // catalog then provides /deploy — the live claim must win; running the
+  // client handler would shadow a host command (upstream: the host catalog is
+  // session-keyed and a collision never shadows it).
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  harness.onCreateSession(() => {
+    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void }).register({
+      name: 'deploy',
+      handler: () => ({ kind: 'success' }),
+    })
+  })
+  mounted.app.setDraft('/deploy prod')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the LATE host claim executes through the command plane')
+  assert.equal(harness.executed[0]?.line, '/deploy prod', 'the host command receives the raw line')
+  assert.deepEqual(calls, [], 'the client handler must not run once the live host catalog claims the name')
+  assert.equal(harness.host.followedUp.length, 0, 'never downgraded to a model prompt')
+  assert.equal(harness.host.steered.length, 0, 'never steered')
+})
+
 test('a sessionless client command runs without creating a session', async (t) => {
   const calls: string[] = []
   const { harness, mounted } = await bootCommandHarness(t, {
@@ -1412,6 +1496,156 @@ test('a sessionless client command runs without creating a session', async (t) =
   }
   assert.deepEqual(calls, ['vimmode'], 'the sessionless client handler runs immediately')
   assert.deepEqual(harness.createdSessionIds, [], 'a sessionless client command never creates a session')
+})
+
+test('a skill wrapper that loads AFTER a same-named client contribution outranks it', async (t) => {
+  // The contribution exists first (bridge-only, so the skill wrapper can
+  // still install); the skill catalog then provides /grilling. A skill
+  // wrapper is TUI-owned agent-facing input: the invocation must take the
+  // loadSkill route — never the client handler.
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    skills: true,
+    hostLoadsSkillBody: true,
+    extensionCommands: [{
+      id: 'grilling-cmd', name: 'grilling', description: 'client grilling',
+      bridgeHandler: () => { calls.push('grilling'); return { kind: 'success' } },
+    }],
+  })
+  await waitForSkillWrapper(harness, 'grilling')
+  mounted.app.setDraft('/grilling args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'skill over contribution')
+  assert.deepEqual(calls, [], 'the client handler must not run for a live skill wrapper')
+  assert.equal(harness.host.followedUp.length, 1, 'the skill invocation queues under busyEnter=queue (loadSkill route)')
+  const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
+  assert.equal(followed.content[0]?.text, '/grilling args', 'the skill line is delivered verbatim')
+  assert.equal(harness.host.injected.length, 0, 'the host loader owns the body injection')
+})
+
+test('a SESSIONLESS client command never shadows a live skill wrapper of the same name', async (t) => {
+  // The namespace order decides it: a live skill wrapper is TUI-owned
+  // agent-facing input and outranks any contribution — including one that
+  // declares sessionless (the generic sessionless branch must not run a
+  // client handler for a wrapper's name).
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'running',
+    skills: true,
+    hostLoadsSkillBody: true,
+    extensionCommands: [{
+      id: 'grilling-cmd', name: 'grilling', description: 'client grilling', sessionless: true,
+      bridgeHandler: () => { calls.push('grilling'); return { kind: 'success' } },
+    }],
+  })
+  await waitForSkillWrapper(harness, 'grilling')
+  mounted.app.setDraft('/grilling args')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'sessionless skill over contribution')
+  assert.deepEqual(calls, [], 'the client handler must not run for a live skill wrapper')
+  assert.equal(harness.host.followedUp.length, 1, 'the skill invocation queues (loadSkill route)')
+  assert.equal(harness.host.injected.length, 0, 'the host loader owns the body')
+})
+
+test('a sessionless client command runs its handler even with a LIVE session', async (t) => {
+  // The namespace order decides this, not the generic sessionless branch: a
+  // client command is client-owned whether or not a session exists. Routing
+  // it through the command plane would miss (no definition) and deliver the
+  // line to the MODEL.
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{
+      id: 'vimmode', name: 'vimmode', description: 'toggle vim mode', sessionless: true,
+      bridgeHandler: () => { calls.push('vimmode'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/vimmode')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && calls.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['vimmode'], 'a sessionless client command runs locally with a live session too')
+  assert.equal(harness.executed.length, 0, 'never the command plane')
+  assert.equal(harness.host.followedUp.length, 0, 'never the model')
+})
+
+test('a dynamic host collision fails the command source (upstream source-failed parity)', async (t) => {
+  let failDeploy = false
+  const { harness, mounted, registerContribution } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [
+      { id: 'deploy-cmd', name: 'deploy', description: 'client deploy', bridgeHandler: () => ({ kind: 'success' }) },
+      { id: 'keep-cmd', name: 'keep', description: 'client keep', bridgeHandler: () => ({ kind: 'success' }) },
+    ],
+  })
+  // T0: both client rows are in the menu.
+  const t0 = mounted.app.commandCompletionsForTest().map(row => row.name)
+  assert.ok(t0.includes('deploy') && t0.includes('keep'), `both client rows installed: ${t0.join(',')}`)
+  // T1: the host catalog gains /deploy; a later registration flushes the
+  // extension invalidation into a completion refresh.
+  const disposeHost = (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+    .register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  const names = mounted.app.commandCompletionsForTest().map(row => row.name)
+  // The command SOURCE failed: its whole group is removed (upstream
+  // `source-failed`), so neither the stale client rows NOR the host rows are
+  // offered — a displayed row can never execute a different command than it
+  // shows.
+  assert.deepEqual(names, [], `the failed source offers no rows: ${names.join(',')}`)
+  // Submitting the name executes the HOST command (claims were refreshed
+  // before the merge).
+  mounted.app.setDraft('/deploy now')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the host command owns the name')
+  assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
+  // Recovery: the host descriptor goes away and a successful synthesis
+  // restores the whole menu.
+  disposeHost()
+  await registerContribution({ id: 'omega-cmd', name: 'omega', description: 'omega', bridgeHandler: () => ({ kind: 'success' }) })
+  const recovered = mounted.app.commandCompletionsForTest().map(row => row.name)
+  assert.ok(recovered.includes('deploy') && recovered.includes('keep') && recovered.includes('omega'),
+    `the menu recovers after a successful synthesis: ${recovered.join(',')}`)
+  void failDeploy
+})
+
+test('a collision health record clears on recovery, while a HANDLER failure record survives an unrelated refresh', async (t) => {
+  const healthOf = (service: { _ledger(): { healthSnapshot(): readonly { id: string; state: string; lastError?: string }[] } }, id: string) =>
+    service._ledger().healthSnapshot().find(entry => entry.id === id)
+  const { harness, mounted, registerContribution, extensionService } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [
+      { id: 'boom-cmd', name: 'boom', description: 'boom', bridgeHandler: () => { throw new Error('handler boom') } },
+      { id: 'deploy-cmd', name: 'deploy', description: 'client deploy', bridgeHandler: () => ({ kind: 'success' }) },
+    ],
+  })
+  // The client handler fails: the health record carries the HANDLER error.
+  mounted.app.setDraft('/boom')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && healthOf(extensionService, 'boom-cmd')?.state !== 'failed'; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.equal(healthOf(extensionService, 'boom-cmd')?.state, 'failed', 'a throwing handler marks its contribution failed')
+  // A dynamic host collision on ANOTHER contribution triggers a failed
+  // synthesis: it must not clear the unrelated handler-failure record.
+  const disposeHost = (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
+    .register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf(extensionService, 'deploy-cmd')?.state, 'failed', 'the colliding contribution is marked failed')
+  assert.equal(healthOf(extensionService, 'boom-cmd')?.state, 'failed', 'the handler failure survives the synthesis')
+  // Recovery: the host descriptor disappears, the contribution merges again,
+  // and only the COLLISION record clears.
+  disposeHost()
+  await registerContribution({ id: 'omega-cmd', name: 'omega', description: 'omega', bridgeHandler: () => ({ kind: 'success' }) })
+  assert.equal(healthOf(extensionService, 'deploy-cmd')?.state, 'active', 'the recovered collision clears')
+  assert.equal(healthOf(extensionService, 'boom-cmd')?.state, 'failed', 'the handler failure is untouched by the recovery')
 })
 
 test('a client command executes locally under both chords (never the plane, never the model)', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -198,6 +198,8 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   /** Every `commands.execute` line, in call order (the command plane). */
   executed: { line: string }[]
   readonly session: LiveSession | undefined
+  /** The session ids `agents.create` produced (the deferred-start gate). */
+  createdSessionIds: string[]
   armCreateGate(): void
   releaseCreateGate(): void
 } {
@@ -239,8 +241,10 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   const armCreateGate = (): void => {
     createGate = new Promise<void>(resolve => { releaseCreateGate = resolve })
   }
+  const createdSessionIds: string[] = []
   const agents = {
     create: async ({ sessionId }: { sessionId: string }) => {
+      createdSessionIds.push(String(sessionId))
       if (createGate !== undefined) await createGate
       const session = makeLiveSession(String(sessionId), { id: String(sessionId), cwd: home, createdAt: Date.now(), version: 0 }, [])
       persisted.set(session.id, session)
@@ -296,6 +300,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   }
   return {
     counting,
+    createdSessionIds,
     agents,
     sessions,
     defaultModel,
@@ -907,17 +912,21 @@ async function bootCommandHarness(
      * service shaped like the dsh-tool-skill loader (hostLoadsSkillBody). */
     skills?: boolean
     hostLoadsSkillBody?: boolean
+    /** Mount WITHOUT a resumed session (the deferred-start gate). */
+    deferredStart?: boolean
     /** Extension command contributions to mount (owner metadata + the
      * plugin's own commands-service registration, like a real plugin). */
     extensionCommands?: readonly {
       id: string
       name: string
       description: string
-      execution: 'local' | 'submission'
-      /** The contribution's LOCAL implementation (the bridge handler). */
-      bridgeHandler?: () => { kind: 'success' | 'error'; text?: string }
-      /** Whether the plugin ALSO registers a commands-service definition
-       * (default true; a bridge-only contribution is a real pattern). */
+      /** The contribution's client behavior (the bridge handler). */
+      bridgeHandler: () => { kind: 'success' | 'error'; text?: string }
+      sessionless?: boolean
+      /** Whether the plugin ALSO registers a commands-service definition for
+       * the same name (a HOST-command collision: the host claim wins and the
+       * candidate synthesis fails loud). Default false — a client command is
+       * bridge-only, exactly like the vim fixture. */
       registerDefinition?: boolean
     }[]
   },
@@ -974,7 +983,7 @@ async function bootCommandHarness(
     // plugin fiber, exactly like a real plugin (registerCommand is
     // fiber-bound).
     const contributions = options.extensionCommands
-    context.provide(TUI_STARTUP_SERVICE, { sessionId: 'command-session', shippedPresetRoot: home })
+    context.provide(TUI_STARTUP_SERVICE, { ...options.deferredStart === true ? {} : { sessionId: 'command-session' }, shippedPresetRoot: home })
     await context.plugin(applyExtensionHost)
     await context.plugin((pluginCtx) => {
       const service = pluginCtx.get(PI_TUI_EXTENSIONS_SERVICE) as {
@@ -982,16 +991,19 @@ async function bootCommandHarness(
           id: string
           name: string
           description: string
-          execution: 'local' | 'submission'
+          sessionless?: boolean
+          handler: () => { kind: 'success' | 'error'; text?: string }
         }): unknown
       }
       for (const contribution of contributions) {
         const { bridgeHandler, registerDefinition: _registerDefinition, ...spec } = contribution
-        service.registerCommand({ ...spec, ...bridgeHandler === undefined ? {} : { handler: bridgeHandler } })
+        service.registerCommand({ ...spec, handler: bridgeHandler })
       }
     })
     for (const contribution of contributions) {
-      if (contribution.registerDefinition === false) continue
+      // Bridge-only by default (the client-command pattern); a test that
+      // wants the HOST-command collision opts in explicitly.
+      if (contribution.registerDefinition !== true) continue
       // The plugin's own commands-service registration: the effective
       // completion surface (and with it the advertised claim) sees the
       // name, exactly like a real plugin's `ctx.commands.register`.
@@ -1001,7 +1013,8 @@ async function bootCommandHarness(
       })
     }
   }
-  const mounted = await mountRunner(context, home, harness, { sessionId: 'command-session' })
+  const mounted = await mountRunner(context, home, harness,
+    options.deferredStart === true ? {} : { sessionId: 'command-session' })
   harness.host.status = options.status
   return { harness, mounted }
 }
@@ -1181,43 +1194,50 @@ test('a dynamic Host command never enters the ordinary inbox while running (PR11
 // ── extension command ownership (PR115-fix problem 2) ──────────────────────
 // An extension contribution declares its own `execution`: 'submission' flows
 // through the session submission policy (steer/queue) like a skill
-// invocation, 'local' never steers. Being advertised in the effective
-// catalog does NOT make either a Host command: the busy policy (and the
-// accelerated chord) must be consulted before any command plane execution.
+// The DSH client command contribution model: a contribution is a CLIENT-OWNED
+// command (menu row + client handler). A name that is also a host command is a
+// COLLISION: the host claim wins and the candidate synthesis fails loud —
+// never a silent shadow, never a downgrade to a model prompt.
 
-test('running + steer: an extension submission command keeps the busy steer, never the Host claim', async (t) => {
+test('a client command colliding with a host command never shadows it: the host runs, the client handler does not', async (t) => {
+  const calls: string[] = []
   const { harness, mounted } = await bootCommandHarness(t, {
     busyEnter: 'steer',
     status: 'running',
-    extensionCommands: [{ id: 'deploy', name: 'deploy', description: 'deploy the app', execution: 'submission' }],
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy the app',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+      // The plugin ALSO registers a commands-service definition: the host
+      // catalog resolves /deploy, so the client contribution collides.
+      registerDefinition: true,
+    }],
   })
   mounted.app.setDraft('/deploy now')
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  await waitForDelivery(harness.host, 'extension submission steer')
-  assert.equal(harness.host.steered.length, 1, 'a submission command steers while the agent is running with busyEnter=steer')
-  const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
-  assert.equal(steered.content[0]?.text, '/deploy now', 'the raw command line travels as the agent prompt')
-  assert.equal(harness.executed.length, 0, 'an advertised extension command must never be claimed as a Host command')
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the HOST command keeps its claim and executes through the plane')
+  assert.equal(harness.executed[0]?.line, '/deploy now', 'the host command receives the raw line')
+  assert.deepEqual(calls, [], 'the client handler must not run for a host-owned name')
+  assert.equal(harness.host.steered.length, 0, 'a host command is never steered')
+  assert.equal(harness.host.followedUp.length, 0, 'a host command is never downgraded to a model prompt')
 })
 
-test('running + steer: an extension submission command delivers its LINE, never the handler (declared ownership)', async (t) => {
+test('a host/client name collision fails the candidate synthesis loud (never a partial menu)', async (t) => {
   const { harness, mounted } = await bootCommandHarness(t, {
-    busyEnter: 'steer',
-    status: 'running',
-    extensionCommands: [{ id: 'deploy', name: 'deploy', description: 'deploy the app', execution: 'submission' }],
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy the app',
+      bridgeHandler: () => ({ kind: 'success' }),
+      registerDefinition: true,
+    }],
   })
-  mounted.app.setDraft('/deploy now')
-  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
-  await waitForDelivery(harness.host, 'queued extension submission')
-  // `execution: 'submission'` means the command flows through the session
-  // submission policy like a skill invocation: the resolved 'queue' mode
-  // delivers its LINE (exactly like an unclaimed slash prompt), and the
-  // plugin's command handler is NOT run ahead of the queue it asked to join.
-  assert.equal(harness.host.followedUp.length, 1, 'the queue mode delivers the line as a queued prompt')
-  const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
-  assert.equal(followed.content[0]?.text, '/deploy now', 'the raw line is the queued prompt')
-  assert.equal(harness.executed.length, 0, 'the queue mode must not execute the plugin command handler')
-  assert.equal(harness.host.steered.length, 0, 'the chord must never steer')
+  // The synthesis pass throws, so the contribution never reaches the menu and
+  // the previous list stays installed (no partial success).
+  const rows = mounted.app.commandCompletionsForTest()
+  assert.equal(rows.some(row => row.name === 'deploy'), false,
+    'a colliding contribution must never appear in the menu')
+  assert.ok(harness.host !== undefined, 'harness wired')
 })
 
 test('running + queue: the DEFAULT preference makes the accelerated chord STEER (web parity)', async (t) => {
@@ -1300,8 +1320,7 @@ test('a live LOCAL command runs its bridge handler — never the model', async (
     busyEnter: 'queue',
     status: 'running',
     extensionCommands: [{
-      id: 'vimmode', name: 'vimmode', description: 'toggle vim mode', execution: 'local',
-      registerDefinition: false,
+      id: 'vimmode', name: 'vimmode', description: 'toggle vim mode',
       bridgeHandler: () => { calls.push('vimmode'); return { kind: 'success' } },
     }],
   })
@@ -1325,7 +1344,7 @@ test('a live LOCAL command prefers its bridge handler over the commands definiti
     busyEnter: 'queue',
     status: 'running',
     extensionCommands: [{
-      id: 'panel', name: 'panel', description: 'toggle the panel', execution: 'local',
+      id: 'panel', name: 'panel', description: 'toggle the panel',
       bridgeHandler: () => { calls.push('panel'); return { kind: 'success' } },
     }],
   })
@@ -1339,24 +1358,88 @@ test('a live LOCAL command prefers its bridge handler over the commands definiti
   assert.equal(harness.host.followedUp.length, 0, 'a local command must never reach the model')
 })
 
-test('running + steer: an extension local command still executes directly under both chords', async (t) => {
+test('a bridge-only client command joins the `/` menu (discoverable without a host definition)', async (t) => {
+  const { mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    extensionCommands: [{
+      id: 'vimmode', name: 'vimmode', description: 'toggle vim mode',
+      bridgeHandler: () => ({ kind: 'success' }),
+    }],
+  })
+  const rows = mounted.app.commandCompletionsForTest()
+  const row = rows.find(entry => entry.name === 'vimmode')
+  assert.ok(row !== undefined, `the client command must appear in the menu: ${JSON.stringify(rows.map(r => r.name))}`)
+  assert.equal(row?.description, 'toggle vim mode', 'the menu row carries the contribution description')
+})
+
+test('a client command is session-backed by default: the session resolves BEFORE the handler', async (t) => {
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    extensionCommands: [{
+      id: 'deploy', name: 'deploy', description: 'deploy',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/deploy')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && calls.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['deploy'], 'the client handler runs')
+  assert.equal(harness.createdSessionIds.length, 1,
+    'a session-backed client command resolves the session first (the host command surface is session-keyed)')
+})
+
+test('a sessionless client command runs without creating a session', async (t) => {
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    extensionCommands: [{
+      id: 'vimmode', name: 'vimmode', description: 'toggle vim mode', sessionless: true,
+      bridgeHandler: () => { calls.push('vimmode'); return { kind: 'success' } },
+    }],
+  })
+  mounted.app.setDraft('/vimmode')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  for (let round = 0; round < 40 && calls.length === 0; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['vimmode'], 'the sessionless client handler runs immediately')
+  assert.deepEqual(harness.createdSessionIds, [], 'a sessionless client command never creates a session')
+})
+
+test('a client command executes locally under both chords (never the plane, never the model)', async (t) => {
+  const calls: string[] = []
   const { harness, mounted } = await bootCommandHarness(t, {
     busyEnter: 'steer',
     status: 'running',
-    extensionCommands: [{ id: 'panel', name: 'panel', description: 'toggle the panel', execution: 'local' }],
+    extensionCommands: [{
+      id: 'panel', name: 'panel', description: 'toggle the panel',
+      bridgeHandler: () => { calls.push('panel'); return { kind: 'success' } },
+    }],
   })
   mounted.app.setDraft('/panel')
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  await waitForCommand(harness)
-  assert.equal(harness.executed.length, 1, 'an extension local command always executes locally')
-  // The Ctrl+Enter chord cannot change a local command's ownership either.
-  mounted.app.setDraft('/panel')
-  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
-  for (let round = 0; round < 20 && harness.executed.length < 2; round += 1) {
+  for (let round = 0; round < 40 && calls.length === 0; round += 1) {
     await new Promise<void>(resolve => setImmediate(resolve))
   }
-  assert.equal(harness.executed.length, 2, 'the chord keeps the local execution')
-  assert.equal(harness.host.steered.length, 0, 'local commands never steer')
+  assert.deepEqual(calls, ['panel'], 'a client command always runs its own handler')
+  // The accelerated chord cannot change a client command's route either.
+  mounted.app.setDraft('/panel')
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  for (let round = 0; round < 40 && calls.length < 2; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.deepEqual(calls, ['panel', 'panel'], 'the chord keeps the local execution')
+  assert.equal(harness.host.steered.length, 0, 'a client command never steers')
+  assert.equal(harness.host.followedUp.length, 0, 'a client command never reaches the model')
+  assert.equal(harness.executed.length, 0, 'a client command never enters the command plane')
 })
 
 test('running + steer: the Ctrl+Enter chord never turns a Host command into a queued prompt', async (t) => {

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -198,7 +198,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   host: FakeAgentHost
   /** Every `commands.execute` call, in order (the command plane), with the
    * submitted attachments the client handed over. */
-  executed: { line: string; attachments: readonly unknown[] }[]
+  executed: { line: string; attachments: readonly unknown[]; outcome: 'executed' | 'rejected' }[]
   readonly session: LiveSession | undefined
   /** The session ids `agents.create` produced (the deferred-start gate). */
   createdSessionIds: string[]
@@ -1705,14 +1705,20 @@ test('a HOST command that does not declare input.attachments refuses an attachme
   await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
   const staged = await stageAttachmentDraft(mounted, path)
   assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
-  const executedBefore = harness.executed.length
   mounted.app.setDraft(`/compact ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
   for (let round = 0; round < 40 && !/does not accept attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
     await new Promise<void>(resolve => setImmediate(resolve))
   }
   assert.match(mounted.app.notifyTextForTest(), /\/compact does not accept attachments; remove them first/)
-  assert.equal(harness.executed.length, executedBefore, 'the undeclared command never executes')
+  // The COMPOSER refuses before dispatch: the host never sees the line, so
+  // there is neither an execution nor an admission rejection. (A rejected
+  // command-plane call would mean the gate let an undeclared invocation
+  // through and the executor had to catch it.)
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/compact')),
+    `the undeclared command never reaches the command plane: ${JSON.stringify(harness.executed)}`)
+  assert.ok(!harness.executed.some(entry => entry.outcome === 'rejected'),
+    'the refusal happened before dispatch, not at host admission')
   assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
   assert.deepEqual(imageSaves, [], 'nothing is admitted either')
   assert.match(mounted.app.getDraft(), /^\/compact /, 'the draft comes back')
@@ -1739,14 +1745,18 @@ test('a declared HOST command still refuses a FILE attachment (no host receipt s
   await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
   const staged = await stageAttachmentDraft(mounted, path)
   assert.match(staged, /\[file #1/)
-  const executedBefore = harness.executed.length
   mounted.app.setDraft(`/goal ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
   for (let round = 0; round < 40 && !/cannot receive file attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
     await new Promise<void>(resolve => setImmediate(resolve))
   }
   assert.match(mounted.app.notifyTextForTest(), /\/goal cannot receive file attachments in this client; remove them first/)
-  assert.equal(harness.executed.length, executedBefore, 'the command never executes with an undeliverable file')
+  // Same as above: an undeliverable file is refused by the composer, never
+  // handed to the host to reject.
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/goal ')),
+    `the file-bearing invocation never reaches the command plane: ${JSON.stringify(harness.executed)}`)
+  assert.ok(!harness.executed.some(entry => entry.outcome === 'rejected'),
+    'the refusal happened before dispatch, not at host admission')
   assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
   assert.match(mounted.app.getDraft(), /\[file #1/, 'the file draft comes back')
 })

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -20,6 +20,7 @@ import { MessageId } from '@deepseek-ai/dsh-llm'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { apply as applyRunner, type Config } from '../src/index.ts'
+import { apply as applyExtensionHost, PI_TUI_EXTENSIONS_SERVICE } from '../src/extensions.ts'
 import { TUI_STARTUP_SERVICE } from '../src/startup.ts'
 import { TuiApp } from '../src/tui-app.ts'
 import { testLifecycle } from './support/temp-lifecycle.ts'
@@ -361,7 +362,12 @@ async function mountRunner(
   config: Config = {},
 ): Promise<{ dispose: () => Promise<void>; app: TuiApp }> {
   ctx.provide('appExit', () => {})
-  ctx.provide(TUI_STARTUP_SERVICE, { ...startup, shippedPresetRoot: home })
+  // The startup service is normally provided here; an extension-hosting
+  // harness provides it earlier (the extension host's `inject` gate needs it
+  // mounted BEFORE the runner reads the service).
+  if (ctx.get(TUI_STARTUP_SERVICE) === undefined) {
+    ctx.provide(TUI_STARTUP_SERVICE, { ...startup, shippedPresetRoot: home })
+  }
   ctx.provide('sessionPersistence', harness.counting.proxy as never)
   ctx.provide('agents', harness.agents as never)
   ctx.provide('sessions', harness.sessions as never)
@@ -875,6 +881,20 @@ async function waitForCommand(harness: ReturnType<typeof makeHarness>): Promise<
   assert.ok(harness.executed.length > 0, 'the submission must reach the command plane')
 }
 
+/** Poll until the per-skill wrapper command is registered (the mount-time
+ * catalog refresh installs it asynchronously). Without the wrapper the
+ * `/name args` line would be a plain prompt and the delivery assertions
+ * would pass for the wrong reason. */
+async function waitForSkillWrapper(harness: ReturnType<typeof makeHarness>, name: string): Promise<void> {
+  for (let round = 0; round < 40; round += 1) {
+    if ((harness.commands as { list(): readonly { name: string }[] }).list().some(def => def.name === name)) return
+    for (let index = 0; index < 50; index += 1) await Promise.resolve()
+    await new Promise<void>(resolve => process.nextTick(resolve))
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.fail(`the ${name} skill wrapper must be registered`)
+}
+
 /** Boot a runner with a resumed session, optional pre-registered Host
  * commands, and a busyEnter preference. */
 async function bootCommandHarness(
@@ -887,6 +907,14 @@ async function bootCommandHarness(
      * service shaped like the dsh-tool-skill loader (hostLoadsSkillBody). */
     skills?: boolean
     hostLoadsSkillBody?: boolean
+    /** Extension command contributions to mount (owner metadata + the
+     * plugin's own commands-service registration, like a real plugin). */
+    extensionCommands?: readonly {
+      id: string
+      name: string
+      description: string
+      execution: 'local' | 'submission'
+    }[]
   },
 ): Promise<{ harness: ReturnType<typeof makeHarness>; mounted: { dispose: () => Promise<void>; app: TuiApp } }> {
   const life = testLifecycle(t)
@@ -907,13 +935,18 @@ async function bootCommandHarness(
     })
   }
   if (options.skills === true) {
+    const summary = {
+      name: 'grilling',
+      description: 'a skill',
+      content: 'skill body',
+      invocation: { userInvocable: true, modelInvocable: true },
+      source: 'bundled',
+      provider: 't',
+    }
     context.provide('skills', {
-      get: async () => ({
-        name: 'grilling',
-        description: 'a skill',
-        content: 'skill body',
-        invocation: { userInvocable: true, modelInvocable: true },
-      }),
+      // The catalog read that installs the per-skill wrapper commands.
+      list: async () => [summary],
+      get: async () => summary,
     } as never)
   }
   if (options.hostLoadsSkillBody === true) {
@@ -928,6 +961,37 @@ async function bootCommandHarness(
       replace: async (next: Record<string, unknown>) => { Object.assign(doc, next) },
     }),
   } as never)
+  if (options.extensionCommands !== undefined) {
+    // The extension host must be mounted BEFORE the runner reads its
+    // service (the runner attaches a SurfaceHost over its ledger), and its
+    // `inject` gate needs the startup service — provided here with the same
+    // payload mountRunner would use. Each contribution is registered by a
+    // plugin fiber, exactly like a real plugin (registerCommand is
+    // fiber-bound).
+    const contributions = options.extensionCommands
+    context.provide(TUI_STARTUP_SERVICE, { sessionId: 'command-session', shippedPresetRoot: home })
+    await context.plugin(applyExtensionHost)
+    await context.plugin((pluginCtx) => {
+      const service = pluginCtx.get(PI_TUI_EXTENSIONS_SERVICE) as {
+        registerCommand(contribution: {
+          id: string
+          name: string
+          description: string
+          execution: 'local' | 'submission'
+        }): unknown
+      }
+      for (const contribution of contributions) service.registerCommand(contribution)
+    })
+    for (const contribution of contributions) {
+      // The plugin's own commands-service registration: the effective
+      // completion surface (and with it the advertised claim) sees the
+      // name, exactly like a real plugin's `ctx.commands.register`.
+      ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void }).register({
+        name: contribution.name,
+        handler: () => ({ kind: 'success' }),
+      })
+    }
+  }
   const mounted = await mountRunner(context, home, harness, { sessionId: 'command-session' })
   harness.host.status = options.status
   return { harness, mounted }
@@ -1039,6 +1103,48 @@ test('running + queue: /skill <name> keeps the steer path when the TUI must inje
   assert.equal(harness.host.followedUp.length, 0, 'no followup — the body order contract forbids it')
 })
 
+test('running + steer: the Ctrl+Enter chord force-queues /skill <name> (delivery mode resolved once)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    skills: true,
+    hostLoadsSkillBody: true,
+  })
+  mounted.app.setDraft('/skill grilling args')
+  // The Ctrl+Enter opposite chord: force the QUEUE delivery regardless of
+  // the busyEnter preference. The chord is a property of THIS submission —
+  // the skill delivery accepts the mode the submit boundary resolved and
+  // must never re-derive it from the persisted preference (busyEnter=steer
+  // here), because a one-shot chord does not survive in settings.
+  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
+  await waitForDelivery(harness.host, 'force-queued skill')
+  assert.equal(harness.host.followedUp.length, 1, 'the chord must force the queue delivery')
+  const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
+  assert.equal(followed.content[0]?.text, '/grilling args', 'the queued line is the normalized /name args form')
+  assert.equal(harness.host.steered.length, 0, 'the chord must never steer')
+  assert.equal(harness.host.injected.length, 0, 'the host owns the body injection — no TUI fallback body')
+})
+
+test('running + steer: the Ctrl+Enter chord force-queues a per-skill wrapper (/grilling args)', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    skills: true,
+    hostLoadsSkillBody: true,
+  })
+  await waitForSkillWrapper(harness, 'grilling')
+  mounted.app.setDraft('/grilling args')
+  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
+  await waitForDelivery(harness.host, 'force-queued skill wrapper')
+  assert.equal(harness.executed.length, 1, 'the wrapper is a TUI command: it executes through the command plane')
+  assert.equal(harness.executed[0]?.line, '/grilling args', 'the wrapper receives its own slash line')
+  assert.equal(harness.host.followedUp.length, 1, 'the chord must force the queue delivery')
+  const followed = harness.host.followedUp[0] as { content: { type: string; text: string }[] }
+  assert.equal(followed.content[0]?.text, '/grilling args', 'the queued line is the original /name args line')
+  assert.equal(harness.host.steered.length, 0, 'the chord must never steer')
+  assert.equal(harness.host.injected.length, 0, 'the host owns the body injection — no TUI fallback body')
+})
+
 test('a dynamic Host command never enters the ordinary inbox while running (PR115-fix problem 1)', async (t) => {
   const { harness, mounted } = await bootCommandHarness(t, {
     busyEnter: 'steer',
@@ -1052,4 +1158,77 @@ test('a dynamic Host command never enters the ordinary inbox while running (PR11
   assert.equal(harness.executed[0]?.line, '/test-host-command')
   assert.equal(harness.host.steered.length, 0, 'no steer — the fix is architectural, not a /compact special case')
   assert.equal(harness.host.followedUp.length, 0, 'no ordinary inbox entry')
+})
+
+// ── extension command ownership (PR115-fix problem 2) ──────────────────────
+// An extension contribution declares its own `execution`: 'submission' flows
+// through the session submission policy (steer/queue) like a skill
+// invocation, 'local' never steers. Being advertised in the effective
+// catalog does NOT make either a Host command: the busy policy (and the
+// force-queue chord) must be consulted before any command plane execution.
+
+test('running + steer: an extension submission command keeps the busy steer, never the Host claim', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    extensionCommands: [{ id: 'deploy', name: 'deploy', description: 'deploy the app', execution: 'submission' }],
+  })
+  mounted.app.setDraft('/deploy now')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'extension submission steer')
+  assert.equal(harness.host.steered.length, 1, 'a submission command steers while the agent is running with busyEnter=steer')
+  const steered = harness.host.steered[0] as { content: { type: string; text: string }[] }
+  assert.equal(steered.content[0]?.text, '/deploy now', 'the raw command line travels as the agent prompt')
+  assert.equal(harness.executed.length, 0, 'an advertised extension command must never be claimed as a Host command')
+})
+
+test('running + steer: the Ctrl+Enter chord force-queues an extension submission command', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    extensionCommands: [{ id: 'deploy', name: 'deploy', description: 'deploy the app', execution: 'submission' }],
+  })
+  mounted.app.setDraft('/deploy now')
+  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
+  await waitForCommand(harness)
+  // The chord resolves 'queue' at the submit boundary; the submission route
+  // hands the line to the command plane (the plugin's own handler owns the
+  // session write), and the TUI never steers it into the running turn.
+  assert.equal(harness.executed.length, 1, 'the queue-side submission route reaches the command plane')
+  assert.equal(harness.executed[0]?.line, '/deploy now')
+  assert.equal(harness.host.steered.length, 0, 'the chord must never steer')
+})
+
+test('running + steer: an extension local command still executes directly under both chords', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    extensionCommands: [{ id: 'panel', name: 'panel', description: 'toggle the panel', execution: 'local' }],
+  })
+  mounted.app.setDraft('/panel')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'an extension local command always executes locally')
+  // The Ctrl+Enter chord cannot change a local command's ownership either.
+  mounted.app.setDraft('/panel')
+  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
+  for (let round = 0; round < 20 && harness.executed.length < 2; round += 1) {
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+  assert.equal(harness.executed.length, 2, 'the chord keeps the local execution')
+  assert.equal(harness.host.steered.length, 0, 'local commands never steer')
+})
+
+test('running + steer: the Ctrl+Enter chord never turns a Host command into a queued prompt', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    hostCommands: ['compact'],
+  })
+  mounted.app.setDraft('/compact')
+  ;(mounted.app as unknown as { submitDraft(forceQueue?: boolean): void }).submitDraft(true)
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'a Host command owns its execution regardless of the chord')
+  assert.equal(harness.host.followedUp.length, 0, 'the chord must not queue a Host command as a prompt')
+  assert.equal(harness.host.steered.length, 0, 'the chord must not steer a Host command')
 })

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -313,6 +313,14 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
       const def = definitions.get(name)
       if (def === undefined) return undefined
       executed.push({ line, attachments: [...attachments] })
+      // The REAL host executor enforces the descriptor declaration at
+      // admission: attachments sent to a command that does not declare
+      // `input.attachments` settle as an error result BEFORE the handler runs
+      // (dsh-commands `execute`). The fake mirrors it, so an integration test
+      // cannot pass by handing the host a payload it would refuse.
+      if (attachments.length > 0 && def.input?.attachments !== true) {
+        return { result: { kind: 'error', text: `/${name} does not accept attachments` } }
+      }
       const rawInput = line.slice(line.indexOf(name) + name.length)
       const result = await (def.handler as (inv: unknown) => unknown)({
         commandId: CommandId('cmd-test'),
@@ -1619,6 +1627,50 @@ test('an attachment-bearing client command defers to a LATE declared host claim 
   const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
   assert.deepEqual([...delivered.content], [{ type: 'text', text: staged.trim() }], 'the line stays plain text')
 })
+
+// Both agent-facing skill forms: the explicit `/skill <name> ...` invocation
+// (`/skill` is itself a registered TUI command, so the policy must not treat
+// it as a non-declaring HOST command) and a live skill WRAPPER (TUI-owned,
+// no host declaration either). In both, the placeholder line stays on the
+// delivery path and the image is admitted there — never handed to the command
+// plane, whose executor rejects attachments for a command that does not
+// declare them.
+for (const form of [
+  { label: 'explicit /skill <name>', line: (staged: string) => `/skill grilling ${staged.trim()}` },
+  { label: 'skill wrapper', line: (staged: string) => `/grilling ${staged.trim()}` },
+] as const) {
+  test(`a skill invocation with an image stays agent-facing (${form.label})`, async (t) => {
+    const life = testLifecycle(t)
+    const root = life.tempDir('dsh-pi-tui-skill-attachment-')
+    const path = join(root, 'shot.png')
+    await writeFile(path, pngHeader(5, 5))
+    const { harness, mounted, imageSaves } = await bootCommandHarness(t, {
+      busyEnter: 'queue',
+      status: 'idle',
+      skills: true,
+      hostLoadsSkillBody: true,
+      attachments: true,
+    })
+    await waitForSkillWrapper(harness, 'grilling')
+    const staged = await stageAttachmentDraft(mounted, path)
+    assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
+    mounted.app.setDraft(form.line(staged))
+    ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+    await waitForDelivery(harness.host, `${form.label} with an image`)
+    assert.equal(harness.host.followedUp.length, 1, 'the skill invocation is delivered')
+    assert.ok(!mounted.app.notifyTextForTest().includes('does not accept attachments'),
+      `a skill invocation is never refused as a command: ${mounted.app.notifyTextForTest()}`)
+    assert.equal(imageSaves.length, 1, 'the image is admitted through the agent-facing path')
+    const delivered = harness.host.followedUp[0] as { content: readonly { type: string }[] }
+    assert.ok([...delivered.content].some(block => block.type === 'image'),
+      `the image rides the skill prompt: ${JSON.stringify(delivered.content)}`)
+    // The command plane either never saw the line (wrapper) or carried it with
+    // NO attachments (`/skill`): the host executor would have rejected them.
+    for (const call of harness.executed) {
+      assert.equal(call.attachments.length, 0, `no command-plane payload for ${call.line}`)
+    }
+  })
+}
 
 test('a HOST command that does not declare input.attachments refuses an attachment (web composer parity)', async (t) => {
   // Upstream `CommandUiRuntime` refuses an attachment-bearing invocation of a

--- a/test/submit-hot-path.test.ts
+++ b/test/submit-hot-path.test.ts
@@ -204,7 +204,11 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   /** The session ids `agents.create` produced (the deferred-start gate). */
   createdSessionIds: string[]
   /** Register a hook that runs as each session is created. */
-  onCreateSession(hook: (sessionId: string) => void): void
+  /** Register a hook that runs as each session is created. The harness
+   * AWAITS it, so an async hook (e.g. registering a late contribution) is
+   * deterministic and a rejection fails the creation loudly — never a bare
+   * fire-and-forget promise. */
+  onCreateSession(hook: (sessionId: string) => void | Promise<void>): void
   armCreateGate(): void
   releaseCreateGate(): void
 } {
@@ -249,11 +253,11 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   const createdSessionIds: string[] = []
   /** Test hook: invoked with each CREATED session id, before the handle is
    * returned — the place a session-scoped host catalog can appear. */
-  let onCreateSession: ((sessionId: string) => void) | undefined
+  let onCreateSession: ((sessionId: string) => void | Promise<void>) | undefined
   const agents = {
     create: async ({ sessionId }: { sessionId: string }) => {
       createdSessionIds.push(String(sessionId))
-      onCreateSession?.(String(sessionId))
+      await onCreateSession?.(String(sessionId))
       if (createGate !== undefined) await createGate
       const session = makeLiveSession(String(sessionId), { id: String(sessionId), cwd: home, createdAt: Date.now(), version: 0 }, [])
       persisted.set(session.id, session)
@@ -293,10 +297,15 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
         if (definitions.get(definition.name) === definition) definitions.delete(definition.name)
       }
     },
+    // The effective catalog mirrors the registry EXACTLY, the descriptor's
+    // input kind included: `input` is the DSH distinction between a
+    // `leadingInput` command (`/goal <objective>`) and an execute-kind one
+    // (`/compact`). Fabricating an `input` for every row would erase the
+    // command KIND and let a name-level routing bug pass.
     list: () => [...definitions.values()].map(({ name, description, input }) => ({
       name,
       description: description ?? '',
-      input: input ?? { hint: '' },
+      ...(input === undefined ? {} : { input }),
     })),
     // The real commands service resolves a definition by name for the
     // global layer too (`find(undefined, name)`); the harness mirrors it so
@@ -343,7 +352,7 @@ function makeHarness(home: string, initial?: { id: string; events: SessionEvent[
   return {
     counting,
     createdSessionIds,
-    onCreateSession: (hook: (sessionId: string) => void) => { onCreateSession = hook },
+    onCreateSession: (hook: (sessionId: string) => void | Promise<void>) => { onCreateSession = hook },
     agents,
     sessions,
     defaultModel,
@@ -966,7 +975,12 @@ async function bootCommandHarness(
   options: {
     busyEnter: 'queue' | 'steer'
     status: 'idle' | 'running'
-    hostCommands?: readonly string[]
+    /** Pre-registered Host commands. A bare NAME registers the execute-kind
+     * shape (DSH `CommandDescriptor` without `input`: `/compact`), which
+     * claims its BARE token only; the object form registers the exact
+     * descriptor, so a `leadingInput` command (`/goal <objective>`) can claim
+     * its argued line. */
+    hostCommands?: readonly (string | { name: string; input: { hint: string; attachments?: boolean } })[]
     /** Provide a skills registry (resolveSkill succeeds) and/or a tools
      * service shaped like the dsh-tool-skill loader (hostLoadsSkillBody). */
     skills?: boolean
@@ -990,6 +1004,10 @@ async function bootCommandHarness(
        * candidate synthesis fails loud). Default false — a client command is
        * bridge-only, exactly like the vim fixture. */
       registerDefinition?: boolean
+      /** The descriptor of that host definition: a `leadingInput` command
+       * (the DSH `/goal` shape) claims its argued line; absent = the
+       * execute-kind shape (`/compact`), which claims the bare token only. */
+      hostInput?: { hint: string; attachments?: boolean }
     }[]
   },
 ): Promise<{
@@ -1005,6 +1023,9 @@ async function bootCommandHarness(
   }): Promise<void>
   /** The recorded image-admission batches (only with `attachments: true`). */
   imageSaves: readonly (readonly { mediaType: string; byteLength: number }[])[]
+  /** Dispose one pre-registered `hostCommands` definition (a catalog name that
+   * disappears — e.g. while a deferred session is being created). */
+  disposeHostCommand(name: string): void
   /** The mounted extension service (health assertions). */
   extensionService: {
     _ledger(): {
@@ -1046,11 +1067,18 @@ async function bootCommandHarness(
     } as never)
   }
   const harness = makeHarness(home, { id: 'command-session', events: sessionEvents('resumed answer') })
-  for (const name of options.hostCommands ?? []) {
-    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void }).register({
-      name,
+  const hostCommandDisposers = new Map<string, () => void>()
+  for (const entry of options.hostCommands ?? []) {
+    const command: { name: string; input?: { hint: string; attachments?: boolean } } =
+      typeof entry === 'string' ? { name: entry } : entry
+    const dispose = (harness.commands as {
+      register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): () => void
+    }).register({
+      name: command.name,
       handler: () => ({ kind: 'success' }),
+      ...(command.input === undefined ? {} : { input: command.input }),
     })
+    hostCommandDisposers.set(command.name, dispose)
   }
   if (options.skills === true) {
     const summary = {
@@ -1134,20 +1162,30 @@ async function bootCommandHarness(
       // The plugin's own commands-service registration: the effective
       // completion surface (and with it the advertised claim) sees the
       // name, exactly like a real plugin's `ctx.commands.register`.
-      ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void }).register({
+      ;(harness.commands as {
+        register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+      }).register({
         name: contribution.name,
         handler: () => ({ kind: 'success' }),
+        ...(contribution.hostInput === undefined ? {} : { input: contribution.hostInput }),
       })
     }
   }
   const mounted = await mountRunner(context, home, harness,
     options.deferredStart === true ? {} : { sessionId: 'command-session' })
   harness.host.status = options.status
-  return { harness, mounted, registerContribution, imageSaves, extensionService: extensionService as {
-    _ledger(): {
-      healthSnapshot(): readonly { id: string; owner: string; extensionPoint: string; state: string; lastError?: string }[]
-    }
-  } }
+  return {
+    harness,
+    mounted,
+    registerContribution,
+    imageSaves,
+    disposeHostCommand: (name: string) => { hostCommandDisposers.get(name)?.() },
+    extensionService: extensionService as {
+      _ledger(): {
+        healthSnapshot(): readonly { id: string; owner: string; extensionPoint: string; state: string; lastError?: string }[]
+      }
+    },
+  }
 }
 
 test('idle /compact executes as a Host command: no followup, no queue, no prompt (PR115-fix problem 1)', async (t) => {
@@ -1181,6 +1219,59 @@ test('running + steer: /compact executes, never steers into the turn (PR115-fix 
   assert.equal(harness.executed.length, 1, 'the command path must be taken before the steer policy')
   assert.equal(harness.host.steered.length, 0, '/compact must never be steered as a prompt')
   assert.equal(harness.host.followedUp.length, 0, 'no followup')
+})
+
+// The claim belongs to the LINE, not to the name (DSH `CommandDescriptor.input`
+// + `CommandUiRuntime.matchEnter`): an execute-kind command (`/compact`, no
+// `input`) claims its BARE token only, so its argued line is an ordinary
+// submission and follows the busy policy like any other prompt.
+
+test('running + queue: an argued execute-kind line queues as an ordinary followup', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'queue', status: 'running', hostCommands: ['compact'] })
+  mounted.app.setDraft('/compact extra')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'argued execute-kind line')
+  assert.equal(harness.executed.length, 0, 'an argued execute-kind line is not a command invocation')
+  assert.equal(harness.host.followedUp.length, 1, 'it takes the ordinary queue delivery')
+  assert.equal(harness.host.steered.length, 0, 'the queue preference never steers')
+})
+
+test('running + steer: an argued execute-kind line steers as an ordinary prompt', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'steer', status: 'running', hostCommands: ['compact'] })
+  mounted.app.setDraft('/compact extra')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'argued execute-kind line')
+  assert.equal(harness.executed.length, 0, 'an argued execute-kind line is not a command invocation')
+  assert.equal(harness.host.steered.length, 1, 'it takes the ordinary steer delivery')
+  assert.equal(harness.host.followedUp.length, 0, 'the steer preference never queues')
+})
+
+test('running + accelerated chord: an argued execute-kind line takes the OPPOSITE policy', async (t) => {
+  const { harness, mounted } = await bootCommandHarness(t, { busyEnter: 'queue', status: 'running', hostCommands: ['compact'] })
+  mounted.app.setDraft('/compact extra')
+  ;(mounted.app as unknown as { submitDraft(request?: string): void }).submitDraft('accelerated')
+  await waitForDelivery(harness.host, 'accelerated argued execute-kind line')
+  assert.equal(harness.executed.length, 0, 'the chord cannot turn the line into a command either')
+  assert.equal(harness.host.steered.length, 1, 'the accelerated chord takes the opposite of the queue preference')
+  assert.equal(harness.host.followedUp.length, 0, 'the chord must not queue')
+})
+
+test('a leadingInput host command claims its argued line under the busy policy (/goal <objective>)', async (t) => {
+  // The other half of the line-level rule: a descriptor WITH `input` claims
+  // its argued line, so the busy queue/steer policy never applies to it.
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    hostCommands: [{ name: 'goal', input: { hint: '<objective>' } }],
+  })
+  mounted.app.setDraft('/goal ship it')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'a leadingInput invocation executes through the command plane')
+  assert.equal(harness.executed[0]?.line, '/goal ship it', 'the host receives the raw argued line')
+  assert.equal(harness.executed[0]?.outcome, 'executed', 'the handler runs')
+  assert.equal(harness.host.steered.length, 0, 'a claimed command is never steered')
+  assert.equal(harness.host.followedUp.length, 0, 'a claimed command never queues')
 })
 
 test('running + queue: an ordinary prompt still queues (PR115-fix problem 1)', async (t) => {
@@ -1339,6 +1430,9 @@ test('a client command colliding with a host command never shadows it: the host 
       // The plugin ALSO registers a commands-service definition: the host
       // catalog resolves /deploy, so the client contribution collides.
       registerDefinition: true,
+      // The `leadingInput` shape (`/goal <objective>`): the host claims the
+      // argued line, which is the line this test submits.
+      hostInput: { hint: '<target>' },
     }],
   })
   mounted.app.setDraft('/deploy now')
@@ -1346,9 +1440,78 @@ test('a client command colliding with a host command never shadows it: the host 
   await waitForCommand(harness)
   assert.equal(harness.executed.length, 1, 'the HOST command keeps its claim and executes through the plane')
   assert.equal(harness.executed[0]?.line, '/deploy now', 'the host command receives the raw line')
-  assert.deepEqual(calls, [], 'the client handler must not run for a host-owned name')
+  assert.deepEqual(calls, [], 'the client handler must not run for a host-claimed line')
   assert.equal(harness.host.steered.length, 0, 'a host command is never steered')
   assert.equal(harness.host.followedUp.length, 0, 'a host command is never downgraded to a model prompt')
+})
+
+test('a name the host catalog resolves with an UNCLAIMED line never runs the colliding client handler', async (t) => {
+  // The collision state (the candidate synthesis failed and withdrew the
+  // source, but the bridge contribution is still live) with an EXECUTE-KIND
+  // host command: the host catalog resolves /compact, and `/compact extra` is
+  // not an invocation. The line is an ordinary submission — upstream
+  // `matchEnter` returns undefined before any contribution route — so the
+  // same-named client handler must not run and the model receives the line.
+  const calls: string[] = []
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'steer',
+    status: 'running',
+    extensionCommands: [{
+      id: 'compact-cmd', name: 'compact', description: 'client compact',
+      bridgeHandler: () => { calls.push('compact'); return { kind: 'success' } },
+      // The plugin ALSO registers the commands-service definition, so the
+      // host catalog resolves /compact and the synthesis fails loud.
+      registerDefinition: true,
+    }],
+  })
+  const rows = mounted.app.commandCompletionsForTest()
+  assert.equal(rows.some(row => row.name === 'compact'), false,
+    'the failed source offers no rows (the collision is live)')
+  mounted.app.setDraft('/compact extra')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'unclaimed line of a host-resolved name')
+  assert.deepEqual(calls, [], 'the colliding client handler must not run for a line the host catalog did not claim')
+  assert.equal(harness.executed.length, 0, 'the command plane is never asked to run it either')
+  assert.equal(harness.host.steered.length, 1, 'the busy policy applies: it is an ordinary submission')
+  assert.equal(harness.host.followedUp.length, 0, 'the steer preference never queues')
+  const steered = harness.host.steered[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual(steered.content.map(block => block.text), ['/compact extra'],
+    'the MODEL receives the raw line')
+})
+
+test('an unclaimed line of a host-resolved name keeps its attachment: ordinary multimodal submission', async (t) => {
+  // The same collision state with a staged image: the attachment gate must not
+  // classify the line as a local client command (the host catalog resolves the
+  // name, so the contribution is not the owner), the image rides the ordinary
+  // submission, and no command refusal is surfaced.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-unclaimed-host-line-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(2, 2))
+  const calls: string[] = []
+  const { harness, mounted, imageSaves } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    attachments: true,
+    extensionCommands: [{
+      id: 'compact-cmd', name: 'compact', description: 'client compact',
+      bridgeHandler: () => { calls.push('compact'); return { kind: 'success' } },
+      registerDefinition: true,
+    }],
+  })
+  const staged = await stageAttachmentDraft(harness, mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
+  mounted.app.setDraft(`/compact ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'unclaimed image line')
+  assert.equal(mounted.app.notifyTextForTest(), '', 'no local-command refusal is surfaced')
+  assert.deepEqual(calls, [], 'the colliding client handler never runs')
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/compact')),
+    `never the command plane: ${JSON.stringify(harness.executed)}`)
+  assert.equal(imageSaves.length, 1, 'the image is admitted through the ordinary model path')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.type), ['text', 'image'],
+    'the model receives the multimodal prompt')
 })
 
 test('a host/client name collision fails the candidate synthesis loud (never a partial menu)', async (t) => {
@@ -1359,6 +1522,7 @@ test('a host/client name collision fails the candidate synthesis loud (never a p
       id: 'deploy', name: 'deploy', description: 'deploy the app',
       bridgeHandler: () => ({ kind: 'success' }),
       registerDefinition: true,
+      hostInput: { hint: '<target>' },
     }],
   })
   // The synthesis pass throws; the containment seam marks the command SOURCE
@@ -1547,9 +1711,13 @@ test('a host command that appears only AFTER the deferred session outranks the c
     }],
   })
   harness.onCreateSession(() => {
-    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void }).register({
+    ;(harness.commands as {
+      register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+    }).register({
       name: 'deploy',
       handler: () => ({ kind: 'success' }),
+      // The `leadingInput` shape: the argued line below is a real invocation.
+      input: { hint: '<target>' },
     })
   })
   mounted.app.setDraft('/deploy prod')
@@ -1557,9 +1725,219 @@ test('a host command that appears only AFTER the deferred session outranks the c
   await waitForCommand(harness)
   assert.equal(harness.executed.length, 1, 'the LATE host claim executes through the command plane')
   assert.equal(harness.executed[0]?.line, '/deploy prod', 'the host command receives the raw line')
-  assert.deepEqual(calls, [], 'the client handler must not run once the live host catalog claims the name')
+  assert.deepEqual(calls, [], 'the client handler must not run once the live host catalog claims the line')
   assert.equal(harness.host.followedUp.length, 0, 'never downgraded to a model prompt')
   assert.equal(harness.host.steered.length, 0, 'never steered')
+})
+
+test('a deferred session that resolves an execute-kind host command does not run its argued line', async (t) => {
+  // A deferred start whose standing catalog does not resolve /compact: the
+  // command plane is initially the decider. The session then commits an
+  // EXECUTE-KIND /compact, so `/compact extra` is NOT an invocation
+  // (upstream `matchEnter`: `if (!bare) return undefined`) — the plane's final
+  // ownership must be re-asked after ensureSession(), or the host registry
+  // resolves the NAME and runs the command anyway.
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  harness.onCreateSession(() => {
+    // No `input`: the execute-kind shape.
+    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void })
+      .register({ name: 'compact', handler: () => ({ kind: 'success' }) })
+  })
+  mounted.app.setDraft('/compact extra')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'late execute-kind argued line')
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/compact')),
+    `the late execute-kind command never runs its argued line: ${JSON.stringify(harness.executed)}`)
+  assert.equal(harness.host.followedUp.length, 1, 'the line is an ordinary submission')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.text), ['/compact extra'],
+    'the MODEL receives the raw line')
+  assert.doesNotMatch(mounted.app.notifyTextForTest(), /not available in the created session/,
+    'an ordinary submission is never consumed as an advertised command miss')
+})
+
+test('a contribution that appears DURING the deferred window never turns an ordinary image line into a local command', async (t) => {
+  // The line is a generic ordinary submission when it is made: no host command
+  // resolves /deploy and no client contribution exists, so its route is the
+  // model (upstream `matchEnter` checks the contribution ONCE, before the
+  // session work). A bridge contribution registered while the session is being
+  // created must not reclassify the line as a UI control under the final
+  // authority — the routing already decided, the new handler never runs, and
+  // the image is an ordinary multimodal submission.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-late-contribution-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(3, 3))
+  const calls: string[] = []
+  const { harness, mounted, imageSaves, registerContribution } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    attachments: true,
+    // Mount the extension host with an unrelated contribution so
+    // `registerContribution` has a live service to register into; /deploy
+    // itself is registered later, during the deferred window.
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  // The harness AWAITS this hook: the contribution is provably live before the
+  // session resolves (so the dispatch really classifies against it), and a
+  // registration failure fails the creation loudly instead of becoming an
+  // invisible unhandled rejection.
+  harness.onCreateSession(async () => {
+    await registerContribution({
+      id: 'late-cmd', name: 'deploy', description: 'late deploy',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    })
+  })
+  const staged = await stageAttachmentDraft(harness, mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'late contribution with an image')
+  assert.equal(mounted.app.notifyTextForTest(), '', 'no local-command refusal is surfaced')
+  assert.deepEqual(calls, [], 'the late contribution never runs for a line it did not own')
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
+    `never the command plane: ${JSON.stringify(harness.executed)}`)
+  assert.equal(imageSaves.length, 1, 'the image is admitted through the ordinary model path')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.type), ['text', 'image'],
+    'the model receives the multimodal prompt')
+})
+
+test('a DISAPPEARED host name never turns an attachment-bearing line into a local command', async (t) => {
+  // The execute-kind -> unresolved mutation with a staged IMAGE and a
+  // same-named bridge contribution: the host catalog resolved /deploy (a known
+  // non-invocation) when the line was submitted, so the contribution never
+  // owned it. When the name then disappears from the session's catalog, the
+  // late attachment classification must not fall back to the contribution and
+  // refuse the line as a local command — it is an ordinary multimodal
+  // submission.
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-vanished-host-attachment-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(2, 2))
+  const calls: string[] = []
+  const { harness, mounted, imageSaves, disposeHostCommand } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    attachments: true,
+    // Execute-kind at submit time; a bridge contribution shares the name.
+    hostCommands: ['deploy'],
+    extensionCommands: [{
+      id: 'deploy-cmd', name: 'deploy', description: 'client deploy',
+      bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
+    }],
+  })
+  harness.onCreateSession(() => { disposeHostCommand('deploy') })
+  const staged = await stageAttachmentDraft(harness, mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
+  mounted.app.setDraft(`/deploy ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'vanished host name with an image')
+  assert.equal(mounted.app.notifyTextForTest(), '', 'no local-command refusal is surfaced')
+  assert.deepEqual(calls, [], 'the colliding client handler never runs')
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
+    `never the command plane: ${JSON.stringify(harness.executed)}`)
+  assert.equal(imageSaves.length, 1, 'the image is admitted through the ordinary model path')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.type), ['text', 'image'],
+    'the model receives the multimodal prompt')
+})
+
+test('a deferred session where the host name DISAPPEARS keeps the argued line an ordinary submission', async (t) => {
+  // The execute-kind -> unresolved mutation. The standing catalog resolves
+  // /deploy as EXECUTE-KIND, so `/deploy prod` is a known NON-invocation when
+  // submitted; the name then vanishes from the session's catalog. An
+  // unresolved name normally leaves the decision to the plane (a
+  // session-scoped command the standing view cannot see), but no
+  // disappearance turns a line that was already not an invocation into one —
+  // and the submit-time advertised claim must not consume it as a miss either.
+  const { harness, mounted, disposeHostCommand } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    // Execute-kind at submit time (no `input`).
+    hostCommands: ['deploy'],
+  })
+  harness.onCreateSession(() => { disposeHostCommand('deploy') })
+  mounted.app.setDraft('/deploy prod')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'disappeared host name')
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
+    `the vanished command is never asked to run the argued line: ${JSON.stringify(harness.executed)}`)
+  assert.equal(harness.host.followedUp.length, 1, 'the line is an ordinary submission')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.text), ['/deploy prod'],
+    'the MODEL receives the raw line')
+  assert.doesNotMatch(mounted.app.notifyTextForTest(), /not available in the created session/,
+    'a known non-invocation is never consumed as an advertised command miss, even when the name disappears')
+})
+
+test('a deferred session that resolves a leadingInput host command executes its argued line', async (t) => {
+  // The reverse descriptor mutation: the standing catalog resolves /deploy as
+  // EXECUTE-KIND, so `/deploy prod` is not an invocation when submitted. The
+  // session then commits a `leadingInput` /deploy — the argued line IS an
+  // invocation for the FINAL catalog, so the plane must run it.
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    // Execute-kind at submit time (no `input`).
+    hostCommands: ['deploy'],
+  })
+  harness.onCreateSession(() => {
+    ;(harness.commands as {
+      register(def: { name: string; handler: () => unknown; input?: { hint: string } }): void
+    }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '<target>' } })
+  })
+  mounted.app.setDraft('/deploy prod')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForCommand(harness)
+  assert.equal(harness.executed.length, 1, 'the final leadingInput claim owns the argued line')
+  assert.equal(harness.executed[0]?.line, '/deploy prod', 'the host command receives the raw line')
+  assert.equal(harness.host.followedUp.length, 0, 'never downgraded to a model prompt')
+})
+
+test('a deferred session that resolves an EXECUTE-KIND host command takes the argued line back', async (t) => {
+  // The exact claimed -> unclaimed mutation (the reverse of the test above): the
+  // standing catalog CLAIMS `/deploy prod` (a `leadingInput` descriptor), so the
+  // submission is routed to the command plane. The committed session then
+  // resolves /deploy as EXECUTE-KIND, where the argued line is NOT an
+  // invocation — the plane's ownership must be re-asked after ensureSession(),
+  // or the old submit-time answer would run the command by NAME. The line is an
+  // ordinary submission, and it is NOT consumed as an advertised miss: its name
+  // WAS advertised at submit time, so the miss gate must follow the final
+  // (non-plane) answer too.
+  const { harness, mounted } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    deferredStart: true,
+    // `leadingInput` at submit time: `/deploy prod` is a real invocation.
+    hostCommands: [{ name: 'deploy', input: { hint: '<target>' } }],
+  })
+  harness.onCreateSession(() => {
+    // The session's catalog replaces the descriptor with the execute-kind
+    // shape (no `input`).
+    ;(harness.commands as { register(def: { name: string; handler: () => unknown }): void })
+      .register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  })
+  mounted.app.setDraft('/deploy prod')
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await waitForDelivery(harness.host, 'claimed -> unclaimed argued line')
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/deploy')),
+    `the final execute-kind command never runs its argued line: ${JSON.stringify(harness.executed)}`)
+  assert.equal(harness.host.followedUp.length, 1, 'the line is an ordinary submission')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.text), ['/deploy prod'],
+    'the MODEL receives the raw line')
+  assert.doesNotMatch(mounted.app.notifyTextForTest(), /not available in the created session/,
+    'the submit-time advertised claim must not consume a line the plane no longer owns')
 })
 
 /** A minimal PNG header (magic + IHDR): the intake parses headers only, so a
@@ -1583,14 +1961,21 @@ function pngHeader(width: number, height: number): Uint8Array {
 /** Stage ONE real generic-file attachment through the REAL `/attach`
  * sessionless command: the intake inserts its placeholder into the editor,
  * which is exactly the draft text the user submits next. */
-async function stageAttachmentDraft(mounted: { app: TuiApp }, path: string): Promise<string> {
+async function stageAttachmentDraft(
+  harness: { commands: unknown },
+  mounted: { app: TuiApp },
+  path: string,
+): Promise<string> {
   // The runner registers its TUI commands during mount, and the mount's
   // readiness can lag under a loaded suite (the full product run mounts many
-  // surfaces in parallel): submitting before `/attach` is advertised makes
-  // the line fall back to the session dispatch, where the intake lands much
-  // later. Wait for the catalog row first (bounded, drain-based).
+  // surfaces in parallel): submitting before `/attach` is registered makes the
+  // line fall back to the session dispatch, where the intake lands much later.
+  // The readiness signal is the REGISTRATION, never the completion ROW: a
+  // colliding client contribution fails the candidate synthesis as a whole
+  // (upstream `source-failed`), so the row list is legitimately EMPTY in those
+  // harnesses while `/attach` itself is perfectly routable.
   await drainUntil(
-    () => mounted.app.commandCompletionsForTest().some(row => row.name === 'attach'),
+    () => (harness.commands as { list(): readonly { name: string }[] }).list().some(def => def.name === 'attach'),
     10_000,
   )
   mounted.app.setDraft(`/attach ${path}`)
@@ -1630,7 +2015,7 @@ test('an attachment-bearing client command defers to a LATE declared host claim 
       register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
     }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '', attachments: true } })
   })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
   assert.deepEqual(harness.createdSessionIds, [], 'the sessionless intake creates no session')
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
@@ -1683,7 +2068,7 @@ for (const form of [
       attachments: true,
     })
     await waitForSkillWrapper(harness, 'grilling')
-    const staged = await stageAttachmentDraft(mounted, path)
+    const staged = await stageAttachmentDraft(harness, mounted, path)
     assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
     mounted.app.setDraft(form.line(staged))
     ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
@@ -1713,7 +2098,9 @@ test('an unknown slash line that becomes an UNDECLARED host command refuses its 
   // policy against the FINAL catalog before the command plane runs. The host
   // executor only validates the SUBMITTED payload, so passing `[]` would let
   // the handler run with the placeholder as a raw argument and then consume
-  // the draft: the attachment would be silently dropped.
+  // the draft: the attachment would be silently dropped. The command is
+  // `leadingInput` (`input.hint`): its argued line IS an invocation, which is
+  // exactly the line an attachment-bearing refusal has to catch.
   const life = testLifecycle(t)
   const root = life.tempDir('dsh-pi-tui-late-host-attachment-')
   const path = join(root, 'shot.png')
@@ -1728,9 +2115,9 @@ test('an unknown slash line that becomes an UNDECLARED host command refuses its 
   harness.onCreateSession(() => {
     ;(harness.commands as {
       register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
-    }).register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+    }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '<target>' } })
   })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
   assert.deepEqual(harness.createdSessionIds, [], 'the sessionless intake creates no session')
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
@@ -1767,7 +2154,7 @@ test('an unknown slash line that becomes a DECLARED host command delivers and co
       register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
     }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '', attachments: true } })
   })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
   await drainUntil(() => harness.executed.some(entry => entry.line.startsWith('/deploy')), 5000)
@@ -1807,7 +2194,7 @@ test('an unknown slash line that becomes a DECLARED host command still refuses a
       register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
     }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '', attachments: true } })
   })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   assert.match(staged, /\[file #1/, `the file is staged: ${JSON.stringify(staged)}`)
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
@@ -1838,7 +2225,7 @@ for (const form of [
       status: 'idle',
       attachments: true,
     })
-    const staged = await stageAttachmentDraft(mounted, image)
+    const staged = await stageAttachmentDraft(harness, mounted, image)
     assert.match(staged, /\[image #1/, `the image is staged: ${JSON.stringify(staged)}`)
     // The shell command would create the marker if it ever ran.
     mounted.app.setDraft(form.line(staged).replace('echo ', `touch ${marker} # `))
@@ -1855,11 +2242,13 @@ for (const form of [
   })
 }
 
-test('a HOST command that does not declare input.attachments refuses an attachment (web composer parity)', async (t) => {
-  // Upstream `CommandUiRuntime` refuses an attachment-bearing invocation of a
-  // command whose descriptor does not declare `input.attachments`. The TUI
-  // must not let the line through and then hand the host a placeholder with
-  // no bytes (the attachment would be silently dropped).
+test('an EXECUTE-KIND host command does not claim its argued line: the image rides the ordinary submission', async (t) => {
+  // DSH `CommandDescriptor.input` decides which LINE a host command claims.
+  // `/compact` is execute-kind (no `input`), so `matchEnter` claims the BARE
+  // token only and `/compact <anything>` is NOT a command invocation: it is
+  // an ordinary multimodal submission. Applying the command's attachment
+  // policy to it would refuse a line the host never owned and drop a real
+  // image prompt.
   const life = testLifecycle(t)
   const root = life.tempDir('dsh-pi-tui-command-attachment-')
   const path = join(root, 'shot.png')
@@ -1870,31 +2259,68 @@ test('a HOST command that does not declare input.attachments refuses an attachme
     attachments: true,
     extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
   })
-  // /compact is a HOST command without an attachment declaration; a registry
-  // change (any extension invalidation) refreshes the effective catalog.
+  // /compact is an execute-kind HOST command; a registry change (any
+  // extension invalidation) refreshes the effective catalog.
   ;(harness.commands as {
     register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
   }).register({ name: 'compact', handler: () => ({ kind: 'success' }) })
   await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
   mounted.app.setDraft(`/compact ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
-  for (let round = 0; round < 40 && !/does not accept attachments/.test(mounted.app.notifyTextForTest()); round += 1) {
-    await new Promise<void>(resolve => setImmediate(resolve))
-  }
-  assert.match(mounted.app.notifyTextForTest(), /\/compact does not accept attachments; remove them first/)
+  await waitForDelivery(harness.host, 'argued execute-kind line')
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/compact')),
+    `the argued line is not a command invocation: ${JSON.stringify(harness.executed)}`)
+  assert.equal(mounted.app.notifyTextForTest(), '', 'no command refusal is surfaced')
+  assert.match(mounted.app.getDraft(), /^$|^\/compact/, 'the submission consumed the draft')
+  assert.equal(imageSaves.length, 1, 'the image is admitted through the ordinary model path')
+  const delivered = harness.host.followedUp[0] as { content: readonly { type: string; text?: string }[] }
+  assert.deepEqual(delivered.content.map(block => block.type), ['text', 'image'],
+    'the model receives the multimodal prompt ("/compact " + the image)')
+  assert.equal(harness.host.steered.length, 0, 'an idle agent queues')
+})
+
+test('an undeclared LEADING-INPUT host command refuses the attachment on its argued line (web composer parity)', async (t) => {
+  // Upstream `CommandUiRuntime.matchEnter`: `/goal ship` + attachments is an
+  // INVOCATION (the descriptor declares `input`) whose descriptor does not
+  // declare `input.attachments` → the composer refuses before dispatch. The
+  // TUI must not let the line through and then hand the host a placeholder
+  // with no bytes (the attachment would be silently dropped).
+  const life = testLifecycle(t)
+  const root = life.tempDir('dsh-pi-tui-command-attachment-')
+  const path = join(root, 'shot.png')
+  await writeFile(path, pngHeader(4, 4))
+  const { harness, mounted, registerContribution, imageSaves } = await bootCommandHarness(t, {
+    busyEnter: 'queue',
+    status: 'idle',
+    attachments: true,
+    extensionCommands: [{ id: 'stub-cmd', name: 'stub', description: 'stub', bridgeHandler: () => ({ kind: 'success' }) }],
+  })
+  // A `leadingInput` host command WITHOUT the attachment declaration (the
+  // upstream `/goal` fixture shape): it claims the argued line and refuses
+  // the attachment.
+  ;(harness.commands as {
+    register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
+  }).register({ name: 'goal', handler: () => ({ kind: 'success' }), input: { hint: '<objective>' } })
+  await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
+  const staged = await stageAttachmentDraft(harness, mounted, path)
+  assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
+  mounted.app.setDraft(`/goal ${staged.trim()}`)
+  ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
+  await drainUntil(() => /does not accept attachments/.test(mounted.app.notifyTextForTest()), 5000)
+  assert.match(mounted.app.notifyTextForTest(), /\/goal does not accept attachments; remove them first/)
   // The COMPOSER refuses before dispatch: the host never sees the line, so
   // there is neither an execution nor an admission rejection. (A rejected
   // command-plane call would mean the gate let an undeclared invocation
   // through and the executor had to catch it.)
-  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/compact')),
+  assert.ok(!harness.executed.some(entry => entry.line.startsWith('/goal')),
     `the undeclared command never reaches the command plane: ${JSON.stringify(harness.executed)}`)
   assert.ok(!harness.executed.some(entry => entry.outcome === 'rejected'),
     'the refusal happened before dispatch, not at host admission')
   assert.equal(harness.host.followedUp.length, 0, 'never a model prompt')
   assert.deepEqual(imageSaves, [], 'nothing is admitted either')
-  assert.match(mounted.app.getDraft(), /^\/compact /, 'the draft comes back')
+  assert.match(mounted.app.getDraft(), /^\/goal /, 'the draft comes back')
   assert.match(mounted.app.getDraft(), /\[image #1/, 'with its attachment placeholder intact')
 })
 
@@ -1916,7 +2342,7 @@ test('a declared HOST command still refuses a FILE attachment (no host receipt s
     register(def: { name: string; handler: () => unknown; input?: { hint: string; attachments?: boolean } }): void
   }).register({ name: 'goal', handler: () => ({ kind: 'success' }), input: { hint: '<objective>', attachments: true } })
   await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   assert.match(staged, /\[file #1/)
   mounted.app.setDraft(`/goal ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
@@ -1956,7 +2382,7 @@ test('a FAILED declared command keeps its attachment (consume only after handler
     input: { hint: '<objective>', attachments: true },
   })
   await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   assert.match(staged, /\[image #1/, `the image is staged through the real intake: ${JSON.stringify(staged)}`)
   mounted.app.setDraft(`/goal ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
@@ -2001,7 +2427,7 @@ test('an attachment-bearing client command is refused AFTER the session resolves
       bridgeHandler: () => { calls.push('deploy'); return { kind: 'success' } },
     }],
   })
-  const staged = await stageAttachmentDraft(mounted, path)
+  const staged = await stageAttachmentDraft(harness, mounted, path)
   mounted.app.setDraft(`/deploy ${staged.trim()}`)
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
   for (let round = 0; round < 60 && !/Attachments cannot be included/.test(mounted.app.notifyTextForTest()); round += 1) {
@@ -2126,10 +2552,12 @@ test('a dynamic host collision fails the command source (upstream source-failed 
   const t0 = mounted.app.commandCompletionsForTest().map(row => row.name)
   assert.ok(t0.includes('deploy') && t0.includes('keep'), `both client rows installed: ${t0.join(',')}`)
   assert.ok(t0.includes('compact'), `the host row shares the source: ${t0.join(',')}`)
-  // T1: the host catalog gains /deploy; a later registration flushes the
-  // extension invalidation into a completion refresh.
-  const disposeHost = (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
-    .register({ name: 'deploy', handler: () => ({ kind: 'success' }) })
+  // T1: the host catalog gains /deploy (a `leadingInput` command — the line
+  // below is argued, so only that shape claims it); a later registration
+  // flushes the extension invalidation into a completion refresh.
+  const disposeHost = (harness.commands as {
+    register(def: { name: string; handler: () => unknown; input?: { hint: string } }): () => void
+  }).register({ name: 'deploy', handler: () => ({ kind: 'success' }), input: { hint: '<target>' } })
   await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
   const names = mounted.app.commandCompletionsForTest().map(row => row.name)
   // The command SOURCE failed: its whole group is removed (upstream
@@ -2260,8 +2688,8 @@ test('known limitation: a handler failure under a colliding name is masked, then
   const extensionServiceOf = (): readonly { id: string; state: string; lastError?: string }[] =>
     extensionService._ledger().healthSnapshot()
   const registerHost = (name: string): (() => void) =>
-    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
-      .register({ name, handler: () => ({ kind: 'success' }) })
+    (harness.commands as { register(def: { name: string; handler: () => unknown; input?: { hint: string } }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }), input: { hint: '<target>' } })
   // 1. The async client handler is IN FLIGHT (no claim yet: the local route).
   mounted.app.setDraft('/deploy')
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
@@ -2312,8 +2740,8 @@ test('known limitation: a handler success clears the still-active collision reco
   const extensionServiceOf = (): readonly { id: string; state: string; lastError?: string }[] =>
     extensionService._ledger().healthSnapshot()
   const registerHost = (name: string): (() => void) =>
-    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
-      .register({ name, handler: () => ({ kind: 'success' }) })
+    (harness.commands as { register(def: { name: string; handler: () => unknown; input?: { hint: string } }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }), input: { hint: '<target>' } })
   // 1. The async client handler is IN FLIGHT.
   mounted.app.setDraft('/deploy')
   ;(mounted.app as unknown as { submitDraft(): void }).submitDraft()
@@ -2363,8 +2791,8 @@ test('known limitation: a HOST command run under a colliding name settles the co
   const extensionServiceOf = (): readonly { id: string; state: string; lastError?: string }[] =>
     extensionService._ledger().healthSnapshot()
   const registerHost = (name: string): (() => void) =>
-    (harness.commands as { register(def: { name: string; handler: () => unknown }): () => void })
-      .register({ name, handler: () => ({ kind: 'success' }) })
+    (harness.commands as { register(def: { name: string; handler: () => unknown; input?: { hint: string } }): () => void })
+      .register({ name, handler: () => ({ kind: 'success' }), input: { hint: '<target>' } })
   const disposeHost = registerHost('deploy')
   await registerContribution({ id: 'zeta-cmd', name: 'zeta', description: 'zeta', bridgeHandler: () => ({ kind: 'success' }) })
   assert.equal(healthOf('deploy-cmd')?.state, 'failed', 'the collision is recorded')

--- a/test/transcript-window.test.ts
+++ b/test/transcript-window.test.ts
@@ -167,3 +167,48 @@ test('history projection remains stable while new turns append', () => {
   assert.equal(after.lastTurn, 50)
   assert.equal(after.hasNewer, true)
 })
+
+// ── older-boundary invariant (PR115-fix problem 2) ────────────────────────
+// The current window already reaching the oldest retained turn must make
+// moveOlder() a no-op: hasOlder=false ⇒ moveOlder=false + no state mutation.
+// A short session can never be paged into a bogus history state that hides
+// its content.
+
+test('older boundary: a single turn never pages into history', () => {
+  const controller = new TranscriptWindowController({ windowTurns: 20, stepTurns: 10, turns: [1] })
+  assert.equal(controller.isLatest(), true)
+  assert.equal(controller.moveOlder(), false, 'one turn fits the window: no older page')
+  assert.equal(controller.isLatest(), true, 'a failed moveOlder must not change the mode')
+  assert.equal(controller.endTurn(), undefined, 'a failed moveOlder must not set a history anchor')
+})
+
+test('older boundary: two turns never page into history', () => {
+  const folder = new TranscriptFolder()
+  folder.hydrate(longSession(2))
+  const controller = new TranscriptWindowController({ windowTurns: 20, stepTurns: 10, turns: folder.turns() })
+  assert.equal(controller.moveOlder(), false, 'both turns already fit the window: no older page')
+  assert.equal(controller.isLatest(), true)
+  assert.equal(controller.endTurn(), undefined)
+  // The projection still contains BOTH turns — nothing was shrunk away.
+  assert.deepEqual(userTurns(folder, { maxTurns: 20 }), [1, 2], 'the short session must stay fully visible')
+})
+
+test('older boundary: exactly one full window never pages into history', () => {
+  const controller = new TranscriptWindowController({ windowTurns: 20, stepTurns: 10, turns: Array.from({ length: 20 }, (_, index) => index + 1) })
+  assert.equal(controller.moveOlder(), false, '20 turns fill the 20-turn window: no older page')
+  assert.equal(controller.isLatest(), true)
+})
+
+test('older boundary: a window that just reached the oldest turn stops paging', () => {
+  const controller = new TranscriptWindowController({ windowTurns: 20, stepTurns: 10, turns: Array.from({ length: 25 }, (_, index) => index + 1) })
+  // 1..25: the first page moves 25 → 15 (window 1..15), which already
+  // reaches the oldest retained turn.
+  assert.equal(controller.moveOlder(), true, '25 turns have an older page')
+  const snapshot = controller.snapshot()
+  assert.equal(snapshot.hasOlder, false, 'the 1..15 window reaches the oldest turn')
+  assert.equal(snapshot.firstTurn, 1)
+  const before = controller.state()
+  assert.equal(controller.moveOlder(), false, 'no older page: the move must be a no-op')
+  assert.deepEqual(controller.state(), before, 'a failed moveOlder must not mutate the controller state')
+  assert.equal(controller.endTurn(), 15, 'the history anchor must stay at the oldest reachable page')
+})

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -2871,7 +2871,7 @@ test('submitDraft with an empty draft and a staged image submits (image-only gat
   await vt.waitForRender()
   // The runner resolves the placeholders to image blocks (plan §11.1): an
   // empty-text draft with images is NOT empty.
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submitted, [''])
   app.stop()
@@ -2889,7 +2889,7 @@ test('submitDraft with an empty draft and no image stays a no-op even with the g
 
   startedApps.add(app)
   await vt.waitForRender()
-  app.submitDraft(false)
+  app.submitDraft('enter')
   await vt.waitForRender()
   assert.deepEqual(submitted, [])
   app.stop()


### PR DESCRIPTION
## Summary

Host-only follow-up batches on top of the merged #115 (`chore(pi-tui): re-vendor Earendil v0.85.1`), based on `next`.

> **Reading order.** The per-commit sections are the record of the round in which each
> change landed. The extension-command contract was reworked twice afterwards, so
> the "Commit 5"/"Commit 9" descriptions of contribution ownership and of the
> collision display state are **superseded** by "Commit 10" (namespace order and
> the settled collision contract) and "Commit 11" (the final notice + docs). Where
> they disagree, commits 10–11 win.

### Commit 1 — `fix(focus): surface injected turn foundation before thought`

Focus treated a turn without a non-steer opening user as process-only. For an injected wake this hid the opening context in collapsed mode and placed a later human steer below the Thought.

- Keep durable `steer`/source facts unchanged; project the **leading injected-context prefix** as the turn foundation, before the Thought in expanded and collapsed Focus
- Collapsed Focus summarizes inputs: opening injected context + **all** human user rows (same-turn steers included) precede the Thought
- Expanded Focus preserves process chronology: later steers and mid-turn injections stay at their real positions
- Click-owner contract preserved: opening context rows carry no Thought collapse mark; process rows keep it; user/final stay unmarked

### Commit 2 — `fix(input): keep host commands out of the busy policy and stop older paging at the oldest turn`

**Host-command arbitration**: a registered Host command (e.g. `/compact`) was classified by the busy-Enter policy as agent-facing input — running + `busyEnter=steer` steered it into the turn as a prompt, and a catalog miss could land it in the ordinary inbox queue. The dispatch now claims Host commands from the **current effective command catalog** (completion-list claims minus TUI-owned skill wrappers) **before** the queue/steer decision:

- Confirmed Host commands always execute through the command plane; the handler decides the busy outcome
- TUI-local commands, plugin-declared local commands, `/skill <name>` invocations, and unknown slash input keep their existing semantics
- No static whitelist, no second command registry

**Transcript older boundary**: `TranscriptWindowController.moveOlder()` only checked whether the page step would move, not whether the current window already reaches the oldest retained turn — a short session could be paged into a bogus history state hiding its content. The move is now a no-op (`false`, no state mutation) when the projected window's start index is 0, so `hasOlder=false ⇒ moveOlder=false`. Main session and subagent viewer share the same controller invariant.

### Commit 3 — `fix(focus): mark injected context rows so orchestration never becomes turn foundation`

Review follow-up. The foundation prefix check used bare `kind === 'system'`, but `llm/retry` and `max-tokens` rows are also `kind: 'system'` (orchestration). An `inject → retry (before any visible output) → reasoning` sequence lifted the retry before the Thought and stripped its process click-owner mark.

- **Plan deviation (documented)**: the original plan asked for projection-only inference, but the leading-`kind` heuristic was falsified by the retry case, so the fold now writes a narrow **source-derived, presentation-only `context: true`** marker on injected-context system rows only (not a durable field, no new session event)
- The icon stays a display field — never a semantic signal; no `context || icon` fallback
- Retry/max-tokens stay inside the expanded process (owner-marked) and hidden under the collapsed Thought
- `docs/surface-decisions.md` records the deviation and the two independent field contracts

### Commit 4 — `fix(input): queue skill invocations under busyEnter=queue like the web`

Review follow-up. A skill invocation is an agent-facing prompt, not a Host command: **the web queues it under `busyEnter=queue`** (`session.prompt` with the policy-resolved mode), but `loadSkill` always steered.

- With the host body loader (`dsh-tool-skill` pre-step) the invocation now **queues** under `busyEnter=queue` (and idle), exactly like a plain prompt — the host injects the body at the next model request
- The TUI's fallback body injection rides next-step, so a followup would let the body arrive **before** the user's words (the driver claims next-step first). Without the host loader the invocation keeps the order-preserving steer path — the documented exception, confined to compositions without the loader
- The test harness command plane now runs the real handler with a `CommandRuntime`-shaped invocation, so `/skill` exercises `loadSkill` end to end
- `docs/surface-decisions.md` records the delivery rule and the exception

### Commit 5 — `fix(input): resolve the submit delivery once for skills and extension commands`

Review follow-up (two P2 findings from the force-queue sweep).

**P2-A — the skill delivery lost the gesture's mode.** `loadSkill` re-derived `queue|steer` from the persisted `busyEnter`, so the Ctrl+Enter force-queue chord could not reach it: `running + busyEnter=steer + Ctrl+Enter /skill grilling` (and the `/grilling args` wrapper) still steered. Downstream re-derivation also re-read `agent.status` *after* the async draft preparation. The submission mode is now resolved **once** at the submit boundary (web `ComposerSubmissionPolicy` parity: idle / `busyEnter=queue` / the chord ⇒ queue) and bound for the command execution that launches the delivery; the skill delivery accepts it and never re-reads settings or status. The `/skill` picker (a modal selection with no dispatcher above it) resolves the same preference rule at its own boundary, so the preference keeps exactly one implementation.

**P2-B — advertised ≠ Host-owned.** `isHostCommand` claimed every name in the effective completion list that is not a TUI skill wrapper, which swallowed extension contributions: a `TuiCommandContribution` with `execution: 'submission'` was executed through the command plane **before** the busy policy, so Enter / queue / the chord all lost their meaning for it. The claim now also excludes any live extension contribution.

The no-host-loader skill fallback keeps its documented order-preserving steer (the fallback body rides next-step, so a followup would invert the message order) — still an explicit exception, never a hidden loss.

Regressions added: `running+steer Ctrl+Enter` force-queues both `/skill <name>` and a per-skill wrapper (`followup=1, steer=0`); an extension submission command keeps the busy steer (`steered=1, executed=0`); an extension local command and a real Host command keep executing under both chords; the `isHostCommand` unit contract pins the ownership predicate.

### Commit 6 — `fix(input): make the accelerated chord the busy-Enter opposite, align extension submissions with the web`

Review round 3 (1 P1 + 3 P2), re-aligned against the **supported DSH baseline `dsh-v0.1.3-alpha.2`** web composer policy.

**P1 — the chord model was wrong.** `ComposerSubmissionPolicy.resolve()` is `!running -> queue`, `enter -> preferred`, `accelerated -> the OPPOSITE`. The old `forceQueue` boolean made Ctrl+Enter a fixed queue, so with the **default** `busyEnter=queue` the TUI did exactly the opposite of the web. The gesture is now first-class (`enter | accelerated`) and resolved once by `resolveComposerDelivery`; the explicit `queue-draft` / `submit-draft` actions and the replacement editor's `queue-submit` raise the separate `explicit-queue` request, so an explicit queue can never become the opposite behavior. The keybinding action is renamed `app.input.queue -> app.input.submitAccelerated` (the old name described the wrong model) with a settings alias so a stored override keeps applying.

**P2 — the `/skill` picker froze its mode at open time.** The SELECTION is the boundary: the mode is resolved when a row is chosen (an agent that went idle while the modal was up queues instead of steering into a stale busy state).

**P2 — no-loader + `busyEnter=steer` silently skipped the skill body.** `/skill <name>` and per-skill wrappers steered a bare line, so the TUI's fallback injection never ran. Skill delivery now always goes through `loadSkill`, which owns the normalized `/name` line, the resolved mode and the body injection.

**P2 — extension `execution: 'submission'` was executed under queue.** The plugin's handler ran immediately although the user had resolved `queue`. A submission contribution is agent-facing input: its LINE is delivered (steer / queue) like an unclaimed slash prompt, never the handler — the public contract docs now say so instead of contradicting the code.

### Commit 7 — `fix(input): declare the extension ownership contract and keep the legacy queue action`

Review round 4 (1 P1 + 2 P2 + follow-ups), with the product owner explicitly authorizing a breaking contract change ("align with dsh-web semantics").

**Extension command ownership (P1).** dsh-web's composer runs a command handler only for a CLAIM; a skill-style line is a plain prompt with the policy-resolved mode. `execution: 'submission'` now means exactly that and is a **declared breaking change** (Unreleased) instead of an undeclared side effect of the busy policy: the raw `/<name> args` line is delivered with the resolved mode (steer / queue) and the commands-service handler is **not** run — the plugin's own pre-step owns expansion. Migration path documented in the JSDoc, `docs/extension-api.md` and both changelogs: declare `execution: 'local'` when handler execution is wanted. In the same batch:

- `submission + sessionless: true` is now **rejected at registration** (`{ kind: 'invalid' }` → `registerCommand` throws): a submission needs a session, and accepting the combination let the line fall into the local path and run a handler the ownership does not run.
- A LOCAL command really runs locally whenever it is submitted: the contribution's bridge handler is the implementation (live session or not, `rawInput` verbatim); the commands-service definition is only the fallback. Previously a bridge-only local contribution (e.g. the vim fixture's `/vimmode`) fell through to the command plane, missed, and was delivered to the **model** with its handler never running.

**Keybinding migration (P2).** The read-time alias re-interpreted the old `app.input.queue` action as the accelerated gesture (silently migrating a stored explicit "queue" remap into its opposite) and left `/keybindings` unable to reset the legacy declaration. The action is kept as a REAL deprecated action with no default key and its original fixed-queue dispatch; `app.input.submitAccelerated` owns Ctrl+Enter. The alias canonicalization is gone, so duplicate tracking works on the action the user actually declared.

### Commit 8 — `docs(extensions): align the ownership comments with the local bridge-handler route`

Closing review follow-up, comment-only: the top-level `TuiCommandContribution` and the public `registerCommand` JSDoc still claimed "the bridge does NOT execute — the commands service does", and the `runLocalCommand` helper doc described sessionless/no-session only. All four spots (plus the vim fixture comment) now state the actual contract: the bridge carries ownership metadata, the RUNNER routes — a local contribution runs its own bridge handler locally (the commands-service definition is the fallback), a submission contribution is delivered as an agent-facing line.

### Commit 9 — `refactor(extensions): make command contributions DSH client commands`

Review round 5 (1 P1 + 2 P2). **Decision record**: the model was settled against the DSH-official source (`packages/client/ui-commands`, baseline `dsh-v0.1.3-alpha.2`) and confirmed by a senior consultation.

**What upstream says.** `CommandContribution` is "a slash-menu entry whose behavior lives entirely on the client (no host descriptor). Merged with the host catalog by name — a collision with a host command fails loud at candidate synthesis, never shadows"; `candidates()` reads the session-keyed host catalog first and throws on a name collision; "sessions are always agent-backed". Upstream has **no prompt-style contribution kind** — an unclaimed `/name args` line is simply a prompt, and the host-owned skill owns its discovery.

**Consequences implemented.**

- **BREAKING**: `execution: 'local' | 'submission'` is removed and `handler` is required — a contribution is a client-owned command, full stop. Migration for `submission`: don't register a contribution; the line is a prompt.
- **Host authority (P1)**: `isHostCommand` no longer excludes contributions and the dispatch claims host commands *before* the contribution route — a contribution can never suppress a host command's claim or turn it into a model prompt (previously an `execution: 'submission'` contribution could).
- **Candidate synthesis (P2)**: contributions merge into the `/` menu with the host catalog (bridge-only commands are discoverable; late registrations refresh through a new extension-invalidate hook); a host/contribution collision **fails the pass as a whole** (nothing installed, previous list kept, collision recorded on the contribution's health + one notice), and host claims refresh *before* the merge so a collision never costs a host command its claim.
- **`sessionless` (P2)**: `true` runs before a session exists; the default `false` resolves/creates the session first, then runs the handler (previously the flag's effect depended on whether the implementation was a bridge handler or a commands-service fallback).
- Fixtures/examples, public JSDoc, `docs/extension-api.md` (new Command-ownership section), `docs/surface-decisions.md` and both changelogs updated; the `submission` semantics introduced in commit 7 is replaced by the removal + migration.

**Regressions** (red-checked by reverting the host-authority order and the menu merge — 5 failures): host-named contribution → host command runs, client handler does not, never the model; collision fails the synthesis (no partial menu); bridge-only client command appears in the menu; session-backed client command resolves the session first while a sessionless one creates none.

### Commit 10 — `fix(extensions): close the namespace-order holes and settle the collision contract`

Review round 6 (2 P1 + 4 P2 around the new client-command namespace).

**Namespace order (P1).** The dispatch order is now explicit and tested: host claim → client command contribution → TUI-owned sessionless → agent-facing input. A client command is client-owned in *every* session state: the generic sessionless branch used to swallow a `sessionless: true` contribution whenever a live session existed and route it through the command plane, where a missing definition delivered a **client** command to the model; live skill wrappers now outrank a same-named contribution in the dispatch, in the deferred-start re-check and in the attachment gate.

**Deferred start (P1).** After `ensureSession()` the authority is re-checked — the session-scoped host catalog (or the skill catalog) may have appeared while the standing view could not see it: a late host claim takes the command plane, a late skill wrapper takes `loadSkill`, and only otherwise does the client handler run.

**Attachment gate (P2).** A live host claim outranks a same-named contribution (the host handler owns its own attachment policy), TUI-owned local commands stay local, and a live skill wrapper stays agent-facing; one shared, unit-tested predicate (`commandIsLocalForAttachments`) is used by the gate.

**Runtime migration fence (P2).** A contribution must declare a function `handler`, and the removed `execution` field is rejected loudly at the bridge/service boundary — a stale plugin can no longer be silently reinterpreted (menu row → no behavior → model prompt).

**Collision contract settled (P2).** A synthesis-time collision fails the whole candidate pass and the command source's rows are **withdrawn** until a synthesis succeeds again (no stale row can survive and execute a different command than it displays), while host claims stay refreshed so input authority is never lost. Registration-time conflicts with the TUI's static catalog keep their early loud rejection. Collision-health recovery is *scoped* to the records that synthesis wrote and only while the record still shows that collision (a handler-failure record in the same slot is never cleared); notice keys are per contribution identity + failure generation, and are dropped on recovery.

**Cleanups.** The never-wired `argumentProvider` field and the runtime-dead `isSessionless` accessor are removed, the bridge module doc no longer describes the deleted ownership metadata, and duplicate/stale contract comments are gone.

### Commit 11 — `fix(extensions): report every collision of a failed command synthesis`

Review round 7 (closing P2s: collision-notice completeness and doc consistency).

**Collision notice completeness.** A failed synthesis carried only its *first* collision, so a contribution that started colliding while another one kept colliding was recorded on its health but never surfaced (the second pass failed on an already-notified identity and stayed silent). The thrown error now carries every collision of the pass, and the notice reports the whole current collision set whenever at least one identity is fresh — a growing collision set is visible, a refresh re-failing on the same set stays quiet, and recovery still drops one identity at a time.

**Consulted question (senior consultation, settled): does a collision hide the whole `/` menu?**

- **Question.** Upstream `source-failed` withdraws the failed source's whole group; the TUI composes host and client rows into one source. Should a collision therefore hide *every* command row (upstream parity), or keep the host rows visible via a documented, friendlier divergence?
- **Verdict: upstream parity (option A).** Under the standing "DSH-official semantics win" priority, option B cannot be recorded as an upstream-equivalent behavior, and the size of the blast radius does not justify diverging unilaterally. The upstream mitigation already present is that *a failed candidate pass does not revoke input authority* — which limits the execution impact, not the discoverability loss.
- **Explicitly accepted user consequence.** While a collision persists, the `/` menu offers **no command rows at all**, built-ins included, and the menu can be empty; a host command can still be typed and executed, but it cannot be discovered through completion. The loss of discoverability can outlast the transient notice.
- **If the product does not accept that cost**, it requires an explicit change of priority (or of the source composition), *not* a re-labeling of option B as official parity. No divergence is documented because none is implemented.
- **Targeted scenario verified** (regression): normal candidates → same-name collision introduced → the menu has no rows at all (the test pins a *host* row sharing the source, so built-ins are covered), no stale rows survive → a manually typed host command still executes through the command plane → removing the collision restores the full candidate list.

**Doc/comment accuracy.** `mergeContributions` and `installCompletionsContained` no longer claim "the previous list stays live" (it is withdrawn), and `docs/surface-decisions.md`, `docs/extension-api.md` and both changelogs describe the withdrawal plus the aggregated notice.

**Cleanups.** The dead `TuiAutocompleteProvider` import, two comments still describing the removed `execution` ownership metadata (the test section header and the vim fixture), and a dead test variable.

### Commit 12 — `docs(extensions): record the command-health diagnostic limit and fix the static-catalog comments`

Closing round: the reviewer accepted the PR with two P2 follow-ups; both are addressed here. No behavior change.

**P2 — same-identity command-health race: recorded as a documented diagnostic limitation (not fixed).** One contribution identity has **three** writers of its single extension-health record — the candidate synthesis, the client handler settlement (`runLocalCommand`), and the session command path that reports the **HOST** command executing under a colliding name (`_recordRegistryHealthRef('command', idFor(name))`) — while the ledger keeps one failure generation per record and deduplicates a repeat (first message wins). Two concrete consequences are now **confirmed by red-checked regressions** (deferred-promise handlers):

- a handler that **rejects** while its name collides has its error deduplicated away by the collision record, and the collision recovery then **clears** the record although the handler never recovered;
- a handler that **resolves** while its name collides **clears** the still-active collision record.

**Decision (second senior consultation, option B of A/B): keep the behavior, own the limitation in the contract docs, and pin it with characterization regressions.** Decisive reason: a tracker making the runner the single writer would *not* establish that contract while the session path keeps writing the record directly, and "re-assert on the next synthesis" is not a synchronization mechanism — a full fix must separate the failure **sources** (and stop attributing a host execution to the contribution), which is out of scope for a closing round. Recorded honestly rather than claimed fixed: the docs say health is a **lossy diagnostic, not an authoritative summary of every unrecovered failure**. User-visible behavior is unaffected and is asserted alongside the limitation: the handler failure is notified and logged immediately, the collision is notified and withdraws the menu rows, and dispatch/claims/menu never consult health.

- `docs/surface-decisions.md` owns the three limitations; `docs/extension-api.md` links to them; the `commands.ts` recovery comments no longer promise that a handler-failure record is never touched.
- Regressions (`test/submit-hot-path.test.ts`, titled `known limitation: …` so they cannot be mistaken for a specification): reject branch (notice carries the handler error, record keeps the collision text, recovery clears the record), resolve branch (record flips to `active` while the claim still owns the name, the failed source still offers no rows, and the client row returns on a successful synthesis), and the host-execution attribution (a HOST command run under a colliding name settles the contribution record). The harness handler type now accepts the public promise-returning `TuiLocalCommandHandler` shape, so the in-flight windows are deterministic.

**P2 — `staticCatalog` docs.** `src/command-bridge.ts` no longer claims the static catalog contains every TUI/host command name or that all host collisions are caught at registration: the catalog is the static ownership sets plus `/plan` (`HOST_COMMAND_CATALOG`), while dynamic/session-scoped host names are caught at **candidate synthesis** — the distinction the changelog already documents. The same correction is applied to the `HOST_COMMAND_CATALOG` doc comment in `src/index.ts`.

In-round gates on `07d7486`: `git diff --check` clean, submit-hot-path 47 pass, `tsc -p tsconfig.json --noEmit` clean, `pnpm build` pass. The deferred `pnpm test:product` / `pnpm verify:prepush` gates are run on this final HEAD.

### Commit 14 — `fix(extensions): fence the deferred client command and bump the stable API to v2`

Review round 8: the three P2s and the P3 from the post-merge sweep of the deferred-start / lifecycle / contract boundaries (the earlier "same-identity command-health race" stays a documented limitation — it is diagnostic-only and asserted as such).

**P2 — attachments deferred with the authority.** An attachment-bearing client command used to be refused as "local" BEFORE `ensureSession()`, so a session-scoped host command (or a skill wrapper) never got its chance to take the line — the session was not even created. The refusal now waits for the same authority resolution the namespace decision waits for, with the referenced drafts **reserved** across the window (a real `/attach`-staged file backs the regression). A late host claim / skill wrapper takes the line **with its attachment**; if the contribution keeps it, the refusal fires after the session resolves and the draft (placeholder intact) returns for a re-attach decision.

**P2 — the captured registration is fenced.** The post-await resolution re-resolved the name only, so a dispose + reload during the window either ran the **new generation's** handler or — with no handler left — fell through `runLocalCommand` to `dispatchViaSession`, delivering a client command to the **model**. The submission now runs only the **exact registration** the user submitted (object identity, so a same owner+id reload is a new generation too); a vanished/replaced one aborts with `/<name> is no longer available` and restores the draft. Red-checked: with the fence disabled the test observes the replacement handler running.

**P2 — dispose→re-register inherited the notice suppression.** A disposed colliding contribution is absent from the snapshot, so the recovery loop never visited it and its notice key survived: re-registering under the same id/owner (plugin reload) failed health again but stayed **silent**. The synthesis now purges bookkeeping for identities that are no longer live, including the empty-snapshot pass that returns early.

**P3 — recovery must match the slot.** `ExtensionHealth` is keyed by `(slot, owner, id)`, but the collision-recovery lookup matched `(id, owner)` only: one plugin may legally reuse an id across slots (a theme and a command), and the lookup could read the **other slot's** record and skip the clear it owns. The extension point now matches too.

**P2 — stable API v2.** `api().apiVersion` reported `1` while the contribution contract broke against the released surface (`v0.4.1`: `execution` required, `handler` optional; now `execution`/`argumentProvider` removed, `handler` required, stale shape rejected at registration). `API_VERSION` is now `2`, the service reports the constant (never a drifting literal), the API contract test is renamed to `test/extension-stable-api.test.ts`, the smoke stubs and docs follow, and `docs/dsh-compatibility.md` records the honest external consequence: the pinned consumer `pi2dsh@0.24.0` hard-gates `apiVersion !== 1`, so it also needs a v2-aware release — its manifest keeps recording `apiVersion=1` because that is the **consumer's** requirement, never silently rewritten to match this host (Gate B was already disabled for the DSH-baseline incompatibility). Both changelogs record the bump and the two deferred-authority behaviours.

New regressions (all red-checked): disposed collision notice generation; slot-accurate collision recovery next to a same-id theme record; deferred attachment refusal with a LATE host claim taking the line; the same deferral refusing after the session resolves (draft + placeholder restored); a REPLACED generation never running and never becoming a prompt. The harness's commands service now resolves `find(undefined, name)` like the real one, which lets the attachment regressions drive the REAL `/attach` intake.

In-round gates on `0e0d49c`: `git diff --check` clean, affected suites 145 pass, submit-hot-path 52 pass, `tsc --noEmit` clean, `pnpm build` pass, `test:docs` 11 pass, `test:tooling` 253 pass. Product/prepush run once this round is accepted.

### Commit 15 — `fix(extensions): key the collision notice on the registration generation`

Review follow-up on commit 14 (P2). The purge added there only removes bookkeeping for identities the synthesis **observes as absent**; the invalidate batcher flushes on a microtask, so a dispose + re-register under the same id/owner inside one tick reaches the synthesis as a single pass over the NEW snapshot — the empty state is never observed and the second generation's collision was silently deduplicated by the first one. `CommandBridge` now stamps every registration with a monotonic **generation** (exposed on the snapshot entries, additive) and the collision identity is `(id, owner, generation)`; a reload is always a new notice generation, while the health record keeps the ledger's `(slot, owner, id)` key. Regression: dispose + re-register in the SAME tick (different colliding name, so suppression is observable) must notify again — red-checked by removing the generation from the identity.

### Commit 16 — `fix(input): deliver command attachments per the DSH declaration contract`

Review follow-up (P1/P2): the TUI let an attachment-bearing command line through, called `commands.execute(agent, line, [], signal)`, and a comment claimed "a success consumed its refs" — nothing admitted the attachments, nothing consumed them, and the host received a placeholder with **no payload** while the user's attachment stayed staged in the client store. The official contract is now implemented (`deepseek-harness` `packages/client/ui-commands` + `dsh-commands` types):

- **Delivery**: `commands.execute` receives the submitted `CommandSubmitAttachment`s — the IMAGES the draft references, encoded from the exact draft bytes (`mediaType`, base64 `data`, optional `name`). The **host** admits them through its own attachment store; the client never saves them locally for a command.
- **Composer-side refusal** (web `desc.input.attachments !== true` parity): a command may be invoked with attachments ONLY when its descriptor declares `input.attachments`; otherwise the line is refused up front (`/<name> does not accept attachments; remove them first`) with the draft (placeholder intact) returned. The declaration is tracked through the catalog summary (`SurfaceCommandSummary.input`), the claims commit and a new `isHostCommandAcceptingAttachments` predicate.
- **Files fail closed**: a FILE attachment is refused even for a declaring command (the host contract carries files as upload receipts this client has no seam to produce) rather than handing over an empty payload.
- **Consume-on-success** (web parity): a successful command consumes the referenced drafts; an ERROR restores the draft AND keeps the attachments. The false "success consumed its refs" comment is gone.
- **Deferred path**: the policy is resolved again AFTER the authority settles — a late host claim that declares attachments takes the line WITH its images, an undeclared one refuses, a skill wrapper still delivers to the model.

Regressions, each red-checked by disabling the specific guard: an undeclared host command refuses an image (draft + placeholder restored); a declared command receives the **exact** encoded bytes and consumes them on success (the same placeholder resubmitted as a plain prompt is plain text, and no local admission happens); a declared command refuses a FILE; a FAILED declared command keeps the attachment (the next plain-prompt submit still admits the image); the deferred late-claim test now asserts encoded delivery + consumption. The harness mirrors production more closely (`input` descriptors are kept, `execute` records the submitted attachments, an optional recording `ctx.attachments` fake makes admission observable) and the staging helper waits with the repository's drain pattern instead of a wall-clock sleep.

**Follow-up on the attachment policy (`979f555`, `486a777` — review found the delivery over-reached).** Handing the encoded payload to *every* `commands.execute` broke the agent-facing skill forms: `/skill <name>` is itself a registered TUI command and a skill wrapper is TUI-owned, neither declares `input.attachments`, and the real host executor settles an attachment-bearing invocation as an **error before the handler** — so an explicit `/skill <name> [image #1]` would have stopped reaching `loadSkill` (and the model) entirely. Fixes: the payload now rides ONLY a host command whose descriptor declares `input.attachments`; every other line passes `[]` and keeps the pre-existing delivery path (images admitted by `loadSkill` → `prepareUserMessage`). The composer policy takes the ONE `isSkillInvocation` predicate as an argument instead of re-deriving it (the argued-`/skill` short-circuit can no longer be lost into the host branch). The harness now **mirrors the host executor's declaration enforcement** (an undeclared command invocation with attachments settles an error before the handler) and records each command-plane call with its settled `outcome` (`executed` | `rejected`), so a refusal can never be miscounted as an execution. **Follow-up: the policy follows the FINAL authority (`485d99a`).** The deferred fix above only covered a *provisional client contribution*. An unknown slash line (`/deploy [image #1]` with no contribution registered) is allowed by the composer — the standing view cannot see the session-scoped host catalog — and `dispatchViaSession` then called `commands.execute(..., [], signal)`. The upstream executor validates only the SUBMITTED payload (`packages/interaction/commands/src/index.ts`), so an undeclared command ran with the placeholder as an ordinary argument and the success path consumed the draft: a silent drop for both images and files. The dispatch now re-applies the same policy after `ensureSession()` and before `commands.execute`, against the final catalog (skill invocations keep the agent-facing bypass): unknown → late undeclared host → refused with the draft restored; unknown → late declaring host → the encoded images ride the invocation; unknown → late declaring host + file → refused, file draft unconsumed. Three regressions, red-checked by disabling the dispatch-side gate.

The composer-refusal regressions assert that invariant directly — the line never reaches the command plane and no recorded call is a host rejection — instead of comparing call counts (`2a5e4d1`).

**The same-family shell edge is fixed too (product request).** The `!`/`!!` local-shell branch sat before the composer gate and `runLocalShell` never touches the draft stores, so `!echo [image #1 (6×6)]` passed the placeholder into the shell as ordinary arguments and left the staged image to the next attach-time prune. It now refuses an attachment-bearing shell line exactly like a local command (draft + placeholder restored), so a placeholder can never enter shell mode. Regression parameterized over `!` and `!!`: a marker file the shell would create proves the shell never ran, the refusal notice fires, nothing is posted to the session, and the draft comes back intact — red-checked with the guard disabled. Regression, parameterized over both skill forms: delivered, no refusal, image admitted on the model path, no command-plane payload; red-checked by removing the declaring-host condition (the enforcing fake rejects it exactly like production would).

The recalled-image note on the command wire rides the small follow-up commit `5d341d6` (a recalled draft carries no local bytes; the host rejects the empty payload at admission and the command settles as an error, keeping the draft and its attachments — documented rather than pretended).

In-round gates on `485d99a`: `git diff --check` clean, affected batch 152 pass (submit-hot-path 60/60), `tsc --noEmit` clean, `pnpm build` pass, `test:docs` 11 pass, `test:tooling` 253 pass. Product/prepush run once this round is accepted.

**The host command claim is a property of the LINE (`86cd3f2` — the P1 that blocked the previous acceptance).** The dispatch asked *"is this NAME in the host catalog"* where the DSH command UI contract asks *"does the host catalog claim THIS LINE"*. Upstream (`packages/client/ui-commands/src/client/commands/service.ts` `matchEnter` + `CommandDescriptor.input`) distinguishes two command kinds: a `leadingInput` command (`/goal`) claims its argued line, an execute-kind one (`/compact`) claims the BARE token only — and an argued line of an execute-kind command is **not an invocation at all**: it is an ordinary submission (busy queue/steer/accelerated policy included, attachments included) and the command never runs. Name-level routing did the opposite: `/compact anything` executed the command, ignored the busy policy while running, and was refused by the command attachment rule when it carried an image. The test catalog also fabricated `input: { hint: '' }` for every row, so no execute-kind host command existed in tests — and a new regression asserted the wrong behaviour as expected.

- **Tri-state claim.** The catalog record keeps the descriptor's input kind; the dispatch asks for the LINE and gets `{claimed: true, attachments}` | `{claimed: false}` (the catalog resolves the name, this line is not an invocation) | `undefined` (the name is not resolved). `isHostCommand` / `isHostCommandAcceptingAttachments` are gone.
- **Four decision sites ask the line**: the namespace/busy routing gate, the composer attachment policy (including the deferred re-check after `ensureSession()`), the `commands.execute` submitted-attachment selection, and the **command-plane hand-off itself** — the host registry resolves by NAME (`commands/index.ts` `execute`), so handing `/compact extra` over would run the command anyway.
- **A resolved name is host territory in both states**: a same-named client contribution never runs for such a line, and it is never classified as a local client command for the attachment gate.
- **Sticky submit-time authority, final-catalog claim.** A name the catalog resolved when the line was submitted stays host territory for that submission even if it disappears later (the plane is not asked, the advertised-miss gate does not consume it, and the attachment gate never falls back to a same-named contribution); only a line whose initial route was a live client contribution keeps the client-local classification, so a contribution mounting during the deferred window cannot reclassify a generic line as a UI control. The CLAIM itself is re-asked against the catalog the session committed, and the advertised-miss gate follows that same answer — so `execute-kind → leadingInput` executes, while `leadingInput → execute-kind`, `execute-kind → unresolved` (with or without an image) and `undefined → unclaimed` are ordinary submissions.

Regressions, each red-checked by reverting its guard: bare `/compact` executes; `/compact extra` + queue → followup, + steer → steer, + accelerated → the opposite policy; `/compact extra` + image → ordinary multimodal submission (the wrong regression rewritten); `/goal <args>` is a host invocation under a busy policy; an undeclared `leadingInput` command refuses an attachment; a name the host resolves with an UNCLAIMED line never runs the colliding client handler (with and without an image); all six deferred authority transitions (`undefined→claimed`, `undefined→unclaimed`, `claimed→unclaimed`, `execute-kind→leadingInput`, `execute-kind→unresolved` with and without an image, plus a contribution mounting during the window).

Test-double honesty: the catalog double no longer fabricates `input`; `hostCommands` registers either descriptor shape; `extensionCommands[].hostInput` declares the colliding host definition; the session-create hook is AWAITED (no bare fire-and-forget promise); and the attachment-staging helper waits on the command REGISTRATION instead of a completion row (a failed candidate synthesis legitimately empties the rows, which previously made it burn a 10s bound on a false signal).

Docs: `docs/surface-decisions.md` (line-level claim, the three catalog states, final-catalog resolution with sticky submit-time non-invocations, the extended deferred rules) and `docs/extension-api.md` (host authority by line, the collision consequence, deferred reloads), plus the bilingual changelog.

**A client command contribution claims its BARE token only (`4b8941e` — the second ownership P1, raised by the product owner).** DSH `matchEnter` checks a contribution with `if (!bare) return undefined`: a contribution is a slash-MENU entry, so `/deploy` runs the client handler while `/deploy explain` is an ordinary submission that reaches the model — busy policy and attachments included. The dispatch still resolved the contribution by NAME, so an argued line ran the plugin handler (the model never saw it) and the composer refused its attachment as a local command. The public API and an earlier regression documented and pinned that as contract; both were wrong.

- One shared `isBareCommandLine(parsed)` predicate (DSH `bare`; trailing whitespace is not input) now gates the contribution routing, the attachment classification's dynamic-local term and the sticky client-local capture.
- Deleted because they became **unreachable**, not speculatively: the deferred attachment deferral, the deferred post-session attachment re-check and a single-use classification thunk. A bare line can never reference a draft (an attachment makes the line argued), so there is no attachment to carry across the deferred window and no refusal to re-fire. Host precedence, skill-wrapper delivery, the TUI-owned command routes and the deferred authority/generation fence are unchanged.
- The full row-by-row audit this prompted (every `matchEnter` row against every TUI decision site: host claim, contribution, skill forms, `LOCAL_COMMANDS`, `SESSIONLESS_COMMANDS`, `!`/`!!`, the `/plan` toggle, the advertised-miss gate, health attribution) found no other name-vs-line mismatch; the two name-keyed survivors are deliberate (the advertised-miss gate consumes only a line the plane owned, and health attribution is a name-level diagnostic).
- API/docs: the bare-token contract in `command-bridge.ts`, `public-types.ts`, `docs/extension-api.md` (new bullet + the v1→v2 breaking note) and `docs/surface-decisions.md`; both changelogs replace the removed deferred client-attachment semantics with the new rule, and every "`rawInput` is empty" claim was corrected to "no non-whitespace input; trailing whitespace is preserved verbatim".

Regressions, each red-checked by reverting its guard: bare `/panel` runs the handler while `/panel args` is an ordinary submission (trailing whitespace keeps the line bare); an argued client-command line follows the busy policy (queue → followup, steer → steer, accelerated → the opposite) and never runs the handler; an argued line with an IMAGE or a FILE is an ordinary multimodal submission with no local-command refusal (the harness gained the streamed `saveFileStream` admission seam so the file bytes are asserted exactly). The old deferred-refusal regression asserted the now-wrong behaviour and became the image regression above.

## Rebase onto the current `next`

The branch was rebased onto `next`'s new tip (`10787ec feat: make the user statusline the builtin default footer`) so the PR is mergeable again. One semantic conflict was resolved by keeping BOTH sides: the `[Unreleased]` changelog sections (the base's `### 变更` / `### Changed` entry first, then this PR's `### 改进` + `### 兼容性` / `### Improved` + `### Compatibility` entries). Everything else replayed cleanly (code content unchanged).

## Verification

All gates on the FINAL HEAD `4b8941e` (25 commits, tree clean, `git diff --check` clean):

| Gate | Result |
|---|---|
| `pnpm test:product` | **4215 pass / 0 fail** |
| `pnpm verify:prepush` | **exit 0** (typecheck:fork, test:fork, test:docs, test:tooling, installation-doc / pi-divergence-ledger / pi-vendor-diff `--strict` / boundary / keybindings gates, naming gate, no-session-events, `pnpm audit --prod --audit-level high`, `pnpm pack:release` + example-plugin smoke) |
| Affected batch (submit-hot-path, extension registry/lifecycle/stable-api, image-command-semantics, busy-enter, attachment/steer/submit/export/preset/skill suites) | 368 pass (submit-hot-path 81/81) |
| Targeted `extension-registry-m5` + `extension-cordis-lifecycle` | 56 pass / 0 fail |
| `pnpm build` / `tsc -p tsconfig.json --noEmit` | pass / clean |
| `test:docs` / `test:tooling` | 11 pass / 253 pass |
| CI (Source checks, Build and pack, Runtime boundary, Tarball smoke ×3, audit) | pass |

Every behavior change in the round carries a regression that was RED-checked by
disabling the specific guard (deferred identity fence, coalesced collision
generation, attachment delivery/consume/refusal, skill command wire, late-host
final authority, stale handle + health untrack, shell placeholder guard).

**Review status: `accepted`** — the durable reviewer's holistic sweeps closed
every finding in both ownership rounds: on the host side the same-name
execute-kind collision, the command-plane re-check in both directions, the
`execute-kind → unresolved` disappearance (with and without an image), the
late-contribution reclassification, the exact `claimed → unclaimed` mutation and
the async session-create hook; on the contribution side the bare-token
invocation, the trailing-whitespace boundary, the five `rawInput` wording
errors and the stale bilingual changelog entries. Its only condition each time
was the held product and prepush gates, both of which passed on `4b8941e`.
Out-of-scope items: none open — the `!`/`!!` shell edge was explicitly requested
and fixed in an earlier round.

`packages/pi-tui/**` and the divergence ledger are untouched. Every commit passed an independent read-only review round.











