### PR TITLE
feat: make the user statusline the builtin default footer

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no-argument/save-location UX as `/export`.
 - **Welcome card visual refresh.** The session-head card now shows an original round-backed whale ASCII mascot (five variants, one picked per process) with three responsive layouts: side-by-side (whale left, facts right) at 72+ columns, stacked (whale centered above the facts) at 24–71 columns, and a compact text layout (🐋 title) below 24 columns. The whale keeps a fixed cyan → blue brand gradient that does not follow theme switches; facts still render in full (long values wrap, never truncate); the idle invitation, the `setWelcomeCard()` contract, and fullscreen scroll/anchor/click mapping are unchanged.
 
+### Changed
+
+- **Updated builtin default Footer layout.** The default statusline (no custom Footer) now uses two rows: row 1 keeps permission, model, tasks, cwd, branch and extension items on the left, with plan state and Focus Mode on the right; row 2 composes token usage, cache hit, TTFB, throughput and the turn/step counters on the left (the semantic decomposition of the stats line), with the full context pressure (`used/window (percent)`) on the right. Users with a saved custom `footerLayout` are unaffected.
+
 ## [0.4.3-alpha.2] - 2026-09-08
 
 ### Installation and version pairing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 - **新增 `/transcript` 命令。** 将当前 Session 保存为可读的 Markdown 对话记录到 Client 本地目录,与 `/export` 相同的无参数/保存位置交互。
 - **Welcome Card 视觉重构。** 首屏欢迎卡引入原创圆润鲸鱼 ASCII mascot(5 种变体,每次启动随机一个),按终端宽度使用三档响应式布局:72 列以上鲸鱼与 session facts 左右并排,24～71 列鲸鱼居中、facts 在下,24 列以下切换为紧凑文本布局(🐋 标题)。鲸鱼保留 cyan → blue 品牌渐变,不随主题切换改色;facts 继续完整显示(长值 wrap、不截断),idle 邀请、`setWelcomeCard()` 契约、fullscreen 滚动/锚点/点击映射均保持不变。
 
+### 变更
+
+- **内置 Footer 默认布局更新。** 未自定义 Footer 的默认 statusline 现在是两行:第一行左侧为权限、Model、Tasks、目录、分支与扩展条目,右侧为 Plan 状态和 Focus Mode;第二行左侧为 token 用量、cache 命中、TTFB、吞吐与 turn/step 计数(stats-line 的语义拆解),右侧为完整 Context 用量(`已用/窗口 (百分比)`)。已保存自定义 `footerLayout` 的用户不受影响。
+
 ## [0.4.3-alpha.2] - 2026-09-08
 
 ### 安装与版本对应

--- a/docs/footer-customization.md
+++ b/docs/footer-customization.md
@@ -214,19 +214,24 @@ Common builtin Style sets include:
 | Turns / steps | `both`, `turns`, `steps` |
 | Version | `tui`, `dsh`, `both` |
 
-The `default` preset's second row composes real semantic placements:
+The `default` preset composes two rows with a left and a right zone each:
 
 ```text
-token-usage:pi · cache-hit:pi · performance:latency · performance:speed
+row 1 left   view-scope · permission-preset · model · tasks · cwd · git-branch · ext:*
+row 1 right  plan-state · focus-mode
+row 2 left   token-usage:pi · cache-hit:pi · performance:latency · performance:speed · turns-steps
+row 2 right  context:full
 ```
 
-rendering as `↑114M ↓54k R520k W12k · CH93.9% · TTFB 8.1s · 51 tok/s`. The
-left group is session cumulative usage; the right group is recent model
-performance — the average time-to-first-token and the effective output
-throughput over the last five completed model requests (a model/provider
-switch resets that window). The session lifetime LLM wall time is still
-accumulated and remains visible on the `/status` detail line, but it is no
-longer part of the default Footer row.
+Items of one zone are joined with two spaces; the right zone renders flush
+right. The second row decomposes the pi-vocabulary stats line into real
+semantic placements: session cumulative usage and the cache-hit share, then
+recent model performance — the average time-to-first-token and the effective
+output throughput over the last five completed model requests (a
+model/provider switch resets that window) — plus the turn/step counters,
+while the context pressure renders in its full `used/window (percent)` form.
+The session lifetime LLM wall time is still accumulated and remains visible
+on the `/status` detail line, but it is not part of the default Footer.
 
 Omitting `format` keeps that item's default Style.
 

--- a/src/footer/builtin-items.ts
+++ b/src/footer/builtin-items.ts
@@ -4,15 +4,16 @@
  * callback is pure, synchronous, I/O-free and reads only the
  * StatusSnapshot + the host surface context.
  *
- * Default-preset composition: the status row is view-conditional — the
- * main-only badges (model/permission/plan/task/context/branch/extension)
- * render only on the main subject, while the data-source items
- * (cwd/turns-steps and the stats-row placements: token-usage/cache-hit/
- * performance) follow the display subject's section values. The default
- * stats row composes semantic placements (token-usage:pi · cache-hit:pi ·
- * performance:latency · performance:speed — the RECENT performance
- * contract); `stats-line` stays registered as the legacy composite for
- * existing custom layouts, never in the default preset.
+ * Default-preset composition: row 1 leads with the view-scope item and
+ * composes the main-only identity badges (permission/model/tasks/branch)
+ * and the extension bridge on the LEFT, with plan-state and focus-mode on
+ * the RIGHT; row 2 composes the stats-line facts as real semantic
+ * placements (token-usage:pi, cache-hit:pi, performance:latency and
+ * performance:speed — the RECENT performance contract) plus the turn/step
+ * counters on the LEFT, with the full context pressure on the RIGHT. The
+ * data-source items (cwd/turns-steps/usage placements) follow the display
+ * subject's section values. `stats-line` stays registered as the legacy
+ * composite for existing custom layouts, never in the default preset.
  * @module @xmoon76/dsh-pi-tui/footer/builtin-items
  */
 

--- a/src/footer/presets.ts
+++ b/src/footer/presets.ts
@@ -1,20 +1,19 @@
 /**
  * The builtin footer presets (plan §10): `default` composes the status
- * row plus a stats row built from REAL semantic placements (session
- * cumulative usage, cache hit, and the recent model performance as two
- * `performance` placements — latency then speed), `compact` drops the
- * stats row. The legacy `full` name maps to `default`.
+ * row plus a stats row, `compact` drops the stats row. The legacy `full`
+ * name maps to `default`.
  * @module @xmoon76/dsh-pi-tui/footer/presets
  */
 
 import type { FooterItemRef, FooterLayoutV1 } from './types.ts'
 
-/** Build the status row's placements, in order. The view-scope item leads:
- * it renders nothing on the main subject and the viewer identity block
- * while viewing (the legacy viewer footer). A FACTORY (never a shared
- * object graph): each preset builds its own placement objects, so no
- * consumer can mutate one preset's refs through another preset's alias. */
-function statusRowPlacements(): FooterItemRef[] {
+/** Build the compact preset's status-row placements, in order. The
+ * view-scope item leads: it renders nothing on the main subject and the
+ * viewer identity block while viewing (the legacy viewer footer). A
+ * FACTORY (never a shared object graph): each preset builds its own
+ * placement objects, so no consumer can mutate one preset's refs through
+ * another preset's alias. */
+function compactStatusRowPlacements(): FooterItemRef[] {
   return [
     { id: 'view-scope' },
     { id: 'permission-preset' },
@@ -29,21 +28,47 @@ function statusRowPlacements(): FooterItemRef[] {
   ]
 }
 
-/** The default layout's second row: semantic placements instead of the
- * legacy composite `stats-line`. Left group = session cumulative usage
- * (tokens + cache), right = recent model performance (TTFB, effective
- * throughput). The per-ref importance overrides define the narrow-width
- * drop order (plan §3.3): cache-hit goes first, then the TTFB, then the
- * throughput; the session usage pair survives longest — at least one
- * usage signal and one speed signal outlive everything else on the row.
- * The duplicated `performance` id is intentional: each placement carries
- * its own format (FooterLayoutV1 allows repeated placements). */
+/** The default layout's status-row LEFT placements, in order: the
+ * main-subject identity facts (permission, model, tasks, cwd, branch)
+ * and the extension bridge; plan state and focus mode ride the RIGHT
+ * zone. The view-scope item leads: it renders nothing on the main
+ * subject and the viewer identity block while viewing (the legacy
+ * viewer footer). A FACTORY (never a shared object graph): each preset
+ * builds its own placement objects, so no consumer can mutate one
+ * preset's refs through another preset's alias. */
+function defaultStatusRowLeftPlacements(): FooterItemRef[] {
+  return [
+    { id: 'view-scope' },
+    { id: 'permission-preset' },
+    { id: 'model' },
+    { id: 'tasks' },
+    { id: 'cwd' },
+    { id: 'git-branch' },
+    { id: 'ext:*' },
+  ]
+}
+
+/** The default layout: the status row (left = the identity facts and the
+ * extension bridge, right = plan state and focus mode) plus a stats row
+ * (left = the stats-line facts as REAL semantic placements — session
+ * cumulative usage, cache hit, and the recent model performance as two
+ * `performance` placements — plus the turn/step counters; right = the
+ * full context pressure). The per-ref importance overrides define the
+ * narrow-width drop order (plan §3.3): cache-hit goes first, then the
+ * TTFB, then the turn/step counters and the throughput (equal importance:
+ * the LATER placement drops first); the session usage pair is the row's
+ * floor and survives longest. The duplicated `performance` id is
+ * intentional: each placement carries its own format (FooterLayoutV1
+ * allows repeated placements). */
 export const DEFAULT_FOOTER_LAYOUT: FooterLayoutV1 = {
   schemaVersion: 1,
   rows: [
     {
-      left: statusRowPlacements(),
-      right: [],
+      left: defaultStatusRowLeftPlacements(),
+      right: [
+        { id: 'plan-state' },
+        { id: 'focus-mode' },
+      ],
     },
     {
       left: [
@@ -51,19 +76,21 @@ export const DEFAULT_FOOTER_LAYOUT: FooterLayoutV1 = {
         { id: 'cache-hit', format: 'pi', importance: 30 },
         { id: 'performance', format: 'latency', importance: 40 },
         { id: 'performance', format: 'speed', importance: 45 },
+        { id: 'turns-steps' },
       ],
-      right: [],
-      separator: { text: ' · ' },
+      right: [
+        { id: 'context', format: 'full' },
+      ],
     },
   ],
 }
 
-/** The compact layout: the status row only (the stats row drops). */
+/** The compact layout: the full status row only (the stats row drops). */
 export const COMPACT_FOOTER_LAYOUT: FooterLayoutV1 = {
   schemaVersion: 1,
   rows: [
     {
-      left: statusRowPlacements(),
+      left: compactStatusRowPlacements(),
       right: [],
     },
   ],

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -981,8 +981,9 @@ function formatDuration(ms: number): string {
  * The performance tail keeps BOTH windows, each labeled: the LIFETIME
  * `LLM ...` wall (this is the detail surface that still shows it — the
  * footer's stats row dropped it) beside the RECENT TTFB and throughput.
- * Context pressure lives in the footer's first line (progress bar), so it
- * is not repeated here. Turn/step counters live there too.
+ * Context pressure and the turn/step counters live in the FOOTER (the
+ * default layout renders them on its stats row), so they are not repeated
+ * here.
  * @param stats - the folded statistics.
  * @returns the display line.
  */

--- a/test/cancel.test.ts
+++ b/test/cancel.test.ts
@@ -210,9 +210,10 @@ test('the exit hint renders in the FOOTER, never the transcript notify', async (
   const lines = surface.vt.getViewport()
   // The 100x24 layout: header (0), editor (1-3), then the footer rows. The
   // instruction is an INDEPENDENT surface (plan 2026-08-31 §7): it APPENDS
-  // after the status + stats rows instead of replacing the stats line-2
-  // slot, so the hint is the footer's LAST line.
-  assert.ok(lines[6]!.includes('Press Ctrl+C again to exit'),
+  // after the layout's rows instead of replacing the stats line-2 slot, so
+  // the hint is the viewport's LAST line (the footer's bottom; an
+  // all-unavailable status row may leave the footer with a single row).
+  assert.ok(footerLine(surface.vt).includes('Press Ctrl+C again to exit'),
     `the hint must sit in the footer's last line:\n${lines.join('\n')}`)
   assert.ok(!lines.slice(0, 4).join('\n').includes('Press Ctrl+C again to exit'),
     `the hint must never enter the transcript notify area:\n${lines.join('\n')}`)

--- a/test/experience.test.ts
+++ b/test/experience.test.ts
@@ -38,7 +38,7 @@ async function viewport(vt: VirtualTerminal): Promise<string> {
   return vt.getViewport().join('\n')
 }
 
-test('footer shows model, cwd, branch, counters, context bar, and stats', async () => {
+test('footer shows model, cwd, branch, counters, context pressure, and stats', async () => {
   const { vt, app } = startApp()
   app.setStatus({
     model: 'opencode-go/deepseek-v4-flash',
@@ -64,8 +64,11 @@ test('footer shows model, cwd, branch, counters, context bar, and stats', async 
   assert.ok(view.includes('me/dsh-pi-tui'), `cwd missing:\n${view}`)
   assert.ok(view.includes(' main '), `branch missing:\n${view}`)
   assert.ok(view.includes('t2/s5'), `counters missing:\n${view}`)
-  assert.ok(view.includes('] 25%'), `context bar missing:\n${view}`)
-  assert.ok(view.includes('↑1.2k ↓3.4k · TTFB 8.1s · 0 tok/s'), `stats line missing:\n${view}`)
+  // The default layout renders the context pressure in its FULL form at
+  // the stats row's right edge (the legacy bar style stays available to
+  // custom layouts).
+  assert.ok(view.includes('25k/100k (25%)'), `context pressure missing:\n${view}`)
+  assert.ok(view.includes('↑1.2k ↓3.4k  TTFB 8.1s  0 tok/s'), `stats line missing:\n${view}`)
 })
 
 test('plan mode shows badges in header and footer and tints the editor border', async () => {

--- a/test/footer-composer-compat.test.ts
+++ b/test/footer-composer-compat.test.ts
@@ -3,15 +3,16 @@
  * the REFERENCE layout for the same state — same parts, same order, same
  * separators, same wrap/cap/dim behavior. The reference is re-implemented
  * here as the string-level oracle (plan 2026-08-31 §6.2: each logical row
- * occupies 1..2 physical lines; the tail line truncates ANSI-safely to its
- * one row; the Host instruction APPENDS as an independent line and never
- * replaces a user row — the legacy replace-last-row swap is gone).
+ * occupies 1..2 physical lines inside the global budget; a row WITH a
+ * right zone keeps its single-line fitted contract; the Host instruction
+ * APPENDS as an independent line and never replaces a user row — the
+ * legacy replace-last-row swap is gone).
  * @module @xmoon76/dsh-pi-tui/footer-composer-compat.test
  */
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { wrapTextWithAnsi, truncateToWidth } from '@xmoon76/pi-tui'
+import { wrapTextWithAnsi, truncateToWidth, visibleWidth } from '@xmoon76/pi-tui'
 import { color } from '../src/theme.ts'
 import { FooterComposer, mergeCommandSurface } from '../src/footer/composer.ts'
 import { createBuiltinFooterRegistry } from '../src/footer/builtin-items.ts'
@@ -86,54 +87,303 @@ function sec(ms: number): string {
   return `${text.endsWith('.0') ? text.slice(0, -2) : text}s`
 }
 
-/** The NEW default stats row: real semantic placements (token-usage:pi,
- * cache-hit:pi, performance:latency, performance:speed) joined by the
- * row separator ' · '. Items whose fact is absent (no cache activity →
- * no cacheHitPct) drop WITH their separator — mirrored here, including
- * the semantic span tones (success = usage/cache, muted = performance). */
-function defaultStatsRow(snap: StatusSnapshot): string {
-  const t = snap.usage.tokens
-  const p = snap.usage.performance
-  const usage = [
-    `↑${fmt(t.input)}`,
-    `↓${fmt(t.output)}`,
-    t.cacheRead > 0 ? `R${fmt(t.cacheRead)}` : '',
-    t.cacheWrite > 0 ? `W${fmt(t.cacheWrite)}` : '',
-  ].filter(part => part !== '').join(' ')
-  const spans: Array<{ text: string; tone: 'success' | 'textMuted' }> = [
-    { text: usage, tone: 'success' },
-  ]
-  if (snap.usage.cacheHitPct !== undefined) {
-    spans.push({ text: `CH${snap.usage.cacheHitPct.toFixed(1)}%`, tone: 'success' })
-  }
-  spans.push({ text: `TTFB ${sec(p.firstTokenMs)}`, tone: 'textMuted' })
-  spans.push({ text: `${p.tokensPerSec} tok/s`, tone: 'textMuted' })
-  return spans
-    .map(span => span.tone === 'success' ? color.success(span.text) : color.textMuted(span.text))
-    .join(' · ')
+/** The row separator the default layout renders with: no persisted
+ * separator → the composer's two-space join. */
+const SEP = '  '
+
+/** One reference zone item: the preferred text, the compact density form
+ * the composer falls back to under pressure, the drop importance and the
+ * reverse-layout-order tie-break position. */
+interface RefItem {
+  text: string
+  readonly compact: string
+  readonly importance: number
+  readonly order: number
 }
 
-/** The REFERENCE footer rows (plan 2026-08-31 §6.2): the first row wraps
- * into 1..2 physical lines (its cap boundary cut with '…'); the tail line
- * row's allowance is the LEFTOVER capacity (up to two lines at generous
- * widths), ANSI-safely truncated to the allowance when it still
- * overflows. The composer's
- * item-level fitting can only DROP more than this reference (semantic
- * importance), never render wider or taller. */
-function referenceFooter(line1: string[], line2: string, width: number): string {
-  const line1Rows = wrapTextWithAnsi(line1.join('  '), width)
-  const rows: string[] = []
-  for (let index = 0; index < Math.min(line1Rows.length, FOOTER_MAX_PHYSICAL_LINES_PER_ROW); index += 1) {
-    const row = line1Rows[index]!
-    rows.push(index === FOOTER_MAX_PHYSICAL_LINES_PER_ROW - 1 && line1Rows.length > FOOTER_MAX_PHYSICAL_LINES_PER_ROW
-      ? `${truncateToWidth(row, Math.max(1, width - 1), '')}…`
-      : row)
+/** The reference zone fit (the composer's compact → drop → truncate
+ * discipline, plan §9.2–§9.4 — the string-level oracle for zone width
+ * pressure: importance ASC, then reverse layout order as the tie-break,
+ * the tail ANSI-safely truncated with '…'). */
+function fitZoneRef(items: RefItem[], budget: number): string {
+  const totalOf = (list: readonly RefItem[]): number =>
+    list.reduce((sum, item, index) => sum + visibleWidth(item.text) + (index === 0 ? 0 : SEP.length), 0)
+  if (totalOf(items) <= budget) return items.map(item => item.text).join(SEP)
+  const kept = [...items]
+  const byImportance = [...kept].sort((a, b) => a.importance - b.importance || b.order - a.order)
+  for (const victim of byImportance) {
+    if (totalOf(kept) <= budget) break
+    if (visibleWidth(victim.compact) < visibleWidth(victim.text)) victim.text = victim.compact
   }
-  if (line2 !== '') {
-    const allowance = Math.min(FOOTER_MAX_PHYSICAL_LINES_PER_ROW, Math.max(1, FOOTER_MAX_PHYSICAL_LINES - rows.length))
-    rows.push(...wrapTextWithAnsi(truncateToWidth(line2, allowance * width, '…'), width).slice(0, allowance))
+  if (totalOf(kept) <= budget) return kept.map(item => item.text).join(SEP)
+  for (const victim of byImportance) {
+    if (kept.length === 1) break
+    const without = kept.filter(item => item !== victim)
+    if (totalOf(without) <= budget) {
+      kept.splice(0, kept.length, ...without)
+      break
+    }
+    if (totalOf(without) < totalOf(kept)) kept.splice(0, kept.length, ...without)
   }
-  return rows.map(row => color.textDim(row)).join('\n')
+  while (totalOf(kept) > budget && kept.length > 1) kept.pop()
+  if (totalOf(kept) > budget && kept.length > 0) {
+    const last = kept[kept.length - 1]!
+    const prefixWidth = totalOf(kept.slice(0, -1))
+    const room = Math.max(1, budget - prefixWidth - (kept.length === 1 ? 0 : SEP.length))
+    last.text = truncateToWidth(last.text, room, '…')
+  }
+  return kept.map(item => item.text).join(SEP)
+}
+
+/** The reference physical rows of ONE logical row (plan 2026-08-31 §6.2):
+ * a row WITHOUT a right zone wraps its preferred form into its 1..2-line
+ * allowance; a row WITH a right zone keeps the composer's single-line fit
+ * contract (the right zone reserves its ideal width first, the left zone
+ * fits the remainder, the right zone re-fits the leftover room and drops
+ * entirely when even one cell is left). */
+function referenceRow(row: { left: RefItem[]; right: RefItem[] }, width: number, allowance: number): string[] {
+  if (row.right.length === 0) {
+    const preferred = wrapTextWithAnsi(row.left.map(item => item.text).join(SEP), width)
+    if (preferred.length <= allowance) return preferred
+    // The fitted form may still wrap past the allowance (word-boundary
+    // waste): shrink the multi-line CELL budget until it fits, then fall
+    // back to the ANSI-safe tail cap — never a slice of the wrapped lines.
+    let cells = width * allowance
+    for (;;) {
+      const wrapped = wrapTextWithAnsi(fitZoneRef(row.left, cells), width)
+      if (wrapped.length <= allowance) return wrapped
+      if (cells <= 1) return [`${truncateToWidth(wrapped[0] ?? '', Math.max(0, width - 1), '')}…`]
+      cells = Math.max(1, cells - Math.max(1, wrapped.length - allowance))
+    }
+  }
+  if (row.left.length === 0) {
+    const fitted = fitZoneRef(row.right, width)
+    return [`${' '.repeat(Math.max(0, width - visibleWidth(fitted)))}${fitted}`]
+  }
+  const rightFull = row.right.map(item => item.text).join(SEP)
+  const leftBudget = Math.max(1, width - visibleWidth(rightFull) - 1)
+  const leftText = fitZoneRef(row.left, leftBudget)
+  const leftWidth = visibleWidth(leftText)
+  const rightRoom = Math.max(0, width - leftWidth - 1)
+  if (rightRoom < 1) return [leftText]
+  const finalRight = fitZoneRef(row.right, rightRoom)
+  const gap = ' '.repeat(Math.max(0, width - leftWidth - visibleWidth(finalRight)))
+  return [`${leftText}${gap}${finalRight}`]
+}
+
+/** The reference footer: the sequential physical-line allocation (every
+ * renderable row earns a baseline line first, the leftover then buys the
+ * demanding rows their second line in layout order, capped at the hard
+ * per-row capability) + the legacy dim pass over every physical row. */
+function referenceFooter(rows: Array<{ left: RefItem[]; right: RefItem[] }>, width: number): string {
+  const renderable = rows.filter(row => row.left.length > 0 || row.right.length > 0)
+  const demands = renderable.map(row => row.right.length === 0
+    ? wrapTextWithAnsi(row.left.map(item => item.text).join(SEP), width).length
+    : 1)
+  const allowances = renderable.map(() => 0)
+  let remaining = FOOTER_MAX_PHYSICAL_LINES
+  for (let index = 0; index < renderable.length; index += 1) {
+    const baseline = Math.min(1, remaining)
+    allowances[index] = baseline
+    remaining -= baseline
+  }
+  for (let index = 0; index < renderable.length && remaining > 0; index += 1) {
+    if (demands[index]! <= 1) continue
+    const extra = Math.min(demands[index]! - 1, FOOTER_MAX_PHYSICAL_LINES_PER_ROW - 1, remaining)
+    allowances[index]! += extra
+    remaining -= extra
+  }
+  const physical: string[] = []
+  renderable.forEach((row, index) => {
+    if (allowances[index]! < 1) return
+    physical.push(...referenceRow(row, width, allowances[index]!))
+  })
+  return physical.map(row => color.textDim(row)).join('\n')
+}
+
+/** The reference short cwd (last two path segments). */
+function shortCwdRef(cwd: string): string {
+  const parts = cwd.split('/').filter(Boolean)
+  return parts.slice(-2).join('/') || cwd
+}
+
+/** The reference cwd basename (the compact density form). */
+function basenameRef(cwd: string): string {
+  const parts = cwd.split('/').filter(Boolean)
+  return parts.at(-1) ?? cwd
+}
+
+/** A reference item tone (the semantic token the definition would carry). */
+type RefTone = 'warning' | 'textMuted' | 'text' | 'primary' | 'success'
+
+/** Apply an item's semantic tone exactly like the composer's renderSpans
+ * (an absent tone leaves the text plain for the final dim pass). */
+function toneText(text: string, tone: RefTone): string {
+  switch (tone) {
+    case 'warning': return color.warning(text)
+    case 'textMuted': return color.textMuted(text)
+    case 'text': return color.text(text)
+    case 'primary': return color.primary(text)
+    case 'success': return color.success(text)
+  }
+}
+
+/** The default layout's row-1 LEFT zone (the identity facts + the
+ * extension bridge; the leading view-scope item renders nothing on the
+ * main subject). The tasks badge mirrors the LEGACY count shape the
+ * compat snapshots carry (no Task Center totals). */
+function defaultRow1Left(snap: StatusSnapshot, context: { taskBrowserAvailable: boolean }, extensionText: string): RefItem[] {
+  const items: RefItem[] = []
+  const push = (text: string, compact: string, importance: number, tone?: RefTone): void => {
+    if (text === '') return
+    items.push({
+      text: tone === undefined ? text : toneText(text, tone),
+      compact: tone === undefined ? compact : toneText(compact, tone),
+      importance,
+      order: items.length,
+    })
+  }
+  const preset = snap.access.permissionPreset
+  if (preset !== undefined) {
+    const badge = preset.id === 'danger-full-access' ? '[yolo]'
+      : preset.id === 'read-only' ? '[read-only]'
+        : preset.id === 'workspace-write' ? '[workspace-write]'
+          : preset.id === 'custom' ? '[custom]' : ''
+    const compact = preset.id === 'read-only' ? 'ro' : preset.id === 'workspace-write' ? 'ww' : badge.slice(1, -1)
+    const tone: RefTone = preset.id === 'danger-full-access' || preset.id === 'custom'
+      ? 'warning'
+      : preset.id === 'read-only' ? 'textMuted' : 'text'
+    push(badge, compact, 110, tone)
+  }
+  const model = snap.composition.model
+  if (model !== undefined) {
+    const label = `${model.provider === undefined ? '' : `${model.provider}/`}${model.id}`
+      + (model.reasoningEffort === undefined ? '' : ` @${model.reasoningEffort}`)
+    push(`[${label}]`, model.id, 100)
+  }
+  const tasks = snap.activity.taskCount
+  const agents = snap.activity.childAgentCount
+  if (tasks > 0 || agents > 0) {
+    const parts: string[] = []
+    const compactParts: string[] = []
+    if (tasks > 0) {
+      parts.push(`${tasks} task${tasks === 1 ? '' : 's'} running`)
+      compactParts.push(`${tasks}t`)
+    }
+    if (agents > 0) {
+      parts.push(`${agents} agent${agents === 1 ? '' : 's'}`)
+      compactParts.push(`${agents}a`)
+    }
+    if (context.taskBrowserAvailable) compactParts.push('↓')
+    push(
+      `[${parts.join(' · ')}${context.taskBrowserAvailable ? ' · ↓ view' : ''}]`,
+      `[${compactParts.join('·')}]`,
+      85,
+      'primary',
+    )
+  }
+  push(snap.workspace.cwd === '' ? '' : shortCwdRef(snap.workspace.cwd), basenameRef(snap.workspace.cwd), 80)
+  push(snap.workspace.branch ?? '', snap.workspace.branch ?? '', 70)
+  push(extensionText, extensionText, 0)
+  return items
+}
+
+/** The default layout's row-1 RIGHT zone: the plan state and the Focus
+ * Mode indicator (both render nothing when inactive). */
+function defaultRow1Right(snap: StatusSnapshot): RefItem[] {
+  const items: RefItem[] = []
+  const state = snap.collaboration.plan.pending !== undefined
+    ? 'plan pending'
+    : snap.collaboration.plan.effective ? 'plan' : undefined
+  if (state !== undefined) {
+    items.push({
+      text: toneText(`[${state}]`, 'warning'),
+      compact: toneText(state, 'warning'),
+      importance: 115,
+      order: 0,
+    })
+  }
+  if (snap.interaction.focusMode) {
+    items.push({
+      text: toneText('focus', 'textMuted'),
+      compact: toneText('focus', 'textMuted'),
+      importance: 120,
+      order: items.length,
+    })
+  }
+  return items
+}
+
+/** The default layout's row-2 LEFT zone: the stats-line facts as REAL
+ * semantic placements (session usage, cache hit, recent latency and
+ * speed) plus the turn/step counters, each with its persisted importance
+ * override (the drop order: cache-hit → latency → speed/turns-steps →
+ * usage). */
+function defaultRow2Left(snap: StatusSnapshot): RefItem[] {
+  const t = snap.usage.tokens
+  const p = snap.usage.performance
+  const items: RefItem[] = [{
+    text: toneText(`↑${fmt(t.input)} ↓${fmt(t.output)}`
+      + (t.cacheRead > 0 ? ` R${fmt(t.cacheRead)}` : '')
+      + (t.cacheWrite > 0 ? ` W${fmt(t.cacheWrite)}` : ''), 'success'),
+    compact: toneText(`↑${fmt(t.input)} ↓${fmt(t.output)}`, 'success'),
+    importance: 55,
+    order: 0,
+  }]
+  if (snap.usage.cacheHitPct !== undefined) {
+    items.push({
+      text: toneText(`CH${snap.usage.cacheHitPct.toFixed(1)}%`, 'success'),
+      compact: toneText(`${snap.usage.cacheHitPct.toFixed(1)}%`, 'success'),
+      importance: 30,
+      order: items.length,
+    })
+  }
+  items.push({
+    text: toneText(`TTFB ${sec(p.firstTokenMs)}`, 'textMuted'),
+    compact: toneText(sec(p.firstTokenMs), 'textMuted'),
+    importance: 40,
+    order: items.length,
+  })
+  items.push({
+    text: toneText(`${p.tokensPerSec} tok/s`, 'textMuted'),
+    compact: toneText(`${p.tokensPerSec}t/s`, 'textMuted'),
+    importance: 45,
+    order: items.length,
+  })
+  items.push({
+    text: `t${snap.usage.turns}/s${snap.usage.steps}`,
+    compact: `t${snap.usage.turns}/s${snap.usage.steps}`,
+    importance: 45,
+    order: items.length,
+  })
+  return items
+}
+
+/** The default layout's row-2 RIGHT zone: the full context pressure. */
+function defaultRow2Right(snap: StatusSnapshot): RefItem[] {
+  const context = snap.usage.context
+  if (context === undefined || context.windowTokens === undefined || context.windowTokens <= 0) return []
+  const used = context.usedTokens ?? 0
+  const window = context.windowTokens
+  const percent = context.percent ?? Math.min(100, Math.max(0, Math.ceil((used * 100) / window)))
+  return [{
+    text: toneText(`${fmt(used)}/${fmt(window)} (${percent}%)`, 'primary'),
+    compact: toneText(`ctx ${percent}%`, 'primary'),
+    importance: 100,
+    order: 0,
+  }]
+}
+
+/** The two reference rows of the builtin default layout. */
+function defaultReferenceRows(
+  snap: StatusSnapshot,
+  context: { taskBrowserAvailable: boolean },
+  extensionText: string,
+): Array<{ left: RefItem[]; right: RefItem[] }> {
+  return [
+    { left: defaultRow1Left(snap, context, extensionText), right: defaultRow1Right(snap) },
+    { left: defaultRow2Left(snap), right: defaultRow2Right(snap) },
+  ]
 }
 
 /** A realistic main-subject snapshot. */
@@ -156,23 +406,34 @@ function mainSnapshot(): StatusSnapshot {
 
 const CONTEXT = { taskBrowserAvailable: true, extensionFooterText: '' }
 
+/** The compact preset's row as reference items (the legacy parts; the
+ * tested width never engages the compact density, so the compact form
+ * mirrors the preferred one). */
+function compactReferenceRows(snap: StatusSnapshot, editorEmpty: boolean, extensionText: string): Array<{ left: RefItem[]; right: RefItem[] }> {
+  const parts = legacyLine1(snap, editorEmpty, extensionText)
+  return [{
+    left: parts.map((text, order) => ({ text, compact: text, importance: 100 - order, order })),
+    right: [],
+  }]
+}
+
 test('default preset output is byte-equivalent to the reference footer (wide)', () => {
   const snap = mainSnapshot()
-  const expected = referenceFooter(legacyLine1(snap, true, ''), defaultStatsRow(snap), 100)
+  const expected = referenceFooter(defaultReferenceRows(snap, CONTEXT, ''), 100)
   const actual = composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
   assert.equal(actual, expected)
 })
 
 test('default preset output is byte-equivalent to the reference footer (narrow, wrapped)', () => {
   const snap = mainSnapshot()
-  const expected = referenceFooter(legacyLine1(snap, true, ''), defaultStatsRow(snap), 40)
+  const expected = referenceFooter(defaultReferenceRows(snap, CONTEXT, ''), 40)
   const actual = composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 40, context: CONTEXT })
   assert.equal(actual, expected)
 })
 
 test('compact preset output is byte-equivalent to the reference compact footer', () => {
   const snap = mainSnapshot()
-  const expected = referenceFooter(legacyLine1(snap, true, ''), '', 100)
+  const expected = referenceFooter(compactReferenceRows(snap, true, ''), 100)
   const actual = composer.render({ snapshot: snap, layout: COMPACT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
   assert.equal(actual, expected)
 })
@@ -183,7 +444,7 @@ test('the dynamic exit instruction appends as an INDEPENDENT line (the stats row
   // render beside it, position-independent.
   const snap = mainSnapshot()
   const expected = [
-    referenceFooter(legacyLine1(snap, true, ''), defaultStatsRow(snap), 100),
+    referenceFooter(defaultReferenceRows(snap, CONTEXT, ''), 100),
     color.textDim('Press Ctrl+Shift+X again to exit'),
   ].join('\n')
   const actual = composer.render({
@@ -196,16 +457,17 @@ test('the dynamic exit instruction appends as an INDEPENDENT line (the stats row
   assert.equal(actual, expected)
 })
 
-test('permission/plan/task variants stay byte-equivalent', () => {
+test('permission/plan/task/focus variants stay byte-equivalent', () => {
   for (const permission of ['danger-full-access', 'read-only', 'custom'] as const) {
     const snap = mainSnapshot()
     const variant: StatusSnapshot = {
       ...snap,
       access: { permissionPreset: { id: permission, label: permission, matched: permission !== 'custom' } },
       collaboration: { plan: { effective: true } },
+      interaction: { ...snap.interaction, focusMode: true },
       activity: { ...snap.activity, taskCount: 1, childAgentCount: 2 },
     }
-    const expected = referenceFooter(legacyLine1(variant, true, ''), defaultStatsRow(variant), 100)
+    const expected = referenceFooter(defaultReferenceRows(variant, CONTEXT, ''), 100)
     const actual = composer.render({ snapshot: variant, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
     assert.equal(actual, expected, `permission ${permission}`)
   }
@@ -213,7 +475,7 @@ test('permission/plan/task variants stay byte-equivalent', () => {
 
 test('extension segments merge at the reference position', () => {
   const snap = mainSnapshot()
-  const expected = referenceFooter(legacyLine1(snap, true, '[EXT-SEG]'), defaultStatsRow(snap), 100)
+  const expected = referenceFooter(defaultReferenceRows(snap, CONTEXT, '[EXT-SEG]'), 100)
   const actual = composer.render({
     snapshot: snap,
     layout: DEFAULT_FOOTER_LAYOUT,
@@ -338,32 +600,49 @@ test('independent golden vectors lock the composed output (wide/narrow/compact)'
   assert.equal(
     composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
       .replace(/\x1b\[[0-9;]*m/g, ''),
-    // The stats row is the semantic placements joined by ' · '; with no
-    // cache activity the cache-hit placement drops WITH its separator.
-    '[workspace-write]  [deepseek/flash]  x/proj  main  [███░░░░░░░░░] 25%  t2/s5\n↑1.2k ↓3.4k · TTFB 0s · 0 tok/s',
+    // The status row (identity facts; the inactive plan/focus right zone
+    // renders nothing) and the stats row: the stats-line facts as semantic
+    // placements plus the counters on the left, the full context pressure
+    // flush right (no cache activity → the cache-hit placement is absent).
+    '[workspace-write]  [deepseek/flash]  x/proj  main\n↑1.2k ↓3.4k  TTFB 0s  0 tok/s  t2/s5                                                  25k/100k (25%)',
   )
   assert.equal(
     composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 40, context: CONTEXT })
       .replace(/\x1b\[[0-9;]*m/g, ''),
-    // 40 columns: the status row fills its 2-line allowance (75 cells →
-    // 2 rows) and the 29-cell stats row keeps a single line.
-    '[workspace-write]  [deepseek/flash]\nx/proj  main  [███░░░░░░░░░] 25%  t2/s5\n↑1.2k ↓3.4k · TTFB 0s · 0 tok/s',
+    // 40 columns: the status row fills its 2-line allowance (50 cells → 2
+    // rows); the stats row is a RIGHT-ZONE row (its single-line fit
+    // contract), so the left zone compacts then drops the latency
+    // placement against the context's reserved width.
+    '[workspace-write]  [deepseek/flash]\nx/proj  main\n↑1.2k ↓3.4k  0t/s  t2/s5  25k/100k (25%)',
   )
   assert.equal(
     composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 20, context: CONTEXT })
       .replace(/\x1b\[[0-9;]*m/g, ''),
-    // 20 columns: the status row's preferred form (75 cells) exceeds the
-    // 2×20-cell row budget — the responsive compact pass shortens the
-    // items FIRST (ww/flash/proj/ctx 25%), and only what still does not
-    // fit drops by importance; never a slice of the wrapped lines (plan
-    // §6.2). The stats row's preferred form (31 cells) fits its 2-line
-    // allowance by WRAPPING — no compaction, no drop.
-    'ww  flash  proj\nmain  ctx 25%  t2/s5\n↑1.2k ↓3.4k · TTFB\n0s · 0 tok/s',
+    // 20 columns: the status row compact-pass shortens its items first
+    // (ww/flash/proj); only the model/cwd/branch survive. The stats row's
+    // left zone loses every placement but the (truncated) usage pair — the
+    // right-zone context stays reserved and renders flush right.
+    '[workspace-write]\nflash  proj  main\n↑1.2… 25k/100k (25%)',
   )
   assert.equal(
     composer.render({ snapshot: snap, layout: COMPACT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
       .replace(/\x1b\[[0-9;]*m/g, ''),
     '[workspace-write]  [deepseek/flash]  x/proj  main  [███░░░░░░░░░] 25%  t2/s5',
+  )
+  // The status row's right zone (plan state + Focus Mode) renders flush
+  // right when active — only the left zone is fitted to the remainder.
+  const focusSnap = mainSnapshot() as DeepMutable<StatusSnapshot>
+  focusSnap.interaction = { ...focusSnap.interaction, focusMode: true }
+  assert.equal(
+    composer.render({ snapshot: focusSnap as StatusSnapshot, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: CONTEXT })
+      .replace(/\x1b\[[0-9;]*m/g, ''),
+    '[workspace-write]  [deepseek/flash]  x/proj  main                                              focus\n↑1.2k ↓3.4k  TTFB 0s  0 tok/s  t2/s5                                                  25k/100k (25%)',
+  )
+  // The extension bridge keeps its position at the status row's tail.
+  assert.equal(
+    composer.render({ snapshot: snap, layout: DEFAULT_FOOTER_LAYOUT, width: 100, context: { ...CONTEXT, extensionFooterText: '[EXT-SEG]' } })
+      .replace(/\x1b\[[0-9;]*m/g, ''),
+    '[workspace-write]  [deepseek/flash]  x/proj  main  [EXT-SEG]\n↑1.2k ↓3.4k  TTFB 0s  0 tok/s  t2/s5                                                  25k/100k (25%)',
   )
   // The dim pass wraps EVERY physical row in the textDim SGR pair.
   const ansi = composer.render({ snapshot: snap, layout: COMPACT_FOOTER_LAYOUT, width: 100, context: CONTEXT })

--- a/test/footer-configurator-model.test.ts
+++ b/test/footer-configurator-model.test.ts
@@ -73,11 +73,14 @@ test('the Row Selector moves between rows; Enter enters the highlighted row', ()
   assert.equal(m.state().rowIndex, 1)
   assert.equal(m.state().cursor, 0)
   // The default layout's second row is the semantic stats row: the usage
-  // pair leads, then cache hit, then the two performance placements.
+  // pair leads (the stats-line facts), then cache hit and the two
+  // performance placements, then the turn/step counters.
   assert.deepEqual(
     m.state().layout.rows[1]!.left.map(ref => ref.id),
-    ['token-usage', 'cache-hit', 'performance', 'performance'],
+    ['token-usage', 'cache-hit', 'performance', 'performance', 'turns-steps'],
   )
+  // ...and its right zone is the full context pressure.
+  assert.deepEqual(m.state().layout.rows[1]!.right.map(ref => ref.id), ['context'])
 })
 
 test('Available is reachable ONLY through the Add picker (no cursor section)', () => {
@@ -87,7 +90,12 @@ test('Available is reachable ONLY through the Add picker (no cursor section)', (
   // it never enters an "available" section.
   for (let i = 0; i < 32; i += 1) m.moveDown()
   assert.equal(m.state().mode, 'row')
-  assert.equal(m.state().cursor, 9, 'the cursor stays within the row items')
+  const row = m.state().layout.rows[0]!
+  assert.equal(
+    m.state().cursor,
+    row.left.length + row.right.length - 1,
+    'the cursor stays within the row items',
+  )
   m.startAdd()
   assert.equal(m.state().mode, 'add')
   assert.ok(m.addMatches().includes('cache-hit'), 'the picker pools the non-layout items')
@@ -96,10 +104,15 @@ test('Available is reachable ONLY through the Add picker (no cursor section)', (
 test('the flat cursor spans Left then Right; ←/→ move between zones', () => {
   const m = model()
   m.activate()
-  walkTo(m, 'ext:*') // the LAST left item (the right zone starts empty)
+  walkTo(m, 'ext:*') // the LAST left item
   m.moveDown()
-  const leftCount = m.state().layout.rows[0]!.left.length
-  assert.equal(m.state().cursor, leftCount - 1, 'the cursor clamps at the row end — no available section')
+  const row = m.state().layout.rows[0]!
+  // ↓ continues into the row's RIGHT zone (plan state, focus mode) — there
+  // is no "available" section after the items.
+  assert.equal(m.state().cursor, row.left.length, 'the cursor moves into the right zone')
+  for (let i = 0; i < 8; i += 1) m.moveDown()
+  assert.equal(m.state().cursor, row.left.length + row.right.length - 1, 'the cursor clamps at the row end')
+  walkTo(m, 'ext:*')
   m.moveZone('right')
   let state = m.state()
   assert.ok(!state.layout.rows[0]!.left.some(ref => ref.id === 'ext:*'))
@@ -117,11 +130,12 @@ test('the flat cursor spans Left then Right; ←/→ move between zones', () => 
 
 test('Space removes the active item; it returns to the Add pool', () => {
   const m = model()
+  m.moveDown() // → Row 2 (the context item lives in its right zone)
   m.activate()
   walkTo(m, 'context')
   m.removeActive()
   const state = m.state()
-  assert.ok(!state.layout.rows[0]!.left.some(ref => ref.id === 'context'))
+  assert.ok(!state.layout.rows[1]!.right.some(ref => ref.id === 'context'))
   assert.ok(m.availableIds().includes('context'), 'removed items return to Available')
   // The cursor clamped onto the next item.
   assert.equal(idAtCursor(m), 'turns-steps')
@@ -229,13 +243,13 @@ test('Move Mode: M enters, ↑↓ reorder within the zone, Enter/Esc exits', () 
   assert.equal(m.state().mode, 'row-move')
   m.moveDown() // reorder: model swaps with tasks
   const left = m.state().layout.rows[0]!.left
-  assert.equal(left[3]!.id, 'tasks')
-  assert.equal(left[4]!.id, 'model')
+  assert.equal(left[2]!.id, 'tasks')
+  assert.equal(left[3]!.id, 'model')
   // Keep walking down: the item slides to the zone end, then stops.
   for (let i = 0; i < 12; i += 1) m.moveDown()
   const state = m.state()
   assert.equal(state.layout.rows[0]!.left.at(-1)!.id, 'model', 'the item stops at the zone end')
-  assert.deepEqual(state.layout.rows[0]!.right.map(ref => ref.id), [], 'the right zone is untouched')
+  assert.deepEqual(state.layout.rows[0]!.right.map(ref => ref.id), ['plan-state', 'focus-mode'], 'the right zone is untouched')
   m.activate()
   assert.equal(m.state().mode, 'row')
   // Esc exits Move Mode back to the row editor (the plan's "Enter/Esc
@@ -249,18 +263,21 @@ test('Move Mode: M enters, ↑↓ reorder within the zone, Enter/Esc exits', () 
 
 test('F cycles the finite format on the Edit Row page (default removes the override)', () => {
   const m = model()
+  m.moveDown() // → Row 2 (the context item lives in its right zone)
   m.activate()
-  walkTo(m, 'context') // formats: bar + percent + full
+  walkTo(m, 'context') // formats: bar + percent + full (persisted: full)
+  // full → bar: the definition default DROPS the persisted override.
   m.cycleFormat()
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
+  assert.equal(m.state().layout.rows[1]!.right.find(ref => ref.id === 'context')!.format, undefined)
   m.cycleFormat()
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
+  assert.equal(m.state().layout.rows[1]!.right.find(ref => ref.id === 'context')!.format, 'percent')
   m.cycleFormat()
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, undefined)
+  assert.equal(m.state().layout.rows[1]!.right.find(ref => ref.id === 'context')!.format, 'full')
 })
 
 test('the Item Editor shows Style for multi-format items and hides it for single-format items', () => {
   const m = model()
+  m.moveDown() // → Row 2 (the context item lives in its right zone)
   m.activate()
   walkTo(m, 'context') // formats: bar + percent + full
   m.activate()
@@ -290,6 +307,7 @@ test('the Item Editor shows Style for multi-format items and hides it for single
 
 test('Esc walks the hierarchy ONE level at a time (row → item → picker → item → row)', () => {
   const m = model()
+  m.moveDown() // → Row 2 (the context item lives in its right zone)
   m.activate()
   walkTo(m, 'context')
   m.activate()
@@ -316,26 +334,29 @@ test('Esc walks the hierarchy ONE level at a time (row → item → picker → i
 
 test('the Style picker applies a format; the inline ←→ change cycles too', () => {
   const m = model()
+  m.moveDown() // → Row 2 (the context item lives in its right zone)
   m.activate()
   walkTo(m, 'context')
+  const contextFormat = (): string | undefined =>
+    m.state().layout.rows[1]!.right.find(ref => ref.id === 'context')!.format
   m.activate() // item editor
-  m.activate() // Style picker (opens on the current format: bar)
+  m.activate() // Style picker (opens on the persisted format: full)
   assert.equal(m.state().mode, 'style')
-  m.moveDown() // Percent
-  m.moveDown() // Full
+  m.moveDown() // clamps at Full
   m.activate()
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
+  assert.equal(contextFormat(), 'full')
   assert.equal(m.state().mode, 'item')
-  // Inline ←→ cycles without opening the picker: full → percent → bar.
+  // Inline ←→ cycles without opening the picker: full → percent → bar
+  // (the default drops the override).
   m.moveZone('left')
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
+  assert.equal(contextFormat(), 'percent')
   m.moveZone('left')
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, undefined)
+  assert.equal(contextFormat(), undefined)
   // → cycles to percent, then full.
   m.moveZone('right')
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
+  assert.equal(contextFormat(), 'percent')
   m.moveZone('right')
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
+  assert.equal(contextFormat(), 'full')
 })
 
 test('format changes preserve item ids, zones, and order', () => {
@@ -368,21 +389,24 @@ test('format changes preserve item ids, zones, and order', () => {
 
 test('the Tone picker persists the semantic token; Auto removes the override', () => {
   const m = model()
+  m.moveDown() // → Row 2 (the context item lives in its right zone)
   m.activate()
   walkTo(m, 'context')
+  const contextTone = (): string | undefined =>
+    m.state().layout.rows[1]!.right.find(ref => ref.id === 'context')!.tone
   m.activate()
   m.moveDown() // Tone
   m.activate()
   assert.equal(m.state().mode, 'tone')
   m.moveDown() // Primary
   m.activate()
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.tone, 'primary')
+  assert.equal(contextTone(), 'primary')
   // Reopen: the picker opens on the current tone; Auto (index 0) removes it.
   m.activate() // tone picker again (menu cursor still on Tone)
   m.moveUp()
   m.moveUp()
   m.activate()
-  assert.equal(m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!.tone, undefined)
+  assert.equal(contextTone(), undefined)
   assert.equal(m.state().mode, 'item')
 })
 
@@ -444,6 +468,7 @@ test('Advanced: prefix/suffix/importance round-trip; empty removes the override'
 
 test('Advanced: Reset to default clears every ref override', () => {
   const m = model()
+  m.moveDown() // → Row 2 (the context item lives in its right zone)
   m.activate()
   walkTo(m, 'context')
   m.cycleFormat()
@@ -459,7 +484,7 @@ test('Advanced: Reset to default clears every ref override', () => {
   m.moveDown()
   assert.equal(m.state().advancedField, 'reset')
   m.activate()
-  const ref = m.state().layout.rows[0]!.left.find(ref => ref.id === 'context')!
+  const ref = m.state().layout.rows[1]!.right.find(ref => ref.id === 'context')!
   assert.equal(ref.format, undefined)
   assert.equal(ref.tone, undefined)
   assert.equal(ref.prefix, undefined)
@@ -684,7 +709,7 @@ test('PR E: item order is dirty; the order round-trip is clean (Move Mode)', () 
 test('PR E: a zone round-trip of the last left item restores clean', () => {
   const m = model()
   m.activate()
-  walkToId(m, 'ext:*') // the right zone starts empty; ext:* is the last left ref
+  walkToId(m, 'ext:*') // ext:* is the last left ref
   m.moveZone('right')
   assert.equal(m.isDirty(), true, 'the zone move is dirty')
   m.moveZone('left')

--- a/test/footer-configurator-ui.test.ts
+++ b/test/footer-configurator-ui.test.ts
@@ -279,7 +279,9 @@ test('the Item Editor edits style/tone; the picker renders live examples', async
   app.setStatus({ model: 'deepseek/flash', cwd: '/home/x/proj' })
   const model = openDefault(app)
   await vt.waitForRender()
-  vt.sendInput('\r') // → Edit Row 1
+  vt.sendInput('\x1b[B') // ↓ Row 2 (the context item lives in its right zone)
+  await vt.waitForRender()
+  vt.sendInput('\r') // → Edit Row 2
   await vt.waitForRender()
   // Walk onto the context item (multi-format) and open the item editor.
   while (idAt(model) !== 'context') vt.sendInput('\x1b[B')
@@ -292,14 +294,18 @@ test('the Item Editor edits style/tone; the picker renders live examples', async
   assert.ok(view.includes('Tone'), `the tone row missing:\n${view}`)
   assert.ok(view.includes('Advanced…'), `the advanced row missing:\n${view}`)
   assert.ok(view.includes('↑↓ Select · Enter Open · ←→ Change · Esc Back'), `item help missing:\n${view}`)
-  // ←→ cycles the style inline: bar → percent → full.
+  const contextFormat = (): string | undefined =>
+    model.preview().rows[1]!.right.find(ref => ref.id === 'context')!.format
+  // ←→ cycles the style inline: full → bar (the definition default drops
+  // the override) → percent.
   vt.sendInput('\x1b[C')
   await vt.waitForRender()
-  assert.equal(model.preview().rows[0]!.left.find(ref => ref.id === 'context')!.format, 'percent')
+  assert.equal(contextFormat(), undefined)
   vt.sendInput('\x1b[C')
   await vt.waitForRender()
-  assert.equal(model.preview().rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
-  // Enter opens the Style picker with live examples.
+  assert.equal(contextFormat(), 'percent')
+  // Enter opens the Style picker with live examples (it opens on the
+  // CURRENT format: percent — the two ↓ presses below clamp on Full).
   vt.sendInput('\r')
   await vt.waitForRender()
   view = vt.getViewport().join('\n')
@@ -312,7 +318,7 @@ test('the Item Editor edits style/tone; the picker renders live examples', async
   vt.sendInput('\x1b[B')
   vt.sendInput('\r')
   await vt.waitForRender()
-  assert.equal(model.preview().rows[0]!.left.find(ref => ref.id === 'context')!.format, 'full')
+  assert.equal(contextFormat(), 'full')
   assert.equal(model.state().mode, 'item')
   app.stop()
 })
@@ -1087,9 +1093,9 @@ for (const cols of [40, 80, 120]) {
       assert.ok(text.includes('Preview'), `the preview must stay visible at ${cols}x${rows}:\n${text}`)
       assert.ok(text.includes('A Add'), `the contextual help must not scroll away at ${cols}x${rows}:\n${text}`)
       // THE key guarantee: the EDITABLE body survives — the cursor's item
-      // (the last one: Extension items) must be on screen, never eaten by
+      // (the last one: Focus mode) must be on screen, never eaten by
       // the fixed preview.
-      assert.ok(text.includes('Extension items'), `the active item must stay visible at ${cols}x${rows}:\n${text}`)
+      assert.ok(text.includes('Focus mode'), `the active item must stay visible at ${cols}x${rows}:\n${text}`)
       // A long label must not break the layout (ANSI-safe truncation).
       assert.ok(!text.split('\n').some(line => line.length > cols + 20), `no line may overflow the frame at ${cols}x${rows}`)
       app.stop()
@@ -1117,7 +1123,7 @@ test('a 4-physical-row preview cannot eat the editable body (10-row terminal)', 
   const text = view.join('\n')
   assert.ok(text.includes('A Add'), `the help must stay visible:\n${text}`)
   assert.ok(text.includes('Preview'), `the preview must stay visible:\n${text}`)
-  assert.ok(text.includes('Extension items'), `the ACTIVE item must stay visible (the body must never be eaten):\n${text}`)
+  assert.ok(text.includes('Focus mode'), `the ACTIVE item must stay visible (the body must never be eaten):\n${text}`)
   app.stop()
 })
 

--- a/test/footer-fullscreen-narrow.test.ts
+++ b/test/footer-fullscreen-narrow.test.ts
@@ -111,8 +111,11 @@ function assertPinnedChromeIntact(
     )
   }
   if (expectStats) {
+    // The stats row's floor is the session usage pair (the highest
+    // importance placement on the row): the shadowing latency/speed
+    // placements legitimately compact or drop at narrower cells.
     assert.ok(
-      view.includes('12.3s'),
+      view.includes('↑0 ↓0'),
       `the stats row was clipped out of the viewport at ${columns}x${viewportRows}:\n${view}`,
     )
   }
@@ -150,11 +153,11 @@ test('the footer never clips out of a narrow fullscreen viewport', async () => {
   // old 4-line budget pushed the stats row below the screen while the
   // transcript was already at zero. 20x10 is the documented EXTREME cell:
   // the 20-column todo panel wraps the chrome, so only TWO footer slots
-  // remain — the surface hands the composer total=2, the footer renders
-  // status + stats (both one line, both visible) and the status row
-  // COMPACTS (ww/flash/ctx 10%) instead of dropping the model, which the
+  // remain — the surface hands the composer total=2, the footer renders its
+  // two rows (the status row compacted to ww/flash/task-badge, the stats
+  // row's squeezed left zone beside the context right zone), and the
   // plan's "footer must not disappear + one high-importance status must
-  // survive" contract covers.
+  // survive" contract covers it.
   for (const [columns, viewportRows, expectStats, expectModel] of [
     [80, 24, true, true], [60, 16, true, true], [40, 12, true, true],
     [40, 10, true, true], [30, 10, true, true], [20, 10, true, false],
@@ -171,11 +174,11 @@ test('the footer never clips out of a narrow fullscreen viewport', async () => {
 })
 
 test('the armed Ctrl+D instruction never pushes the footer out of a narrow fullscreen viewport', async () => {
-  // Ctrl+D (arm) shows the Host instruction: 3 physical lines were then
-  // spent on the status row + the exit hint and the stats row clipped.
   // The instruction is an INDEPENDENT surface with a 1-line contract
   // (plan §7): 1 status line + 1 stats line + 1 instruction line must fit
-  // — inside the same 3-line budget, read from the footer component.
+  // — inside the same 3-line budget, read from the footer component. (The
+  // historical shape of this regression: the old status row spent 3
+  // physical lines beside the hint and the stats row was clipped.)
   const { vt, app } = await startFullscreenApp(40, 10)
   try {
     vt.sendInput('\x04') // arm the exit window: the hint owns its own line
@@ -184,7 +187,7 @@ test('the armed Ctrl+D instruction never pushes the footer out of a narrow fulls
     const view = lines.join('\n')
     assert.ok(view.includes('Press Ctrl+D again to exit'), `the exit hint must stay visible:\n${view}`)
     assert.ok(view.includes('workspace-write') || view.includes('ww'), `the status row must survive beside the hint:\n${view}`)
-    assert.ok(view.includes('TTFB 12.3s'), `the stats row must survive beside the hint:\n${view}`)
+    assert.ok(view.includes('12.3s'), `the stats row must survive beside the hint (the latency keeps its compact form):\n${view}`)
     const footerLines = [...app.footerRenderRowsForTest()]
     assert.equal(footerLines.length, 3, `the footer with its instruction must stay inside the effective budget:\n${view}`)
     assert.ok(footerLines[footerLines.length - 1]!.includes('Press Ctrl+D again'), `the hint must be the footer's last line:\n${view}`)
@@ -295,11 +298,12 @@ test('a regular -> fullscreen switch recomposes the budget (widgets are fullscre
   // REGULAR at 80x8: the regular surface is a FLOWING document — overflow
   // enters the terminal scrollback and the footer is never
   // viewport-clipped there, so it always receives the FULL capacity
-  // (demand-limited to 3 rows here) and populated widgets never squeeze
-  // it (PR #57 review P2: do not trade fullscreen clipping for regular
-  // information loss).
+  // (demand-limited to 2 rows here: the status row fits one line at 80
+  // columns and the stats row is a single-line right-zone row) and
+  // populated widgets never squeeze it (PR #57 review P2: do not trade
+  // fullscreen clipping for regular information loss).
   const regularRows = [...app.footerRenderRowsForTest()]
-  assert.equal(regularRows.length, 3, `the regular footer keeps its full demand inside the capacity, saw ${regularRows.length}:\n${regularRows.join('\n')}`)
+  assert.equal(regularRows.length, 2, `the regular footer keeps its full demand inside the capacity, saw ${regularRows.length}:\n${regularRows.join('\n')}`)
   // FULLSCREEN at unchanged geometry: the widgets are NOT mounted (and
   // the widgets stay unrendered), but the pinned chrome IS — the budget
   // recomposes to the surface capacity (8 - header 1 - editor 3 = 4 →

--- a/test/footer-row-budget.test.ts
+++ b/test/footer-row-budget.test.ts
@@ -85,13 +85,12 @@ test('every logical row of the default layout stays inside the 1..2-line row con
       const truncatedSgr = line.match(/\x1b\[(?:[0-9;]*[^0-9;m]|[0-9;]*$)/)
       assert.equal(truncatedSgr, null, `truncated ANSI at ${width}: ${JSON.stringify(line)}`)
     }
-    // The stats row keeps at least one visible line within its allowance —
-    // with the hard capacity of 4 it may even wrap INTO two when the
-    // surface has the room (its demand is lower in layout order). At
-    // degenerate widths the truncated stats row may no longer carry its
-    // 'tok/s' text, only its leading '↑' counter.
+    // The stats row keeps at least one visible line within its allowance:
+    // it is a RIGHT-ZONE row (the full context pressure reserves its width
+    // first), so at degenerate widths the left zone truncates to its '…'
+    // marker while the context survives in its compact form.
     if (width > 4) {
-      const stats = lines.find(line => line.includes('tok/s') || line.includes('↑'))
+      const stats = lines.find(line => line.includes('ctx') || line.includes('↑') || line.includes('160k/1.0M'))
       assert.ok(stats !== undefined && visibleWidth(stats) <= Math.max(1, width), `stats row lost at ${width}:\n${JSON.stringify(lines)}`)
     }
   }
@@ -156,15 +155,18 @@ test('the Host instruction never deletes a user row when the budget fits', () =>
 test('the Host instruction reserves its line; capacity 4 gives status 2 + stats 1 + hint', () => {
   // Instruction + default 2-row layout at 40 columns with the effective
   // total of 4 (the plan §7 example): the hint reserves 1, the two rows
-  // share the remaining 3 — a baseline each, the leftover buys the status
-  // row its second line. 2 + 1 + 1 = 4; nothing replaced, nothing
-  // overflows.
-  const snap = busySnapshot()
+  // share the remaining 3 — a baseline each, the leftover buys the
+  // LEFT-ONLY status row its second line (no plan/focus: its right zone
+  // renders nothing; the stats row always carries the context right zone,
+  // so it keeps its single-line fit contract). 2 + 1 + 1 = 4; nothing
+  // replaced, nothing overflows.
+  const snap = busySnapshot() as DeepMutable<StatusSnapshot>
+  snap.collaboration.plan.effective = false
   const lines = plainPhysical(snap, DEFAULT_FOOTER_LAYOUT, 40, { instruction: INSTRUCTION })
   assert.equal(lines.length, 4, `2 + 1 + hint inside the capacity of 4:\n${JSON.stringify(lines)}`)
   assert.ok(lines[lines.length - 1]!.includes('Press Ctrl+D again to exit'), `the hint must be its own line:\n${JSON.stringify(lines)}`)
   assert.ok(lines.some(line => line.includes('yolo')), `the status row must survive:\n${JSON.stringify(lines)}`)
-  assert.ok(lines.some(line => line.includes('tok/s')), `the stats row must survive (not be replaced):\n${JSON.stringify(lines)}`)
+  assert.ok(lines.some(line => line.includes('160k/1.0M (16%)')), `the stats row must survive (not be replaced):\n${JSON.stringify(lines)}`)
 })
 
 test('a 3-row layout under the DEFAULT budget fits beside the instruction', () => {
@@ -197,7 +199,7 @@ test('a DYNAMIC total of 2 still keeps the instruction and drops the stats tail'
   assert.equal(lines.length, 2, `exactly the surface budget, hint included:\n${JSON.stringify(lines)}`)
   assert.ok(lines[lines.length - 1]!.includes('Press Ctrl+D again to exit'), `the hint must be last:\n${JSON.stringify(lines)}`)
   assert.ok(lines.some(line => line.includes('yolo')), `the highest-importance row must survive:\n${JSON.stringify(lines)}`)
-  assert.ok(!lines.some(line => line.includes('tok/s')), `the stats tail must drop under height pressure:\n${JSON.stringify(lines)}`)
+  assert.ok(!lines.some(line => line.includes('↑')), `the stats row must drop under height pressure:\n${JSON.stringify(lines)}`)
 })
 
 test('a capacity of 4 lets BOTH rows wrap (2 + 2) when no instruction competes', () => {

--- a/test/footer-wrap.test.ts
+++ b/test/footer-wrap.test.ts
@@ -45,10 +45,11 @@ function startApp(columns: number): { vt: VirtualTerminal; app: TuiApp } {
   return { vt, app }
 }
 
-/** Realistic status: at 40 columns the status row's preferred form exceeds
- * the 2-line row cap, so the overflow resolves by IMPORTANCE — the pin
- * keeps permission/model/stats; branch and the counters are DESIGNED to
- * compact/drop first, not "must survive". */
+/** Realistic status: at 40 columns the STATUS row's preferred form exceeds
+ * the 2-line row cap, so its overflow resolves by IMPORTANCE — the pin
+ * keeps permission/model; branch is DESIGNED to compact/drop first, not
+ * "must survive". The stats facts live on row 2 (its own single-line
+ * right-zone fit), so they are unaffected by the status row's squeeze. */
 const SHORT_STATUS: StatusData = {
   model: 'deepseek/flash',
   cwd: '/home/x/proj',
@@ -126,16 +127,16 @@ test('runaway host content is capped at the 4-line capacity, tail cut', async ()
   await vt.waitForRender()
   const view = vt.getViewport().join('\n')
   const rows = footerRows(app)
-  // The composer hard capacity is FOUR physical lines now (2 lines per
-  // logical row × 2 rows) — the extreme state spends it as 2 + 2: the
-  // wrapped rows are never sliced; the overflow resolves by importance
-  // and the remnants cut with '…'.
+  // The composer hard capacity is FOUR physical lines (2 lines per logical
+  // row × 2 rows). At 40 columns the runaway branch (43 cells) cannot fit
+  // a line even alone, so the status row resolves by IMPORTANCE: the
+  // branch drops, the permission/model/cwd floor survives, and nothing is
+  // sliced. The stats row stays its single-line right-zone row — 2 rows
+  // total, inside the capacity.
   assert.ok(rows.length <= FOOTER_MAX_PHYSICAL_LINES, `the footer must never exceed ${FOOTER_MAX_PHYSICAL_LINES} rows, saw ${rows.length}:\n${view}`)
-  assert.ok(rows.length >= 3, `the extreme state must still wrap to multiple rows, saw ${rows.length}:\n${view}`)
-  // The extreme state spends the capacity as 2 status rows + 2 stats
-  // rows; the overflow resolves by IMPORTANCE (highest facts survive)
-  // with no viewport overflow. '…' only appears when the ANSI-safe
-  // truncate (not drops) settles the row — drops may fit without it.
+  assert.ok(rows.length >= 2, `the extreme state must keep both logical rows, saw ${rows.length}:\n${view}`)
+  assert.ok(view.includes('deepseek-v4-flash'), `the model must survive the runaway branch:\n${view}`)
+  assert.ok(!view.includes('pluginization-phase2-5'), `the runaway branch must drop by importance:\n${view}`)
   for (const row of rows) {
     assert.ok(visibleWidth(row.replace(/\x1b\[[0-9;]*m/g, '')) <= 40, `row overflows:\n${view}`)
   }
@@ -177,10 +178,10 @@ test('extension footer segments still merge into the wrapped footer', async () =
   } finally {
     wide.app.dispose()
   }
-  // Narrower: the responsive compact pass shortens the host items FIRST
-  // (ww/flash/proj/ctx 10%) — at 40 columns that frees enough room for
-  // the segment (importance 0) to SURVIVE; the compact-before-drop
-  // discipline only sacrifices it when compact alone cannot fit the row.
+  // Narrower: the responsive compact pass shortens the ROW-1 host items
+  // FIRST (ww/flash/proj) — at 40 columns that frees enough room for the
+  // segment (importance 0) to SURVIVE; the compact-before-drop discipline
+  // only sacrifices it when compact alone cannot fit the row.
   const narrow = await startExtApp(40)
   try {
     const view = narrow.vt.getViewport().join('\n')
@@ -191,13 +192,17 @@ test('extension footer segments still merge into the wrapped footer', async () =
     narrow.app.dispose()
   }
   // Extreme narrow: the segment (importance 0) drops FIRST (importance
-  // order), never overflowing or breaking the composed rows.
-  const extreme = await startExtApp(30)
+  // order), never overflowing or breaking the composed rows. The status
+  // row's item set is smaller than the legacy one, so the squeeze point
+  // moved in from 30 to 24 columns.
+  const extreme = await startExtApp(24)
   try {
     const view = extreme.vt.getViewport().join('\n')
     assert.ok(!view.includes('[EXT-SEG]'), `the low-importance segment must drop under extreme pressure:\n${view}`)
     assert.ok(view.includes('workspace-write') || view.includes('ww'), `high-importance state must survive:\n${view}`)
-    assert.ok(view.includes('12.3s'), `the stats row must survive:\n${view}`)
+    // The stats row survives with its usage-pair floor (the latency
+    // placement legitimately drops at this width).
+    assert.ok(view.includes('↑0 ↓0'), `the stats row must survive:\n${view}`)
   } finally {
     extreme.app.dispose()
   }
@@ -240,10 +245,11 @@ test('below-editor widget rows are NEVER counted as footer rows', async () => {
     const view = vt.getViewport().join('\n')
     assert.ok(view.includes('below-widget-row-1'), `the below-widget zone must render:\n${view}`)
     const rows = footerRows(app)
-    // 80 columns: the status row's preferred form (89 cells) wraps into
-    // exactly TWO lines + the stats row = 3 — the budget, unaffected by
-    // the widget zone (the old viewport heuristic would have counted 5+).
-    assert.equal(rows.length, 3, `a populated widgetsBelow must not inflate the footer count, saw ${rows.length}:\n${rows.join('\n')}`)
+    // 80 columns: the status row fits ONE line (its preferred form is 64
+    // cells and the responsive pass keeps it there) + the stats row = 2 —
+    // the demand, unaffected by the widget zone (the old viewport
+    // heuristic would have counted 5+).
+    assert.equal(rows.length, 2, `a populated widgetsBelow must not inflate the footer count, saw ${rows.length}:\n${rows.join('\n')}`)
     assert.ok(!rows.some(row => row.includes('below-widget')), `widget rows must not land in the footer component:\n${rows.join('\n')}`)
   } finally {
     app.stop()

--- a/test/tui-app.test.ts
+++ b/test/tui-app.test.ts
@@ -989,24 +989,25 @@ test('fullscreen click on the todo summary dock row opens the todo panel', async
   let view = vt.getViewport().join('\n')
   assert.ok(view.includes('☑'), `todo summary must render in the dock:\n${view}`)
   assert.ok(!app.isTodoPanelVisible(), 'panel starts closed')
-  // The dock summary row sits at 0-based row 18 (editor seat 3 + footer 2
-  // at the bottom on the 80x24 test terminal; the closed panel renders
-  // zero rows, so the todo region clamps to [18, 19) — exactly the dock
-  // row).
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  // The dock summary row sits at 0-based row 19 (editor seat 3 + footer 1
+  // at the bottom on the 80x24 test terminal: an all-unavailable status
+  // row renders nothing, so the stats row is the whole footer; the closed
+  // panel renders zero rows, so the todo region clamps to [19, 20) —
+  // exactly the dock row).
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(app.isTodoPanelVisible(), 'click on the summary row must open the panel')
   assert.ok(!app.isTodoPanelExpanded(), 'opens compact')
   view = vt.getViewport().join('\n')
   assert.ok(view.includes('todo item 0'), `compact panel must show after the click:\n${view}`)
   // With the panel open the summary is hidden and the panel owns rows
-  // 12..19 — the same cell is now a panel row, so the next click runs the
+  // 13..19 — the same cell is now a panel row, so the next click runs the
   // compact → full step of the loop. Paced beyond the todo click-coalescing
   // window: a DELIBERATE second gesture, not a rapid double-click.
   await sleepBeyondTodoCoalesce()
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(app.isTodoPanelVisible(), 'panel must stay open (the cell is now a panel row)')
   assert.ok(app.isTodoPanelExpanded(), 'the click now expands the panel (compact → full)')
@@ -1028,11 +1029,12 @@ test('fullscreen todo: a dock press cannot run the panel action after a keyboard
   let view = vt.getViewport()
   assert.ok(view.join('\n').includes('☑'), `todo summary must render in the dock:\n${view.join('\n')}`)
   assert.ok(!app.isTodoPanelVisible(), 'panel starts closed')
-  // The dock summary row sits at 0-based row 18 (editor seat 3 + footer 2
-  // at the bottom on the 80x24 test terminal; the closed panel renders
-  // zero rows, so the todo region clamps to [18, 19) — exactly the dock
-  // row).
-  const dockY = 18
+  // The dock summary row sits at 0-based row 19 (editor seat 3 + footer 1
+  // at the bottom on the 80x24 test terminal: an all-unavailable status
+  // row renders nothing, so the stats row is the whole footer; the closed
+  // panel renders zero rows, so the todo region clamps to [19, 20) —
+  // exactly the dock row).
+  const dockY = 19
   // Press the dock row (no release): the press identity is todo:dock.
   vt.sendInput(`\x1b[<0;20;${dockY + 1}M`)
   await vt.waitForRender()
@@ -1075,11 +1077,12 @@ test('fullscreen todo: a dock press cannot toggle the panel across a session swi
   let view = vt.getViewport()
   assert.ok(view.join('\n').includes('☑'), `todo summary must render in the dock:\n${view.join('\n')}`)
   assert.ok(!app.isTodoPanelVisible(), 'panel starts closed')
-  // The dock summary row sits at 0-based row 18 (editor seat 3 + footer 2
-  // at the bottom on the 80x24 test terminal; the closed panel renders
-  // zero rows, so the todo region clamps to [18, 19) — exactly the dock
-  // row).
-  const dockY = 18
+  // The dock summary row sits at 0-based row 19 (editor seat 3 + footer 1
+  // at the bottom on the 80x24 test terminal: an all-unavailable status
+  // row renders nothing, so the stats row is the whole footer; the closed
+  // panel renders zero rows, so the todo region clamps to [19, 20) —
+  // exactly the dock row).
+  const dockY = 19
   // Press the dock row (no release): the press identity is todo:dock.
   vt.sendInput(`\x1b[<0;20;${dockY + 1}M`)
   await vt.waitForRender()
@@ -1151,7 +1154,10 @@ test('fullscreen todo: a session switch resets the click-coalescing window (mous
   let view = vt.getViewport()
   assert.ok(view.join('\n').includes('☑'), `todo summary must render in the dock:\n${view.join('\n')}`)
   assert.ok(!app.isTodoPanelVisible(), 'panel starts closed')
-  const dockY = 18
+  // The dock summary row sits at 0-based row 19 (editor seat 3 + footer 1
+  // at the bottom on the 80x24 test terminal: an all-unavailable status
+  // row renders nothing, so the stats row is the whole footer).
+  const dockY = 19
   // A completed todo click in session A opens the panel AND sets the
   // click-coalescing window.
   vt.sendInput(`\x1b[<0;20;${dockY + 1}M`)
@@ -1420,23 +1426,24 @@ test('todo state machine: ≤5 items is a two-state summary ↔ list (no redunda
   app.setTodoSummary(todos)
   app.setFullscreen(true)
   await vt.waitForRender()
-  // The dock summary row sits at 0-based row 18 (editor seat 3 + footer 2
-  // at the bottom on the 80x24 test terminal; the closed panel renders
-  // zero rows, so the todo region clamps to [18, 19) — exactly the dock
-  // row). Click it: summary → list.
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  // The dock summary row sits at 0-based row 19 (editor seat 3 + footer 1
+  // at the bottom on the 80x24 test terminal: an all-unavailable status
+  // row renders nothing, so the stats row is the whole footer; the closed
+  // panel renders zero rows, so the todo region clamps to [19, 20) —
+  // exactly the dock row). Click it: summary → list.
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(app.isTodoPanelVisible(), 'dock click opens the panel')
   assert.ok(!app.isTodoPanelExpanded(), 'opens compact (visually identical to full at ≤5)')
-  // With the panel open (border + title + 5 rows = rows 15..21) the same
+  // With the panel open (border + title + 5 rows = rows 14..19) the same
   // cell is a panel row: a DELIBERATE second click (paced beyond the
   // coalescing window) must close the panel DIRECTLY — the second click
   // returns to the summary, no third click needed, and no intermediate
   // todoExpanded state exists.
   await sleepBeyondTodoCoalesce()
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(!app.isTodoPanelVisible(), 'second click closes the panel (list → summary)')
   assert.ok(!app.isTodoPanelExpanded(), 'no ghost expanded state at ≤5')
@@ -1454,20 +1461,22 @@ test('todo rapid double-click at the SAME coordinate is ONE gesture (no flash op
   app.setTodoSummary(todos)
   app.setFullscreen(true)
   await vt.waitForRender()
-  // The dock summary row sits at 0-based row 18. Two press/release groups
-  // at the SAME coordinate, the first render landing between them, both
-  // inside the double-click window (no pacing): the first click opens the
-  // panel, the layout mutates (the dock vanishes, the panel takes its
-  // rows), and the second click would land on a panel row — WITHOUT the
-  // todo coalescing it would immediately close the panel (the todo
-  // "flashes and vanishes"). The coalesced pair must leave the todo in
-  // the state the FIRST click produced.
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  // The dock summary row sits at 0-based row 19 (editor seat 3 + footer 1
+  // at the bottom on the 80x24 test terminal: an all-unavailable status
+  // row renders nothing, so the stats row is the whole footer). Two
+  // press/release groups at the SAME coordinate, the first render landing
+  // between them, both inside the double-click window (no pacing): the
+  // first click opens the panel, the layout mutates (the dock vanishes,
+  // the panel takes its rows), and the second click would land on a panel
+  // row — WITHOUT the todo coalescing it would immediately close the panel
+  // (the todo "flashes and vanishes"). The coalesced pair must leave the
+  // todo in the state the FIRST click produced.
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(app.isTodoPanelVisible(), 'fixture: the first click opens the panel')
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(app.isTodoPanelVisible(), 'the rapid second click must be coalesced — the panel stays open')
   assert.ok(!app.isTodoPanelExpanded(), 'and stays in the first click\'s state (compact)')
@@ -1476,8 +1485,8 @@ test('todo rapid double-click at the SAME coordinate is ONE gesture (no flash op
   vt.sendInput('\x1b[<0;40;5M')
   vt.sendInput('\x1b[<0;40;5m')
   await vt.waitForRender()
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(!app.isTodoPanelVisible(), 'after a different-target click the next todo click works')
   app.setFullscreen(false)
@@ -1490,14 +1499,16 @@ test('todo state machine: 1 item also closes on the second click (boundary)', as
   app.setTodoSummary([{ content: 'only todo', status: 'in_progress' }])
   app.setFullscreen(true)
   await vt.waitForRender()
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  // The dock summary row: 0-based 19 (editor seat 3 + footer 1 on the
+  // 80x24 terminal with an all-unavailable status row).
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(app.isTodoPanelVisible(), 'dock click opens the panel')
   // Deliberate second gesture (paced beyond the coalescing window).
   await sleepBeyondTodoCoalesce()
-  vt.sendInput('\x1b[<0;20;19M')
-  vt.sendInput('\x1b[<0;20;19m')
+  vt.sendInput('\x1b[<0;20;20M')
+  vt.sendInput('\x1b[<0;20;20m')
   await vt.waitForRender()
   assert.ok(!app.isTodoPanelVisible(), 'second click closes the 1-item panel')
   assert.ok(!app.isTodoPanelExpanded(), 'no expanded state with 1 item')


### PR DESCRIPTION
## What

Replaces the builtin default Footer layout (`DEFAULT_FOOTER_LAYOUT`) with the
user's persisted statusline composition:

- row 1: `view-scope, permission-preset, model, tasks, cwd, git-branch, ext:*`
  on the left; `plan-state, focus-mode` on the right
- row 2: the stats-line facts as real semantic placements (`token-usage:pi`,
  `cache-hit:pi`, `performance:latency`, `performance:speed`) plus
  `turns-steps` on the left; `context` (`format: full`) on the right
- no persisted separator: items join with the composer's two-space default

## Scope

- Only the default LAYOUT changes: a fresh install (`footer: full` / `default`)
  sees the new composition.
- `COMPACT_FOOTER_LAYOUT`, the default footer mode, the command surface and the
  extension boundary are untouched.
- A persisted custom `footerLayout` keeps rendering the user's own layout.
- The legacy `stats-line` composite stays registered for existing custom
  layouts; it is no longer part of the default.
- `packages/pi-tui` untouched, no new dependencies.

## Validation

- `pnpm build`, `pnpm typecheck`, `git diff --check`, client-boundary gate: OK
- Full suite: fork 1151/1151, product 4123/4123, tooling 253/253, docs 11/11 — 0 failures
- Real TUI run in an isolated DSH_HOME (tmux) confirms the default renders:
  `focus` flush right on row 1 and `t0/s0` at the end of row 2
- Docs updated: `docs/footer-customization.md` plus both changelogs

## Review

The change set went through 4 rounds of an external holistic review loop; the
final round returned **accepted** with no findings.
