### PR TITLE
fix(focus): preserve answers crossed by steer

### DIFF
--- a/src/focus-activity.ts
+++ b/src/focus-activity.ts
@@ -26,7 +26,7 @@ import { color } from './theme.ts'
 import { formatTokens } from './token-usage.ts'
 import { iconFor, type IconSemantic, type IconStyle } from './icons.ts'
 import { toolTitle } from './present.ts'
-import { assistantBlocksVisibleNow, assistantLatestStepOf, assistantStepOf, type TurnActivity, type TranscriptMessage } from './transcript.ts'
+import { assistantBlocksVisibleNow, assistantCommittedBeforeSteer, assistantLatestStepOf, assistantStepOf, type TurnActivity, type TranscriptMessage } from './transcript.ts'
 import { displayFailureText } from './failure-presentation.ts'
 
 /** The max tool-type names the header stats show before the `+N` tail
@@ -389,11 +389,11 @@ export class FocusActivityComponent {
  * polluted with a fake `focus-activity` kind and the session data stays
  * lossless.
  *
- * Collapsed turns HIDE the process rows — thinking, tool, mid-turn
- * system/inject and intermediate-assistant — entirely: they cannot leak
- * through Ctrl+O/Alt+T because they are not in the rendered list at all
- * (plan §15.2). The LEADING injected-context prefix (the turn foundation)
- * and every human user row stay visible before the Thought. The final
+ * Collapsed turns HIDE process rows — thinking, tool, mid-turn system/inject
+ * and ordinary intermediate-assistant — so they cannot leak through
+ * Ctrl+O/Alt+T (plan §15.2). A committed pre-steer answer is the explicit
+ * persistent-row exception. The LEADING injected-context prefix (the turn
+ * foundation) and every human user row stay visible before the Thought. The final
  * assistant only appears after the authoritative `turn/end` (plan §13.1)
  * and never duplicates in the expanded view (it stays at its
  * chronological position).
@@ -457,6 +457,8 @@ export function projectFocus(
     // row (shared by the expanded and collapsed branches — one semantic,
     // never two drifting copies).
     const final = finalAssistantSelection(activity, group)
+    const isCommittedAnswer = (member: TranscriptMessage): boolean =>
+      activity !== undefined && assistantCommittedBeforeSteer(activity, member)
     if (expanded) {
       // The open Thought reveals the FULL process in ORIGINAL order —
       // compaction cards included at their chronological position — with
@@ -475,8 +477,9 @@ export function projectFocus(
       // scan of mid-process system rows). Consecutive users after the
       // boundary stay in chronological order; they are not a multi-row
       // initial prompt (plan: no adjacency guessing). Every revealed
-      // process row carries the owner-turn collapse mark; the user's rows,
-      // the lead foundation rows and the FINAL assistant stay unmarked
+      // ordinary process row carries the owner-turn collapse mark;
+       // committed pre-steer answers, the user's rows, the lead foundation
+      // rows and the FINAL assistant stay unmarked
       // (clicking them must not collapse the Thought — review P2).
       const boundary = thoughtLeadBoundary(group)
       for (const member of group.slice(0, boundary)) {
@@ -488,7 +491,11 @@ export function projectFocus(
           out.push({ kind: 'message', message: member })
         } else {
           if (final !== undefined && member === final.message) continue
-          out.push({ kind: 'message', message: member, collapseFocusOwnerOnClick: turn })
+          if (isCommittedAnswer(member)) {
+            out.push({ kind: 'message', message: member })
+          } else {
+            out.push({ kind: 'message', message: member, collapseFocusOwnerOnClick: turn })
+          }
         }
       }
       if (final !== undefined) {
@@ -496,25 +503,42 @@ export function projectFocus(
       }
       continue
     }
-    // Collapsed Focus summarizes the turn's INPUTS before the Thought: the
-    // leading injected-context prefix (the turn foundation) and EVERY human
-    // user row (same-turn steers included) precede the Thought; the process
-    // stays hidden inside it. This is a summary, not strict chronology — a
-    // steer-only turn still shows its user input above the Thought. Only
-    // the LEADING injected-context prefix is lifted; mid-turn injected
-    // context and orchestration rows (llm/retry, max-tokens) stay process
-    // content, hidden under the collapsed Thought.
+    // Collapsed Focus normally summarizes the turn's INPUTS before the
+    // Thought: the leading injected-context prefix (the turn foundation) and
+    // EVERY human user row (same-turn steers included) precede it; process
+    // rows stay hidden inside the Thought. A committed pre-steer answer is
+    // the one exception: from that exact raw boundary onward, preserve the
+    // conversation rows in chronology so the answer cannot be swallowed by
+    // the Thought or move when the disclosure changes.
     for (const member of group.slice(0, leadingInjectedContextPrefixEnd(group))) {
       out.push({ kind: 'message', message: member })
     }
-    for (const member of group) {
-      if (member.kind === 'user') out.push({ kind: 'message', message: member })
-    }
-    if (activity !== undefined) out.push({ kind: 'activity', activity })
-    // Compaction cards keep their existing lifecycle in the collapsed
-    // view (plan §12.3 v1 — never hidden into the Thought).
-    for (const member of group) {
-      if (member.kind === 'compaction') out.push({ kind: 'message', message: member })
+    const firstCommittedIndex = group.findIndex(isCommittedAnswer)
+    if (firstCommittedIndex < 0) {
+      for (const member of group) {
+        if (member.kind === 'user') out.push({ kind: 'message', message: member })
+      }
+      if (activity !== undefined) out.push({ kind: 'activity', activity })
+      // Compaction cards keep their existing lifecycle in the collapsed
+      // view (plan §12.3 v1 — never hidden into the Thought).
+      for (const member of group) {
+        if (member.kind === 'compaction') out.push({ kind: 'message', message: member })
+      }
+    } else {
+      const beforeCommitted = group.slice(0, firstCommittedIndex)
+      for (const member of beforeCommitted) {
+        if (member.kind === 'user') out.push({ kind: 'message', message: member })
+      }
+      if (activity !== undefined) out.push({ kind: 'activity', activity })
+      for (const member of beforeCommitted) {
+        if (member.kind === 'compaction') out.push({ kind: 'message', message: member })
+      }
+      for (const member of group.slice(firstCommittedIndex)) {
+        if (final !== undefined && member === final.message) continue
+        if (member.kind === 'user' || member.kind === 'compaction' || isCommittedAnswer(member)) {
+          out.push({ kind: 'message', message: member })
+        }
+      }
     }
     // The collapsed final: only after the authoritative turn/end.
     if (final !== undefined) {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -3582,11 +3582,13 @@ export class TranscriptFolder {
           const activity = this.activityFor(this.currentTurn)
           if (activity.pendingPreSteerAnswerStep !== undefined) {
             const firstVisible = activity.firstVisibleAssistantTimes.get(activity.pendingPreSteerAnswerStep)
+            // Keep an early same-turn steer pending for a later message in
+            // the same admitted next-step batch.
             if (isMidTurnSteer
                && claimedIdentity !== undefined
                && firstVisible !== undefined
                && firstVisible <= claimedIdentity.insertionTime) this.commitPreSteerAnswer(activity)
-            else activity.pendingPreSteerAnswerStep = undefined
+            else if (!isMidTurnSteer) activity.pendingPreSteerAnswerStep = undefined
           }
           this.appendItem({
             kind: 'user',

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -653,6 +653,9 @@ interface MutableTurnActivity {
   /** The exact previous assistant step that may become persistent when the
    * next step admits a same-turn human steer. */
   pendingPreSteerAnswerStep?: number
+  /** First visible Assistant output timestamp per step. This is private
+   * timing evidence for the steer boundary, not a rendered fact. */
+  firstVisibleAssistantTimes: Map<number, number>
   /** Assistant steps that crossed an admitted human-steer boundary and are
    * therefore persistent conversation answers rather than Focus process. */
   committedAnswerSteps: Set<number>
@@ -759,6 +762,35 @@ export function subCallDisplayStatus(child: {
 function assistantEntryBlocks(entry: Extract<TranscriptMessage, { kind: 'assistant' }>): readonly ContentBlock[] {
   if (entry.content !== undefined) return entry.content
   return entry.text === '' ? [] : [{ type: 'text', text: entry.text }]
+}
+
+interface AssistantVisibilityChunk {
+  readonly type: string
+  readonly text?: string
+  readonly block?: { readonly type: string; readonly text?: string }
+}
+
+/** Whether one Assistant stream chunk produces Focus-visible reply content.
+ * Reasoning, tool-call protocol, and open block starts are process evidence;
+ * text deltas and finalized visible blocks are the answer boundary. */
+function assistantChunkHasVisibleReply(chunk: AssistantVisibilityChunk): boolean {
+  if (chunk.type === 'text-delta') return typeof chunk.text === 'string' && chunk.text.trim() !== ''
+  if (chunk.type !== 'block-end') return false
+  const block = chunk.block
+  if (block === undefined) return false
+  if (block.type === 'text') return typeof block.text === 'string' && block.text.trim() !== ''
+  if (block.type === 'reasoning' || block.type === 'tool-call') return false
+  return true
+}
+
+/** Rebuild the first Focus-visible Assistant timestamp from a durable compact
+ * stream. Missing or empty streams deliberately provide no timing evidence. */
+function firstVisibleAssistantTimeFromStream(stream: readonly unknown[] | undefined): number | undefined {
+  if (stream === undefined) return undefined
+  for (const member of expandAssistantStream(stream as Parameters<typeof expandAssistantStream>[0])) {
+    if (assistantChunkHasVisibleReply(member.chunk)) return member.time
+  }
+  return undefined
 }
 
 /** Whether Assistant content is visible before an interruption override. */
@@ -1226,6 +1258,8 @@ interface NextStepInboxIdentity {
   id: string
   /** The turn that was open when this identity entered next-step, if any. */
   insertionTurn: number | undefined
+  /** The Session timestamp when this identity entered next-step. */
+  insertionTime: number
 }
 
 /** The raw item index of each active run's card (search dirty marking);
@@ -1235,8 +1269,8 @@ export class TranscriptFolder {
   private readonly items: TranscriptMessage[] = []
   /** Durable next-step identities awaiting a claim or replacement. */
   private readonly pendingNextSteps: NextStepInboxIdentity[] = []
-  /** Claimed next-step ids and the turn that was open at insertion. */
-  private readonly claimedNextStepTurns = new Map<string, number | undefined>()
+  /** Claimed next-step identities, including their insertion time. */
+  private readonly claimedNextStepTurns = new Map<string, NextStepInboxIdentity>()
   /** The assistant message object per (turn, step); streaming text lands in place. */
   private readonly assistantEntries = new Map<string, Extract<TranscriptMessage, { kind: 'assistant' }>>()
   /** In-flight live block state keyed by logical step. This is required for
@@ -1411,6 +1445,7 @@ export class TranscriptFolder {
         thinkingTail: '',
         confirmedSteps: new Set(),
         settledSteps: new Set(),
+        firstVisibleAssistantTimes: new Map(),
         committedAnswerSteps: new Set(),
         revision: 0,
       }
@@ -2356,6 +2391,10 @@ export class TranscriptFolder {
         // the failed one's. Reopen parity: the durable log restores the
         // step's reasoning from its LATEST source.
         const key = stepKey(input.turn, input.step)
+        const activity = this.activityByTurn.get(input.turn)
+        if (activity !== undefined && !activity.settledSteps.has(input.step)) {
+          activity.firstVisibleAssistantTimes.delete(input.step)
+        }
         this.liveAssistantBlocks.set(key, {
           states: new Map(),
           order: [],
@@ -2385,7 +2424,7 @@ export class TranscriptFolder {
         break
       }
       case 'chunk':
-        this.applyAssistantChunk(input.turn, input.step, input.chunk)
+        this.applyAssistantChunk(input.turn, input.step, input.chunk, input.time)
         break
       case 'end':
         // An abandoned attempt has no durable settlement and is tombstoned.
@@ -2465,7 +2504,7 @@ export class TranscriptFolder {
   /** Fold one live assistant chunk (Session v2 transient plane) into the
    * streaming entries and Focus aggregation. Live block state is retained per
    * logical step so a completed block can replace earlier deltas exactly. */
-  private applyAssistantChunk(turn: number, step: number, chunk: AssistantLiveChunk): void {
+  private applyAssistantChunk(turn: number, step: number, chunk: AssistantLiveChunk, time: number): void {
     // After turn/end a late assistant event is a replay artifact: it
     // must not mutate the finalized surface entry — the final-answer
     // selection reads the exact last assistant (review finding).
@@ -2518,6 +2557,12 @@ export class TranscriptFolder {
         const previous = projection.states.get(chunk.index)
         if (applyAssistantBlockChunk(projection.states, chunk)) {
           this.updateLiveAssistantProjection(projection, chunk.index, previous)
+          if (assistantChunkHasVisibleReply(chunk)) {
+            const firstVisible = activity.firstVisibleAssistantTimes.get(step)
+            if (firstVisible === undefined || time < firstVisible) {
+              activity.firstVisibleAssistantTimes.set(step, time)
+            }
+          }
           this.syncLiveAssistantPresentation(turn, step)
         }
         break
@@ -3226,15 +3271,16 @@ export class TranscriptFolder {
     }
   }
 
-  /** Reset same-step presentation at the scheduled retry boundary. The
-   * separate usage fold intentionally remains untouched so first-token timing
-   * and committed usage span the retry wait. */
+  /** Reset same-step presentation and first-visible boundary at the scheduled
+   * retry boundary. The separate usage fold intentionally remains untouched so
+   * first-token timing and committed usage span the retry wait. */
   private resetThinkingForRetry(turn: number, step: number): void {
     this.liveAssistantBlocks.delete(stepKey(turn, step))
     this.hideTransientAssistantEntry(turn, step)
     this.hideThinkingEntry(turn, step)
     const activity = this.activityByTurn.get(turn)
     if (activity === undefined) return
+    if (!activity.settledSteps.has(step)) activity.firstVisibleAssistantTimes.delete(step)
     this.clearThinkingPreview(activity, step)
     const candidate = activity.messageCandidate
     if (candidate !== undefined && candidate.step === step
@@ -3370,7 +3416,7 @@ export class TranscriptFolder {
         inserted: readonly { id: string }[]
         outcome?: 'canceled'
       }
-      const inserted = data.inserted.map(message => ({ id: message.id, insertionTurn: this.openTurn }))
+      const inserted = data.inserted.map(message => ({ id: message.id, insertionTurn: this.openTurn, insertionTime: event.time }))
       let removed: NextStepInboxIdentity[] = []
       if (data.target === 'next-step') {
         removed = this.pendingNextSteps.splice(
@@ -3381,7 +3427,7 @@ export class TranscriptFolder {
       }
       for (const { id } of inserted) this.claimedNextStepTurns.delete(id)
       if (data.target === 'next-step' && data.outcome !== 'canceled') {
-        for (const { id, insertionTurn } of removed) this.claimedNextStepTurns.set(id, insertionTurn)
+        for (const identity of removed) this.claimedNextStepTurns.set(identity.id, identity)
       }
       return
     }
@@ -3513,12 +3559,14 @@ export class TranscriptFolder {
         break
       }
       case 'user/message': {
-        const claimedInsertionTurn = this.claimedNextStepTurns.get(event.data.id)
+        const claimedIdentity = this.claimedNextStepTurns.get(event.data.id)
         const wasClaimedFromNextStep = this.claimedNextStepTurns.delete(event.data.id)
         // Only a next-step identity inserted during this admission turn is a
         // mid-turn steer; an idle wake or a claim carried across turns is an
         // ordinary opening/follow-up user message.
-        const isMidTurnSteer = wasClaimedFromNextStep && claimedInsertionTurn === this.currentTurn
+        const isMidTurnSteer = wasClaimedFromNextStep
+          && claimedIdentity !== undefined
+          && claimedIdentity.insertionTurn === this.currentTurn
         const blocks = event.data.content
         // User messages keep known attachment markers at their original
         // positions in the FLAT text; the ordered `content` blocks stay the
@@ -3533,7 +3581,11 @@ export class TranscriptFolder {
           if (!userBlocksVisibleNow(blocks)) break
           const activity = this.activityFor(this.currentTurn)
           if (activity.pendingPreSteerAnswerStep !== undefined) {
-            if (isMidTurnSteer) this.commitPreSteerAnswer(activity)
+            const firstVisible = activity.firstVisibleAssistantTimes.get(activity.pendingPreSteerAnswerStep)
+            if (isMidTurnSteer
+               && claimedIdentity !== undefined
+               && firstVisible !== undefined
+               && firstVisible <= claimedIdentity.insertionTime) this.commitPreSteerAnswer(activity)
             else activity.pendingPreSteerAnswerStep = undefined
           }
           this.appendItem({
@@ -3587,6 +3639,9 @@ export class TranscriptFolder {
         const alreadySettled = activity.settledSteps.has(event.data.step)
         const messageBlocks = event.data.message.content
         const text = textOf(messageBlocks)
+        const firstVisible = firstVisibleAssistantTimeFromStream(event.data.stream)
+        if (firstVisible === undefined) activity.firstVisibleAssistantTimes.delete(event.data.step)
+        else activity.firstVisibleAssistantTimes.set(event.data.step, firstVisible)
         const wasVisible = entry !== undefined && this.isVisible(entry)
         if (entry !== undefined) {
           rememberAssistantStep(entry, event.data.step)

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -145,6 +145,18 @@ export function assistantLatestStepOf(activity: TurnActivity): number | undefine
   return (activity as MutableTurnActivity).lastAssistantStep
 }
 
+/** Whether an Assistant crossed an admitted human-steer boundary and is
+ * therefore a persistent conversation answer rather than Focus process. */
+export function assistantCommittedBeforeSteer(
+  activity: TurnActivity,
+  message: TranscriptMessage,
+): boolean {
+  if (message.kind !== 'assistant') return false
+  const step = assistantStepOf(message)
+  return step !== undefined
+    && (activity as MutableTurnActivity).committedAnswerSteps.has(step)
+}
+
 function rememberAssistantStep(message: Extract<TranscriptMessage, { kind: 'assistant' }>, step: number): void {
   assistantStepIdentities.set(message, step)
 }
@@ -638,6 +650,12 @@ interface MutableTurnActivity {
    * is ignored — it must never corrupt the settled preview (review
    * finding). */
   settledSteps: Set<number>
+  /** The exact previous assistant step that may become persistent when the
+   * next step admits a same-turn human steer. */
+  pendingPreSteerAnswerStep?: number
+  /** Assistant steps that crossed an admitted human-steer boundary and are
+   * therefore persistent conversation answers rather than Focus process. */
+  committedAnswerSteps: Set<number>
   /** The step of the turn's LAST assistant output (streaming or settled)
    * — the turn/end final-answer check compares the candidate's step
    * against this. */
@@ -1393,6 +1411,7 @@ export class TranscriptFolder {
         thinkingTail: '',
         confirmedSteps: new Set(),
         settledSteps: new Set(),
+        committedAnswerSteps: new Set(),
         revision: 0,
       }
       this.activityByTurn.set(turn, activity)
@@ -1705,6 +1724,23 @@ export class TranscriptFolder {
     activity.messageConfirmedStep = candidate.step
     activity.confirmedSteps.add(candidate.step)
     activity.messageCandidate = undefined
+  }
+
+  /** Commit the exact previous text-only answer once its next step admits a
+   * same-turn human steer. It leaves the replay fences intact and only moves
+   * that step out of the transient Message slot. */
+  private commitPreSteerAnswer(activity: MutableTurnActivity): void {
+    const step = activity.pendingPreSteerAnswerStep
+    if (step === undefined) return
+    activity.pendingPreSteerAnswerStep = undefined
+    activity.committedAnswerSteps.add(step)
+    if (activity.messageCandidate?.step === step) activity.messageCandidate = undefined
+    if (activity.messageConfirmedStep === step) {
+      activity.messageConfirmed = undefined
+      activity.messageConfirmedStep = undefined
+    }
+    this.syncMessage(activity)
+    activity.revision += 1
   }
 
   /** Materialize the Message slot from the candidate (running) or the
@@ -3405,6 +3441,18 @@ export class TranscriptFolder {
         // accumulator state (review finding).
         const activity = this.activityFor(event.data.turn)
         if (activity.completed) break
+        activity.pendingPreSteerAnswerStep = undefined
+        const previousStep = event.data.step - 1
+        if (activity.lastAssistantStep === previousStep
+          && activity.settledSteps.has(previousStep)) {
+          const previous = this.assistantEntries.get(stepKey(event.data.turn, previousStep))
+          if (previous !== undefined && previous.interrupted !== true) {
+            const blocks = assistantEntryBlocks(previous)
+            const visible = assistantBlocksVisibleNow(blocks)
+            const hasToolCall = blocks.some(block => block.type === 'tool-call')
+            if (visible && !hasToolCall) activity.pendingPreSteerAnswerStep = previousStep
+          }
+        }
         this.usage.onStepStart(event.data.turn, event.data.step)
         // Owner lifecycle: the step is now open (plan §5.1). Guarded by the
         // same replay fence as the usage accounting — a late step/start
@@ -3483,6 +3531,11 @@ export class TranscriptFolder {
         // process block must not turn into an empty system row.
         if (event.data.source.kind === 'user') {
           if (!userBlocksVisibleNow(blocks)) break
+          const activity = this.activityFor(this.currentTurn)
+          if (activity.pendingPreSteerAnswerStep !== undefined) {
+            if (isMidTurnSteer) this.commitPreSteerAnswer(activity)
+            else activity.pendingPreSteerAnswerStep = undefined
+          }
           this.appendItem({
             kind: 'user',
             turn: this.currentTurn,
@@ -3863,6 +3916,7 @@ export class TranscriptFolder {
         // leave a stale open step behind (re-projection is idempotent).
         this.workflow.onTurnEnd(endTurn)
         const endActivity = this.activityFor(endTurn)
+        endActivity.pendingPreSteerAnswerStep = undefined
         if (endActivity.completed) break
         // Every still-open thinking entry of THIS turn stops streaming when
         // the turn closes (interrupted steps never see their

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -3587,7 +3587,7 @@ export class TranscriptFolder {
             if (isMidTurnSteer
                && claimedIdentity !== undefined
                && firstVisible !== undefined
-               && firstVisible <= claimedIdentity.insertionTime) this.commitPreSteerAnswer(activity)
+               && firstVisible < claimedIdentity.insertionTime) this.commitPreSteerAnswer(activity)
             else if (!isMidTurnSteer) activity.pendingPreSteerAnswerStep = undefined
           }
           this.appendItem({

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2539,7 +2539,14 @@ test('a later steer in one claimed batch can still commit the answer boundary', 
     eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 9146, 154),
   ]
   const live = new TranscriptFolder()
-  applyMixed(live, events)
+  const firstSteerIndex = events.findIndex(event => event.type === 'user/message'
+    && (event.data as { id?: unknown }).id === firstSteer.id)
+  assert.ok(firstSteerIndex >= 0)
+  applyMixed(live, events.slice(0, firstSteerIndex + 1))
+  const afterFirstSteer = live.turnActivity(0)
+  assert.ok(afterFirstSteer !== undefined)
+  assert.equal(afterFirstSteer.message?.text, 'assistant A', 'the early steer does not consume the pending boundary')
+  applyMixed(live, events.slice(firstSteerIndex + 1))
   const collapsed = projectTools(live.messages(), live.turnActivities(), new Set())
   assert.deepEqual(blockKinds(collapsed), ['user', 'activity', 'assistant', 'user', 'user', 'assistant'])
   assert.deepEqual(

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2350,13 +2350,13 @@ function steerMessage(id: string, text: string): {
 }
 
 /** Queue one human message without admitting it yet. */
-function queueSteer(message: ReturnType<typeof steerMessage>, time: number, seq: number): SessionEvent {
-  return eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, time, seq)
+function queueSteer(message: ReturnType<typeof steerMessage>, time: number, seq: number, start = 0): SessionEvent {
+  return eventAt('agent/inbox/spliced', { target: 'next-step', start, inserted: [message] }, time, seq)
 }
 
-/** Claim the queued message immediately before the next step starts. */
-function claimSteer(time: number, seq: number): SessionEvent {
-  return eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, time, seq)
+/** Claim queued messages immediately before the next step starts. */
+function claimSteer(time: number, seq: number, removedCount = 1): SessionEvent {
+  return eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount, inserted: [] }, time, seq)
 }
 
 /** A turn with an initial user, thinking, a tool, a MID-TURN steer, and a
@@ -2510,6 +2510,55 @@ test('a steer inserted before the first visible assistant output does not commit
   assert.deepEqual(
     replayCollapsed.map(block => block.kind === 'message' && 'text' in block.message ? block.message.text : 'Thought'),
     collapsed.map(block => block.kind === 'message' && 'text' in block.message ? block.message.text : 'Thought'),
+  )
+})
+
+test('a later steer in one claimed batch can still commit the answer boundary', () => {
+  const initial = steerMessage('batch-initial', 'initial prompt')
+  const firstSteer = steerMessage('batch-steer-1', 'steer #1')
+  const secondSteer = steerMessage('batch-steer-2', 'steer #2')
+  const events: SessionEvent[] = [
+    eventAt('turn/start', { turn: 0 }, 9000, 140),
+    eventAt('step/start', { turn: 0, step: 1 }, 9001, 141),
+    eventAt('user/message', initial, 9002, 142),
+    queueSteer(firstSteer, 9100, 143),
+    eventAt('assistant/chunk', {
+      turn: 0,
+      step: 1,
+      chunk: { type: 'text-delta', index: 0, text: 'assistant A' },
+    }, 9110, 144),
+    queueSteer(secondSteer, 9120, 145, 1),
+    assistantSettlement(0, 1, 'batch-a', 'assistant A', 9130, 146, undefined, 9110),
+    eventAt('step/end', { turn: 0, step: 1 }, 9131, 147),
+    claimSteer(9140, 148, 2),
+    eventAt('step/start', { turn: 0, step: 2 }, 9141, 149),
+    eventAt('user/message', firstSteer, 9142, 150),
+    eventAt('user/message', secondSteer, 9143, 151),
+    assistantSettlement(0, 2, 'batch-b', 'assistant B', 9144, 152),
+    eventAt('step/end', { turn: 0, step: 2 }, 9145, 153),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 9146, 154),
+  ]
+  const live = new TranscriptFolder()
+  applyMixed(live, events)
+  const collapsed = projectTools(live.messages(), live.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'activity', 'assistant', 'user', 'user', 'assistant'])
+  assert.deepEqual(
+    collapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'user' ? [block.message.text] : []),
+    ['initial prompt', 'steer #1', 'steer #2'],
+  )
+  assert.deepEqual(
+    collapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message.text] : []),
+    ['assistant A', 'assistant B'],
+    'the later steer still commits A even though the first steer was early',
+  )
+
+  const replay = new TranscriptFolder()
+  replay.hydrate(events)
+  const replayCollapsed = projectTools(replay.messages(), replay.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(replayCollapsed), blockKinds(collapsed), 'batch admission keeps live/replay parity')
+  assert.deepEqual(
+    replayCollapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message.text] : []),
+    ['assistant A', 'assistant B'],
   )
 })
 

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2310,6 +2310,53 @@ function claimedSteer(id: string, text: string, time: number, seq: number): Sess
   ]
 }
 
+/** Build one durable Assistant settlement with an optional full content
+ * payload (used by the tool-call negative case). */
+function assistantSettlement(
+  turn: number,
+  step: number,
+  id: string,
+  text: string,
+  time: number,
+  seq: number,
+  content: readonly unknown[] = [{ type: 'text', text }],
+): SessionEvent {
+  return eventAt('assistant/message', {
+    turn,
+    step,
+    message: {
+      id: MessageId(id),
+      role: 'assistant',
+      content,
+      source: { kind: 'model', provider: 'p', model: 'm' },
+    },
+  }, time, seq)
+}
+
+function steerMessage(id: string, text: string): {
+  id: MessageId
+  role: 'user'
+  content: [{ type: 'text'; text: string }]
+  source: { kind: 'user' }
+} {
+  return {
+    id: MessageId(id),
+    role: 'user',
+    content: [{ type: 'text', text }],
+    source: { kind: 'user' },
+  }
+}
+
+/** Queue one human message without admitting it yet. */
+function queueSteer(message: ReturnType<typeof steerMessage>, time: number, seq: number): SessionEvent {
+  return eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, inserted: [message] }, time, seq)
+}
+
+/** Claim the queued message immediately before the next step starts. */
+function claimSteer(time: number, seq: number): SessionEvent {
+  return eventAt('agent/inbox/spliced', { target: 'next-step', start: 0, removedCount: 1, inserted: [] }, time, seq)
+}
+
 /** A turn with an initial user, thinking, a tool, a MID-TURN steer, and a
  * final answer: user → thinking → tool → user(steer) → assistant → end. */
 function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionEvent[] {
@@ -2342,6 +2389,251 @@ function steeredTurn(turn: number, baseSeq: number, startTime: number): SessionE
     eventAt('turn/end', { turn, reason: { kind: 'completed' } }, startTime + 6000, baseSeq + 9),
   ]
 }
+
+test('a settled text-only answer crossed by a human steer stays persistent before the next answer', () => {
+  const folder = new TranscriptFolder()
+  const initial = steerMessage('focus-initial', 'initial prompt')
+  const steer = steerMessage('focus-steer', 'human steer')
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 1000, 0),
+    eventAt('step/start', { turn: 0, step: 1 }, 1001, 1),
+    eventAt('user/message', initial, 1002, 2),
+    // A is still streaming when the human steer enters next-step.
+    eventAt('assistant/chunk', {
+      turn: 0,
+      step: 1,
+      chunk: { type: 'text-delta', index: 0, text: 'assistant A' },
+    }, 1003, 3),
+    queueSteer(steer, 1004, 4),
+    assistantSettlement(0, 1, 'focus-a', 'assistant A', 1005, 5),
+    eventAt('step/end', { turn: 0, step: 1 }, 1006, 6),
+    claimSteer(1007, 7),
+    eventAt('step/start', { turn: 0, step: 2 }, 1008, 8),
+    eventAt('user/message', steer, 1009, 9),
+  ])
+
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message, undefined, 'committing A removes it from the Thought Message slot immediately')
+  const beforeB = folder.messages()
+  const collapsedBeforeB = projectTools(beforeB, folder.turnActivities(), new Set())
+  const expandedBeforeB = projectTools(beforeB, folder.turnActivities(), new Set([0]))
+  assert.deepEqual(blockKinds(collapsedBeforeB), ['user', 'activity', 'assistant', 'user'])
+  assert.deepEqual(blockKinds(expandedBeforeB), ['user', 'activity', 'assistant', 'user'])
+  const collapsedAssistant = collapsedBeforeB.find(block => block.kind === 'message' && block.message.kind === 'assistant')
+  assert.ok(collapsedAssistant?.kind === 'message' && collapsedAssistant.message.kind === 'assistant')
+  if (collapsedAssistant?.kind === 'message' && collapsedAssistant.message.kind === 'assistant') {
+    assert.equal(collapsedAssistant.message.text, 'assistant A')
+  }
+  const expandedAssistant = expandedBeforeB.find(block => block.kind === 'message' && block.message.kind === 'assistant')
+  assert.ok(expandedAssistant?.kind === 'message' && expandedAssistant.message.kind === 'assistant')
+  if (expandedAssistant?.kind === 'message' && expandedAssistant.message.kind === 'assistant') {
+    assert.equal(expandedAssistant.message.text, 'assistant A')
+    assert.equal(expandedAssistant.collapseFocusOwnerOnClick, undefined,
+      'a committed pre-steer answer is persistent in expanded Focus')
+  }
+
+  applyMixed(folder, [
+    eventAt('assistant/chunk', {
+      turn: 0,
+      step: 2,
+      chunk: { type: 'text-delta', index: 0, text: 'assistant B' },
+    }, 1010, 10),
+    assistantSettlement(0, 2, 'focus-b', 'assistant B', 1011, 11),
+    eventAt('step/end', { turn: 0, step: 2 }, 1012, 12),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 1013, 13),
+  ])
+  const completed = folder.messages()
+  const collapsed = projectTools(completed, folder.turnActivities(), new Set())
+  const expanded = projectTools(completed, folder.turnActivities(), new Set([0]))
+  assert.deepEqual(blockKinds(collapsed), ['user', 'activity', 'assistant', 'user', 'assistant'])
+  assert.deepEqual(blockKinds(expanded), ['user', 'activity', 'assistant', 'user', 'assistant'])
+  assert.deepEqual(
+    collapsed.flatMap(block => block.kind === 'message' && (block.message.kind === 'user' || block.message.kind === 'assistant')
+      ? [`${block.message.kind}:${block.message.text}`] : []),
+    ['user:initial prompt', 'assistant:assistant A', 'user:human steer', 'assistant:assistant B'],
+  )
+  assert.equal(activity.message, undefined, 'the final B remains outside the Thought Message slot')
+
+  const raw = folder.messages()
+  const off = projectFocus(raw, folder.turnActivities(), new Set(), false)
+  assert.deepEqual(off.map(block => block.kind === 'message' ? block.message : undefined), raw,
+    'Focus off leaves the raw transcript chronology unchanged')
+})
+
+test('an assistant with text plus tool-call stays process evidence across a steer boundary', () => {
+  const folder = new TranscriptFolder()
+  const initial = steerMessage('tool-initial', 'initial prompt')
+  const steer = steerMessage('tool-steer', 'human steer')
+  const toolCallId = ToolCallId('focus-tool-call')
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 2000, 20),
+    eventAt('step/start', { turn: 0, step: 1 }, 2001, 21),
+    eventAt('user/message', initial, 2002, 22),
+    assistantSettlement(0, 1, 'tool-a', '我先检查一下', 2003, 23, [
+      { type: 'text', text: '我先检查一下' },
+      { type: 'tool-call', id: toolCallId, name: 'read', arguments: '{}' },
+    ]),
+    eventAt('tool/call', {
+      turn: 0,
+      step: 1,
+      callId: toolCallId,
+      name: 'read',
+      arguments: '{}',
+    }, 2004, 24),
+    eventAt('tool/result', {
+      turn: 0,
+      step: 1,
+      message: {
+        id: MessageId('tool-r'),
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId, content: [{ type: 'text', text: 'ok' }] }],
+        source: { kind: 'tool', callId: toolCallId },
+      },
+    }, 2005, 25),
+    eventAt('step/end', { turn: 0, step: 1 }, 2006, 26),
+    queueSteer(steer, 2007, 27),
+    claimSteer(2008, 28),
+    eventAt('step/start', { turn: 0, step: 2 }, 2009, 29),
+    eventAt('user/message', steer, 2010, 30),
+    assistantSettlement(0, 2, 'tool-b', 'final B', 2011, 31),
+    eventAt('step/end', { turn: 0, step: 2 }, 2012, 32),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 2013, 33),
+  ])
+
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.toolCalls, 1)
+  assert.equal(activity.tool?.name, 'read')
+  assert.equal(activity.message?.text, '我先检查一下', 'tool-call text remains available as process evidence')
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'user', 'activity', 'assistant'])
+  const assistants = collapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message.text] : [])
+  assert.deepEqual(assistants, ['final B'], 'the tool-call prefix is never promoted to an independent answer')
+})
+
+test('multiple text-only answers crossed by steers preserve conversation chronology', () => {
+  const folder = new TranscriptFolder()
+  const initial = steerMessage('multi-initial', 'initial prompt')
+  const steer1 = steerMessage('multi-steer-1', 'steer 1')
+  const steer2 = steerMessage('multi-steer-2', 'steer 2')
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 3000, 40),
+    eventAt('step/start', { turn: 0, step: 1 }, 3001, 41),
+    eventAt('user/message', initial, 3002, 42),
+    assistantSettlement(0, 1, 'multi-a', 'assistant A', 3003, 43),
+    eventAt('step/end', { turn: 0, step: 1 }, 3004, 44),
+    queueSteer(steer1, 3005, 45),
+    claimSteer(3006, 46),
+    eventAt('step/start', { turn: 0, step: 2 }, 3007, 47),
+    eventAt('user/message', steer1, 3008, 48),
+    assistantSettlement(0, 2, 'multi-b', 'assistant B', 3009, 49),
+    eventAt('step/end', { turn: 0, step: 2 }, 3010, 50),
+    queueSteer(steer2, 3011, 51),
+    claimSteer(3012, 52),
+    eventAt('step/start', { turn: 0, step: 3 }, 3013, 53),
+    eventAt('user/message', steer2, 3014, 54),
+    assistantSettlement(0, 3, 'multi-c', 'assistant C', 3015, 55),
+    eventAt('step/end', { turn: 0, step: 3 }, 3016, 56),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 3017, 57),
+  ])
+
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  const expanded = projectTools(folder.messages(), folder.turnActivities(), new Set([0]))
+  const expectedKinds = ['user', 'activity', 'assistant', 'user', 'assistant', 'user', 'assistant']
+  assert.deepEqual(blockKinds(collapsed), expectedKinds)
+  assert.deepEqual(blockKinds(expanded), expectedKinds)
+  const textRows = (blocks: readonly FocusProjectedBlock[]): string[] => blocks.flatMap(block =>
+    block.kind === 'message' && (block.message.kind === 'user' || block.message.kind === 'assistant')
+      ? [block.message.text] : [])
+  assert.deepEqual(textRows(collapsed), ['initial prompt', 'assistant A', 'steer 1', 'assistant B', 'steer 2', 'assistant C'])
+  assert.deepEqual(textRows(expanded), textRows(collapsed))
+  const committedRows = expanded.filter(block => block.kind === 'message' && block.message.kind === 'assistant')
+  assert.equal(committedRows.length, 3)
+  for (const block of committedRows) {
+    assert.equal(block.kind, 'message')
+    assert.equal(block.collapseFocusOwnerOnClick, undefined)
+  }
+})
+
+test('the pre-steer answer boundary is identical for live fold and cold replay', () => {
+  const initial = steerMessage('replay-initial', 'initial prompt')
+  const steer = steerMessage('replay-steer', 'human steer')
+  const events: SessionEvent[] = [
+    eventAt('turn/start', { turn: 0 }, 4000, 60),
+    eventAt('step/start', { turn: 0, step: 1 }, 4001, 61),
+    eventAt('user/message', initial, 4002, 62),
+    assistantSettlement(0, 1, 'replay-a', 'assistant A', 4003, 63),
+    eventAt('step/end', { turn: 0, step: 1 }, 4004, 64),
+    queueSteer(steer, 4005, 65),
+    claimSteer(4006, 66),
+    eventAt('step/start', { turn: 0, step: 2 }, 4007, 67),
+    eventAt('user/message', steer, 4008, 68),
+    assistantSettlement(0, 2, 'replay-b', 'assistant B', 4009, 69),
+    eventAt('step/end', { turn: 0, step: 2 }, 4010, 70),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 4011, 71),
+  ]
+  const live = new TranscriptFolder()
+  live.apply(events)
+  const replay = new TranscriptFolder()
+  replay.hydrate(events)
+  const liveProjected = projectTools(live.messages(), live.turnActivities(), new Set())
+  const replayProjected = projectTools(replay.messages(), replay.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(liveProjected), ['user', 'activity', 'assistant', 'user', 'assistant'])
+  assert.deepEqual(blockKinds(replayProjected), blockKinds(liveProjected))
+  assert.deepEqual(
+    replayProjected.map(block => block.kind === 'message' && 'text' in block.message ? block.message.text : 'Thought'),
+    liveProjected.map(block => block.kind === 'message' && 'text' in block.message ? block.message.text : 'Thought'),
+  )
+})
+
+test('a direct non-steer user clears a pending pre-steer boundary', () => {
+  const folder = new TranscriptFolder()
+  const initial = steerMessage('clear-initial', 'initial prompt')
+  const queued = steerMessage('clear-queued', 'queued steer')
+  const ordinary = steerMessage('clear-ordinary', 'ordinary follow-up')
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 5000, 80),
+    eventAt('step/start', { turn: 0, step: 1 }, 5001, 81),
+    eventAt('user/message', initial, 5002, 82),
+    assistantSettlement(0, 1, 'clear-a', 'assistant A', 5003, 83),
+    eventAt('step/end', { turn: 0, step: 1 }, 5004, 84),
+    queueSteer(queued, 5005, 85),
+    claimSteer(5006, 86),
+    eventAt('step/start', { turn: 0, step: 2 }, 5007, 87),
+    // This direct row is not the claimed queued steer, so it must not commit A.
+    eventAt('user/message', ordinary, 5008, 88),
+  ])
+  const activity = folder.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message?.text, 'assistant A')
+  const collapsed = projectTools(folder.messages(), folder.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'user', 'activity'])
+})
+
+test('committed pre-steer answers do not alter the raw Focus-off projection', () => {
+  const folder = new TranscriptFolder()
+  const initial = steerMessage('off-initial', 'initial prompt')
+  const steer = steerMessage('off-steer', 'human steer')
+  applyMixed(folder, [
+    eventAt('turn/start', { turn: 0 }, 6000, 90),
+    eventAt('step/start', { turn: 0, step: 1 }, 6001, 91),
+    eventAt('user/message', initial, 6002, 92),
+    assistantSettlement(0, 1, 'off-a', 'assistant A', 6003, 93),
+    eventAt('step/end', { turn: 0, step: 1 }, 6004, 94),
+    queueSteer(steer, 6005, 95),
+    claimSteer(6006, 96),
+    eventAt('step/start', { turn: 0, step: 2 }, 6007, 97),
+    eventAt('user/message', steer, 6008, 98),
+  ])
+  const raw = folder.messages()
+  const projected = projectFocus(raw, folder.turnActivities(), new Set(), false)
+  assert.equal(projected.length, raw.length)
+  projected.forEach((block, index) => {
+    assert.equal(block.kind, 'message')
+    if (block.kind === 'message') assert.equal(block.message, raw[index])
+  })
+})
 
 test('completed open opaque output remains process evidence, not a final Assistant', () => {
   const folder = new TranscriptFolder()

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2320,10 +2320,12 @@ function assistantSettlement(
   time: number,
   seq: number,
   content: readonly unknown[] = [{ type: 'text', text }],
+  firstVisibleTime: number = time,
 ): SessionEvent {
   return eventAt('assistant/message', {
     turn,
     step,
+    stream: [{ type: 'text-chunks', time0: firstVisibleTime, index: 0, dt: [], texts: [text] }],
     message: {
       id: MessageId(id),
       role: 'assistant',
@@ -2403,9 +2405,10 @@ test('a settled text-only answer crossed by a human steer stays persistent befor
       turn: 0,
       step: 1,
       chunk: { type: 'text-delta', index: 0, text: 'assistant A' },
-    }, 1003, 3),
+    }, 1004, 3),
+    // Same-millisecond output and insertion still count as pre-steer.
     queueSteer(steer, 1004, 4),
-    assistantSettlement(0, 1, 'focus-a', 'assistant A', 1005, 5),
+    assistantSettlement(0, 1, 'focus-a', 'assistant A', 1005, 5, [{ type: 'text', text: 'assistant A' }], 1004),
     eventAt('step/end', { turn: 0, step: 1 }, 1006, 6),
     claimSteer(1007, 7),
     eventAt('step/start', { turn: 0, step: 2 }, 1008, 8),
@@ -2459,6 +2462,98 @@ test('a settled text-only answer crossed by a human steer stays persistent befor
   const off = projectFocus(raw, folder.turnActivities(), new Set(), false)
   assert.deepEqual(off.map(block => block.kind === 'message' ? block.message : undefined), raw,
     'Focus off leaves the raw transcript chronology unchanged')
+})
+
+test('a steer inserted before the first visible assistant output does not commit that answer', () => {
+  const initial = steerMessage('late-initial', 'initial prompt')
+  const steer = steerMessage('late-steer', 'human steer')
+  const events: SessionEvent[] = [
+    eventAt('turn/start', { turn: 0 }, 7000, 100),
+    eventAt('step/start', { turn: 0, step: 1 }, 7001, 101),
+    eventAt('user/message', initial, 7002, 102),
+    eventAt('assistant/chunk', {
+      turn: 0,
+      step: 1,
+      chunk: { type: 'reasoning-delta', index: 0, text: 'thinking…' },
+    }, 7003, 103),
+    queueSteer(steer, 7004, 104),
+    eventAt('assistant/chunk', {
+      turn: 0,
+      step: 1,
+      chunk: { type: 'text-delta', index: 0, text: 'assistant A' },
+    }, 7005, 105),
+    assistantSettlement(0, 1, 'late-a', 'assistant A', 7006, 106, [{ type: 'text', text: 'assistant A' }], 7005),
+    eventAt('step/end', { turn: 0, step: 1 }, 7007, 107),
+    claimSteer(7008, 108),
+    eventAt('step/start', { turn: 0, step: 2 }, 7009, 109),
+    eventAt('user/message', steer, 7010, 110),
+    assistantSettlement(0, 2, 'late-b', 'assistant B', 7011, 111),
+    eventAt('step/end', { turn: 0, step: 2 }, 7012, 112),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 7013, 113),
+  ]
+  const live = new TranscriptFolder()
+  applyMixed(live, events)
+  const activity = live.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message?.text, 'assistant A', 'A remains process evidence after the early steer')
+  const collapsed = projectTools(live.messages(), live.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'user', 'activity', 'assistant'])
+  assert.deepEqual(
+    collapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message.text] : []),
+    ['assistant B'],
+  )
+
+  const replay = new TranscriptFolder()
+  replay.hydrate(events)
+  const replayCollapsed = projectTools(replay.messages(), replay.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(replayCollapsed), blockKinds(collapsed), 'durable timed stream preserves the same boundary')
+  assert.deepEqual(
+    replayCollapsed.map(block => block.kind === 'message' && 'text' in block.message ? block.message.text : 'Thought'),
+    collapsed.map(block => block.kind === 'message' && 'text' in block.message ? block.message.text : 'Thought'),
+  )
+})
+
+test('a retry resets earlier visible timing before a later steer boundary', () => {
+  const initial = steerMessage('retry-initial', 'initial prompt')
+  const steer = steerMessage('retry-steer', 'human steer')
+  const live = new TranscriptFolder()
+  live.apply([
+    eventAt('turn/start', { turn: 0 }, 8000, 120),
+    eventAt('step/start', { turn: 0, step: 1 }, 8001, 121),
+    eventAt('user/message', initial, 8002, 122),
+  ])
+  live.applyLiveInput({ kind: 'start', sessionId: 'test', attemptId: 'attempt-a', turn: 0, step: 1 })
+  live.applyLiveInput(liveChunk(0, 1, { type: 'text-delta', index: 0, text: 'failed A' }, 8003))
+  live.apply([queueSteer(steer, 8004, 123)])
+  live.apply([eventAt('llm/retry', {
+    turn: 0,
+    step: 1,
+    retry: 1,
+    delayMs: 0,
+    failure: { code: 'RETRY', message: 'failed' },
+  }, 8005, 124)])
+  live.applyLiveInput({ kind: 'start', sessionId: 'test', attemptId: 'attempt-b', turn: 0, step: 1 })
+  live.applyLiveInput(liveChunk(0, 1, { type: 'text-delta', index: 0, text: 'final A' }, 8006))
+  live.apply([
+    assistantSettlement(0, 1, 'retry-a', 'final A', 8007, 125, [{ type: 'text', text: 'final A' }], 8006),
+    eventAt('step/end', { turn: 0, step: 1 }, 8008, 126),
+    claimSteer(8009, 127),
+    eventAt('step/start', { turn: 0, step: 2 }, 8010, 128),
+    eventAt('user/message', steer, 8011, 129),
+    assistantSettlement(0, 2, 'retry-b', 'assistant B', 8012, 130),
+    eventAt('step/end', { turn: 0, step: 2 }, 8013, 131),
+    eventAt('turn/end', { turn: 0, reason: { kind: 'completed' } }, 8014, 132),
+  ])
+  const collapsed = projectTools(live.messages(), live.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'user', 'activity', 'assistant'])
+  assert.deepEqual(
+    collapsed.flatMap(block => block.kind === 'message' && block.message.kind === 'assistant' ? [block.message.text] : []),
+    ['assistant B'],
+    'the retry output after the steer remains process evidence',
+  )
+  const activity = live.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message?.text, 'final A')
 })
 
 test('an assistant with text plus tool-call stays process evidence across a steer boundary', () => {

--- a/test/focus-mode.test.ts
+++ b/test/focus-mode.test.ts
@@ -2405,10 +2405,10 @@ test('a settled text-only answer crossed by a human steer stays persistent befor
       turn: 0,
       step: 1,
       chunk: { type: 'text-delta', index: 0, text: 'assistant A' },
-    }, 1004, 3),
-    // Same-millisecond output and insertion still count as pre-steer.
+    }, 1003, 3),
+    // A's first visible output is strictly before the steer insertion.
     queueSteer(steer, 1004, 4),
-    assistantSettlement(0, 1, 'focus-a', 'assistant A', 1005, 5, [{ type: 'text', text: 'assistant A' }], 1004),
+    assistantSettlement(0, 1, 'focus-a', 'assistant A', 1005, 5, [{ type: 'text', text: 'assistant A' }], 1003),
     eventAt('step/end', { turn: 0, step: 1 }, 1006, 6),
     claimSteer(1007, 7),
     eventAt('step/start', { turn: 0, step: 2 }, 1008, 8),
@@ -2462,6 +2462,45 @@ test('a settled text-only answer crossed by a human steer stays persistent befor
   const off = projectFocus(raw, folder.turnActivities(), new Set(), false)
   assert.deepEqual(off.map(block => block.kind === 'message' ? block.message : undefined), raw,
     'Focus off leaves the raw transcript chronology unchanged')
+})
+
+test('same-millisecond steer and assistant output stays process evidence', () => {
+  const initial = steerMessage('equal-initial', 'initial prompt')
+  const steer = steerMessage('equal-steer', 'human steer')
+  const events: SessionEvent[] = [
+    eventAt('turn/start', { turn: 0 }, 1100, 20),
+    eventAt('step/start', { turn: 0, step: 1 }, 1101, 21),
+    eventAt('user/message', initial, 1102, 22),
+    // The output event is applied first, but its timestamp collides with the
+    // next-step insertion timestamp and therefore cannot prove ordering.
+    eventAt('assistant/chunk', {
+      turn: 0,
+      step: 1,
+      chunk: { type: 'text-delta', index: 0, text: 'assistant A' },
+    }, 1104, 23),
+    queueSteer(steer, 1104, 24),
+    assistantSettlement(0, 1, 'equal-a', 'assistant A', 1105, 25, undefined, 1104),
+    eventAt('step/end', { turn: 0, step: 1 }, 1106, 26),
+    claimSteer(1107, 27),
+    eventAt('step/start', { turn: 0, step: 2 }, 1108, 28),
+    eventAt('user/message', steer, 1109, 29),
+  ]
+  const live = new TranscriptFolder()
+  applyMixed(live, events)
+  const activity = live.turnActivity(0)
+  assert.ok(activity !== undefined)
+  assert.equal(activity.message?.text, 'assistant A', 'ambiguous timing does not commit A')
+  const collapsed = projectTools(live.messages(), live.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(collapsed), ['user', 'user', 'activity'])
+  assert.equal(collapsed.some(block => block.kind === 'message' && block.message.kind === 'assistant'), false)
+
+  const replay = new TranscriptFolder()
+  replay.hydrate(events)
+  const replayActivity = replay.turnActivity(0)
+  assert.ok(replayActivity !== undefined)
+  assert.equal(replayActivity.message?.text, 'assistant A')
+  const replayCollapsed = projectTools(replay.messages(), replay.turnActivities(), new Set())
+  assert.deepEqual(blockKinds(replayCollapsed), ['user', 'user', 'activity'])
 })
 
 test('a steer inserted before the first visible assistant output does not commit that answer', () => {


### PR DESCRIPTION
## Summary
- preserve a settled, visible, text-only assistant answer when a same-turn human steer opens the next step
- gate that boundary by the assistant's first visible stream timestamp being strictly earlier than the steer insertion timestamp; equal milliseconds fail closed
- retain the pending boundary across multiple messages admitted from one next-step batch
- keep tool-call and post-steer assistant output inside Focus process content, including retry and cold replay paths
- add regression coverage for strict-before, equal-timestamp, timed replay, batch claim, retry, chronology, click ownership, and Focus-off behavior

## UX decision
- This PR keeps collapsed Focus steer placement on existing durable admission chronology. Insertion-time placement for earlier queued steers is a separate follow-up and is not part of this correctness fix.

## Validation
- `pnpm build`
- `pnpm test`
- Focus tests: 149 passed
- Product tests: 4226 passed
- `pnpm typecheck`
- `pnpm gate:boundary`
- `git diff --check`

Holistic review loop: accepted with no unresolved P0/P1/P2 findings.